### PR TITLE
Removing remote calls in internalExecutor of ClientExecutionService

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.spi.impl;
 
 import com.hazelcast.client.spi.ClientExecutionService;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -39,6 +40,17 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
 
     private static final ILogger LOGGER = Logger.getLogger(ClientExecutionService.class);
     private static final long TERMINATE_TIMEOUT_SECONDS = 30;
+    private static final ExecutionCallback FAILURE_LOGGING_EXECUTION_CALLBACK = new ExecutionCallback() {
+        @Override
+        public void onResponse(Object response) {
+
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            LOGGER.warning("Rejected internal execution on scheduledExecutor", t);
+        }
+    };
     private final ExecutorService userExecutor;
     private final ExecutorService internalExecutor;
     private final ScheduledExecutorService scheduledExecutor;
@@ -97,6 +109,25 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
         return futureTask;
     }
 
+    /**
+     * Utilized when given command needs to make a remote call. Response of remote call is not handled in runnable itself
+     * but rather in  execution callback so that executor is not blocked because of a remote operation
+     *
+     * @param command
+     * @param delay
+     * @param unit
+     * @param executionCallback
+     * @return scheduledFuture
+     */
+    public ScheduledFuture<?> schedule(final Runnable command, long delay, TimeUnit unit,
+                                       final ExecutionCallback executionCallback) {
+        return scheduledExecutor.schedule(new Runnable() {
+            public void run() {
+                executeInternalSafely(command, executionCallback);
+            }
+        }, delay, unit);
+    }
+
     @Override
     public <T> ICompletableFuture<T> submit(Callable<T> task) {
         CompletableFutureTask<T> futureTask = new CompletableFutureTask<T>(task, getAsyncExecutor());
@@ -108,7 +139,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     public ScheduledFuture<?> schedule(final Runnable command, long delay, TimeUnit unit) {
         return scheduledExecutor.schedule(new Runnable() {
             public void run() {
-                executeInternalSafely(command);
+                executeInternalSafely(command, FAILURE_LOGGING_EXECUTION_CALLBACK);
             }
         }, delay, unit);
     }
@@ -117,7 +148,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     public ScheduledFuture<?> scheduleAtFixedRate(final Runnable command, long initialDelay, long period, TimeUnit unit) {
         return scheduledExecutor.scheduleAtFixedRate(new Runnable() {
             public void run() {
-                executeInternalSafely(command);
+                executeInternalSafely(command, FAILURE_LOGGING_EXECUTION_CALLBACK);
             }
         }, initialDelay, period, unit);
     }
@@ -126,7 +157,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     public ScheduledFuture<?> scheduleWithFixedDelay(final Runnable command, long initialDelay, long period, TimeUnit unit) {
         return scheduledExecutor.scheduleWithFixedDelay(new Runnable() {
             public void run() {
-                executeInternalSafely(command);
+                executeInternalSafely(command, FAILURE_LOGGING_EXECUTION_CALLBACK);
             }
         }, initialDelay, period, unit);
     }
@@ -142,11 +173,11 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
         shutdownExecutor("internal", internalExecutor);
     }
 
-    private void executeInternalSafely(Runnable command) {
+    private void executeInternalSafely(Runnable command, ExecutionCallback executionCallback) {
         try {
-            executeInternal(command);
+            submitInternal(command).andThen(executionCallback);
         } catch (RejectedExecutionException e) {
-            LOGGER.warning("Rejected internal execution on scheduledExecutor", e);
+            executionCallback.onFailure(e);
         }
     }
 

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -29,7 +29,6 @@ import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.HazelcastOverloadException;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -44,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_INTERVAL;
 import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECONDS;
 
-public class ClientInvocation implements Runnable {
+public class ClientInvocation implements Runnable, ExecutionCallback {
 
     public static final long RETRY_WAIT_TIME_IN_SECONDS = 1;
     private static final int UNASSIGNED_PARTITION = -1;
@@ -234,33 +233,8 @@ public class ClientInvocation implements Runnable {
     }
 
     private void rescheduleInvocation() {
-        executionService.schedule(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    ICompletableFuture<?> future = ((ClientExecutionServiceImpl) executionService)
-                            .submitInternal(ClientInvocation.this);
-                    future.andThen(new ExecutionCallback() {
-                        @Override
-                        public void onResponse(Object response) {
-                        }
-
-                        @Override
-                        public void onFailure(Throwable t) {
-                            if (LOGGER.isFinestEnabled()) {
-                                LOGGER.finest("Failure during retry ", t);
-                            }
-                            clientInvocationFuture.setResponse(t);
-                        }
-                    });
-                } catch (RejectedExecutionException e) {
-                    if (LOGGER.isFinestEnabled()) {
-                        LOGGER.finest("Could not reschedule invocation.", e);
-                    }
-                    notifyException(e);
-                }
-            }
-        }, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);
+        ClientExecutionServiceImpl executionServiceImpl = (ClientExecutionServiceImpl) this.executionService;
+        executionServiceImpl.schedule(this, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS, this);
     }
 
     private boolean isBindToSingleConnection() {
@@ -305,5 +279,17 @@ public class ClientInvocation implements Runnable {
         return t instanceof IOException
                 || t instanceof HazelcastInstanceNotActiveException
                 || t instanceof AuthenticationException;
+    }
+
+    @Override
+    public void onResponse(Object response) {
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+        if (LOGGER.isFinestEnabled()) {
+            LOGGER.finest("Failure during retry ", t);
+        }
+        clientInvocationFuture.setResponse(t);
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -28,7 +28,6 @@ import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.HazelcastOverloadException;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -50,7 +49,7 @@ import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECO
  * 2) Should it be retried
  * 3) How many times it is retried
  */
-public class ClientInvocation implements Runnable {
+public class ClientInvocation implements Runnable, ExecutionCallback {
 
     public static final long RETRY_WAIT_TIME_IN_SECONDS = 1;
     protected static final int UNASSIGNED_PARTITION = -1;
@@ -218,33 +217,8 @@ public class ClientInvocation implements Runnable {
     }
 
     private void rescheduleInvocation() {
-        executionService.schedule(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    ICompletableFuture<?> future = ((ClientExecutionServiceImpl) executionService)
-                            .submitInternal(ClientInvocation.this);
-                    future.andThen(new ExecutionCallback() {
-                        @Override
-                        public void onResponse(Object response) {
-                        }
-
-                        @Override
-                        public void onFailure(Throwable t) {
-                            if (LOGGER.isFinestEnabled()) {
-                                LOGGER.finest("Failure during retry ", t);
-                            }
-                            clientInvocationFuture.setResponse(t);
-                        }
-                    });
-                } catch (RejectedExecutionException e) {
-                    if (LOGGER.isFinestEnabled()) {
-                        LOGGER.finest("Could not reschedule invocation.", e);
-                    }
-                    notifyException(e);
-                }
-            }
-        }, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);
+        ClientExecutionServiceImpl executionServiceImpl = (ClientExecutionServiceImpl) this.executionService;
+        executionServiceImpl.schedule(this, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS, this);
     }
 
     protected boolean shouldRetry() {
@@ -309,5 +283,18 @@ public class ClientInvocation implements Runnable {
         return t instanceof IOException
                 || t instanceof HazelcastInstanceNotActiveException
                 || t instanceof AuthenticationException;
+    }
+
+
+    @Override
+    public void onResponse(Object response) {
+    }
+
+    @Override
+    public void onFailure(Throwable t) {
+        if (LOGGER.isFinestEnabled()) {
+            LOGGER.finest("Failure during retry ", t);
+        }
+        clientInvocationFuture.setResponse(t);
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -31,7 +31,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -159,17 +158,6 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
 
     @Override
     public void andThen(ExecutionCallback<ClientMessage> callback, Executor executor) {
-        synchronized (this) {
-            if (response != null) {
-                runAsynchronous(callback, executor);
-                return;
-            }
-            callbackNodeList.add(new ExecutionCallbackNode(callback, executor));
-        }
-    }
-
-    public void andThenInternal(ExecutionCallback<ClientMessage> callback) {
-        ExecutorService executor = executionService.getAsyncExecutor();
         synchronized (this) {
             if (response != null) {
                 runAsynchronous(callback, executor);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -23,7 +23,8 @@ import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.cluster.memberselector.MemberSelectors;
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.logging.ILogger;
@@ -53,6 +54,7 @@ public final class ClientPartitionServiceImpl
     private static final long PERIOD = 10;
     private static final long INITIAL_DELAY = 10;
     private static final int PARTITION_WAIT_TIME = 1000;
+    private final ExecutionCallback<ClientMessage> refreshTaskCallback = new RefreshTaskCallback();
 
     private final HazelcastClientInstanceImpl client;
 
@@ -72,10 +74,16 @@ public final class ClientPartitionServiceImpl
     }
 
     public void refreshPartitions() {
-        ClientExecutionServiceImpl executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
+        if (!updating.compareAndSet(false, true)) {
+            return;
+        }
+        ClientExecutionService executionService = client.getClientExecutionService();
         try {
-            executionService.executeInternal(new RefreshTask());
+            ICompletableFuture future = executionService.submit(new RefreshTask());
+            future.andThen(refreshTaskCallback);
+
         } catch (RejectedExecutionException ignored) {
+            updating.set(false);
             EmptyStatement.ignore(ignored);
         }
     }
@@ -100,35 +108,43 @@ public final class ClientPartitionServiceImpl
         return clusterService.getMembers(MemberSelectors.DATA_MEMBER_SELECTOR).isEmpty();
     }
 
-    private boolean getPartitions() {
+    private Connection getOwnerConnection() {
         ClientClusterService clusterService = client.getClientClusterService();
         Address ownerAddress = clusterService.getOwnerConnectionAddress();
         if (ownerAddress == null) {
-            return false;
+            return null;
         }
         Connection connection = client.getConnectionManager().getConnection(ownerAddress);
-        ClientGetPartitionsCodec.ResponseParameters response = getPartitionsFrom(connection);
-        if (response != null) {
-            return processPartitionResponse(response);
-        }
-        return false;
-    }
-
-    private ClientGetPartitionsCodec.ResponseParameters getPartitionsFrom(Connection connection) {
         if (connection == null) {
             return null;
         }
+        return connection;
+    }
+
+    private boolean getPartitions() {
+        Connection connection = getOwnerConnection();
+        if (connection == null) {
+            return false;
+        }
         try {
-            ClientMessage requestMessage = ClientGetPartitionsCodec.encodeRequest();
-            Future<ClientMessage> future = new ClientInvocation(client, requestMessage, connection).invokeUrgent();
+            Future<ClientMessage> future = getPartitionsFrom(connection);
             ClientMessage responseMessage = future.get();
-            return ClientGetPartitionsCodec.decodeResponse(responseMessage);
+            ClientGetPartitionsCodec.ResponseParameters response = ClientGetPartitionsCodec.decodeResponse(responseMessage);
+            if (response == null) {
+                return false;
+            }
+            return processPartitionResponse(response);
         } catch (Exception e) {
             if (client.getLifecycleService().isRunning()) {
                 LOGGER.warning("Error while fetching cluster partition table!", e);
             }
         }
-        return null;
+        return false;
+    }
+
+    private ClientInvocationFuture getPartitionsFrom(Connection connection) {
+        ClientMessage requestMessage = ClientGetPartitionsCodec.encodeRequest();
+        return new ClientInvocation(client, requestMessage, connection).invokeUrgent();
     }
 
     private boolean processPartitionResponse(ClientGetPartitionsCodec.ResponseParameters response) {
@@ -212,8 +228,7 @@ public final class ClientPartitionServiceImpl
         }
     }
 
-    private class RefreshTask
-            implements Runnable {
+    private class RefreshTask implements Runnable {
 
         @Override
         public void run() {
@@ -221,13 +236,40 @@ public final class ClientPartitionServiceImpl
                 return;
             }
 
+            Connection connection = getOwnerConnection();
+            if (connection == null) {
+                return;
+            }
+            ClientInvocationFuture clientInvocationFuture = getPartitionsFrom(connection);
+            clientInvocationFuture.andThen(refreshTaskCallback);
+
+        }
+    }
+
+    private class RefreshTaskCallback
+            implements ExecutionCallback<ClientMessage> {
+
+
+        @Override
+        public void onResponse(ClientMessage responseMessage) {
             try {
-                getPartitions();
-            } catch (HazelcastInstanceNotActiveException ignored) {
-                EmptyStatement.ignore(ignored);
+                if (responseMessage == null) {
+                    return;
+                }
+                ClientGetPartitionsCodec.ResponseParameters response = ClientGetPartitionsCodec.decodeResponse(responseMessage);
+                processPartitionResponse(response);
+
             } finally {
                 updating.set(false);
             }
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            if (client.getLifecycleService().isRunning()) {
+                LOGGER.warning("Error while fetching cluster partition table!", t);
+            }
+            updating.set(false);
         }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -66,7 +66,7 @@ public class ClientDelegatingFuture<V> implements ICompletableFuture<V> {
     }
 
     public <R> void andThenInternal(final ExecutionCallback<R> callback) {
-        future.andThenInternal(new DelegatingExecutionCallback<R>(callback, false));
+        future.andThen(new DelegatingExecutionCallback<R>(callback, false));
     }
 
     @Override


### PR DESCRIPTION
Conflict and review fix for #7061

Since internalExecutor is used by critical operations like
CleanResourcesTask(responsible for setting free all invocations
waiting on dead connection) or HeartBeat task, there shouldn't
be any blocking operation on this executor.

Refactored LoadAllTask and PartitionService since they were doing
remote calls.

Fixed a bug on rescheduleInvocation. There were a rare change that
An invocation is scheduled but not able to send to internal executor.
In that case, the rescheduled invocation will not be aware that
it is not able to run. Added a callback to be able to notify it in
this situation.