### PR TITLE
Operation retry fixed in PartitionCheckIfLoadedOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionCheckIfLoadedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionCheckIfLoadedOperation.java
@@ -72,8 +72,17 @@ public class PartitionCheckIfLoadedOperation extends MapOperation implements Par
 
     @Override
     public boolean returnsResponse() {
-        // has to return true in all cases in order to enable the default retry invocation mechanism
-        return true;
+        return !waitForKeyLoad;
+    }
+
+    @Override
+    public void onExecutionFailure(Throwable e) {
+        if (!returnsResponse()) {
+            // In case of execution failure the CallbackResponseSender will be never invoked
+            // and the operation will be never retried. That is the reason why we need to propagate the
+            // exception to the caller manually.
+            sendResponse(e);
+        }
     }
 
     @Override
@@ -91,7 +100,6 @@ public class PartitionCheckIfLoadedOperation extends MapOperation implements Par
     }
 
     private class CallbackResponseSender implements ExecutionCallback<Boolean> {
-
         @Override
         public void onResponse(Boolean response) {
             sendResponse(response);


### PR DESCRIPTION
Fix for #7114, regression from #7056
The decoupling of operation result from operation retry mechanism will be followed on in 3.7 - there's a PRD for this. For now it's a fix for MapLoader that doesn't change the default behavior.