### PR TITLE
Synced SecondsBasedEntryTaskScheduler to overcome race conditions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/EntryTaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/EntryTaskScheduler.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.util.scheduler;
 
-import java.util.Set;
-
 /**
  * Schedules (or reschedules) the execution of given entry.
  *
@@ -43,9 +41,5 @@ public interface EntryTaskScheduler<K, V> {
 
     ScheduledEntry<K, V> get(K key);
 
-    Set<K> flush(Set<K> keys);
-
     void cancelAll();
-
-    int size();
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduleType.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/ScheduleType.java
@@ -17,5 +17,5 @@
 package com.hazelcast.util.scheduler;
 
 public enum ScheduleType {
-    POSTPONE, FOR_EACH, SCHEDULE_IF_NEW
+    POSTPONE, FOR_EACH
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskScheduler.java
@@ -21,12 +21,11 @@ import com.hazelcast.util.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -68,15 +67,15 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
         }
     };
 
-    private final ConcurrentMap<Object, Integer> secondsOfKeys = new ConcurrentHashMap<Object, Integer>(1000);
-    private final ConcurrentMap<Integer, ConcurrentMap<Object, ScheduledEntry<K, V>>> scheduledEntries
-            = new ConcurrentHashMap<Integer, ConcurrentMap<Object, ScheduledEntry<K, V>>>(1000);
+    private final Map<Object, Integer> secondsOfKeys = new HashMap<Object, Integer>(1000);
+    private final Map<Integer, Map<Object, ScheduledEntry<K, V>>> scheduledEntries
+            = new HashMap<Integer, Map<Object, ScheduledEntry<K, V>>>(1000);
     private final ScheduledExecutorService scheduledExecutorService;
     private final ScheduledEntryProcessor<K, V> entryProcessor;
     private final ScheduleType scheduleType;
-    private final ConcurrentMap<Integer, ScheduledFuture> scheduledTaskMap
-            = new ConcurrentHashMap<Integer, ScheduledFuture>(1000);
+    private final Map<Integer, ScheduledFuture> scheduledTaskMap = new HashMap<Integer, ScheduledFuture>(1000);
     private final AtomicLong uniqueIdGenerator = new AtomicLong();
+    private final Object mutex = new Object();
 
     SecondsBasedEntryTaskScheduler(ScheduledExecutorService scheduledExecutorService,
                                    ScheduledEntryProcessor<K, V> entryProcessor, ScheduleType scheduleType) {
@@ -89,8 +88,6 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
     public boolean schedule(long delayMillis, K key, V value) {
         if (scheduleType.equals(ScheduleType.POSTPONE)) {
             return schedulePostponeEntry(delayMillis, key, value);
-        } else if (scheduleType.equals(ScheduleType.SCHEDULE_IF_NEW)) {
-            return scheduleIfNew(delayMillis, key, value);
         } else if (scheduleType.equals(ScheduleType.FOR_EACH)) {
             return scheduleEntry(delayMillis, key, value);
         } else {
@@ -98,103 +95,109 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
         }
     }
 
-    @Override
-    public Set<K> flush(Set<K> keys) {
-        if (scheduleType.equals(ScheduleType.FOR_EACH)) {
-            return flushByCompositeKeys(keys);
-        }
-        List<ScheduledEntry<K, V>> res = new ArrayList<ScheduledEntry<K, V>>(keys.size());
-        Set<K> processedKeys = new HashSet<K>();
-        for (K key : keys) {
-            final Integer second = secondsOfKeys.remove(key);
-            if (second != null) {
-                final ConcurrentMap<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
-                if (entries != null) {
-                    processedKeys.add(key);
-                    res.add(entries.remove(key));
+    private boolean schedulePostponeEntry(long delayMillis, K key, V value) {
+        int delaySeconds = ceilToSecond(delayMillis);
+        Integer newSecond = findRelativeSecond(delayMillis);
+        synchronized (mutex) {
+            Integer existingSecond = secondsOfKeys.put(key, newSecond);
+            if (existingSecond != null) {
+                if (existingSecond.equals(newSecond)) {
+                    return false;
                 }
+                removeKeyFromSecond(key, existingSecond);
             }
+            long id = uniqueIdGenerator.incrementAndGet();
+            ScheduledEntry<K, V> scheduledEntry = new ScheduledEntry<K, V>(key, value, delayMillis, delaySeconds, id);
+            doSchedule(key, scheduledEntry, newSecond);
         }
-        entryProcessor.process(this, sortForEntryProcessing(res));
-        return processedKeys;
+        return true;
     }
 
-    private Set flushByCompositeKeys(Set keys) {
-        List<ScheduledEntry<K, V>> res = new ArrayList<ScheduledEntry<K, V>>(keys.size());
-        Set<CompositeKey> candidateKeys = new HashSet<CompositeKey>();
-        Set processedKeys = new HashSet();
-        for (Object key : keys) {
-            for (Object skey : secondsOfKeys.keySet()) {
-                CompositeKey compositeKey = (CompositeKey) skey;
-                if (key.equals(compositeKey.getKey())) {
-                    candidateKeys.add(compositeKey);
-                }
-            }
+    private boolean scheduleEntry(long delayMillis, K key, V value) {
+        int delaySeconds = ceilToSecond(delayMillis);
+        Integer newSecond = findRelativeSecond(delayMillis);
+        synchronized (mutex) {
+            long id = uniqueIdGenerator.incrementAndGet();
+            Object compositeKey = new CompositeKey(key, id);
+            secondsOfKeys.put(compositeKey, newSecond);
+            ScheduledEntry<K, V> scheduledEntry = new ScheduledEntry<K, V>(key, value, delayMillis, delaySeconds, id);
+            doSchedule(compositeKey, scheduledEntry, newSecond);
         }
-        for (CompositeKey compositeKey : candidateKeys) {
-            final Integer second = secondsOfKeys.remove(compositeKey);
-            if (second != null) {
-                final ConcurrentMap<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
-                if (entries != null) {
-                    res.add(entries.remove(compositeKey));
-                    processedKeys.add(compositeKey.getKey());
-                }
-            }
+        return true;
+    }
 
+    private void doSchedule(Object mapKey, ScheduledEntry<K, V> entry, Integer second) {
+        Map<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
+        boolean shouldSchedule = false;
+        if (entries == null) {
+            entries = new HashMap<Object, ScheduledEntry<K, V>>(INITIAL_CAPACITY);
+            scheduledEntries.put(second, entries);
+
+            // we created the second
+            // so we will schedule its execution
+            shouldSchedule = true;
         }
-        entryProcessor.process(this, sortForEntryProcessing(res));
-        return processedKeys;
+        entries.put(mapKey, entry);
+        if (shouldSchedule) {
+            schedule(second, entry.getActualDelaySeconds());
+        }
     }
 
     @Override
     public ScheduledEntry<K, V> cancel(K key) {
-        if (scheduleType.equals(ScheduleType.FOR_EACH)) {
-            return cancelByCompositeKey(key);
+        synchronized (mutex) {
+            if (scheduleType.equals(ScheduleType.FOR_EACH)) {
+                return cancelByCompositeKey(key);
+            }
+            Integer second = secondsOfKeys.remove(key);
+            if (second == null) {
+                return null;
+            }
+            Map<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
+            if (entries == null) {
+                return null;
+            }
+            return cancelAndCleanUpIfEmpty(second, entries, key);
         }
-        final Integer second = secondsOfKeys.remove(key);
-        if (second == null) {
-            return null;
-        }
-        final ConcurrentMap<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
-        if (entries == null) {
-            return null;
-        }
-        return cancelAndCleanUpIfEmpty(second, entries, key);
     }
 
     @Override
     public int cancelIfExists(K key, V value) {
-        final ScheduledEntry<K, V> scheduledEntry = new ScheduledEntry<K, V>(key, value, 0, 0, 0);
+        synchronized (mutex) {
+            ScheduledEntry<K, V> scheduledEntry = new ScheduledEntry<K, V>(key, value, 0, 0, 0);
 
-        if (scheduleType.equals(ScheduleType.FOR_EACH)) {
-            return cancelByCompositeKey(key, scheduledEntry);
-        }
+            if (scheduleType.equals(ScheduleType.FOR_EACH)) {
+                return cancelByCompositeKey(key, scheduledEntry);
+            }
 
-        final Integer second = secondsOfKeys.remove(key);
-        if (second == null) {
-            return 0;
-        }
-        final ConcurrentMap<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
-        if (entries == null) {
-            return 0;
-        }
+            Integer second = secondsOfKeys.remove(key);
+            if (second == null) {
+                return 0;
+            }
+            Map<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
+            if (entries == null) {
+                return 0;
+            }
 
-        return cancelAndCleanUpIfEmpty(second, entries, key, scheduledEntry) ? 1 : 0;
+            return cancelAndCleanUpIfEmpty(second, entries, key, scheduledEntry) ? 1 : 0;
+        }
     }
 
     @Override
     public ScheduledEntry<K, V> get(K key) {
-        if (scheduleType.equals(ScheduleType.FOR_EACH)) {
-            return getByCompositeKey(key);
-        }
-        final Integer second = secondsOfKeys.get(key);
-        if (second != null) {
-            final ConcurrentMap<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
-            if (entries != null) {
-                return entries.get(key);
+        synchronized (mutex) {
+            if (scheduleType.equals(ScheduleType.FOR_EACH)) {
+                return getByCompositeKey(key);
             }
+            Integer second = secondsOfKeys.get(key);
+            if (second != null) {
+                Map<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
+                if (entries != null) {
+                    return entries.get(key);
+                }
+            }
+            return null;
         }
-        return null;
     }
 
     private ScheduledEntry<K, V> cancelByCompositeKey(K key) {
@@ -202,11 +205,11 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
 
         ScheduledEntry<K, V> result = null;
         for (CompositeKey compositeKey : candidateKeys) {
-            final Integer second = secondsOfKeys.remove(compositeKey);
+            Integer second = secondsOfKeys.remove(compositeKey);
             if (second == null) {
                 continue;
             }
-            final ConcurrentMap<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
+            Map<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
             if (entries == null) {
                 continue;
             }
@@ -215,14 +218,14 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
         return result;
     }
 
-    private int cancelByCompositeKey(K key, final ScheduledEntry<K, V> entryToRemove) {
+    private int cancelByCompositeKey(K key, ScheduledEntry<K, V> entryToRemove) {
         int cancelled = 0;
         for (CompositeKey compositeKey : getCompositeKeys(key)) {
-            final Integer second = secondsOfKeys.remove(compositeKey);
+            Integer second = secondsOfKeys.remove(compositeKey);
             if (second == null) {
                 continue;
             }
-            final ConcurrentMap<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
+            Map<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
             if (entries == null) {
                 continue;
             }
@@ -235,7 +238,7 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
     }
 
     private Set<CompositeKey> getCompositeKeys(K key) {
-        final Set<CompositeKey> candidateKeys = new HashSet<CompositeKey>();
+        Set<CompositeKey> candidateKeys = new HashSet<CompositeKey>();
         for (Object keyObj : secondsOfKeys.keySet()) {
             CompositeKey compositeKey = (CompositeKey) keyObj;
             if (compositeKey.getKey().equals(key)) {
@@ -246,12 +249,12 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
     }
 
     public ScheduledEntry<K, V> getByCompositeKey(K key) {
-        final Set<CompositeKey> candidateKeys = getCompositeKeys(key);
+        Set<CompositeKey> candidateKeys = getCompositeKeys(key);
         ScheduledEntry<K, V> result = null;
         for (CompositeKey compositeKey : candidateKeys) {
-            final Integer second = secondsOfKeys.get(compositeKey);
+            Integer second = secondsOfKeys.get(compositeKey);
             if (second != null) {
-                final ConcurrentMap<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
+                Map<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
                 if (entries != null) {
                     result = entries.get(compositeKey);
                 }
@@ -260,135 +263,70 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
         return result;
     }
 
-    private boolean schedulePostponeEntry(long delayMillis, K key, V value) {
-        final int delaySeconds = ceilToSecond(delayMillis);
-        final Integer newSecond = findRelativeSecond(delayMillis);
-        final Integer existingSecond = secondsOfKeys.put(key, newSecond);
-        if (existingSecond != null) {
-            if (existingSecond.equals(newSecond)) {
-                return false;
-            }
-            removeKeyFromSecond(key, existingSecond);
-        }
-        final long id = uniqueIdGenerator.incrementAndGet();
-        doSchedule(key, new ScheduledEntry<K, V>(key, value, delayMillis, delaySeconds, id), newSecond);
-        return true;
-    }
-
-    private boolean scheduleEntry(long delayMillis, K key, V value) {
-        final int delaySeconds = ceilToSecond(delayMillis);
-        final Integer newSecond = findRelativeSecond(delayMillis);
-        final long id = uniqueIdGenerator.incrementAndGet();
-        Object compositeKey = new CompositeKey(key, id);
-        secondsOfKeys.put(compositeKey, newSecond);
-        doSchedule(compositeKey, new ScheduledEntry<K, V>(key, value, delayMillis, delaySeconds, id), newSecond);
-        return true;
-    }
-
-    private boolean scheduleIfNew(long delayMillis, K key, V value) {
-        final int delaySeconds = ceilToSecond(delayMillis);
-        final Integer newSecond = findRelativeSecond(delayMillis);
-        if (secondsOfKeys.putIfAbsent(key, newSecond) != null) {
-            return false;
-        }
-        final long id = uniqueIdGenerator.incrementAndGet();
-        doSchedule(key, new ScheduledEntry<K, V>(key, value, delayMillis, delaySeconds, id), newSecond);
-        return true;
-    }
-
-    private int findRelativeSecond(long delayMillis) {
-        long now = Clock.currentTimeMillis();
-        long d = (now + delayMillis - INITIAL_TIME_MILLIS);
-        return ceilToSecond(d);
-    }
-
-    private int ceilToSecond(long delayMillis) {
-        return (int) Math.ceil(delayMillis / FACTOR);
-    }
-
-    private void doSchedule(Object mapKey, ScheduledEntry<K, V> entry, Integer second) {
-        ConcurrentMap<Object, ScheduledEntry<K, V>> entries = scheduledEntries.get(second);
-        boolean shouldSchedule = false;
-        if (entries == null) {
-            entries = new ConcurrentHashMap<Object, ScheduledEntry<K, V>>(INITIAL_CAPACITY);
-            ConcurrentMap<Object, ScheduledEntry<K, V>> existingScheduleKeys
-                    = scheduledEntries.putIfAbsent(second, entries);
-            if (existingScheduleKeys != null) {
-                entries = existingScheduleKeys;
-            } else {
-                // we created the second
-                // so we will schedule its execution
-                shouldSchedule = true;
-            }
-        }
-        entries.put(mapKey, entry);
-        if (shouldSchedule) {
-            schedule(second, entry.getActualDelaySeconds());
-        }
-    }
-
     private void removeKeyFromSecond(Object key, Integer existingSecond) {
-        ConcurrentMap<Object, ScheduledEntry<K, V>> scheduledKeys = scheduledEntries.get(existingSecond);
+        Map<Object, ScheduledEntry<K, V>> scheduledKeys = scheduledEntries.get(existingSecond);
         if (scheduledKeys != null) {
             cancelAndCleanUpIfEmpty(existingSecond, scheduledKeys, key);
         }
     }
 
-
     /**
      * Removes the entry from being scheduled to be evicted.
-     *
+     * <p/>
      * Cleans up parent container (second -> entries map) if it doesn't hold anymore items this second.
-     *
+     * <p/>
      * Cancels associated scheduler (second -> scheduler map ) if there are no more items to remove for this second.
-     *
+     * <p/>
      * Returns associated scheduled entry.
      *
-     * @param second second at which this entry was scheduled to be evicted
+     * @param second  second at which this entry was scheduled to be evicted
      * @param entries entries which were already scheduled to be evicted for this second
-     * @param key entry key
+     * @param key     entry key
      * @return associated scheduled entry
      */
-    private ScheduledEntry<K, V> cancelAndCleanUpIfEmpty(Integer second, ConcurrentMap<Object, ScheduledEntry<K, V>> entries,
-                                                         Object key) {
-        final ScheduledEntry<K, V> result = entries.remove(key);
+    private ScheduledEntry<K, V> cancelAndCleanUpIfEmpty(Integer second, Map<Object, ScheduledEntry<K, V>> entries, Object key) {
+        ScheduledEntry<K, V> result = entries.remove(key);
         cleanUpScheduledFuturesIfEmpty(second, entries);
         return result;
     }
 
     /**
      * Removes the entry if it exists from being scheduled to be evicted.
-     *
+     * <p/>
      * Cleans up parent container (second -> entries map) if it doesn't hold anymore items this second.
-     *
+     * <p/>
      * Cancels associated scheduler (second -> scheduler map ) if there are no more items to remove for this second.
-     *
+     * <p/>
      * Returns associated scheduled entry.
      *
-     * @param second second at which this entry was scheduled to be evicted
-     * @param entries entries which were already scheduled to be evicted for this second
-     * @param key entry key
+     * @param second        second at which this entry was scheduled to be evicted
+     * @param entries       entries which were already scheduled to be evicted for this second
+     * @param key           entry key
      * @param entryToRemove entry value that is expected to exist in the map
      * @return true if entryToRemove exists in the map and removed
      */
-    private boolean cancelAndCleanUpIfEmpty(Integer second, ConcurrentMap<Object, ScheduledEntry<K, V>> entries, Object key,
+    private boolean cancelAndCleanUpIfEmpty(Integer second, Map<Object, ScheduledEntry<K, V>> entries, Object key,
                                             ScheduledEntry<K, V> entryToRemove) {
-        final boolean removed = entries.remove(key, entryToRemove);
+        ScheduledEntry<K, V> entry = entries.get(key);
+        if (entry == null || !entry.equals(entryToRemove)) {
+            return false;
+        }
+        entries.remove(key);
         cleanUpScheduledFuturesIfEmpty(second, entries);
-        return removed;
+        return true;
     }
 
     /**
      * Cancels the scheduled future and removes the entries map for the given second If no entries are left
-     *
+     * <p/>
      * Cleans up parent container (second -> entries map) if it doesn't hold anymore items this second.
-     *
+     * <p/>
      * Cancels associated scheduler (second -> scheduler map ) if there are no more items to remove for this second.
      *
-     * @param second second at which this entry was scheduled to be evicted
+     * @param second  second at which this entry was scheduled to be evicted
      * @param entries entries which were already scheduled to be evicted for this second
      */
-    private void cleanUpScheduledFuturesIfEmpty(Integer second, ConcurrentMap<Object, ScheduledEntry<K, V>> entries) {
+    private void cleanUpScheduledFuturesIfEmpty(Integer second, Map<Object, ScheduledEntry<K, V>> entries) {
         if (entries.isEmpty()) {
             scheduledEntries.remove(second);
 
@@ -399,60 +337,32 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
         }
     }
 
-    private void schedule(final Integer second, final int delaySeconds) {
+    private void schedule(Integer second, int delaySeconds) {
         EntryProcessorExecutor command = new EntryProcessorExecutor(second);
         ScheduledFuture scheduledFuture = scheduledExecutorService.schedule(command, delaySeconds, TimeUnit.SECONDS);
         scheduledTaskMap.put(second, scheduledFuture);
     }
 
-    private final class EntryProcessorExecutor implements Runnable {
-        private final Integer second;
-
-        private EntryProcessorExecutor(Integer second) {
-            this.second = second;
-        }
-
-        @Override
-        public void run() {
-            scheduledTaskMap.remove(second);
-            final Map<Object, ScheduledEntry<K, V>> entries = scheduledEntries.remove(second);
-            if (entries == null || entries.isEmpty()) {
-                return;
-            }
-            List<ScheduledEntry<K, V>> values = new ArrayList<ScheduledEntry<K, V>>(entries.size());
-            for (Map.Entry<Object, ScheduledEntry<K, V>> entry : entries.entrySet()) {
-                Integer removed = secondsOfKeys.remove(entry.getKey());
-                if (removed != null) {
-                    values.add(entry.getValue());
-                }
-            }
-            //sort entries asc by schedule times and send to processor.
-            entryProcessor.process(SecondsBasedEntryTaskScheduler.this, sortForEntryProcessing(values));
-        }
-    }
-
-    private List<ScheduledEntry<K, V>> sortForEntryProcessing(List<ScheduledEntry<K, V>> coll) {
-        if (coll == null || coll.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        Collections.sort(coll, SCHEDULED_ENTRIES_COMPARATOR);
-        return coll;
-    }
-
-
-    @Override
+    /**
+     * used only for testing
+     *
+     * @return
+     */
     public int size() {
-        return secondsOfKeys.size();
+        synchronized (mutex) {
+            return secondsOfKeys.size();
+        }
     }
 
     public void cancelAll() {
-        secondsOfKeys.clear();
-        scheduledEntries.clear();
-        for (ScheduledFuture task : scheduledTaskMap.values()) {
-            task.cancel(false);
+        synchronized (mutex) {
+            secondsOfKeys.clear();
+            scheduledEntries.clear();
+            for (ScheduledFuture task : scheduledTaskMap.values()) {
+                task.cancel(false);
+            }
+            scheduledTaskMap.clear();
         }
-        scheduledTaskMap.clear();
     }
 
     @Override
@@ -465,5 +375,53 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
                 + "] ="
                 + scheduledEntries.keySet()
                 + '}';
+    }
+
+    private static <K, V> List<ScheduledEntry<K, V>> sortForEntryProcessing(List<ScheduledEntry<K, V>> coll) {
+        if (coll == null || coll.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Collections.sort(coll, SCHEDULED_ENTRIES_COMPARATOR);
+        return coll;
+    }
+
+    private static int findRelativeSecond(long delayMillis) {
+        long now = Clock.currentTimeMillis();
+        long d = (now + delayMillis - INITIAL_TIME_MILLIS);
+        return ceilToSecond(d);
+    }
+
+    private static int ceilToSecond(long delayMillis) {
+        return (int) Math.ceil(delayMillis / FACTOR);
+    }
+
+    private final class EntryProcessorExecutor implements Runnable {
+        private final Integer second;
+
+        private EntryProcessorExecutor(Integer second) {
+            this.second = second;
+        }
+
+        @Override
+        public void run() {
+            List<ScheduledEntry<K, V>> values;
+            synchronized (mutex) {
+                scheduledTaskMap.remove(second);
+                Map<Object, ScheduledEntry<K, V>> entries = scheduledEntries.remove(second);
+                if (entries == null || entries.isEmpty()) {
+                    return;
+                }
+                values = new ArrayList<ScheduledEntry<K, V>>(entries.size());
+                for (Map.Entry<Object, ScheduledEntry<K, V>> entry : entries.entrySet()) {
+                    Integer removed = secondsOfKeys.remove(entry.getKey());
+                    if (removed != null) {
+                        values.add(entry.getValue());
+                    }
+                }
+            }
+            //sort entries asc by schedule times and send to processor.
+            entryProcessor.process(SecondsBasedEntryTaskScheduler.this, sortForEntryProcessing(values));
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerStressTest.java
@@ -54,11 +54,6 @@ public class SecondsBasedEntryTaskSchedulerStressTest {
     }
 
     @Test
-    public void test_ifNew() {
-        test_forScheduleType(ScheduleType.SCHEDULE_IF_NEW);
-    }
-
-    @Test
     public void test_forEach() {
         test_forScheduleType(ScheduleType.FOR_EACH);
     }
@@ -72,6 +67,7 @@ public class SecondsBasedEntryTaskSchedulerStressTest {
         for (int i = 0; i < NUMBER_OF_THREADS; i++) {
             final Thread thread = new Thread() {
                 final Random random = new Random();
+
                 @Override
                 public void run() {
                     for (int j = 0; j < NUMBER_OF_EVENTS_PER_THREAD; j++) {
@@ -86,8 +82,7 @@ public class SecondsBasedEntryTaskSchedulerStressTest {
             thread.start();
         }
 
-        final long numberOfExpectedEvents = getExpectedEventCount(scheduleType, NUMBER_OF_THREADS,
-                NUMBER_OF_EVENTS_PER_THREAD);
+        final long numberOfExpectedEvents = NUMBER_OF_THREADS * NUMBER_OF_EVENTS_PER_THREAD;
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -111,6 +106,7 @@ public class SecondsBasedEntryTaskSchedulerStressTest {
         for (int i = 0; i < NUMBER_OF_THREADS; i++) {
             final Thread thread = new Thread() {
                 final Random random = new Random();
+
                 @Override
                 public void run() {
                     for (int j = 0; j < NUMBER_OF_EVENTS_PER_THREAD; j++) {
@@ -150,15 +146,6 @@ public class SecondsBasedEntryTaskSchedulerStressTest {
         });
     }
 
-    private long getExpectedEventCount(ScheduleType scheduleType, int numberOfThreads, long numberOfPerThreadExpectedEvents) {
-        if (scheduleType == ScheduleType.FOR_EACH) {
-            return numberOfThreads * numberOfPerThreadExpectedEvents;
-        } else if (scheduleType == ScheduleType.SCHEDULE_IF_NEW) {
-            return numberOfPerThreadExpectedEvents;
-        }
-        throw new IllegalArgumentException();
-    }
-
     private static class EventCountingEntryProcessor implements ScheduledEntryProcessor {
         final AtomicInteger numberOfEvents = new AtomicInteger();
 
@@ -177,7 +164,7 @@ public class SecondsBasedEntryTaskSchedulerStressTest {
 
         @Override
         public void process(EntryTaskScheduler<Integer, Integer> scheduler,
-                Collection<ScheduledEntry<Integer, Integer>> entries) {
+                            Collection<ScheduledEntry<Integer, Integer>> entries) {
 
             // scheduler is single threaded
             for (ScheduledEntry<Integer, Integer> entry : entries) {

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
@@ -17,12 +17,8 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.scheduler.ScheduleType.FOR_EACH;
 import static com.hazelcast.util.scheduler.ScheduleType.POSTPONE;
-import static com.hazelcast.util.scheduler.ScheduleType.SCHEDULE_IF_NEW;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -45,51 +41,11 @@ public class SecondsBasedEntryTaskSchedulerTest {
     }
 
     @Test
-    public void test_scheduleEntry_scheduleIfNew() {
-        final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
-                new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
-
-        assertTrue(scheduler.schedule(100, 1, 1));
-        assertNotNull(scheduler.get(1));
-        assertEquals(1, scheduler.size());
-    }
-
-    @Test
-    public void test_scheduleEntryOnlyOnce_scheduleIfNew() {
-        final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
-                new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
-
-        assertTrue(scheduler.schedule(100, 1, 1));
-        assertFalse(scheduler.schedule(100, 1, 1));
-        assertNotNull(scheduler.get(1));
-        assertEquals(1, scheduler.size());
-    }
-
-    @Test
-    public void test_cancelEntry_scheduleIfNew() {
-        final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
-                new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
-
-        assertTrue(scheduler.schedule(100, 1, 1));
-        assertEquals(1, scheduler.size());
-        assertNotNull(scheduler.cancel(1));
-        assertEquals(0, scheduler.size());
-    }
-
-    @Test
-    public void test_cancelEntry_notExistingKey() {
-        final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
-                new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
-
-        assertNull(scheduler.cancel(1));
-    }
-
-    @Test
     public void test_scheduleEntry_postpone() {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
+        scheduler.schedule(100, 1, 1);
         assertNotNull(scheduler.get(1));
         assertEquals(1, scheduler.size());
     }
@@ -99,8 +55,8 @@ public class SecondsBasedEntryTaskSchedulerTest {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
-        assertTrue(scheduler.schedule(10000, 1, 1));
+        scheduler.schedule(100, 1, 1);
+        scheduler.schedule(10000, 1, 1);
         assertNotNull(scheduler.get(1));
         assertEquals(1, scheduler.size());
     }
@@ -112,8 +68,8 @@ public class SecondsBasedEntryTaskSchedulerTest {
             final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                     new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
-            assertTrue(scheduler.schedule(0, 1, 1));
-            assertFalse(scheduler.schedule(0, 1, 1));
+            scheduler.schedule(0, 1, 1);
+            scheduler.schedule(0, 1, 1);
             assertNotNull(scheduler.get(1));
             assertEquals(1, scheduler.size());
         } finally {
@@ -126,7 +82,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
+        scheduler.schedule(100, 1, 1);
         assertEquals(1, scheduler.size());
         assertNotNull(scheduler.cancel(1));
         assertEquals(0, scheduler.size());
@@ -137,7 +93,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
+        scheduler.schedule(100, 1, 1);
         assertNotNull(scheduler.get(1));
         assertEquals(1, scheduler.size());
     }
@@ -147,19 +103,10 @@ public class SecondsBasedEntryTaskSchedulerTest {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
-        assertTrue(scheduler.schedule(100, 1, 1));
+        scheduler.schedule(100, 1, 1);
+        scheduler.schedule(100, 1, 1);
         assertNotNull(scheduler.get(1));
         assertEquals(2, scheduler.size());
-    }
-
-    @Test
-    public void test_cancelIfExists_scheduleIfNew() {
-        final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
-                new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
-
-        assertTrue(scheduler.schedule(100, 1, 1));
-        assertEquals(1, scheduler.cancelIfExists(1, 1));
     }
 
     @Test
@@ -167,7 +114,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
+        scheduler.schedule(100, 1, 1);
         assertEquals(1, scheduler.cancelIfExists(1, 1));
     }
 
@@ -176,7 +123,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
+        scheduler.schedule(100, 1, 1);
         assertEquals(1, scheduler.cancelIfExists(1, 1));
     }
 
@@ -185,7 +132,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
+        scheduler.schedule(100, 1, 1);
         assertEquals(0, scheduler.cancelIfExists(1, 0));
     }
 
@@ -194,17 +141,9 @@ public class SecondsBasedEntryTaskSchedulerTest {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
-        assertTrue(scheduler.schedule(100, 1, 2));
+        scheduler.schedule(100, 1, 1);
+        scheduler.schedule(100, 1, 2);
         assertEquals(1, scheduler.cancelIfExists(1, 1));
-    }
-
-    @Test
-    public void test_cancelIfExists_notExistingKey() {
-        final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
-                new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
-
-        assertEquals(0, scheduler.cancelIfExists(1, 0));
     }
 
     @Test
@@ -212,8 +151,8 @@ public class SecondsBasedEntryTaskSchedulerTest {
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
                 new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
-        assertTrue(scheduler.schedule(100, 1, 2));
+        scheduler.schedule(100, 1, 1);
+        scheduler.schedule(100, 1, 2);
         scheduler.cancelAll();
         assertEquals(0, scheduler.size());
     }
@@ -225,9 +164,9 @@ public class SecondsBasedEntryTaskSchedulerTest {
                 mock(ScheduledFuture.class));
 
         final SecondsBasedEntryTaskScheduler<Integer, Integer> scheduler =
-                new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, SCHEDULE_IF_NEW);
+                new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
 
-        assertTrue(scheduler.schedule(100, 1, 1));
+        scheduler.schedule(100, 1, 1);
         assertEquals(1, scheduler.size());
 
         final Runnable runnable = runnableCaptor.getValue();


### PR DESCRIPTION
- Removed `flush` and `size` methods from `EntryTaskScheduler` interface since they were not used
- Removed `ScheduleType.SCHEDULE_IF_NEW` since it was not used, no need to maintain something which we do not use.
- Made SecondsBasedEntryTaskScheduler synchronized to overcome race conditions, converted `ConcurrentMap`s to normal maps since they are not necessary anymore.

fixes https://github.com/hazelcast/hazelcast/issues/7094
fixes #6141