### PR TITLE
Increases test coverage of NearCacheInvalidatorImpl

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -19,35 +19,33 @@ package com.hazelcast.client.map.impl.nearcache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddNearCacheEntryListenerCodec;
-import com.hazelcast.client.proxy.NearCachedClientMapProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.RunParallel;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.instance.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED;
-import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
@@ -58,9 +56,18 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunParallel
+@RunWith(HazelcastTestRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientMapNearCacheTest {
+
+    @Parameterized.Parameter
+    public boolean batchInvalidationEnabled;
+
+    @Parameterized.Parameters(name = "batchInvalidationEnabled:{0}")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
+    }
 
     protected static final int MAX_TTL_SECONDS = 3;
     protected static final int MAX_IDLE_SECONDS = 1;
@@ -496,54 +503,6 @@ public class ClientMapNearCacheTest {
         });
     }
 
-    @Test
-    public void testServerMapExpiration_doesNotInvalidateClientNearCache() {
-        String mapName = randomMapName();
-        HazelcastInstance server = hazelcastFactory.newHazelcastInstance(newConfig());
-        NearCacheConfig nearCacheConfig = newLongMaxIdleNearCacheConfig();
-        ClientConfig clientConfig = newClientConfig();
-        clientConfig.addNearCacheConfig(nearCacheConfig);
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
-
-        IMap<Integer, Integer> serverMap = server.getMap(mapName);
-        IMap<Integer, Integer> clientMap = client.getMap(mapName);
-
-        // add EntryExpiredListener to catch expiration events
-        final CountDownLatch expiredEventLatch = new CountDownLatch(2);
-        EntryExpiredListener listener = new EntryExpiredListener() {
-            @Override
-            public void entryExpired(EntryEvent event) {
-                expiredEventLatch.countDown();
-            }
-        };
-        serverMap.addEntryListener(listener, false);
-        clientMap.addEntryListener(listener, false);
-
-        // add NearCacheEventListener to catch near cache invalidation event on client side
-        final CountDownLatch eventAddedLatch = new CountDownLatch(1);
-        addNearCacheInvalidateListener(clientMap, eventAddedLatch);
-
-        // put entry with TTL into server map
-        serverMap.put(1, 23, 6, TimeUnit.SECONDS);
-        assertNotNull("The TTL value should still be available in the server map right after it was put there", serverMap.get(1));
-
-        // wait until near cache invalidation is done after ADDED event
-        assertOpenEventually(eventAddedLatch);
-        assertThatOwnedEntryCountEquals(clientMap, 0);
-
-        // get() operation puts entry into client near cache
-        assertNotNull("The TTL value should still be available after the invalidation event arrived", clientMap.get(1));
-        assertThatOwnedEntryCountEquals(clientMap, 1);
-
-        // assert that the entry is not available on the server after expiration
-        assertOpenEventually(expiredEventLatch);
-        assertNull("The TTL value should be gone in the server map after its expiration", serverMap.get(1));
-
-        // assert that the entry is still available on the client and in the client near cache
-        assertNotNull("The TTL value should still be available in the near cache after server side expiration", clientMap.get(1));
-        assertThatOwnedEntryCountEquals(clientMap, 1);
-    }
-
     protected void populateNearCache(IMap<Integer, Integer> map, int size) {
         for (int i = 0; i < size; i++) {
             map.put(i, i);
@@ -572,13 +531,6 @@ public class ClientMapNearCacheTest {
 
     protected void triggerEviction(IMap<Integer, Integer> map) {
         map.put(0, 0);
-    }
-
-    protected void addNearCacheInvalidateListener(IMap clientMap, CountDownLatch eventAddedLatch) {
-        NearCacheEventListener listener = new NearCacheEventListener(eventAddedLatch);
-
-        NearCachedClientMapProxy mapProxy = (NearCachedClientMapProxy) clientMap;
-        mapProxy.addNearCacheInvalidateListener(listener);
     }
 
     protected static class NearCacheEventListener extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler
@@ -651,14 +603,6 @@ public class ClientMapNearCacheTest {
         return nearCacheConfig;
     }
 
-    protected NearCacheConfig newLongMaxIdleNearCacheConfig() {
-        NearCacheConfig nearCacheConfig = newNearCacheConfig();
-        nearCacheConfig.setInvalidateOnChange(true);
-        nearCacheConfig.setMaxIdleSeconds(LONG_MAX_IDLE_SECONDS);
-
-        return nearCacheConfig;
-    }
-
     protected NearCacheConfig newMaxIdleSecondsNearCacheConfig() {
         NearCacheConfig nearCacheConfig = newNearCacheConfig();
         nearCacheConfig.setInvalidateOnChange(false);
@@ -690,7 +634,7 @@ public class ClientMapNearCacheTest {
 
     protected Config newConfig() {
         Config config = new Config();
-        config.setProperty(MAP_INVALIDATION_MESSAGE_BATCH_ENABLED, "false");
+        config.setProperty(MAP_INVALIDATION_MESSAGE_BATCH_ENABLED, String.valueOf(batchInvalidationEnabled));
         return config;
     }
 
@@ -721,7 +665,6 @@ public class ClientMapNearCacheTest {
     protected void assertNearCacheInvalidation_whenMaxSizeExceeded(NearCacheConfig config) {
         final IMap<Integer, Integer> map = getNearCachedMapFromClient(config);
         populateNearCache(map, MAX_CACHE_SIZE);
-        assertThatOwnedEntryCountEquals(map, MAX_CACHE_SIZE);
 
         triggerEviction(map);
         assertTrueEventually(new AssertTask() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -59,8 +59,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     MapContainer getMapContainer(String mapName);
 
-    MapContainer getOrNullMapContainer(String mapName);
-
     Map<String, MapContainer> getMapContainers();
 
     PartitionContainer getPartitionContainer(int partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -149,10 +149,6 @@ class MapServiceContextImpl implements MapServiceContext {
         return ConcurrencyUtil.getOrPutSynchronized(mapContainers, mapName, mapContainers, mapConstructor);
     }
 
-    @Override
-    public MapContainer getOrNullMapContainer(String mapName) {
-        return mapContainers.get(mapName);
-    }
 
     @Override
     public Map<String, MapContainer> getMapContainers() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidatorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidatorImpl.java
@@ -240,8 +240,7 @@ public class NearCacheInvalidatorImpl implements NearCacheInvalidator {
     }
 
     public void accumulateOrSendBatchInvalidation(String mapName, Data key) {
-        if (!isServerNearCacheInvalidationEnabled(mapName)
-                && !hasInvalidationListener(mapName)) {
+        if (!mapServiceContext.getMapContainer(mapName).isInvalidationEnabled()) {
             return;
         }
 
@@ -253,19 +252,12 @@ public class NearCacheInvalidatorImpl implements NearCacheInvalidator {
     }
 
     private boolean isServerNearCacheInvalidationEnabled(String mapName) {
-        MapContainer mapContainer = mapServiceContext.getOrNullMapContainer(mapName);
-        if (mapContainer == null) {
-            return false;
-        }
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
         return mapContainer.isServerNearCacheInvalidationEnabled();
     }
 
     protected boolean hasInvalidationListener(String mapName) {
-        MapContainer mapContainer = mapServiceContext.getOrNullMapContainer(mapName);
-        if (mapContainer == null) {
-            return false;
-        }
-
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
         return mapContainer.hasInvalidationListener();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
@@ -21,7 +21,13 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.core.*;
+import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapStoreAdapter;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.AbstractEntryProcessor;
 import com.hazelcast.map.impl.MapService;
@@ -35,17 +41,24 @@ import com.hazelcast.query.PredicateBuilder;
 import com.hazelcast.query.SampleObjects;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.RunParallel;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -53,11 +66,23 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunParallel
+@RunWith(HazelcastTestRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class NearCacheTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public boolean batchInvalidationEnabled;
+
+    @Parameterized.Parameters(name = "batchInvalidationEnabled:{0}")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
+    }
 
     @Test
     public void testBasicUsage() throws Exception {
@@ -110,6 +135,13 @@ public class NearCacheTest extends HazelcastTestSupport {
 
     protected NearCacheConfig newNearCacheConfig() {
         return new NearCacheConfig();
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = super.getConfig();
+        config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED, String.valueOf(batchInvalidationEnabled));
+        return config;
     }
 
     @Test
@@ -661,7 +693,7 @@ public class NearCacheTest extends HazelcastTestSupport {
             }
         }, callback);
 
-        latch.await(3,TimeUnit.SECONDS);
+        latch.await(3, TimeUnit.SECONDS);
         NearCacheStats nearCacheStats = map.getLocalMapStats().getNearCacheStats();
         assertEquals(mapSize - 1, nearCacheStats.getOwnedEntryCount());
     }


### PR DESCRIPTION
- Also removed test `testServerMapExpiration_doesNotInvalidateClientNearCache`, it became obsolete after nearcache-invalidation system changes.