### PR TITLE
ClientServiceTest sometimes may fail at 

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -214,11 +214,14 @@ public class ClientServiceTest extends HazelcastTestSupport {
         final HazelcastInstance client1 = hazelcastFactory.newHazelcastClient();
         final HazelcastInstance client2 = hazelcastFactory.newHazelcastClient();
 
+        assertTrue("[testClientListener] ClientListener did not get two events for new clients",
+                latchAdd.await(6, TimeUnit.SECONDS));
+
         client1.getLifecycleService().shutdown();
         client2.getLifecycleService().shutdown();
 
-        assertTrue(latchAdd.await(6, TimeUnit.SECONDS));
-        assertTrue(latchRemove.await(6, TimeUnit.SECONDS));
+        assertTrue("[testClientListener] ClientListener did not get two events for client shutdowns",
+                latchRemove.await(6, TimeUnit.SECONDS));
 
         assertTrue(clientService.removeClientListener(id));
 


### PR DESCRIPTION
Sometimes on ZuluJDK the testClientListener failed on latchAdd.await failing to get all the new client add events. With a small possibility the client shutdown may be faster which may cause the server client service registration to be cleaned up before the client add event is actually delivered. Since the logs are mixed due to parallel test execution it is not easy to verify this but changing the latch wait before client shutdown shall eliminate such a small possibility. I could not generate the failure in local machine.

Fix for https://github.com/hazelcast/hazelcast/issues/7044 .