### PR TITLE
[3.6-EA3] At load-all operation, exception should not be wrapped and underlying exception should be propagated

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -54,8 +54,6 @@ import com.hazelcast.core.Client;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.executor.CompletedFuture;
@@ -97,8 +95,6 @@ abstract class AbstractClientInternalCacheProxy<K, V>
 
     private static final long MAX_COMPLETION_LATCH_WAIT_TIME = TimeUnit.MINUTES.toMillis(5);
     private static final long COMPLETION_LATCH_WAIT_TIME_STEP = TimeUnit.SECONDS.toMillis(1);
-
-    protected final ILogger logger = Logger.getLogger(getClass());
 
     protected final HazelcastClientCacheManager cacheManager;
     protected final NearCacheManager nearCacheManager;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
@@ -28,13 +28,21 @@ import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.ExceptionUtil;
 
 import javax.cache.CacheException;
 import javax.cache.integration.CompletionListener;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -47,18 +55,34 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 abstract class AbstractClientCacheProxyBase<K, V> implements ICacheInternal<K, V> {
 
+    static final int TIMEOUT = 10;
+
     private static final ClientMessageDecoder LOAD_ALL_DECODER = new ClientMessageDecoder() {
         @Override
         public <T> T decodeClientMessage(ClientMessage clientMessage) {
             return (T) Boolean.TRUE;
         }
     };
+    private static final CompletionListener NULL_COMPLETION_LISTENER = new CompletionListener() {
+        @Override
+        public void onCompletion() {
+        }
+
+        @Override
+        public void onException(Exception e) {
+        }
+    };
+
+    protected final ILogger logger = Logger.getLogger(getClass());
 
     protected final ClientContext clientContext;
     protected final CacheConfig<K, V> cacheConfig;
     //this will represent the name from the user perspective
     protected final String name;
     protected final String nameWithPrefix;
+
+    private final ConcurrentMap<Future, CompletionListener> loadAllCalls
+            = new ConcurrentHashMap<Future, CompletionListener>();
 
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
     private final AtomicBoolean isDestroyed = new AtomicBoolean(false);
@@ -87,7 +111,24 @@ abstract class AbstractClientCacheProxyBase<K, V> implements ICacheInternal<K, V
         if (!isClosed.compareAndSet(false, true)) {
             return;
         }
+        waitOnGoingLoadAllCallsToFinish();
         closeListeners();
+    }
+
+    private void waitOnGoingLoadAllCallsToFinish() {
+        Iterator<Map.Entry<Future, CompletionListener>> iterator = loadAllCalls.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Future, CompletionListener> entry = iterator.next();
+            Future f = entry.getKey();
+            CompletionListener completionListener = entry.getValue();
+            try {
+                f.get(TIMEOUT, TimeUnit.SECONDS);
+            } catch (Throwable t) {
+                logger.finest("Error occurred at loadAll operation execution while waiting it to finish on cache close!", t);
+                handleFailureOnCompletionListener(completionListener, t);
+            }
+            iterator.remove();
+        }
     }
 
     public void destroy() {
@@ -166,41 +207,52 @@ abstract class AbstractClientCacheProxyBase<K, V> implements ICacheInternal<K, V
 
     protected void submitLoadAllTask(final ClientMessage request, final CompletionListener completionListener,
                                      final Set<Data> keys) {
+        final CompletionListener compListener = completionListener != null ? completionListener : NULL_COMPLETION_LISTENER;
+        ClientDelegatingFuture<V> delegatingFuture = null;
         try {
             final long start = System.nanoTime();
-            ClientInvocationFuture future = new ClientInvocation(
+            final ClientInvocationFuture future = new ClientInvocation(
                     (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance(), request).invoke();
             SerializationService serializationService = clientContext.getSerializationService();
-            final ClientDelegatingFuture<V> delegatingFuture =
-                    new ClientDelegatingFuture(future, serializationService, LOAD_ALL_DECODER);
+            delegatingFuture = new ClientDelegatingFuture(future, serializationService, LOAD_ALL_DECODER);
+            final Future delFuture = delegatingFuture;
+            loadAllCalls.put(delegatingFuture, compListener);
             delegatingFuture.andThen(new ExecutionCallback<V>() {
                 @Override
                 public void onResponse(V response) {
-                    if (completionListener != null) {
-                        completionListener.onCompletion();
-                        onLoadAll(keys, response, start, System.nanoTime());
-                    }
+                    loadAllCalls.remove(delFuture);
+                    onLoadAll(keys, response, start, System.nanoTime());
+                    compListener.onCompletion();
                 }
 
                 @Override
                 public void onFailure(Throwable t) {
-                    if (completionListener != null) {
-                        completionListener.onException(new CacheException(t));
-                    }
+                    loadAllCalls.remove(delFuture);
+                    handleFailureOnCompletionListener(compListener, t);
                 }
             });
-
-        } catch (Exception e) {
-            if (completionListener != null) {
-                completionListener.onException(e);
-            }
         } catch (Throwable t) {
+            if (delegatingFuture != null) {
+                loadAllCalls.remove(delegatingFuture);
+            }
+            handleFailureOnCompletionListener(compListener, t);
+        }
+    }
+
+    private void handleFailureOnCompletionListener(CompletionListener completionListener,
+                                                   Throwable t) {
+        if (t instanceof Exception) {
+            Throwable cause = t.getCause();
+            if (t instanceof ExecutionException && cause instanceof CacheException) {
+                completionListener.onException((CacheException) cause);
+            } else {
+                completionListener.onException((Exception) t);
+            }
+        } else {
             if (t instanceof OutOfMemoryError) {
                 ExceptionUtil.rethrow(t);
             } else {
-                if (completionListener != null) {
-                    completionListener.onException(new CacheException(t));
-                }
+                completionListener.onException(new CacheException(t));
             }
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -54,8 +54,6 @@ import com.hazelcast.core.Client;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.executor.CompletedFuture;
@@ -136,8 +134,6 @@ abstract class AbstractClientInternalCacheProxy<K, V>
             return (T) Boolean.valueOf(CachePutIfAbsentCodec.decodeResponse(clientMessage).response);
         }
     };
-
-    protected final ILogger logger = Logger.getLogger(getClass());
 
     protected final HazelcastClientCacheManager cacheManager;
     protected final NearCacheManager nearCacheManager;


### PR DESCRIPTION
…  Also on cache close, on-going load-all calls should be waited to finish.