### PR TITLE
RefreshTask in ClientPartitionService should release flag when owner connection not available

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -235,6 +235,7 @@ public final class ClientPartitionServiceImpl implements ClientPartitionService 
 
             Connection connection = getOwnerConnection();
             if (connection == null) {
+                updating.set(false);
                 return;
             }
             ClientInvocationFuture clientInvocationFuture = getPartitionsFrom(connection);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -238,6 +238,7 @@ public final class ClientPartitionServiceImpl
 
             Connection connection = getOwnerConnection();
             if (connection == null) {
+                updating.set(false);
                 return;
             }
             ClientInvocationFuture clientInvocationFuture = getPartitionsFrom(connection);


### PR DESCRIPTION
Fixes #7134, and also some of the failures in #7133 also seem to be related to this.