### PR TITLE
Use immutable event object for ClientService events

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client;
 
 import com.hazelcast.client.impl.client.ClientPrincipal;
+import com.hazelcast.core.Client;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.transaction.TransactionContext;
@@ -28,7 +29,7 @@ import java.util.concurrent.Callable;
 /**
  * Represents an endpoint to a client. So for each client connected to a member, a ClientEndpoint object is available.
  */
-public interface ClientEndpoint {
+public interface ClientEndpoint extends Client {
 
     /**
      * Checks if the endpoint is alive.
@@ -70,8 +71,6 @@ public interface ClientEndpoint {
      * @return true if remove is successful
      */
     boolean removeDestroyAction(String id);
-
-    String getUuid();
 
     Credentials getCredentials();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEvent.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.core.Client;
+import com.hazelcast.core.ClientType;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Event used for notification of client connection and disconnection
+ */
+public class ClientEvent implements Client {
+
+    private final String uuid;
+    private final ClientEventType eventType;
+    private final InetSocketAddress address;
+    private final ClientType clientType;
+
+    public ClientEvent(String uuid, ClientEventType eventType, InetSocketAddress address, ClientType clientType) {
+        this.uuid = uuid;
+        this.eventType = eventType;
+        this.address = address;
+        this.clientType = clientType;
+    }
+
+    @Override
+    public String getUuid() {
+        return uuid;
+    }
+
+    @Override
+    public InetSocketAddress getSocketAddress() {
+        return address;
+    }
+
+    @Override
+    public ClientType getClientType() {
+        return clientType;
+    }
+
+    public ClientEventType getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientEvent{"
+                + "uuid='" + uuid + '\''
+                + ", eventType=" + eventType
+                + ", address=" + address
+                + ", clientType=" + clientType
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEventType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+/**
+ * Event type used for client connection and disconnect events
+ */
+public enum ClientEventType {
+    /**
+     * Client Connected Event
+     */
+    CONNECTED,
+
+    /**
+     * Client Disconnected Event
+     */
+    DISCONNECTED
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -21,7 +21,6 @@ import com.hazelcast.client.impl.client.ClientPrincipal;
 import com.hazelcast.client.impl.exceptionconverters.ClientExceptionConverter;
 import com.hazelcast.client.impl.exceptionconverters.ClientExceptionConverters;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.internal.serialization.impl.HeapData;
@@ -46,7 +45,7 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * The {@link com.hazelcast.client.ClientEndpoint} and {@link com.hazelcast.core.Client} implementation.
  */
-public final class ClientEndpointImpl implements Client, ClientEndpoint {
+public final class ClientEndpointImpl implements ClientEndpoint {
 
     private final ClientEngineImpl clientEngine;
     private final Connection conn;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -18,6 +18,8 @@ package com.hazelcast.client.impl;
 
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.ClientEndpointManager;
+import com.hazelcast.client.ClientEvent;
+import com.hazelcast.client.ClientEventType;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
@@ -137,7 +139,11 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
                 }
             }, DESTROY_ENDPOINT_DELAY_MS, TimeUnit.MILLISECONDS);
         }
-        clientEngine.sendClientEvent(endpoint);
+        ClientEvent event = new ClientEvent(endpoint.getUuid(),
+                ClientEventType.DISCONNECTED,
+                endpoint.getSocketAddress(),
+                endpoint.getClientType());
+        clientEngine.sendClientEvent(event);
     }
 
     public void removeEndpoints(String memberUuid) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -20,6 +20,8 @@ import com.hazelcast.client.AuthenticationException;
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.ClientEndpointManager;
 import com.hazelcast.client.ClientEngine;
+import com.hazelcast.client.ClientEvent;
+import com.hazelcast.client.ClientEventType;
 import com.hazelcast.client.impl.client.AuthenticationRequest;
 import com.hazelcast.client.impl.client.ClientRequest;
 import com.hazelcast.client.impl.client.ClientResponse;
@@ -95,7 +97,7 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmpty
  * Class that requests, listeners from client handled in node side.
  */
 public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwareService,
-        ManagedService, MembershipAwareService, EventPublishingService<ClientEndpointImpl, ClientListener> {
+        ManagedService, MembershipAwareService, EventPublishingService<ClientEvent, ClientListener> {
 
     /**
      * Service name to be used in requests.
@@ -271,19 +273,23 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
             Address address = new Address(conn.getRemoteSocketAddress());
             ((TcpIpConnection) conn).setEndPoint(address);
         }
-        sendClientEvent(endpoint);
+        ClientEvent event = new ClientEvent(endpoint.getUuid(),
+                ClientEventType.CONNECTED,
+                endpoint.getSocketAddress(),
+                endpoint.getClientType());
+        sendClientEvent(event);
     }
 
-    void sendClientEvent(ClientEndpoint endpoint) {
+    void sendClientEvent(ClientEvent event) {
         final EventService eventService = nodeEngine.getEventService();
         final Collection<EventRegistration> regs = eventService.getRegistrations(SERVICE_NAME, SERVICE_NAME);
-        String uuid = endpoint.getUuid();
-        eventService.publishEvent(SERVICE_NAME, regs, endpoint, uuid.hashCode());
+        String uuid = event.getUuid();
+        eventService.publishEvent(SERVICE_NAME, regs, event, uuid.hashCode());
     }
 
     @Override
-    public void dispatchEvent(ClientEndpointImpl event, ClientListener listener) {
-        if (event.isAuthenticated()) {
+    public void dispatchEvent(ClientEvent event, ClientListener listener) {
+        if (event.getEventType() == ClientEventType.CONNECTED) {
             listener.clientConnected(event);
         } else {
             listener.clientDisconnected(event);


### PR DESCRIPTION
ClientService events were using the mutable ClientEndpoint object,
which could change state after the event is dispatched.

Fixes #7044