### PR TITLE
Add support for read-through

### DIFF
--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -33,7 +33,7 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
 
-        <org.springframework.version>4.0.2.RELEASE</org.springframework.version>
+        <org.springframework.version>4.3.0.RELEASE</org.springframework.version>
         <jsr250.api.version>1.0</jsr250.api.version>
         <hazelcast.latest.version>3.6</hazelcast.latest.version>
     </properties>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.cache;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.hamcrest.core.Is.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link HazelcastCache}.
+ *
+ * @author Stephane Nicoll
+ */
+@RunWith(CustomSpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"simple-config.xml"})
+@Category(QuickTest.class)
+public class HazelcastCacheTest {
+
+    @Autowired
+    public CacheManager cacheManager;
+
+    private Cache cache;
+
+    @Before
+    public void setup() {
+        this.cache = cacheManager.getCache("test");
+    }
+
+    @Test
+    public void testCacheGetCallable() {
+        doTestCacheGetCallable("test");
+    }
+
+    @Test
+    public void testCacheGetCallableWithNull() {
+        doTestCacheGetCallable(null);
+    }
+
+    private void doTestCacheGetCallable(final Object returnValue) {
+        String key = createRandomKey();
+
+        assertNull(cache.get(key));
+        Object value = cache.get(key, new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return returnValue;
+            }
+        });
+        assertEquals(returnValue, value);
+        assertEquals(value, cache.get(key).get());
+    }
+
+    @Test
+    public void testCacheGetCallableNotInvokedWithHit() {
+        doTestCacheGetCallableNotInvokedWithHit("existing");
+    }
+
+    @Test
+    public void testCacheGetCallableNotInvokedWithHitNull() {
+        doTestCacheGetCallableNotInvokedWithHit(null);
+    }
+
+    private void doTestCacheGetCallableNotInvokedWithHit(Object initialValue) {
+        String key = createRandomKey();
+        cache.put(key, initialValue);
+
+        Object value = cache.get(key, new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                throw new IllegalStateException("Should not have been invoked");
+            }
+        });
+        assertEquals(initialValue, value);
+    }
+
+    @Test
+    public void testCacheGetCallableFail() {
+        String key = createRandomKey();
+        assertNull(cache.get(key));
+
+        try {
+            cache.get(key, new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    throw new UnsupportedOperationException("Expected exception");
+                }
+            });
+        }
+        catch (Cache.ValueRetrievalException ex) {
+            assertNotNull(ex.getCause());
+            assertEquals(UnsupportedOperationException.class, ex.getCause().getClass());
+        }
+    }
+
+    /**
+     * Test that a call to get with a Callable concurrently properly synchronize the
+     * invocations.
+     */
+    @Test
+    public void testCacheGetSynchronized() throws InterruptedException {
+        final AtomicInteger counter = new AtomicInteger();
+        final List<Object> results = new CopyOnWriteArrayList<Object>();
+        final CountDownLatch latch = new CountDownLatch(10);
+
+        final String key = createRandomKey();
+        Runnable run = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Integer value = cache.get(key, new Callable<Integer>() {
+                        @Override
+                        public Integer call() throws Exception {
+
+                            Thread.sleep(50); // make sure the thread will overlap
+                            return counter.incrementAndGet();
+                        }
+                    });
+                    results.add(value);
+                }
+                finally {
+                    latch.countDown();
+                }
+            }
+        };
+
+        for (int i = 0; i < 10; i++) {
+            new Thread(run).start();
+        }
+        latch.await();
+
+        assertEquals(10, results.size());
+        for (Object result : results) {
+            assertThat((Integer) result, is(1));
+        }
+    }
+
+    protected String createRandomKey() {
+        return UUID.randomUUID().toString();
+    }
+
+}

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/cache/simple-config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+
+    <hz:hazelcast id="instance">
+        <hz:config>
+            <hz:map name="test" />
+        </hz:config>
+    </hz:hazelcast>
+
+    <bean id="cacheManager" class="com.hazelcast.spring.cache.HazelcastCacheManager">
+        <constructor-arg ref="instance"/>
+    </bean>
+
+</beans>


### PR DESCRIPTION
Update HazelcastCache to implement a new method introduced in Spring Framework 4.3.

See https://jira.spring.io/browse/SPR-9254 for more details.

You'll need our snapshot repository for the time being if you want to build this PR. Adding the following to your main pom and running `mvn package -PspringSnapshot` should do the trick in the meantime.

```xml
<profile>
	<id>springSnapshot</id>
	<repositories>
		<repository>
			<id>spring-snapshots</id>
			<name>Spring Snapshots</name>
			<url>http://repo.spring.io/snapshot</url>
			<snapshots>
				<enabled>true</enabled>
			</snapshots>
		</repository>
	</repositories>
</profile>