### PR TITLE
Remove redundant XPath check for each node in AbstractConfigBuilder

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -333,6 +333,12 @@ public class XmlClientConfigBuilderTest {
         buildConfig(xml);
     }
 
+    @Test(expected = InvalidConfigurationException.class)
+    public void testHazelcastClientTagAppearsTwice() {
+        String xml = HAZELCAST_CLIENT_START_TAG + "<hazelcast-client/></<hazelcast-client>";
+        buildConfig(xml);
+    }
+
     private void testXSDConfigXML(String xmlFileName) throws SAXException, IOException {
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-client-config-3.6.xsd");

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -334,6 +334,12 @@ public class XmlClientConfigBuilderTest {
         buildConfig(xml);
     }
 
+    @Test(expected = InvalidConfigurationException.class)
+    public void testHazelcastClientTagAppearsTwice() {
+        String xml = HAZELCAST_CLIENT_START_TAG + "<hazelcast-client/></<hazelcast-client>";
+        buildConfig(xml);
+    }
+
     static ClientConfig buildConfig(String xml, Properties properties) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
         XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder(bis);

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
@@ -27,7 +27,6 @@ import org.w3c.dom.NodeList;
 import javax.xml.namespace.NamespaceContext;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 import java.io.InputStream;
 import java.net.URL;
@@ -131,13 +130,7 @@ public abstract class AbstractConfigBuilder extends AbstractXmlConfigHelper {
      */
     protected abstract ConfigType getXmlType();
 
-    private void traverseChildsAndReplaceVariables(Node root) throws XPathExpressionException {
-        NodeList misplacedHazelcastTag = (NodeList) xpath.evaluate(
-                "//" + this.getXmlType().name, root.getOwnerDocument(), XPathConstants.NODESET);
-        if (misplacedHazelcastTag.getLength() > 1) {
-            throw new InvalidConfigurationException(
-                    '<' + this.getXmlType().name + "> element can appear only once in the XML");
-        }
+    private void traverseChildsAndReplaceVariables(Node root) {
         NamedNodeMap attributes = root.getAttributes();
         if (attributes != null) {
             for (int k = 0; k < attributes.getLength(); k++) {

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1227,4 +1227,10 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         String xml = HAZELCAST_START_TAG + "</hazelcast>";
         buildConfig(xml);
     }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testHazelcastTagAppearsTwice() {
+        String xml = HAZELCAST_START_TAG + "<hazelcast/></hazelcast>";
+        buildConfig(xml);
+    }
 }


### PR DESCRIPTION
There was an xpath check on each node in the config file to see if there
was an additional hazelcast tag. This is already handled by schema
validation and also seems to be causing some deadlock issues on IBM JDK.
 Fixes #6153