### PR TITLE
Create scheduler for locks per partition instead of per node

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockService.java
@@ -26,17 +26,19 @@ public interface InternalLockService extends LockService {
      * at the time of eviction.
      *
      * @param namespace namespace of the lock
+     * @param partitionId partitionId the key falls into
      * @param key locked key
      * @param version version of a lock to evict.
      * @param delayMillis delay in ms
      */
-    void scheduleEviction(ObjectNamespace namespace, Data key, int version, long delayMillis);
+    void scheduleEviction(ObjectNamespace namespace, int partitionId, Data key, int version, long delayMillis);
 
     /**
      * Cancel scheduled lock eviction.
      *
      * @param namespace namespace of the lock
+     * @param partitionId partitionId the key falls into
      * @param key locked key
      */
-    void cancelEviction(ObjectNamespace namespace, Data key);
+    void cancelEviction(ObjectNamespace namespace, int partitionId, Data key);
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -42,40 +42,22 @@ import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ConstructorFunction;
-import com.hazelcast.util.scheduler.EntryTaskScheduler;
-import com.hazelcast.util.scheduler.EntryTaskSchedulerFactory;
-import com.hazelcast.util.scheduler.ScheduleType;
 
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
-import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
 
 public final class LockServiceImpl implements InternalLockService, ManagedService, RemoteService, MembershipAwareService,
         MigrationAwareService, ClientAwareService {
 
     private final NodeEngine nodeEngine;
     private final LockStoreContainer[] containers;
-    private final ConcurrentMap<ObjectNamespace, EntryTaskScheduler> evictionProcessors
-            = new ConcurrentHashMap<ObjectNamespace, EntryTaskScheduler>();
     private final ConcurrentMap<String, ConstructorFunction<ObjectNamespace, LockStoreInfo>> constructors
             = new ConcurrentHashMap<String, ConstructorFunction<ObjectNamespace, LockStoreInfo>>();
-    private final ConstructorFunction<ObjectNamespace, EntryTaskScheduler> schedulerConstructor =
-            new ConstructorFunction<ObjectNamespace, EntryTaskScheduler>() {
-                @Override
-                public EntryTaskScheduler createNew(ObjectNamespace namespace) {
-                    LockEvictionProcessor entryProcessor = new LockEvictionProcessor(nodeEngine, namespace);
-                    ScheduledExecutorService scheduledExecutor =
-                            nodeEngine.getExecutionService().getDefaultScheduledExecutor();
-                    return EntryTaskSchedulerFactory
-                            .newScheduler(scheduledExecutor, entryProcessor, ScheduleType.FOR_EACH);
-                }
-            };
 
     private final long maxLeaseTimeInMillis;
 
@@ -89,8 +71,8 @@ public final class LockServiceImpl implements InternalLockService, ManagedServic
         maxLeaseTimeInMillis = getMaxLeaseTimeInMillis(nodeEngine.getGroupProperties());
     }
 
-    public static long getMaxLeaseTimeInMillis(GroupProperties groupProperties) {
-        return groupProperties.getMillis(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS);
+    NodeEngine getNodeEngine() {
+        return nodeEngine;
     }
 
     @Override
@@ -166,16 +148,12 @@ public final class LockServiceImpl implements InternalLockService, ManagedServic
         container.clearLockStore(namespace);
     }
 
-    public void scheduleEviction(ObjectNamespace namespace, Data key, int version, long delay) {
-        EntryTaskScheduler scheduler = getOrPutSynchronized(
-                evictionProcessors, namespace, evictionProcessors, schedulerConstructor);
-        scheduler.schedule(delay, key, version);
+    public void scheduleEviction(ObjectNamespace namespace, int partitionId, Data key, int version, long delay) {
+        getLockContainer(partitionId).scheduleEviction(namespace, key, version, delay);
     }
 
-    public void cancelEviction(ObjectNamespace namespace, Data key) {
-        EntryTaskScheduler scheduler = getOrPutSynchronized(
-                evictionProcessors, namespace, evictionProcessors, schedulerConstructor);
-        scheduler.cancel(key);
+    public void cancelEviction(ObjectNamespace namespace, int partitionId, Data key) {
+        getLockContainer(partitionId).cancelEviction(namespace, key);
     }
 
     public LockStoreContainer getLockContainer(int partitionId) {
@@ -293,7 +271,7 @@ public final class LockServiceImpl implements InternalLockService, ManagedServic
                 }
 
                 long leaseTime = expirationTime - now;
-                scheduleEviction(ls.getNamespace(), lock.getKey(), lock.getVersion(), leaseTime);
+                scheduleEviction(ls.getNamespace(), partitionId, lock.getKey(), lock.getVersion(), leaseTime);
             }
         }
     }
@@ -335,5 +313,9 @@ public final class LockServiceImpl implements InternalLockService, ManagedServic
     @Override
     public void clientDisconnected(String clientUuid) {
         releaseLocksOwnedBy(clientUuid);
+    }
+
+    public static long getMaxLeaseTimeInMillis(GroupProperties groupProperties) {
+        return groupProperties.getMillis(GroupProperty.LOCK_MAX_LEASE_TIME_SECONDS);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -38,26 +38,29 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
 
     private final transient ConstructorFunction<Data, LockResourceImpl> lockConstructor =
             new ConstructorFunction<Data, LockResourceImpl>() {
-        public LockResourceImpl createNew(Data key) {
-            return new LockResourceImpl(key, LockStoreImpl.this);
-        }
-    };
+                public LockResourceImpl createNew(Data key) {
+                    return new LockResourceImpl(key, LockStoreImpl.this);
+                }
+            };
 
     private final ConcurrentMap<Data, LockResourceImpl> locks = new ConcurrentHashMap<Data, LockResourceImpl>();
     private ObjectNamespace namespace;
     private int backupCount;
     private int asyncBackupCount;
+    private int partitionId;
 
     private InternalLockService lockService;
 
     public LockStoreImpl() {
     }
 
-    public LockStoreImpl(InternalLockService lockService, ObjectNamespace name, int backupCount, int asyncBackupCount) {
+    public LockStoreImpl(InternalLockService lockService, ObjectNamespace name,
+                         int backupCount, int asyncBackupCount, int partitionId) {
+        this.lockService = lockService;
         this.namespace = name;
         this.backupCount = backupCount;
         this.asyncBackupCount = asyncBackupCount;
-        this.lockService = lockService;
+        this.partitionId = partitionId;
     }
 
     @Override
@@ -209,11 +212,11 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     void scheduleEviction(Data key, int version, long leaseTime) {
-        lockService.scheduleEviction(namespace, key, version, leaseTime);
+        lockService.scheduleEviction(namespace, partitionId, key, version, leaseTime);
     }
 
     void cancelEviction(Data key) {
-        lockService.cancelEviction(namespace, key);
+        lockService.cancelEviction(namespace, partitionId, key);
     }
 
     void setLockService(LockServiceImpl lockService) {

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
@@ -56,7 +56,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     public void setUp() {
         mockLockServiceImpl = mock(InternalLockService.class);
         when(mockLockServiceImpl.getMaxLeaseTimeInMillis()).thenReturn(Long.MAX_VALUE);
-        lockStore = new LockStoreImpl(mockLockServiceImpl, OBJECT_NAME_SPACE, BACKUP_COUNT, ASYNC_BACKUP_COUNT);
+        lockStore = new LockStoreImpl(mockLockServiceImpl, OBJECT_NAME_SPACE, BACKUP_COUNT, ASYNC_BACKUP_COUNT, -1);
     }
 
     @Test


### PR DESCRIPTION
We've converted our scheduler to synchronized due to race problems and this change introduced performance regression on locks (with lease). To overcome this contention we are now creating a scheduler for each partition. 

PS: ReplicatedMap and IQueue already use this approach(per-partition) while using scheduler.