### PR TITLE
Renames WAN acknowledge type ACK_ON_TRANSMIT to ACK_ON_RECEIPT

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
@@ -2449,7 +2449,7 @@
 
     <xs:simpleType name="wan-ack-type-format-enum">
         <xs:restriction base="xs:string">
-            <xs:enumeration value="ACK_ON_TRANSMIT"/>
+            <xs:enumeration value="ACK_ON_RECEIPT"/>
             <xs:enumeration value="ACK_ON_OPERATION_COMPLETE"/>
         </xs:restriction>
     </xs:simpleType>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -561,8 +561,8 @@ public class TestFullApplicationContext {
         assertEquals(wanReplication, wcfg.getTargetClusterConfigs().get(1).getReplicationImplObject());
         WanTargetClusterConfig targetClusterConfig0 = wcfg.getTargetClusterConfigs().get(0);
         WanTargetClusterConfig targetClusterConfig1 = wcfg.getTargetClusterConfigs().get(1);
-        assertEquals(WanAcknowledgeType.ACK_ON_TRANSMIT, targetClusterConfig0.getAcknowledgeType());
-        assertEquals(WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE, targetClusterConfig1.getAcknowledgeType());
+        assertEquals(WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE, targetClusterConfig0.getAcknowledgeType());
+        assertEquals(WanAcknowledgeType.ACK_ON_RECEIPT, targetClusterConfig1.getAcknowledgeType());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, targetClusterConfig0.getQueueFullBehavior());
         assertEquals(7, targetClusterConfig0.getBatchSize());
         assertEquals(14, targetClusterConfig0.getBatchMaxDelayMillis());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullcacheconfig-applicationContext-hazelcast.xml
@@ -56,7 +56,7 @@
                         <hz:address>10.2.1.1:5701</hz:address>
                         <hz:address>10.2.1.2:5701</hz:address>
                     </hz:end-points>
-                    <hz:acknowledge-type>ACK_ON_TRANSMIT</hz:acknowledge-type>
+                    <hz:acknowledge-type>ACK_ON_OPERATION_COMPLETE</hz:acknowledge-type>
                     <hz:queue-full-behavior>THROW_EXCEPTION</hz:queue-full-behavior>
                     <hz:batch-size>7</hz:batch-size>
                     <hz:batch-max-delay-millis>14</hz:batch-max-delay-millis>

--- a/hazelcast/src/main/java/com/hazelcast/config/WanAcknowledgeType.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanAcknowledgeType.java
@@ -22,9 +22,9 @@ package com.hazelcast.config;
 public enum WanAcknowledgeType {
 
     /**
-     * ACK when operation is invoked successfully on target cluster
+     * ACK after WAN operation is received by the target cluster (without waiting the result of actual operation invocation.)
      */
-    ACK_ON_TRANSMIT(0),
+    ACK_ON_RECEIPT(0),
 
     /**
      * Wait till the operation is complete on target cluster

--- a/hazelcast/src/main/java/com/hazelcast/config/WanTargetClusterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanTargetClusterConfig.java
@@ -23,7 +23,7 @@ import java.util.List;
  */
 public class WanTargetClusterConfig {
 
-    private static final WanAcknowledgeType DEFAULT_ACK_TYPE = WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE;
+    private static final WanAcknowledgeType DEFAULT_ACK_TYPE = WanAcknowledgeType.ACK_ON_RECEIPT;
     private static final WANQueueFullBehavior QUEUE_FULL_BEHAVIOR = WANQueueFullBehavior.DISCARD_AFTER_MUTATION;
     private static final int DEFAULT_BATCH_SIZE = 500;
     private static final long DEFAULT_BATCH_MAX_DELAY_MILLIS = 1000;

--- a/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
@@ -2805,7 +2805,7 @@
 
     <xs:simpleType name="wan-ack-type">
         <xs:restriction base="non-space-string">
-            <xs:enumeration value="ACK_ON_TRANSMIT"/>
+            <xs:enumeration value="ACK_ON_RECEIPT"/>
             <xs:enumeration value="ACK_ON_OPERATION_COMPLETE"/>
         </xs:restriction>
     </xs:simpleType>

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -838,7 +838,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                         "          <address>20.30.40.50:5701</address>\n" +
                         "          <address>20.30.40.50:5702</address>\n" +
                         "       </end-points>\n" +
-                        "       <acknowledge-type>ACK_ON_TRANSMIT</acknowledge-type>\n" +
+                        "       <acknowledge-type>ACK_ON_RECEIPT</acknowledge-type>\n" +
                         "       <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>\n" +
                         "       <batch-size>7</batch-size>" +
                         "       <batch-max-delay-millis>14</batch-max-delay-millis>\n" +
@@ -860,7 +860,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(2, targetEndpoints.size());
         assertTrue(targetEndpoints.contains("20.30.40.50:5701"));
         assertTrue(targetEndpoints.contains("20.30.40.50:5702"));
-        assertEquals(WanAcknowledgeType.ACK_ON_TRANSMIT, targetClusterConfig.getAcknowledgeType());
+        assertEquals(WanAcknowledgeType.ACK_ON_RECEIPT, targetClusterConfig.getAcknowledgeType());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, targetClusterConfig.getQueueFullBehavior());
         assertEquals(7, targetClusterConfig.getBatchSize());
         assertEquals(14, targetClusterConfig.getBatchMaxDelayMillis());

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanAcknowledgeTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanAcknowledgeTypeTest.java
@@ -9,7 +9,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.config.WanAcknowledgeType.ACK_ON_OPERATION_COMPLETE;
-import static com.hazelcast.config.WanAcknowledgeType.ACK_ON_TRANSMIT;
+import static com.hazelcast.config.WanAcknowledgeType.ACK_ON_RECEIPT;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
@@ -19,7 +19,7 @@ public class WanAcknowledgeTypeTest {
 
     @Test
     public void test() {
-        assertSame(ACK_ON_TRANSMIT, WanAcknowledgeType.getById(ACK_ON_TRANSMIT.getId()));
+        assertSame(ACK_ON_RECEIPT, WanAcknowledgeType.getById(ACK_ON_RECEIPT.getId()));
         assertSame(ACK_ON_OPERATION_COMPLETE, WanAcknowledgeType.getById(ACK_ON_OPERATION_COMPLETE.getId()));
         assertNull(WanAcknowledgeType.getById(-1));
     }

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -56,7 +56,7 @@
                 <address>10.3.5.1:5701</address>
                 <address>10.3.5.2:5701</address>
             </end-points>
-            <acknowledge-type>ACK_ON_TRANSMIT</acknowledge-type>
+            <acknowledge-type>ACK_ON_RECEIPT</acknowledge-type>
             <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>
             <batch-size>7</batch-size>
             <batch-max-delay-millis>14</batch-max-delay-millis>


### PR DESCRIPTION
Also changes default behavior to ACK_ON_RECEIPT.
resolves https://github.com/hazelcast/hazelcast-enterprise/issues/594