### PR TITLE
TTL for RingbufferAddReadOneStressTest is increased

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddReadOneStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddReadOneStressTest.java
@@ -35,7 +35,7 @@ public class RingbufferAddReadOneStressTest extends HazelcastTestSupport {
     public void whenTTLEnabled() throws Exception {
         RingbufferConfig ringbufferConfig = new RingbufferConfig("foo")
                 .setCapacity(200 * 1000)
-                .setTimeToLiveSeconds(1);
+                .setTimeToLiveSeconds(2);
         test(ringbufferConfig);
     }
 
@@ -43,7 +43,7 @@ public class RingbufferAddReadOneStressTest extends HazelcastTestSupport {
     public void whenLongTTLAndSmallBuffer() throws Exception {
         RingbufferConfig ringbufferConfig = new RingbufferConfig("foo")
                 .setCapacity(1000)
-                .setTimeToLiveSeconds(1);
+                .setTimeToLiveSeconds(30);
         test(ringbufferConfig);
     }
 
@@ -51,7 +51,7 @@ public class RingbufferAddReadOneStressTest extends HazelcastTestSupport {
     public void whenShortTTLAndBigBuffer() throws Exception {
         RingbufferConfig ringbufferConfig = new RingbufferConfig("foo")
                 .setCapacity(20 * 1000 * 1000)
-                .setTimeToLiveSeconds(1);
+                .setTimeToLiveSeconds(2);
         test(ringbufferConfig);
     }
 


### PR DESCRIPTION
Consumer threads should catch up with TTL. I tried to sleep them 5 ms and even then test was failed.

I think we can do more than 2 seconds of TTL, which is more healthy.

fixes #6895