### PR TITLE
Fixes wrong exception send to user

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -188,14 +188,16 @@ public class ClientInvocation implements Runnable {
         }
 
         Exception exception = (Exception) response;
-        if (!lifecycleService.isRunning()) {
-            clientInvocationFuture.setResponse(new HazelcastClientNotActiveException(exception.getMessage()));
-            return;
-        }
         notifyException(exception);
     }
 
     private void notifyException(Exception exception) {
+
+        if (!lifecycleService.isRunning()) {
+            clientInvocationFuture.setResponse(new HazelcastClientNotActiveException(exception.getMessage()));
+            return;
+        }
+
         if (exception instanceof IOException
                 || exception instanceof HazelcastInstanceNotActiveException
                 || exception instanceof AuthenticationException


### PR DESCRIPTION
User is waiting HazelcastClientNotActive exception but gets
RejectedExecutionException when client is shutting down at the
same time there is a request on the fly. Place of isRunning check
is moved to fix the issue.

Fixes #7181