### PR TITLE
Shutdown instances on tear down of `AbstractOutOfMemoryHandlerTest` 

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
@@ -1,11 +1,13 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.nio.Packet;
 import com.hazelcast.test.HazelcastTestSupport;
-
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
+import org.junit.After;
 
 public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSupport {
 
@@ -15,14 +17,108 @@ public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSuppor
     public void initHazelcastInstances() throws Exception {
         Config config = new Config();
 
-        ConnectionManager connectionManager = mock(ConnectionManager.class);
-        doThrow(new OutOfMemoryError()).when(connectionManager).shutdown();
-
         NodeContext nodeContext = new TestNodeContext();
-        NodeContext nodeContextWithThrowable = new TestNodeContext(connectionManager);
+        NodeContext nodeContextWithThrowable = new TestNodeContext(new FailingConnectionManager());
 
         hazelcastInstance = new HazelcastInstanceImpl("OutOfMemoryHandlerHelper", config, nodeContext);
         hazelcastInstanceThrowsException = new HazelcastInstanceImpl("OutOfMemoryHandlerHelperThrowsException", config,
                 nodeContextWithThrowable);
     }
+
+    @After
+    public void tearDown() {
+        if (hazelcastInstance != null) {
+            hazelcastInstance.shutdown();
+        }
+        if (hazelcastInstanceThrowsException != null) {
+            ConnectionManager connectionManager = hazelcastInstanceThrowsException.node.getConnectionManager();
+            // Failing connection manager throws error, so we should disable this behaviour to shutdown instance properly
+            ((FailingConnectionManager) connectionManager).switchToDummyMode();
+            hazelcastInstanceThrowsException.shutdown();
+        }
+    }
+
+    private static class FailingConnectionManager implements ConnectionManager {
+
+        private boolean dummyMode;
+
+        private void switchToDummyMode() {
+            dummyMode = true;
+        }
+
+        @Override
+        public int getCurrentClientConnections() {
+            return 0;
+        }
+
+        @Override
+        public int getAllTextConnections() {
+            return 0;
+        }
+
+        @Override
+        public int getConnectionCount() {
+            return 0;
+        }
+
+        @Override
+        public int getActiveConnectionCount() {
+            return 0;
+        }
+
+        @Override
+        public Connection getConnection(Address address) {
+            return null;
+        }
+
+        @Override
+        public Connection getOrConnect(Address address) {
+            return null;
+        }
+
+        @Override
+        public Connection getOrConnect(Address address, boolean silent) {
+            return null;
+        }
+
+        @Override
+        public boolean registerConnection(Address address, Connection connection) {
+            return false;
+        }
+
+        @Override
+        public void destroyConnection(Connection connection) {
+        }
+
+        @Override
+        public void addConnectionListener(ConnectionListener listener) {
+        }
+
+        @Override
+        public boolean transmit(Packet packet, Connection connection) {
+            return false;
+        }
+
+        @Override
+        public boolean transmit(Packet packet, Address target) {
+            return false;
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public void stop() {
+        }
+
+        @Override
+        public void shutdown() {
+            if (!dummyMode) {
+                throw new OutOfMemoryError();
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
... which is inherited (used) by `OutOfMemoryHandlerTest` and `OutOfMemoryHandlerHelperTest`

I have noticed problem while looking at this logs https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-3.x-IbmJDK1.6/785/artifact/hazelcast/target/surefire-reports/com.hazelcast.cache.CacheBasicServerTest-output.txt

There are so many non-terminated threads from `OutOfMemoryHandlerTest` and `OutOfMemoryHandlerHelperTest`.