### PR TITLE
Distinguish map/cache service reset, shutdown and single map/cache destroy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -1460,7 +1460,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     @Override
-    public void close() {
+    public void close(boolean onShutdown) {
         clear();
         closeListeners();
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -114,14 +114,22 @@ public abstract class AbstractCacheService
 
     @Override
     public void reset() {
+        reset(false);
+    }
+
+    private void reset(boolean onShutdown) {
         for (String objectName : configs.keySet()) {
             deleteCache(objectName, true, null, false);
         }
         final CachePartitionSegment[] partitionSegments = segments;
         for (CachePartitionSegment partitionSegment : partitionSegments) {
             if (partitionSegment != null) {
-                partitionSegment.clear();
-                partitionSegment.init();
+                if (onShutdown) {
+                    partitionSegment.shutdown();
+                } else {
+                    partitionSegment.clear();
+                    partitionSegment.init();
+                }
             }
         }
     }
@@ -130,7 +138,7 @@ public abstract class AbstractCacheService
     public void shutdown(boolean terminate) {
         if (!terminate) {
             cacheEventHandler.shutdown();
-            reset();
+            reset(true);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -79,7 +79,7 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
         } else {
             store = recordStores.get(name);
             if (store != null) {
-                store.close();
+                store.close(false);
             }
         }
     }
@@ -108,19 +108,10 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
         }
     }
 
-    public void destroy() {
+    public void shutdown() {
         synchronized (mutex) {
             for (ICacheRecordStore store : recordStores.values()) {
-                store.destroy();
-            }
-        }
-        recordStores.clear();
-    }
-
-    public void close() {
-        synchronized (mutex) {
-            for (ICacheRecordStore store : recordStores.values()) {
-                store.close();
+                store.close(true);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -318,10 +318,12 @@ public interface ICacheRecordStore {
      *     <li>unregister all listeners.</li>
      * </ul>
      *
+     * @param onShutdown true if {@code close} is called during CacheService shutdown,
+     *                   false otherwise.
      * @see #clear()
      * @see #destroy()
      */
-    void close();
+    void close(boolean onShutdown);
 
     /**
      * Destroy is equivalent to below operations in the given order:
@@ -332,7 +334,7 @@ public interface ICacheRecordStore {
      * </ul>
      *
      * @see #clear()
-     * @see #close()
+     * @see #close(boolean)
      */
     void destroy();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
@@ -64,9 +64,7 @@ public class MapManagedService implements ManagedService {
 
         // clear internal resources, these are the resources wholly managed by hazelcast,
         // means they have no external interaction like map-stores.
-        mapServiceContext.clearPartitions();
-        mapServiceContext.getNearCacheProvider().shutdown();
-        mapServiceContext.getMapContainers().clear();
+        mapServiceContext.shutdown();
     }
 
     private class ObjectNamespaceLockStoreInfoConstructorFunction implements ConstructorFunction<ObjectNamespace, LockStoreInfo> {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -69,7 +69,13 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     MapService getService();
 
-    void clearPartitions();
+    /**
+     * Clears all partition based data allocated by MapService.
+     *
+     * @param onShutdown true if {@code clearPartitions} is called during MapService shutdown,
+     *                   false otherwise.
+     */
+    void clearPartitions(boolean onShutdown);
 
     void destroyMapStores();
 
@@ -78,6 +84,12 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     void destroyMap(String mapName);
 
     void reset();
+
+    /**
+     * Releases internal resources solely managed by Hazelcast. This method is
+     * called when MapService is shutting down.
+     */
+    void shutdown();
 
     NearCacheProvider getNearCacheProvider();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -194,11 +194,11 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
-    public void clearPartitions() {
+    public void clearPartitions(boolean onShutdown) {
         final PartitionContainer[] containers = partitionContainers;
         for (PartitionContainer container : containers) {
             if (container != null) {
-                container.clear();
+                container.clear(onShutdown);
             }
         }
     }
@@ -245,8 +245,15 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public void reset() {
-        clearPartitions();
+        clearPartitions(false);
         getNearCacheProvider().reset();
+    }
+
+    @Override
+    public void shutdown() {
+        clearPartitions(true);
+        nearCacheProvider.shutdown();
+        mapContainers.clear();
     }
 
     @Override


### PR DESCRIPTION
Added a flag to map/cache clear/close operations to denote service shutdown.
It's possible to avoid some operations during service shutdown,
which are required when map/cache is closed on normal runtime.

_This is required to fix issue: https://github.com/hazelcast/hazelcast-enterprise/issues/613_