### PR TITLE
Make sure the cluster uptime > 0 when running VersionCheckTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/util/VersionCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/VersionCheckTest.java
@@ -39,9 +39,9 @@ public class VersionCheckTest extends HazelcastTestSupport {
 
     @Test
     public void testVersionCheckParameters() throws Exception {
-        assertClusterSizeEventually(1, hz1);
         Node node1 = TestUtil.getNode(hz1);
         VersionCheck check = new VersionCheck();
+        sleepAtLeastMillis(1);
         Map<String, String> parameters = check.doCheck(node1, "test_version", false);
 
         assertEquals(parameters.get("version"), "test_version");


### PR DESCRIPTION
Fixes #7192

Reasoning:
The test assumes the cluster-uptime is always greater than 0 (ms).
The cluster uptime is defined as "no. of ms since cluster has started".
However if the test is too fast then the cluster time is 0 -> the test
is failing.

I am also reverting 418784b as it has no effect here and it's
effectively noise only.