### PR TITLE
[FORWARD-PORT] Make sure the cluster uptime > 0 when running PhoneHomeTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
@@ -39,9 +39,9 @@ public class PhoneHomeTest extends HazelcastTestSupport {
 
     @Test
     public void testPhoneHomeParameters() throws Exception {
-        assertClusterSizeEventually(1, hz1);
         Node node1 = TestUtil.getNode(hz1);
         PhoneHome phoneHome = new PhoneHome();
+        sleepAtLeastMillis(1);
         Map<String, String> parameters = phoneHome.phoneHome(node1, "test_version", false);
 
         assertEquals(parameters.get("version"), "test_version");


### PR DESCRIPTION
Forward-port of #7197, Fixes #7192

Reasoning:
The test assumes the cluster-uptime is always greater than 0 (ms).
The cluster uptime is defined as "no. of ms since cluster has started".
However if the test is too fast then the cluster time is 0 -> the test
is failing.

I am also reverting b170651b3 as it has no effect here and it's
effectively noise only.