### PR TITLE
Fixes repeatedly checks made from InvocationMonitor for timeout

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -504,13 +504,14 @@ abstract class Invocation implements OperationResponseHandler, Runnable {
         long maxCallTimeout = invocationFuture.getMaxCallTimeout();
         long expirationTime = op.getInvocationTime() + maxCallTimeout;
 
+        boolean done = invocationFuture.isDone();
         boolean hasResponse = pendingResponse != null;
         boolean hasWaitingThreads = invocationFuture.getWaitingThreadsCount() > 0;
         boolean notExpired = maxCallTimeout == Long.MAX_VALUE
                 || expirationTime < 0
                 || expirationTime >= Clock.currentTimeMillis();
 
-        if (hasResponse || hasWaitingThreads || notExpired) {
+        if (hasResponse || hasWaitingThreads || notExpired || done) {
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -30,8 +30,9 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
 import com.hazelcast.util.counters.MwCounter;
 import com.hazelcast.util.counters.SwCounter;
-
 import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -155,6 +156,15 @@ public class InvocationRegistry {
 
     public Collection<Invocation> invocations() {
         return invocations.values();
+    }
+
+    /**
+     * Intention to expose the entry set is to mutate it.
+     *
+     * @return set of invocations in this registry
+     */
+    public Set<Map.Entry<Long, Invocation>> entrySet() {
+        return invocations.entrySet();
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
@@ -1,24 +1,30 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.instance.Node;
+import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.concurrent.Future;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.Future;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -66,6 +72,54 @@ public class Invocation_RetryTest extends HazelcastTestSupport {
             fail();
         } catch (MemberLeftException expected) {
 
+        }
+    }
+
+    @Test
+    public void testNoStuckInvocationsWhenRetriedMultipleTimes() throws Exception {
+        Config config = new Config();
+        config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS, "3000");
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance local = factory.newHazelcastInstance(config);
+        HazelcastInstance remote = factory.newHazelcastInstance(config);
+        warmUpPartitions(local, remote);
+        NodeEngineImpl localNodeEngine = getNodeEngineImpl(local);
+        NodeEngineImpl remoteNodeEngine = getNodeEngineImpl(remote);
+        final OperationServiceImpl operationService = (OperationServiceImpl) localNodeEngine.getOperationService();
+        NonResponsiveOperation op = new NonResponsiveOperation();
+        op.setValidateTarget(false);
+        op.setPartitionId(1);
+        InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null
+                , op, remoteNodeEngine.getThisAddress());
+        Field invocationField = InvocationFuture.class.getDeclaredField("invocation");
+        invocationField.setAccessible(true);
+        Invocation invocation = (Invocation) invocationField.get(future);
+
+        invocation.notifyError(new RetryableHazelcastException());
+        invocation.notifyError(new RetryableHazelcastException());
+
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Collection<Invocation> invocations = operationService.invocationsRegistry.invocations();
+                assertEquals(0, invocations.size());
+            }
+        });
+    }
+
+    /**
+     * Non-responsive operation.
+     */
+    public static class NonResponsiveOperation extends AbstractOperation {
+
+        @Override
+        public void run() throws InterruptedException {
+        }
+
+        @Override
+        public boolean returnsResponse() {
+            return false;
         }
     }
 


### PR DESCRIPTION
Problematic scenario :
If an invocation with callId 1 is retried twice for any reason, two new innovations created and registered to invocation registry with callId’s 2 and 3 respectively. Both new invocations are sharing the same operation.

When one of the new invocations, say the one with callId 2 finishes, it de-registers itself from the invocation registry. When doing the de-registration it sets the shared operation’s callId to 0. After that when the invocation with the callId 3 completes, it tries to de-register itself from invocation registry but fails to do so since the invocation callId and the callId on the operation are not matching anymore. 

When InvocationMonitor thread kicks in, it sees that there is an invocation in the registry, and asks whether invocation is finished or not. Even if the remote node replies with invocation is timed out, It can’t be de-registered from the registry because of aforementioned non-matching callId scenario.

Workaround:
When InvocationMonitor kicks in, it will do a check for invocations that are completed but their callId's are not matching with their operations. If any invocation found for that type, it is removed from the invocation registry.

Actual solution to this problem could be re-designing the invocations by making only one retry can be done at the same time.


Fixes #7170