### PR TITLE
Removed client/server failover tests to separate test suites.

### DIFF
--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/JettyClientFailOverTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/JettyClientFailOverTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wm.test;
+
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(WebTestRunner.class)
+@DelegatedRunWith(Parameterized.class)
+@Category(SlowTest.class)
+public class JettyClientFailOverTest extends  WebFilterClientFailOverTests {
+
+    public JettyClientFailOverTest(String name, String serverXml1, String serverXml2) {
+        super(serverXml1, serverXml2);
+    }
+
+    @Override
+    protected ServletContainer getServletContainer(int port, String sourceDir, String serverXml) throws Exception{
+        return new JettyServer(port,sourceDir,serverXml);
+    }
+}

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/TomcatClientFailOverTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/TomcatClientFailOverTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wm.test;
+
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(WebTestRunner.class)
+@DelegatedRunWith(Parameterized.class)
+@Category(SlowTest.class)
+public class TomcatClientFailOverTest extends WebFilterClientFailOverTests {
+
+    public TomcatClientFailOverTest(String name, String serverXml1, String serverXml2) {
+        super(serverXml1,serverXml2);
+    }
+
+    @Override
+    protected ServletContainer getServletContainer(int port, String sourceDir, String serverXml) throws Exception {
+        return new TomcatServer(port,sourceDir,serverXml);
+    }
+}

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/WebFilterClientFailOverTests.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/WebFilterClientFailOverTests.java
@@ -1,0 +1,128 @@
+package com.hazelcast.wm.test;
+
+import com.hazelcast.config.FileSystemXmlConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.IMap;
+import org.apache.http.client.CookieStore;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class WebFilterClientFailOverTests extends AbstractWebFilterTest {
+
+
+    @Parameterized.Parameters(name = "Executing: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(
+                new Object[]{"client - not deferred", "node1-client.xml", "node2-client.xml"}, //
+                new Object[]{"client - deferred", "node1-client-deferred.xml", "node2-client-deferred.xml"} //
+        );
+    }
+
+    private String testName;
+
+    protected WebFilterClientFailOverTests(String serverXml1) {
+        super(serverXml1);
+    }
+
+    protected WebFilterClientFailOverTests(String serverXml1, String serverXml2) {
+        super(serverXml1, serverXml2);
+        testName = serverXml1;
+    }
+
+    @After
+    public void destroy() {
+        hz.shutdown();
+    }
+
+    @Test
+    public void whenClusterIsDown_enabledDeferredWrite() throws Exception {
+        CookieStore cookieStore = new BasicCookieStore();
+        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+        hz.shutdown();
+
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+        assertEquals("true", executeRequest("remove", serverPort1, cookieStore));
+        assertEquals("null", executeRequest("read", serverPort1, cookieStore));
+
+        hz = Hazelcast.newHazelcastInstance(
+                new FileSystemXmlConfig(new File(sourceDir + "/WEB-INF/", "hazelcast.xml")));
+        assertClusterSizeEventually(1, hz);
+
+        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+    }
+
+    @Test
+    public void whenClusterIsDownAtBeginning_enabledDeferredWrite() throws Exception {
+        hz.shutdown();
+
+        CookieStore cookieStore = new BasicCookieStore();
+        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+        assertEquals("true", executeRequest("remove", serverPort1, cookieStore));
+        assertEquals("null", executeRequest("read", serverPort1, cookieStore));
+
+        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+
+        hz = Hazelcast.newHazelcastInstance(
+                new FileSystemXmlConfig(new File(sourceDir + "/WEB-INF/", "hazelcast.xml")));
+        assertClusterSizeEventually(1, hz);
+
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+        assertEquals("true", executeRequest("remove", serverPort1, cookieStore));
+        assertEquals("null", executeRequest("read", serverPort1, cookieStore));
+
+    }
+
+    @Test
+    public void testWhenClusterIsDownAtBeginningInNonDeferredMode() throws Exception {
+        if (!testName.equals("client - not deferred")) {
+            return;
+        }
+
+        hz.shutdown();
+        CookieStore cookieStore = new BasicCookieStore();
+        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+
+        hz = Hazelcast.newHazelcastInstance(
+                new FileSystemXmlConfig(new File(sourceDir + "/WEB-INF/", "hazelcast.xml")));
+        assertClusterSizeEventually(1, hz);
+
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+        IMap<String, Object> map = hz.getMap(DEFAULT_MAP_NAME);
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testWhenClusterIsDownAtBeginningInDeferedMode() throws Exception {
+        if (!testName.equals("client - not deferred")) {
+            return;
+        }
+
+        hz.shutdown();
+        CookieStore cookieStore = new BasicCookieStore();
+        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+
+        hz = Hazelcast.newHazelcastInstance(
+                new FileSystemXmlConfig(new File(sourceDir + "/WEB-INF/", "hazelcast.xml")));
+        assertClusterSizeEventually(1, hz);
+        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
+
+        IMap<String, Object> map = hz.getMap(DEFAULT_MAP_NAME);
+        assertEquals(0, map.size());
+    }
+}

--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/WebFilterSlowTests.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/WebFilterSlowTests.java
@@ -1,7 +1,5 @@
 package com.hazelcast.wm.test;
 
-import com.hazelcast.config.FileSystemXmlConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.web.SessionState;
@@ -9,9 +7,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.CookieStore;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.junit.Test;
-import org.junit.Ignore;
-
-import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -125,65 +120,6 @@ public abstract class WebFilterSlowTests extends AbstractWebFilterTest {
         assertEquals("value-updated", executeRequest("read", serverPort1, cookieStore));
     }
 
-    @Test
-    public void whenClusterIsDown_enabledDeferredWrite() throws Exception {
-        if (!testName.contains("deferred")) return;
-        if (!testName.contains("client")) return;
-        CookieStore cookieStore = new BasicCookieStore();
-        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
-        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
-        hz.shutdown();
-        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
-        assertEquals("true", executeRequest("remove", serverPort1, cookieStore));
-        assertEquals("null", executeRequest("read", serverPort1, cookieStore));
-        hz = Hazelcast.newHazelcastInstance(
-                new FileSystemXmlConfig(new File(sourceDir + "/WEB-INF/", "hazelcast.xml")));
-        Thread.sleep(8000);
-        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
-        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
-    }
-
-    @Test
-    public void whenClusterIsDownAtBeginning_enabledDeferredWrite() throws Exception {
-        if (!testName.contains("deferred")) return;
-        if (!testName.contains("client")) return;
-        hz.shutdown();
-        CookieStore cookieStore = new BasicCookieStore();
-        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
-        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
-
-        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
-        assertEquals("true", executeRequest("remove", serverPort1, cookieStore));
-        assertEquals("null", executeRequest("read", serverPort1, cookieStore));
-
-        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
-        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
-        hz = Hazelcast.newHazelcastInstance(
-                new FileSystemXmlConfig(new File(sourceDir + "/WEB-INF/", "hazelcast.xml")));
-        Thread.sleep(8000);
-        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
-        assertEquals("true", executeRequest("remove", serverPort1, cookieStore));
-        assertEquals("null", executeRequest("read", serverPort1, cookieStore));
-    }
-
-    @Test
-    @Ignore
-    public void whenClusterIsDownAtBeginning_MapSizeAfterClusterIsUp() throws Exception {
-        if (!testName.contains("deferred")) return;
-        if (!testName.contains("client")) return;
-        Hazelcast.shutdownAll();
-        CookieStore cookieStore = new BasicCookieStore();
-        assertEquals("true", executeRequest("write", serverPort1, cookieStore));
-        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
-
-        hz = Hazelcast.newHazelcastInstance(
-                new FileSystemXmlConfig(new File(sourceDir + "/WEB-INF/", "hazelcast.xml")));
-        Thread.sleep(8000);
-        assertEquals("value", executeRequest("read", serverPort1, cookieStore));
-        IMap<String, Object> map = hz.getMap(DEFAULT_MAP_NAME);
-        assertEquals(1, map.size());
-    }
-
     @Test(timeout = 60000)
     public void testAttributeInvalidate() throws Exception {
         IMap<String, Object> map = hz.getMap(DEFAULT_MAP_NAME);
@@ -239,6 +175,4 @@ public abstract class WebFilterSlowTests extends AbstractWebFilterTest {
         assertEquals("false", executeRequest("isNew", serverPort1, cookieStore));
         assertEquals("false", executeRequest("isNew", serverPort2, cookieStore));
     }
-
-
 }


### PR DESCRIPTION
We have two new test classes `JettyClientFailOverTest` and `TomcatClientFailOverTest`.
Fixes #7180