### PR TITLE
Client Partition Service Update Problem

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -193,4 +193,8 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
             LOGGER.warning(name + " executor await termination is interrupted", e);
         }
     }
+
+    public ExecutorService getInternalExecutor() {
+        return internalExecutor;
+    }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -194,4 +194,8 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
             LOGGER.warning(name + " executor await termination is interrupted", e);
         }
     }
+
+    public ExecutorService getInternalExecutor() {
+        return internalExecutor;
+    }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -20,11 +20,9 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientGetPartitionsCodec;
 import com.hazelcast.client.spi.ClientClusterService;
-import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.logging.ILogger;
@@ -39,6 +37,7 @@ import com.hazelcast.util.HashUtil;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -69,21 +68,19 @@ public final class ClientPartitionServiceImpl
     }
 
     public void start() {
-        ClientExecutionService clientExecutionService = client.getClientExecutionService();
-        clientExecutionService.scheduleWithFixedDelay(new RefreshTask(), INITIAL_DELAY, PERIOD, TimeUnit.SECONDS);
+        ClientExecutionServiceImpl clientExecutionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
+        // Use internal execution service for all partition refresh process (Do not use the user executor thread)
+        ExecutorService internalExecutor = clientExecutionService.getInternalExecutor();
+        clientExecutionService.scheduleWithFixedDelay(new RefreshTask(internalExecutor), INITIAL_DELAY, PERIOD, TimeUnit.SECONDS);
     }
 
     public void refreshPartitions() {
-        if (!updating.compareAndSet(false, true)) {
-            return;
-        }
-        ClientExecutionService executionService = client.getClientExecutionService();
+        ClientExecutionServiceImpl executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
         try {
-            ICompletableFuture future = executionService.submit(new RefreshTask());
-            future.andThen(refreshTaskCallback);
-
+            // Use internal execution service for all partition refresh process (Do not use the user executor thread)
+            ExecutorService internalExecutor = executionService.getInternalExecutor();
+            executionService.submitInternal(new RefreshTask(internalExecutor));
         } catch (RejectedExecutionException ignored) {
-            updating.set(false);
             EmptyStatement.ignore(ignored);
         }
     }
@@ -148,6 +145,7 @@ public final class ClientPartitionServiceImpl
     }
 
     private boolean processPartitionResponse(ClientGetPartitionsCodec.ResponseParameters response) {
+        LOGGER.finest("Processing partition response.");
         Map<Address, List<Integer>> partitionResponse = response.partitions;
         for (Map.Entry<Address, List<Integer>> entry : partitionResponse.entrySet()) {
             Address address = entry.getKey();
@@ -229,6 +227,11 @@ public final class ClientPartitionServiceImpl
     }
 
     private class RefreshTask implements Runnable {
+        private ExecutorService executionService;
+
+        public RefreshTask(ExecutorService service) {
+            this.executionService = service;
+        }
 
         @Override
         public void run() {
@@ -241,16 +244,21 @@ public final class ClientPartitionServiceImpl
                 updating.set(false);
                 return;
             }
-            ClientInvocationFuture clientInvocationFuture = getPartitionsFrom(connection);
-            clientInvocationFuture.andThen(refreshTaskCallback);
 
+            try {
+                ClientInvocationFuture clientInvocationFuture = getPartitionsFrom(connection);
+                clientInvocationFuture.andThen(refreshTaskCallback, executionService);
+            } catch (Exception e) {
+                if (client.getLifecycleService().isRunning()) {
+                    LOGGER.warning("Error while fetching cluster partition table!", e);
+                }
+            } finally {
+                updating.set(false);
+            }
         }
     }
-
     private class RefreshTaskCallback
             implements ExecutionCallback<ClientMessage> {
-
-
         @Override
         public void onResponse(ClientMessage responseMessage) {
             try {
@@ -259,7 +267,6 @@ public final class ClientPartitionServiceImpl
                 }
                 ClientGetPartitionsCodec.ResponseParameters response = ClientGetPartitionsCodec.decodeResponse(responseMessage);
                 processPartitionResponse(response);
-
             } finally {
                 updating.set(false);
             }


### PR DESCRIPTION
No need to submit the partition refresh response processing for the client into a separate thread using the executor. If it is offloaded to such an executor then ClientRegressionWithMockNetworkTest.testDeadlock_WhenDoingOperationFromLifecycleListener test fails.