### PR TITLE
Extract migration queue from InternalPartitionServiceImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/MigrationQueue.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.partition.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Manages migration tasks and migration status flag for {@link InternalPartitionServiceImpl} safely. Once a migration task
+ * is added to the queue, queue has to be notified via {@link MigrationQueue#afterTaskCompletion(Runnable)} after its execution.
+ */
+class MigrationQueue {
+
+    private final AtomicInteger migrateTaskCount = new AtomicInteger();
+
+    private final BlockingQueue<Runnable> queue = new LinkedBlockingQueue<Runnable>();
+
+    public void add(Runnable task) {
+        if (task instanceof InternalPartitionServiceImpl.MigrateTask) {
+            migrateTaskCount.incrementAndGet();
+        }
+
+        queue.offer(task);
+    }
+
+    public Runnable poll(int timeout, TimeUnit unit)
+            throws InterruptedException {
+        return queue.poll(timeout, unit);
+    }
+
+    public void clear() {
+        List<Runnable> sink = new ArrayList<Runnable>();
+        queue.drainTo(sink);
+
+        for (Runnable task : sink) {
+            afterTaskCompletion(task);
+        }
+    }
+
+    public void afterTaskCompletion(Runnable task) {
+        if (task instanceof InternalPartitionServiceImpl.MigrateTask) {
+            if (migrateTaskCount.decrementAndGet() < 0) {
+                throw new IllegalStateException();
+            }
+        }
+    }
+
+    public boolean hasMigrationTasks() {
+        return migrateTaskCount.get() > 0;
+    }
+
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+    public boolean isNonEmpty() {
+        return !queue.isEmpty();
+    }
+
+    public int size() {
+        return queue.size();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/partition/impl/MigrationQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/impl/MigrationQueueTest.java
@@ -1,0 +1,77 @@
+package com.hazelcast.partition.impl;
+
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@Category(QuickTest.class)
+public class MigrationQueueTest {
+
+    private final MigrationQueue migrationQueue = new MigrationQueue();
+
+    @Test
+    public void test_migrationTaskCount_incremented_onMigrateTask() {
+        migrationQueue.add(mock(InternalPartitionServiceImpl.MigrateTask.class));
+
+        assertTrue(migrationQueue.hasMigrationTasks());
+        assertEquals(1, migrationQueue.size());
+    }
+
+    @Test
+    public void test_migrationTaskCount_notIncremented_onNonMigrateTask() {
+        migrationQueue.add(mock(Runnable.class));
+
+        assertFalse(migrationQueue.hasMigrationTasks());
+        assertEquals(1, migrationQueue.size());
+    }
+
+    @Test
+    public void test_migrationTaskCount_notDecremented_afterMigrateTaskPolled()
+            throws InterruptedException {
+        migrationQueue.add(mock(InternalPartitionServiceImpl.MigrateTask.class));
+        migrationQueue.poll(1, TimeUnit.SECONDS);
+
+        assertTrue(migrationQueue.hasMigrationTasks());
+    }
+
+    @Test
+    public void test_migrateTaskCount_decremented_afterMigrateTaskCompleted()
+            throws InterruptedException {
+        final InternalPartitionServiceImpl.MigrateTask migrateTask = mock(InternalPartitionServiceImpl.MigrateTask.class);
+
+        migrationQueue.add(migrateTask);
+        migrationQueue.afterTaskCompletion(migrateTask);
+
+        assertFalse(migrationQueue.hasMigrationTasks());
+    }
+
+    @Test
+    public void test_migrateTaskCount_notDecremented_afterNonMigrateTaskCompleted()
+            throws InterruptedException {
+        migrationQueue.add(mock(InternalPartitionServiceImpl.MigrateTask.class));
+        migrationQueue.afterTaskCompletion(mock(Runnable.class));
+
+        assertTrue(migrationQueue.hasMigrationTasks());
+    }
+
+    @Test
+    public void test_migrateTaskCount_decremented_onClear() {
+        migrationQueue.add(mock(InternalPartitionServiceImpl.MigrateTask.class));
+        migrationQueue.clear();
+
+        assertFalse(migrationQueue.hasMigrationTasks());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void test_migrateTaskCount_notDecremented_belowZero() {
+        migrationQueue.afterTaskCompletion(mock(InternalPartitionServiceImpl.MigrateTask.class));
+    }
+
+}


### PR DESCRIPTION
Extract management of migrations tasks into a separate class. It makes it easier to manage migration state of the partition service. It also solves the race problem occurs during starting a migration task polled from the migration queue. 

Fixes #7191 