### PR TITLE
[Backport] Fixes repeatedly checks made from InvocationMonitor for timeout

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -462,13 +462,14 @@ abstract class Invocation implements ResponseHandler, Runnable {
         long maxCallTimeout = invocationFuture.getMaxCallTimeout();
         long expirationTime = op.getInvocationTime() + maxCallTimeout;
 
+        boolean done = invocationFuture.isDone();
         boolean hasResponse = pendingResponse != null;
         boolean hasWaitingThreads = invocationFuture.getWaitingThreadsCount() > 0;
         boolean notExpired = maxCallTimeout == Long.MAX_VALUE
                 || expirationTime < 0
                 || expirationTime >= Clock.currentTimeMillis();
 
-        if (hasResponse || hasWaitingThreads || notExpired) {
+        if (hasResponse || hasWaitingThreads || notExpired || done) {
             return false;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRetryTest.java
@@ -1,23 +1,29 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.instance.Node;
+import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.concurrent.Future;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.Future;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -67,6 +73,56 @@ public class InvocationRetryTest extends HazelcastTestSupport {
 
         }
     }
+
+
+    @Test
+    public void testNoStuckInvocationsWhenRetriedMultipleTimes() throws Exception {
+        Config config = new Config();
+        config.setProperty(GroupProperties.PROP_OPERATION_CALL_TIMEOUT_MILLIS, "3000");
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance local = factory.newHazelcastInstance(config);
+        HazelcastInstance remote = factory.newHazelcastInstance(config);
+        warmUpPartitions(local, remote);
+        NodeEngineImpl localNodeEngine = getNodeEngineImpl(local);
+        NodeEngineImpl remoteNodeEngine = getNodeEngineImpl(remote);
+        final OperationServiceImpl operationService = (OperationServiceImpl) localNodeEngine.getOperationService();
+        NonResponsiveOperation op = new NonResponsiveOperation();
+        op.setValidateTarget(false);
+        op.setPartitionId(1);
+        InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null
+                , op, remoteNodeEngine.getThisAddress());
+        Field invocationField = InvocationFuture.class.getDeclaredField("invocation");
+        invocationField.setAccessible(true);
+        Invocation invocation = (Invocation) invocationField.get(future);
+
+        invocation.notifyError(new RetryableHazelcastException());
+        invocation.notifyError(new RetryableHazelcastException());
+
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Collection<Invocation> invocations = operationService.invocationsRegistry.invocations();
+                assertEquals(0, invocations.size());
+            }
+        });
+    }
+
+    /**
+     * Non-responsive operation.
+     */
+    public static class NonResponsiveOperation extends AbstractOperation {
+
+        @Override
+        public void run() throws InterruptedException {
+        }
+
+        @Override
+        public boolean returnsResponse() {
+            return false;
+        }
+    }
+
 
     /**
      * Operation send to a specific member.


### PR DESCRIPTION
Invocations that has been done are not scheduled to check if they are timeout and removed from the invocation registry. Fixes #7170