### PR TITLE
LockStoreImpl has to serialize its partitionId during serialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -311,6 +311,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(partitionId);
         out.writeObject(namespace);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
@@ -325,6 +326,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
+        partitionId = in.readInt();
         namespace = in.readObject();
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.concurrent.lock;
 
+import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.spi.DefaultObjectNamespace;
@@ -57,6 +59,18 @@ public class LockStoreImplTest extends HazelcastTestSupport {
         mockLockServiceImpl = mock(InternalLockService.class);
         when(mockLockServiceImpl.getMaxLeaseTimeInMillis()).thenReturn(Long.MAX_VALUE);
         lockStore = new LockStoreImpl(mockLockServiceImpl, OBJECT_NAME_SPACE, BACKUP_COUNT, ASYNC_BACKUP_COUNT, -1);
+    }
+
+    @Test
+    public void givenPartitionIsSetToX_whenSerializedAndDeserilized_thenPartitionIsStillX() throws NoSuchFieldException, IllegalAccessException {
+        int partitionId = Integer.MAX_VALUE;
+        LockStoreImpl original = new LockStoreImpl(mockLockServiceImpl, OBJECT_NAME_SPACE, BACKUP_COUNT, ASYNC_BACKUP_COUNT, partitionId);
+
+        SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+        Data serialized = serializationService.toData(original);
+        LockStoreImpl deserialized = serializationService.toObject(serialized);
+
+        assertFieldEqualsTo(deserialized, "partitionId", partitionId);
     }
 
     @Test
@@ -452,4 +466,5 @@ public class LockStoreImplTest extends HazelcastTestSupport {
         referenceId++;
         return isUnlocked;
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -43,6 +43,7 @@ import org.junit.Assert;
 import org.junit.ComparisonFailure;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -807,6 +808,20 @@ public abstract class HazelcastTestSupport {
                 }
             }
         }, timeoutInSeconds);
+    }
+
+    public static void assertFieldEqualsTo(Object object, String fieldName, Object expectedValue) {
+        Class<?> clazz = object.getClass();
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Object actualValue = field.get(object);
+            assertEquals(expectedValue, actualValue);
+        } catch (NoSuchFieldException e) {
+            fail("Class " + clazz + " does not have field named " + fieldName + " declared");
+        } catch (IllegalAccessException e) {
+            fail("Cannot access field " + fieldName + " on class " + clazz);
+        }
     }
 
     public static void assertTrueFiveSeconds(AssertTask task) {


### PR DESCRIPTION
#7156 introduced per-partition locks, but it was missing partitionId field in serialization methods
as a result the partition was set to 0 on during migration and this result in contention issues.