### PR TITLE
Make PerformanceMonitor output easier to read

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/renderers/HumanFriendlyProbeRenderer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/renderers/HumanFriendlyProbeRenderer.java
@@ -21,8 +21,8 @@ package com.hazelcast.internal.metrics.renderers;
  *
  * The output will be something like:
  * <code>
- *     a=1
- *     b=2
+ *     longVal = 9,980,213
+ *     doubleVal = 9.9802e+06
  * </code>
  */
 public class HumanFriendlyProbeRenderer implements ProbeRenderer {
@@ -36,22 +36,22 @@ public class HumanFriendlyProbeRenderer implements ProbeRenderer {
 
     @Override
     public void renderLong(String name, long value) {
-        sb.append(name).append('=').append(value).append('\n');
+        sb.append(String.format("%s = %,d%n", name, value));
     }
 
     @Override
     public void renderDouble(String name, double value) {
-        sb.append(name).append('=').append(value).append('\n');
+        sb.append(String.format("%s = %.4e%n", name, value));
     }
 
     @Override
     public void renderException(String name, Exception e) {
-        sb.append(name).append('=').append(e.getMessage()).append('\n');
+        sb.append(name).append(" = ").append(e.getMessage()).append('\n');
     }
 
     @Override
     public void renderNoValue(String name) {
-        sb.append(name).append('=').append("NA").append('\n');
+        sb.append(name).append(" = NA\n");
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/renderers/HumanFriendlyProbeRendererTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/renderers/HumanFriendlyProbeRendererTest.java
@@ -32,10 +32,10 @@ public class HumanFriendlyProbeRendererTest extends HazelcastTestSupport {
 
         String s = renderer.getResult();
 
-        assertEquals("long=1\n" +
-                "double=2.0\n" +
-                "exception=somemessage\n" +
-                "novalue=NA\n", s);
+        assertEquals("long = 1\n" +
+                "double = 2.0000e+00\n" +
+                "exception = somemessage\n" +
+                "novalue = NA\n", s);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
@@ -14,7 +14,6 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,11 +42,9 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class PerformanceMonitorTest extends HazelcastTestSupport {
 
-    private PerformanceMonitor performanceMonitor;
     private PerformanceLogFile performanceLogFile;
     private InternalOperationService operationService;
     private MetricsRegistry metricsRegistry;
-    private HazelcastInstance hz;
 
     @Before
     public void setup() {
@@ -60,9 +57,9 @@ public class PerformanceMonitorTest extends HazelcastTestSupport {
         config.setProperty(SLOW_OPERATION_DETECTOR_ENABLED, "true");
         config.setProperty(SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "2000");
 
-        hz = createHazelcastInstance(config);
+        HazelcastInstance hz = createHazelcastInstance(config);
 
-        performanceMonitor = getPerformanceMonitor(hz);
+        PerformanceMonitor performanceMonitor = getPerformanceMonitor(hz);
         performanceLogFile = performanceMonitor.performanceLogFile;
         operationService = getOperationService(hz);
         metricsRegistry = getMetricsRegistry(hz);
@@ -190,11 +187,11 @@ public class PerformanceMonitorTest extends HazelcastTestSupport {
         });
     }
 
-    private void assertNotExist(File file) {
+    private static void assertNotExist(File file) {
         assertFalse("file:" + file + " should not exist", file.exists());
     }
 
-    private void assertExist(File file) {
+    private static void assertExist(File file) {
         assertTrue("file:" + file + " should exist", file.exists());
     }
 
@@ -228,7 +225,7 @@ public class PerformanceMonitorTest extends HazelcastTestSupport {
 
                 while (line != null) {
                     sb.append(line);
-                    sb.append("\n");
+                    sb.append('\n');
                     line = br.readLine();
                 }
                 return sb.toString();


### PR DESCRIPTION
Sample output after the change:
```
os.committedVirtualMemorySize = 5,195,792,384
os.freePhysicalMemorySize = 3,259,703,296
os.freeSwapSpaceSize = 1,556,348,928
os.maxFileDescriptorCount = 10,240
os.openFileDescriptorCount = 237
os.processCpuLoad = 6.3156e-01
os.processCpuTime = 2,811,414,000
os.systemCpuLoad = 1.0000e+00
os.systemLoadAverage = 1.3064e+03
```