### PR TITLE
Fix Long2LongHashMap iteration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/renderers/HumanFriendlyProbeRenderer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/renderers/HumanFriendlyProbeRenderer.java
@@ -21,8 +21,8 @@ package com.hazelcast.internal.metrics.renderers;
  *
  * The output will be something like:
  * <code>
- *     a=1
- *     b=2
+ *     longVal = 9,980,213
+ *     doubleVal = 9.9802e+06
  * </code>
  */
 public class HumanFriendlyProbeRenderer implements ProbeRenderer {
@@ -36,22 +36,22 @@ public class HumanFriendlyProbeRenderer implements ProbeRenderer {
 
     @Override
     public void renderLong(String name, long value) {
-        sb.append(name).append('=').append(value).append('\n');
+        sb.append(String.format("%s = %,d%n", name, value));
     }
 
     @Override
     public void renderDouble(String name, double value) {
-        sb.append(name).append('=').append(value).append('\n');
+        sb.append(String.format("%s = %.4e%n", name, value));
     }
 
     @Override
     public void renderException(String name, Exception e) {
-        sb.append(name).append('=').append(e.getMessage()).append('\n');
+        sb.append(name).append(" = ").append(e.getMessage()).append('\n');
     }
 
     @Override
     public void renderNoValue(String name) {
-        sb.append(name).append('=').append("NA").append('\n');
+        sb.append(name).append(" = NA\n");
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/renderers/HumanFriendlyProbeRendererTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/renderers/HumanFriendlyProbeRendererTest.java
@@ -32,10 +32,10 @@ public class HumanFriendlyProbeRendererTest extends HazelcastTestSupport {
 
         String s = renderer.getResult();
 
-        assertEquals("long=1\n" +
-                "double=2.0\n" +
-                "exception=somemessage\n" +
-                "novalue=NA\n", s);
+        assertEquals("long = 1\n" +
+                "double = 2.0000e+00\n" +
+                "exception = somemessage\n" +
+                "novalue = NA\n", s);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
@@ -14,7 +14,6 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,11 +42,9 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class PerformanceMonitorTest extends HazelcastTestSupport {
 
-    private PerformanceMonitor performanceMonitor;
     private PerformanceLogFile performanceLogFile;
     private InternalOperationService operationService;
     private MetricsRegistry metricsRegistry;
-    private HazelcastInstance hz;
 
     @Before
     public void setup() {
@@ -60,9 +57,9 @@ public class PerformanceMonitorTest extends HazelcastTestSupport {
         config.setProperty(SLOW_OPERATION_DETECTOR_ENABLED, "true");
         config.setProperty(SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS, "2000");
 
-        hz = createHazelcastInstance(config);
+        HazelcastInstance hz = createHazelcastInstance(config);
 
-        performanceMonitor = getPerformanceMonitor(hz);
+        PerformanceMonitor performanceMonitor = getPerformanceMonitor(hz);
         performanceLogFile = performanceMonitor.performanceLogFile;
         operationService = getOperationService(hz);
         metricsRegistry = getMetricsRegistry(hz);
@@ -190,11 +187,11 @@ public class PerformanceMonitorTest extends HazelcastTestSupport {
         });
     }
 
-    private void assertNotExist(File file) {
+    private static void assertNotExist(File file) {
         assertFalse("file:" + file + " should not exist", file.exists());
     }
 
-    private void assertExist(File file) {
+    private static void assertExist(File file) {
         assertTrue("file:" + file + " should exist", file.exists());
     }
 
@@ -228,7 +225,7 @@ public class PerformanceMonitorTest extends HazelcastTestSupport {
 
                 while (line != null) {
                     sb.append(line);
-                    sb.append("\n");
+                    sb.append('\n');
                     line = br.readLine();
                 }
                 return sb.toString();

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
@@ -18,7 +18,6 @@
 package com.hazelcast.util.collection;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.collection.Long2LongHashMap.LongLongCursor;
@@ -35,7 +34,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import static java.lang.Long.MAX_VALUE;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -184,9 +182,9 @@ public class Long2LongHashMapTest {
 
         final Iterator<Entry<Long, Long>> it = entrySet.iterator();
         assertTrue(it.hasNext());
-        assertEntryIs(it.next(), 2L, 3L);
-        assertTrue(it.hasNext());
         assertEntryIs(it.next(), 1L, 1L);
+        assertTrue(it.hasNext());
+        assertEntryIs(it.next(), 2L, 3L);
         assertFalse(it.hasNext());
     }
 

--- a/hazelcast/src/test/resources/log4j.properties
+++ b/hazelcast/src/test/resources/log4j.properties
@@ -21,6 +21,6 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n
 
 log4j.logger.com.hazelcast.cluster=trace
-log4j.logger.com.hazelcast.spi.hotrestart=debug
+log4j.logger.com.hazelcast.spi.hotrestart=info
 
 log4j.rootLogger=info, stdout


### PR DESCRIPTION
During Simulator tests a bug was discovered in `Long2LongHashMap`'s iteration logic. `entrySet().iterator()` would sometimes wrap over and iterate forever.

Bug was fixed by backporting new version of iteration code from Agrona.