### PR TITLE
Operation toString includes System.identityHash

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -577,7 +577,8 @@ public abstract class Operation implements DataSerializable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(getClass().getName()).append('{');
-        sb.append("serviceName='").append(getServiceName()).append('\'');
+        sb.append("identityHash='").append(System.identityHashCode(this));
+        sb.append(", serviceName='").append(getServiceName()).append('\'');
         sb.append(", partitionId=").append(partitionId);
         sb.append(", replicaIndex=").append(replicaIndex);
         sb.append(", callId=").append(callId);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -118,7 +118,7 @@ public class IsStillRunningService {
             nodeEngine.getExecutionService().execute(SYSTEM_EXECUTOR,
                     new InvokeIsStillRunningOperationRunnable(invocation, isStillExecuting, callback));
         } catch (Exception e) {
-            invocation.logger.warning("While asking 'is-executing': " + toString(), e);
+            invocation.logger.warning("While asking 'is-executing': " + invocation.toString(), e);
         }
     }
 


### PR DESCRIPTION
This PR contains 2 improvements:
* Included the System.identityHash in the Operation.toString. The consequence is when this toString is called, biased locking doesn't work anymore for the object. Which probably is fine. The reason for this is that we currently have no good way to identify an operation since callId can be updated on retry. This makes dealing with invocation issues a lot more problematic.
*  The IsStillRunnningService prints itself instead of the invocation it is dealing with. So this prevent doing proper analysis of what is happening. 