### PR TITLE
Operation.toString includes identity hash

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -488,7 +488,8 @@ public abstract class Operation implements DataSerializable {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder(getClass().getName()).append('{');
-        sb.append("serviceName='").append(serviceName).append('\'');
+        sb.append("identityHash=").append(System.identityHashCode(this));
+        sb.append(", serviceName='").append(serviceName).append('\'');
         sb.append(", partitionId=").append(partitionId);
         sb.append(", callId=").append(callId);
         sb.append(", invocationTime=").append(invocationTime);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -118,7 +118,7 @@ public class IsStillRunningService {
             nodeEngine.getExecutionService().execute(SYSTEM_EXECUTOR,
                     new InvokeIsStillRunningOperationRunnable(invocation, isStillExecuting, callback));
         } catch (Exception e) {
-            invocation.logger.warning("While asking 'is-executing': " + toString(), e);
+            invocation.logger.warning("While asking 'is-executing': " + invocation, e);
         }
     }
 


### PR DESCRIPTION
Operation.toString includes identityHash for improved log analysis.

Also fixed issue with toString in isstillrunningservice where the service.toString is called instead of the invocation.

Backport of #7247