### PR TITLE
[BACKPORT] Don't update expiry time on update if update duration of used expiry policy is not available

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -637,7 +637,9 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected boolean updateRecordWithExpiry(Data key, Object value, R record, long expiryTime, long now,
                                              boolean disableWriteThrough, int completionId, String source, String origin) {
-        record.setExpirationTime(expiryTime);
+        if (expiryTime != CacheRecord.EXPIRATION_TIME_NOT_AVAILABLE) {
+            record.setExpirationTime(expiryTime);
+        }
         if (!disableWriteThrough) {
             writeThroughCache(key, value);
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -18,6 +18,7 @@ import javax.cache.Cache;
 import javax.cache.configuration.FactoryBuilder;
 import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
 import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.CreatedExpiryPolicy;
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.expiry.ModifiedExpiryPolicy;
@@ -743,5 +744,23 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
             entry.setValue(result);
             return result;
         }
+    }
+
+    // https://github.com/hazelcast/hazelcast/issues/7236
+    @Test
+    public void expiryTimeShouldNotBeChangedOnUpdateWhenCreatedExpiryPolicyIsUsed() {
+        final int CRETAED_EXPIRY_TIME_IN_MSEC = 1000;
+
+        Duration duration = new Duration(TimeUnit.MILLISECONDS, CRETAED_EXPIRY_TIME_IN_MSEC);
+        CacheConfig<Integer, String> cacheConfig = new CacheConfig<Integer, String>();
+        cacheConfig.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(duration));
+
+        Cache<Integer, String> cache = createCache(cacheConfig);
+        cache.put(1, "value");
+        cache.put(1, "value");
+
+        sleepAtLeastMillis(CRETAED_EXPIRY_TIME_IN_MSEC + 1);
+
+        assertNull(cache.get(1));
     }
 }


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/7250