### PR TITLE
Include owner connection to heart beat check

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.impl;
 
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.ClientEngine;
+import com.hazelcast.core.ClientType;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -77,7 +78,7 @@ public class ClientHeartbeatMonitor implements Runnable {
     }
 
     private void monitor(String memberUuid, ClientEndpointImpl clientEndpoint) {
-        if (clientEndpoint.isFirstConnection()) {
+        if (clientEndpoint.isFirstConnection() && ClientType.CPP.equals(clientEndpoint.getClientType())) {
             return;
         }
 


### PR DESCRIPTION
When client is inactive, server needs to close the
connection so that resources(e.g locks) associated with that connection
can be released. When there are 2 connection from client to server,
we did not want to check owner connection since there were no
heartbeat send over it.
After removing separate owner connection from the system this check
caused a bug. With one connection to each node, all connections
needs to be checked and closed.

Leaving the check for C++ client until, it's architecture is updated
as other clients.

Backport of #7252
Fixes #5054
