### PR TITLE
[3.6-RC1] Return cache config as response even though found and created cache config could not put into cache configs inside cache service 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
@@ -50,17 +50,17 @@ public class CacheGetConfigOperation
     public void run()
             throws Exception {
         final ICacheService service = getService();
-        final CacheConfig cacheConfig = service.getCacheConfig(name);
+        CacheConfig cacheConfig = service.getCacheConfig(name);
         if (cacheConfig == null) {
             CacheSimpleConfig simpleConfig = service.findCacheConfig(simpleName);
             if (simpleConfig != null) {
                 try {
-                    CacheConfig cacheConfigFromSimpleConfig = new CacheConfig(simpleConfig);
-                    cacheConfigFromSimpleConfig.setName(simpleName);
-                    cacheConfigFromSimpleConfig.setManagerPrefix(name.substring(0, name.lastIndexOf(simpleName)));
-                    if (service.putCacheConfigIfAbsent(cacheConfigFromSimpleConfig) == null) {
-                        response = cacheConfigFromSimpleConfig;
-                        return;
+                    cacheConfig = new CacheConfig(simpleConfig);
+                    cacheConfig.setName(simpleName);
+                    cacheConfig.setManagerPrefix(name.substring(0, name.lastIndexOf(simpleName)));
+                    CacheConfig existingCacheConfig = service.putCacheConfigIfAbsent(cacheConfig);
+                    if (existingCacheConfig != null) {
+                        cacheConfig = existingCacheConfig;
                     }
                 } catch (Exception e) {
                     //Cannot create the actual config from the declarative one


### PR DESCRIPTION
… in case of parallel access

Backport of https://github.com/hazelcast/hazelcast/pull/7274 for 3.6-RC1 branch