### PR TITLE
PartitionIteratingOperation.toString include factory name

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -110,6 +110,13 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
         return new PartitionResponse(results);
     }
 
+    @Override
+    protected void toString(StringBuilder sb) {
+        super.toString(sb);
+
+        sb.append(", operationFactory=").append(operationFactory);
+    }
+
     private static class ResponseQueue implements OperationResponseHandler {
         final BlockingQueue b = ResponseQueueFactory.newResponseQueue();
 


### PR DESCRIPTION
The operationFactory is included in the toString output so we can at least see, if a bug reports come in that involves a PartitionIteratingOperation, what kind of operation this PartitionIteratingOperation actually is executing. 

For more information see the log message from the following github ticket:
https://github.com/hazelcast/hazelcast/issues/7280