### PR TITLE
Enforces only one SENDER_BACKUP loader

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapKeyLoaderUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapKeyLoaderUtilTest.java
@@ -1,0 +1,102 @@
+package com.hazelcast.map.impl;
+
+import org.junit.Test;
+
+import static com.hazelcast.map.impl.MapKeyLoader.Role;
+import static com.hazelcast.map.impl.MapKeyLoader.Role.NONE;
+import static com.hazelcast.map.impl.MapKeyLoader.Role.RECEIVER;
+import static com.hazelcast.map.impl.MapKeyLoader.Role.SENDER;
+import static com.hazelcast.map.impl.MapKeyLoader.Role.SENDER_BACKUP;
+import static org.junit.Assert.assertEquals;
+
+public class MapKeyLoaderUtilTest {
+
+    @Test
+    public void assingRole_SENDER() {
+        boolean isPartitionOwner = true;
+        boolean isMapNamePartition = true;
+        boolean isMapNamePartitionFirstReplica = false;
+
+        Role role = MapKeyLoaderUtil.assignRole(isPartitionOwner, isMapNamePartition, isMapNamePartitionFirstReplica);
+
+        assertEquals(SENDER, role);
+    }
+
+    @Test
+    public void assingRole_SENDER_BACKUP() {
+        boolean isPartitionOwner = false;
+        boolean isMapNamePartition = true;
+        boolean isMapNamePartitionFirstReplica = true;
+
+        Role role = MapKeyLoaderUtil.assignRole(isPartitionOwner, isMapNamePartition, isMapNamePartitionFirstReplica);
+
+        assertEquals(SENDER_BACKUP, role);
+    }
+
+    @Test
+    public void assingRole_NOT_SENDER_BACKUP() {
+        boolean isPartitionOwner = false;
+        boolean isMapNamePartition = true;
+        boolean isMapNamePartitionFirstReplica = false;
+
+        Role role = MapKeyLoaderUtil.assignRole(isPartitionOwner, isMapNamePartition, isMapNamePartitionFirstReplica);
+
+        assertEquals(NONE, role);
+    }
+
+    @Test
+    public void assingRole_RECEIVER_insignificantFlagFalse() {
+        boolean isPartitionOwner = true;
+        boolean isMapNamePartition = false;
+        boolean insignificant = false;
+
+        Role role = MapKeyLoaderUtil.assignRole(isPartitionOwner, isMapNamePartition, insignificant);
+
+        assertEquals(RECEIVER, role);
+    }
+
+    @Test
+    public void assingRole_RECEIVER_insignificantFlagTrue() {
+        boolean isPartitionOwner = true;
+        boolean isMapNamePartition = false;
+        boolean insignificant = true;
+
+        Role role = MapKeyLoaderUtil.assignRole(isPartitionOwner, isMapNamePartition, insignificant);
+
+        assertEquals(RECEIVER, role);
+    }
+
+    @Test
+    public void assingRole_NONE_insignificantFlagFalse() {
+        boolean isPartitionOwner = false;
+        boolean isMapNamePartition = false;
+        boolean insignificant = false;
+
+        Role role = MapKeyLoaderUtil.assignRole(isPartitionOwner, isMapNamePartition, insignificant);
+
+        assertEquals(NONE, role);
+    }
+
+    @Test
+    public void assingRole_NONE_insignificantFlagTrue() {
+        boolean isPartitionOwner = false;
+        boolean isMapNamePartition = false;
+        boolean insignificant = true;
+
+        Role role = MapKeyLoaderUtil.assignRole(isPartitionOwner, isMapNamePartition, insignificant);
+
+        assertEquals(NONE, role);
+    }
+
+    @Test
+    public void assingRole_NONE_impossibleCombination() {
+        boolean isPartitionOwner = false;
+        boolean isMapNamePartition = false;
+        boolean insignificant = true;
+
+        Role role = MapKeyLoaderUtil.assignRole(isPartitionOwner, isMapNamePartition, insignificant);
+
+        assertEquals(NONE, role);
+    }
+
+}


### PR DESCRIPTION
**WAS:**
With a couple of nodes and couple of backups configured for a map hazelcast would create more than one `SENDER_BACKUP` loader. Given that the `SENDER_BACKUP` nodes are notified by a call with `setReplicaIndex(1)` only one `SENDER_BACKUP`` is notified about the load statu, and the other ones are just stuck with the loading status.

**IS:**
There will be just one SENDER_BACKUP - the one with the `replicaIndex == 1`