### PR TITLE
Fix cache record creation with expiry time

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -497,7 +497,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected R createRecord(Data key, Object value, long expiryTime,
                              long now, boolean disableWriteThrough, int completionId, String origin) {
-        R record = createRecord(value, expiryTime);
+        R record = createRecord(value, now, expiryTime);
         try {
             doPutRecord(key, record);
         } catch (Throwable error) {


### PR DESCRIPTION
Cache record should be created using already available `now` time,
instead of `System.currentMillis()`. Because expiry time is calculated
and relative to `now`.
Otherwise, when System.currentMillis() is used and TTL is very small,
difference between  expiry time and creation time can be less than 0,
which leads to no expiry at all.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/679