### PR TITLE
[BACKPORT] Trigger quorum listener when memberlist changes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/QuorumImpl.java
@@ -60,7 +60,9 @@ public class QuorumImpl implements Quorum {
     }
 
     public void update(Collection<Member> members) {
-        setLocalResult(quorumFunction.apply(members));
+        boolean presence = quorumFunction.apply(members);
+        setLocalResult(presence);
+        updateLastResultAndFireEvent(members, presence);
     }
 
     public String getName() {


### PR DESCRIPTION
when a change happens in the member list, it is also reflected to quorum listeners besides quorum state. Fixes #7300