### PR TITLE
[DONT MERGE] IO thread starvation problem

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
@@ -40,6 +40,8 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
     private static final int SELECT_WAIT_TIME_MILLIS = 5000;
     private static final int SELECT_FAILURE_PAUSE_MILLIS = 1000;
 
+    public static final int MAXIMUM_ITEMS_TAKEN_FROM_TASK_QUEUE_RENAME_ME_I_AM_SILLY = Integer.getInteger("ioselector.batchsize", 10);
+
     @Probe(name = "taskQueueSize")
     private final Queue<Runnable> taskQueue = new ConcurrentLinkedQueue<Runnable>();
     @Probe
@@ -198,9 +200,9 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
 
     private void runSelectLoop() throws IOException {
         while (!isInterrupted()) {
-            processTaskQueue();
+            boolean queueFullyProcessed = processTaskQueue();
 
-            int selectedKeys = selector.select(SELECT_WAIT_TIME_MILLIS);
+            int selectedKeys = queueFullyProcessed ? selector.select(SELECT_WAIT_TIME_MILLIS) : selector.selectNow();
             if (selectedKeys > 0) {
                 lastSelectTimeMs = currentTimeMillis();
                 handleSelectionKeys();
@@ -220,14 +222,18 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
         }
     }
 
-    private void processTaskQueue() {
-        while (!isInterrupted()) {
+    /**
+     * @return true is all tasks have been processed
+     */
+    private boolean processTaskQueue() {
+        for (int i = 0; i < MAXIMUM_ITEMS_TAKEN_FROM_TASK_QUEUE_RENAME_ME_I_AM_SILLY && !isInterrupted(); i++) {
             Runnable task = taskQueue.poll();
             if (task == null) {
-                return;
+                return true;
             }
             executeTask(task);
         }
+        return false;
     }
 
     private void executeTask(Runnable task) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
@@ -222,15 +222,30 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
         }
     }
 
+    private Runnable pending;
+
     /**
      * @return true is all tasks have been processed
      */
     private boolean processTaskQueue() {
+        Runnable first = pending;
+
+        if (first != null) {
+            executeTask(first);
+            pending = null;
+        }
+
         for (int i = 0; i < MAXIMUM_ITEMS_TAKEN_FROM_TASK_QUEUE_RENAME_ME_I_AM_SILLY && !isInterrupted(); i++) {
             Runnable task = taskQueue.poll();
             if (task == null) {
                 return true;
+            } else if (first == null) {
+                first = task;
+            } else if (first == task) {
+                pending = first;
+                return false;
             }
+
             executeTask(task);
         }
         return false;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -57,12 +57,12 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
 
     private static final long TIMEOUT = 3;
 
+    @Probe(name = "out.writeQueueSize")
+    final Queue<OutboundFrame> writeQueue = new ConcurrentLinkedQueue<OutboundFrame>();
+    @Probe(name = "out.priorityWriteQueueSize")
+    final Queue<OutboundFrame> urgentWriteQueue = new ConcurrentLinkedQueue<OutboundFrame>();
     @Probe(name = "out.eventCount")
     private final SwCounter eventCount = newSwCounter();
-    @Probe(name = "out.writeQueueSize")
-    private final Queue<OutboundFrame> writeQueue = new ConcurrentLinkedQueue<OutboundFrame>();
-    @Probe(name = "out.priorityWriteQueueSize")
-    private final Queue<OutboundFrame> urgentWriteQueue = new ConcurrentLinkedQueue<OutboundFrame>();
     private final AtomicBoolean scheduled = new AtomicBoolean(false);
     private ByteBuffer outputBuffer;
     @Probe(name = "out.bytesWritten")

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/PacketSampler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/PacketSampler.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.IOService;
+import com.hazelcast.nio.OutboundFrame;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Random;
+import java.util.Set;
+
+import static java.util.Collections.synchronizedSet;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * The PacketSampler is a debug aid that periodically scans the Connection.writeQueues and samples the content.
+ * This helps to figure out what is happening when writeQueues are very large. The PacketSampler is disabled
+ * by default.
+ */
+public class PacketSampler extends Thread {
+    // the delay between taking samples. Sampling has quite a lot of overhead, so doing it too frequent, will change
+    // the behavior of the system.
+    private static final int INTERVAL_SECONDS = Integer.getInteger("hazelcast.io.packetSampler.intervalSeconds", 0);
+    // the minimum number of packets in the write queue. If there are less packets than the threshold, the connection
+    // isn't sampled.
+    private static final int THRESHOLD = Integer.getInteger("hazelcast.io.packetSampler.threshold", 10000);
+    // the number of samples taken. The more samples, the more precise the information, but the more overhead (since it
+    // involves deserialization).
+    private static final int SAMPLE_COUNT = Integer.getInteger("hazelcast.io.packetSampler.sampleCount", 1000);
+
+    private volatile boolean stop;
+    private final ILogger logger;
+    private final IOService ioService;
+    private final StringBuilder sb = new StringBuilder();
+    private final Map<String, Integer> occurrenceMap = new HashMap<String, Integer>();
+    private final ArrayList<OutboundFrame> packets = new ArrayList<OutboundFrame>();
+    private final Random random = new Random();
+    private final Set<TcpIpConnection> connections = synchronizedSet(new HashSet<TcpIpConnection>());
+
+    public PacketSampler(
+            HazelcastThreadGroup hazelcastThreadGroup,
+            IOService ioService) {
+        super(hazelcastThreadGroup.getInternalThreadGroup(),
+                hazelcastThreadGroup.getThreadNamePrefix("packetSamplerThread"));
+
+        this.ioService = ioService;
+        this.logger = ioService.getLogger(PacketSampler.class.getName());
+
+        if (INTERVAL_SECONDS > 0) {
+            logger.info("Enabling PacketSampler, interval-seconds:" + INTERVAL_SECONDS
+                    + " threshold:" + THRESHOLD
+                    + " sampleCount:" + SAMPLE_COUNT);
+        }
+    }
+
+    public static boolean isPacketSamplerEnabled() {
+        return INTERVAL_SECONDS > 0;
+    }
+
+    public void onConnectionAdded(TcpIpConnection connection) {
+        connections.add(connection);
+    }
+
+    public void onConnectionRemoved(TcpIpConnection connection) {
+        connections.remove(connection);
+    }
+
+    @Override
+    public void run() {
+        while (!stop) {
+            try {
+                Thread.sleep(SECONDS.toMillis(INTERVAL_SECONDS));
+            } catch (InterruptedException e) {
+                if (stop) {
+                    return;
+                }
+            }
+
+            scan();
+        }
+    }
+
+    private void scan() {
+        for (TcpIpConnection connection : connections) {
+            scan(connection, false);
+            scan(connection, true);
+        }
+    }
+
+    public void scan(TcpIpConnection connection, boolean priority) {
+        clear();
+
+        NonBlockingSocketWriter writer = (NonBlockingSocketWriter) connection.getSocketWriter();
+        Queue<OutboundFrame> q = priority ? writer.urgentWriteQueue : writer.writeQueue;
+
+        if (!sample(q)) {
+            return;
+        }
+
+        sb.append("\n\t").append(connection).append('\n');
+        if (priority) {
+            sb.append("\turgent-packets:").append(packets.size()).append('\n');
+        } else {
+            sb.append("\tpackets:").append(packets.size()).append('\n');
+        }
+        sb.append("\tsample-count:").append(occurrenceMap.size()).append('\n');
+        sb.append("\tsamples:\n");
+
+        for (Map.Entry<String, Integer> entry : occurrenceMap.entrySet()) {
+            sb.append('\t').append('\t').append(entry.getKey()).append('=').append(entry.getValue()).append('\n');
+        }
+
+        logger.info(sb.toString());
+    }
+
+    private void clear() {
+        sb.setLength(0);
+        occurrenceMap.clear();
+        packets.clear();
+    }
+
+    private boolean sample(Queue<OutboundFrame> q) {
+        for (OutboundFrame frame : q) {
+            packets.add(frame);
+        }
+
+        if (packets.size() < THRESHOLD) {
+            return false;
+        }
+
+        int sampleCount = Math.min(SAMPLE_COUNT, packets.size());
+
+        for (int k = 0; k < sampleCount; k++) {
+            OutboundFrame packet = packets.get(random.nextInt(packets.size()));
+            String key = toKey(packet);
+
+            if (key != null) {
+                Integer value = occurrenceMap.get(key);
+                if (value == null) {
+                    value = 0;
+                }
+                value++;
+                occurrenceMap.put(key, value);
+            }
+        }
+
+        return true;
+    }
+
+    private String toKey(OutboundFrame packet) {
+        if (packet instanceof Packet) {
+            try {
+                Object result = ioService.toObject((Packet) packet);
+                if (result == null) {
+                    return "null";
+                } else if (result instanceof Backup) {
+                    Backup backup = (Backup) result;
+                    return Backup.class.getName() + "#" + backup.getBackupOp().getClass().getName();
+                } else {
+                    return result.getClass().getName();
+                }
+            } catch (Exception ignore) {
+                logger.severe(ignore);
+                return null;
+            }
+        } else {
+            return packet.getClass().getName();
+        }
+    }
+
+    public void shutdown() {
+        stop = true;
+        interrupt();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -78,6 +78,10 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         }
     }
 
+    public Operation getBackupOp() {
+        return backupOp;
+    }
+
     @Override
     public void beforeRun() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();

--- a/hazelcast/src/test/java/com/hazelcast/Main.java
+++ b/hazelcast/src/test/java/com/hazelcast/Main.java
@@ -1,0 +1,29 @@
+package com.hazelcast;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.test.HazelcastTestSupport;
+
+/**
+ * Created by alarmnummer on 1/13/16.
+ */
+public class Main extends HazelcastTestSupport{
+    public static void main(String[] args){
+        HazelcastInstance hz1 = Hazelcast.newHazelcastInstance();
+        HazelcastInstance hz2 = Hazelcast.newHazelcastInstance();
+
+        String topicName = generateKeyOwnedBy(hz2);
+        ITopic topic = hz1.getTopic("foo");
+
+        for(int k=0;k<1000 * 1000;k++){
+            topic.publish("");
+
+            if(k% 10000 == 0){
+                System.out.println("at: "+k);
+            }
+        }
+
+        System.out.println("done");
+    }
+}


### PR DESCRIPTION
The problem which can lead to OOME is there can be an infinite loop of SocketWriters getting processed in the NonBlockingIOThread.processTaskQueue method. It can happen that the same SocketWriter is picked up again and again in the same loop. This has been confirmed with a  demo program in combination with some detection. If the NonBlockingIOThread get 'stuck' in this loop, it will not be processing any connections that rely on a write event to get their data written to socket, and for these connections a buildup of packet in the connection queue is the consequence. This buildup eventually can lead to an OOME;  especially with a large number of connections (e,g. many clients).

This PR contains 2 fixes:
- there is a hard cap on the number of items to be processed.
- there is detection of a duplicate. As soon as the same item is found twice, the loop ends and the selection keys get processed first.

We are currently experimenting to see the impact on performance. For the time being it seems that setting the cap to 1, even leads to a performance increase of 3..5% which of course is a nice bonus.