### PR TITLE
Packet sampler for connection.writeQueue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -57,12 +57,12 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
 
     private static final long TIMEOUT = 3;
 
+    @Probe(name = "out.writeQueueSize")
+    final Queue<OutboundFrame> writeQueue = new ConcurrentLinkedQueue<OutboundFrame>();
+    @Probe(name = "out.priorityWriteQueueSize")
+    final Queue<OutboundFrame> urgentWriteQueue = new ConcurrentLinkedQueue<OutboundFrame>();
     @Probe(name = "out.eventCount")
     private final SwCounter eventCount = newSwCounter();
-    @Probe(name = "out.writeQueueSize")
-    private final Queue<OutboundFrame> writeQueue = new ConcurrentLinkedQueue<OutboundFrame>();
-    @Probe(name = "out.priorityWriteQueueSize")
-    private final Queue<OutboundFrame> urgentWriteQueue = new ConcurrentLinkedQueue<OutboundFrame>();
     private final AtomicBoolean scheduled = new AtomicBoolean(false);
     private ByteBuffer outputBuffer;
     @Probe(name = "out.bytesWritten")

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/PacketSampler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/PacketSampler.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp.nonblocking;
+
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.IOService;
+import com.hazelcast.nio.OutboundFrame;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Random;
+import java.util.Set;
+
+import static java.util.Collections.synchronizedSet;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * The PacketSampler is a debug aid that periodically scans the Connection.writeQueues and samples the content.
+ * This helps to figure out what is happening when writeQueues are very large. The PacketSampler is disabled
+ * by default.
+ */
+public class PacketSampler extends Thread {
+    // the delay between taking samples. Sampling has quite a lot of overhead, so doing it too frequent, will change
+    // the behavior of the system.
+    private static final int INTERVAL_SECONDS = Integer.getInteger("hazelcast.io.packetSampler.intervalSeconds", 0);
+    // the minimum number of packets in the write queue. If there are less packets than the threshold, the connection
+    // isn't sampled.
+    private static final int THRESHOLD = Integer.getInteger("hazelcast.io.packetSampler.threshold", 10000);
+    // the number of samples taken. The more samples, the more precise the information, but the more overhead (since it
+    // involves deserialization).
+    private static final int SAMPLE_COUNT = Integer.getInteger("hazelcast.io.packetSampler.sampleCount", 1000);
+
+    private volatile boolean stop;
+    private final ILogger logger;
+    private final IOService ioService;
+    private final StringBuilder sb = new StringBuilder();
+    private final Map<String, Integer> occurrenceMap = new HashMap<String, Integer>();
+    private final ArrayList<OutboundFrame> packets = new ArrayList<OutboundFrame>();
+    private final Random random = new Random();
+    private final Set<TcpIpConnection> connections = synchronizedSet(new HashSet<TcpIpConnection>());
+
+    public PacketSampler(
+            HazelcastThreadGroup hazelcastThreadGroup,
+            IOService ioService) {
+        super(hazelcastThreadGroup.getInternalThreadGroup(),
+                hazelcastThreadGroup.getThreadNamePrefix("packetSamplerThread"));
+
+        this.ioService = ioService;
+        this.logger = ioService.getLogger(PacketSampler.class.getName());
+
+        if (INTERVAL_SECONDS > 0) {
+            logger.info("Enabling PacketSampler, interval-seconds:" + INTERVAL_SECONDS
+                    + " threshold:" + THRESHOLD
+                    + " sampleCount:" + SAMPLE_COUNT);
+        }
+    }
+
+    public static boolean isPacketSamplerEnabled() {
+        return INTERVAL_SECONDS > 0;
+    }
+
+    public void onConnectionAdded(TcpIpConnection connection) {
+        connections.add(connection);
+    }
+
+    public void onConnectionRemoved(TcpIpConnection connection) {
+        connections.remove(connection);
+    }
+
+    @Override
+    public void run() {
+        while (!stop) {
+            try {
+                Thread.sleep(SECONDS.toMillis(INTERVAL_SECONDS));
+            } catch (InterruptedException e) {
+                if (stop) {
+                    return;
+                }
+            }
+
+            scan();
+        }
+    }
+
+    private void scan() {
+        for (TcpIpConnection connection : connections) {
+            scan(connection, false);
+            scan(connection, true);
+        }
+    }
+
+    public void scan(TcpIpConnection connection, boolean priority) {
+        clear();
+
+        NonBlockingSocketWriter writer = (NonBlockingSocketWriter) connection.getSocketWriter();
+        Queue<OutboundFrame> q = priority ? writer.urgentWriteQueue : writer.writeQueue;
+
+        if (!sample(q)) {
+            return;
+        }
+
+        sb.append("\n\t").append(connection).append('\n');
+        if (priority) {
+            sb.append("\turgent-packets:").append(packets.size()).append('\n');
+        } else {
+            sb.append("\tpackets:").append(packets.size()).append('\n');
+        }
+        sb.append("\tsample-count:").append(occurrenceMap.size()).append('\n');
+        sb.append("\tsamples:\n");
+
+        for (Map.Entry<String, Integer> entry : occurrenceMap.entrySet()) {
+            sb.append('\t').append('\t').append(entry.getKey()).append('=').append(entry.getValue()).append('\n');
+        }
+
+        logger.info(sb.toString());
+    }
+
+    private void clear() {
+        sb.setLength(0);
+        occurrenceMap.clear();
+        packets.clear();
+    }
+
+    private boolean sample(Queue<OutboundFrame> q) {
+        for (OutboundFrame frame : q) {
+            packets.add(frame);
+        }
+
+        if (packets.size() < THRESHOLD) {
+            return false;
+        }
+
+        int sampleCount = Math.min(SAMPLE_COUNT, packets.size());
+
+        for (int k = 0; k < sampleCount; k++) {
+            OutboundFrame packet = packets.get(random.nextInt(packets.size()));
+            String key = toKey(packet);
+
+            if (key != null) {
+                Integer value = occurrenceMap.get(key);
+                if (value == null) {
+                    value = 0;
+                }
+                value++;
+                occurrenceMap.put(key, value);
+            }
+        }
+
+        return true;
+    }
+
+    private String toKey(OutboundFrame packet) {
+        if (packet instanceof Packet) {
+            try {
+                Object result = ioService.toObject((Packet) packet);
+                if (result == null) {
+                    return "null";
+                } else if (result instanceof Backup) {
+                    Backup backup = (Backup) result;
+                    return Backup.class.getName() + "#" + backup.getBackupOp().getClass().getName();
+                } else {
+                    return result.getClass().getName();
+                }
+            } catch (Exception ignore) {
+                logger.severe(ignore);
+                return null;
+            }
+        } else {
+            return packet.getClass().getName();
+        }
+    }
+
+    public void shutdown() {
+        stop = true;
+        interrupt();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -78,6 +78,10 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         }
     }
 
+    public Operation getBackupOp() {
+        return backupOp;
+    }
+
     @Override
     public void beforeRun() throws Exception {
         NodeEngine nodeEngine = getNodeEngine();


### PR DESCRIPTION
A debug tool to see what is happening on the connection.writeQueue. It will take samples for large queues so we get some idea of its content. 

The following program demonstrates the PacketSampler:

```
package com.hazelcast;

import com.hazelcast.core.Hazelcast;
import com.hazelcast.core.HazelcastInstance;
import com.hazelcast.core.IMap;
import com.hazelcast.core.ITopic;
import com.hazelcast.core.Message;
import com.hazelcast.core.MessageListener;
import com.hazelcast.test.HazelcastTestSupport;
import org.apache.log4j.Level;


public class Main extends HazelcastTestSupport {
    public static void main(String[] args) throws InterruptedException {
        setLoggingLog4j();
        setLogLevel(Level.INFO);

        HazelcastInstance hz1 = Hazelcast.newHazelcastInstance();
        HazelcastInstance hz2 = Hazelcast.newHazelcastInstance();
        warmUpPartitions(hz1, hz2);

        String topicName = generateKeyOwnedBy(hz2);
        ITopic topic = hz1.getTopic(topicName);


        System.out.println("starting");
        IMap<Object, Object> map = hz1.getMap("foo");

        for (int l = 0; l < 100; l++) {
            for (int k = 0; k < 10 * 1000 * 1000; k++) {
                map.putAsync(k,k);
            }
            Thread.sleep(1000);
        }

        System.out.println("done");
    }
}
```

And it will output something like:
```
    Connection [/192.168.122.1:45510 -> /192.168.122.1:5701], endpoint=Address[192.168.122.1]:5701, alive=true, type=MEMBER
    packets:6464
    samples:
        com.hazelcast.spi.impl.operationservice.impl.operations.Backup#com.hazelcast.map.impl.operation.PutBackupOperation=405
        com.hazelcast.spi.impl.operationservice.impl.responses.BackupResponse=219
        com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse=376
```