### PR TITLE
Defaulting properties when negative value is generalized

### DIFF
--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/config/ClientProperty.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/config/ClientProperty.java
@@ -150,7 +150,14 @@ public enum ClientProperty implements HazelcastProperty {
     }
 
     @Override
+    public boolean isDisablable() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return name;
     }
+
+
 }

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -111,11 +111,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         connectionTimeout = connTimeout == 0 ? Integer.MAX_VALUE : connTimeout;
 
         ClientProperties clientProperties = client.getClientProperties();
-        long timeout = clientProperties.getMillis(HEARTBEAT_TIMEOUT);
-        this.heartBeatTimeout = timeout > 0 ? timeout : Integer.parseInt(HEARTBEAT_TIMEOUT.getDefaultValue());
-
-        long interval = clientProperties.getMillis(HEARTBEAT_INTERVAL);
-        heartBeatInterval = interval > 0 ? interval : Integer.parseInt(HEARTBEAT_INTERVAL.getDefaultValue());
+        heartBeatTimeout = clientProperties.getMillis(HEARTBEAT_TIMEOUT);
+        heartBeatInterval = clientProperties.getMillis(HEARTBEAT_INTERVAL);
 
         executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
 

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -161,6 +161,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         threadGroup = new ThreadGroup(instanceName);
         lifecycleService = new LifecycleServiceImpl(this);
         clientProperties = new ClientProperties(config);
+        clientProperties.setLogger(Logger.getLogger(ClientProperties.class));
         serializationService = clientExtension.createSerializationService();
         proxyManager = new ProxyManager(this);
         executionService = initExecutionService();

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
@@ -45,6 +45,10 @@ public interface ClientInvocationService {
 
     void handlePacket(Packet packet);
 
+    long getHeartBeatIntervalMillis();
+
+    long getClientInvocationTimeoutMillis();
+
     void cleanConnectionResources(ClientConnection connection);
 
     //TODO just to be called by stabilizer at the moment

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -256,8 +256,7 @@ public final class ProxyManager {
 
     private long getRetryCountLimit() {
         ClientProperties clientProperties = client.getClientProperties();
-        int waitTime = clientProperties.getSeconds(INVOCATION_TIMEOUT_SECONDS);
-        long retryTimeoutInSeconds = waitTime > 0 ? waitTime : Integer.parseInt(INVOCATION_TIMEOUT_SECONDS.getDefaultValue());
+        long retryTimeoutInSeconds = clientProperties.getSeconds(INVOCATION_TIMEOUT_SECONDS);
         return retryTimeoutInSeconds / ClientInvocation.RETRY_WAIT_TIME_IN_SECONDS;
     }
 

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -106,14 +106,14 @@ public class ClientInvocationFuture<V> implements ICompletableFuture<V> {
 
     @Override
     public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        final int heartBeatInterval = invocation.getHeartBeatInterval();
+        long heartBeatIntervalMillis = invocation.getHeartBeatIntervalMillis();
         if (response == null) {
             long waitMillis = unit.toMillis(timeout);
             if (waitMillis > 0) {
                 synchronized (this) {
                     while (waitMillis > 0 && response == null) {
                         long start = Clock.currentTimeMillis();
-                        this.wait(Math.min(heartBeatInterval, waitMillis));
+                        this.wait(Math.min(heartBeatIntervalMillis, waitMillis));
                         long elapsed = Clock.currentTimeMillis() - start;
                         waitMillis -= elapsed;
                         if (!invocation.isConnectionHealthy(elapsed)) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
@@ -150,7 +150,14 @@ public enum ClientProperty implements HazelcastProperty {
     }
 
     @Override
+    public boolean isDisablable() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return name;
     }
+
+
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -112,11 +112,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         connectionTimeout = connTimeout == 0 ? Integer.MAX_VALUE : connTimeout;
 
         ClientProperties clientProperties = client.getClientProperties();
-        long timeout = clientProperties.getMillis(HEARTBEAT_TIMEOUT);
-        this.heartBeatTimeout = timeout > 0 ? timeout : Integer.parseInt(HEARTBEAT_TIMEOUT.getDefaultValue());
-
-        long interval = clientProperties.getMillis(HEARTBEAT_INTERVAL);
-        heartBeatInterval = interval > 0 ? interval : Integer.parseInt(HEARTBEAT_INTERVAL.getDefaultValue());
+        heartBeatTimeout = clientProperties.getMillis(HEARTBEAT_TIMEOUT);
+        heartBeatInterval = clientProperties.getMillis(HEARTBEAT_INTERVAL);
 
         executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -161,6 +161,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         threadGroup = new ThreadGroup(instanceName);
         lifecycleService = new LifecycleServiceImpl(this);
         clientProperties = new ClientProperties(config);
+        clientProperties.setLogger(Logger.getLogger(ClientProperties.class));
         serializationService = clientExtension.createSerializationService((byte) -1);
         proxyManager = new ProxyManager(this);
         executionService = initExecutionService();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -274,8 +274,7 @@ public final class ProxyManager {
 
     private long getRetryCountLimit() {
         ClientProperties clientProperties = client.getClientProperties();
-        int waitTime = clientProperties.getSeconds(INVOCATION_TIMEOUT_SECONDS);
-        long retryTimeoutInSeconds = waitTime > 0 ? waitTime : Integer.parseInt(INVOCATION_TIMEOUT_SECONDS.getDefaultValue());
+        long retryTimeoutInSeconds = clientProperties.getSeconds(INVOCATION_TIMEOUT_SECONDS);
         return retryTimeoutInSeconds / ClientInvocation.RETRY_WAIT_TIME_IN_SECONDS;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -60,7 +60,7 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
     private final ClientInvocationService invocationService;
     private final ClientExecutionService executionService;
     private final ClientMessage clientMessage;
-    private final int heartBeatInterval;
+    private final long heartBeatInterval;
 
     private final Address address;
     private final int partitionId;
@@ -85,14 +85,9 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
 
         ClientProperties clientProperties = client.getClientProperties();
         long waitTime = clientProperties.getMillis(INVOCATION_TIMEOUT_SECONDS);
-        long waitTimeResolved = waitTime > 0 ? waitTime : Integer.parseInt(INVOCATION_TIMEOUT_SECONDS.getDefaultValue());
-        retryTimeoutPointInMillis = System.currentTimeMillis() + waitTimeResolved;
-
+        retryTimeoutPointInMillis = System.currentTimeMillis() + waitTime;
         clientInvocationFuture = new ClientInvocationFuture(this, client, clientMessage);
-
-
-        int interval = clientProperties.getInteger(HEARTBEAT_INTERVAL);
-        this.heartBeatInterval = interval > 0 ? interval : Integer.parseInt(HEARTBEAT_INTERVAL.getDefaultValue());
+        heartBeatInterval = clientProperties.getMillis(HEARTBEAT_INTERVAL);
     }
 
     public ClientInvocation(HazelcastClientInstanceImpl client, ClientMessage clientMessage) {
@@ -248,7 +243,7 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
         this.handler = handler;
     }
 
-    public int getHeartBeatInterval() {
+    public long getHeartBeatInterval() {
         return heartBeatInterval;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -80,7 +80,7 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
 
     @Override
     public ClientMessage get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        final int heartBeatInterval = invocation.getHeartBeatInterval();
+        long heartBeatInterval = invocation.getHeartBeatInterval();
         if (response == null) {
             long waitMillis = unit.toMillis(timeout);
             if (waitMillis > 0) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -37,7 +37,6 @@ import java.util.logging.Level;
 public class ClientHeartbeatMonitor implements Runnable {
 
     private static final int HEART_BEAT_CHECK_INTERVAL_SECONDS = 10;
-    private static final int DEFAULT_CLIENT_HEARTBEAT_TIMEOUT_SECONDS = 60;
 
     private final ClientEndpointManagerImpl clientEndpointManager;
     private final ClientEngine clientEngine;
@@ -52,16 +51,8 @@ public class ClientHeartbeatMonitor implements Runnable {
         this.clientEndpointManager = endpointManager;
         this.clientEngine = clientEngine;
         this.executionService = executionService;
-        this.heartbeatTimeoutSeconds = getHeartBeatTimeout(groupProperties);
-    }
-
-    private long getHeartBeatTimeout(GroupProperties groupProperties) {
-        long configuredTimeout = groupProperties.getSeconds(GroupProperty.CLIENT_HEARTBEAT_TIMEOUT_SECONDS);
-        if (configuredTimeout > 0) {
-            return configuredTimeout;
-        }
-
-        return DEFAULT_CLIENT_HEARTBEAT_TIMEOUT_SECONDS;
+        this.heartbeatTimeoutSeconds =
+                groupProperties.getSeconds(GroupProperty.CLIENT_HEARTBEAT_TIMEOUT_SECONDS);
     }
 
     public void start() {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterHeartbeatManager.java
@@ -105,8 +105,7 @@ public class ClusterHeartbeatManager {
     }
 
     private static long getHeartBeatInterval(GroupProperties groupProperties) {
-        long heartbeatInterval = groupProperties.getMillis(GroupProperty.HEARTBEAT_INTERVAL_SECONDS);
-        return heartbeatInterval > 0 ? heartbeatInterval : TimeUnit.SECONDS.toMillis(1);
+        return groupProperties.getMillis(GroupProperty.HEARTBEAT_INTERVAL_SECONDS);
     }
 
     void init() {
@@ -119,7 +118,6 @@ public class ClusterHeartbeatManager {
         }, heartbeatIntervalMillis, heartbeatIntervalMillis, TimeUnit.MILLISECONDS);
 
         long masterConfirmationInterval = node.groupProperties.getSeconds(GroupProperty.MASTER_CONFIRMATION_INTERVAL_SECONDS);
-        masterConfirmationInterval = (masterConfirmationInterval > 0 ? masterConfirmationInterval : 1);
         executionService.scheduleWithFixedDelay(EXECUTOR_NAME, new Runnable() {
             public void run() {
                 sendMasterConfirmation();
@@ -127,7 +125,6 @@ public class ClusterHeartbeatManager {
         }, masterConfirmationInterval, masterConfirmationInterval, TimeUnit.SECONDS);
 
         long memberListPublishInterval = node.groupProperties.getSeconds(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS);
-        memberListPublishInterval = (memberListPublishInterval > 0 ? memberListPublishInterval : 1);
         executionService.scheduleWithFixedDelay(EXECUTOR_NAME, new Runnable() {
             public void run() {
                 sendMemberListToOthers();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterServiceImpl.java
@@ -188,13 +188,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         long mergeFirstRunDelayMs = node.groupProperties.getMillis(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS);
-        mergeFirstRunDelayMs = (mergeFirstRunDelayMs > 0 ? mergeFirstRunDelayMs : DEFAULT_MERGE_RUN_DELAY_MILLIS);
 
         ExecutionService executionService = nodeEngine.getExecutionService();
         executionService.register(EXECUTOR_NAME, 2, CLUSTER_EXECUTOR_QUEUE_CAPACITY, ExecutorType.CACHED);
 
         long mergeNextRunDelayMs = node.groupProperties.getMillis(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS);
-        mergeNextRunDelayMs = (mergeNextRunDelayMs > 0 ? mergeNextRunDelayMs : DEFAULT_MERGE_RUN_DELAY_MILLIS);
         executionService.scheduleWithFixedDelay(EXECUTOR_NAME, new SplitBrainHandler(node), mergeFirstRunDelayMs,
                 mergeNextRunDelayMs, TimeUnit.MILLISECONDS);
 
@@ -875,8 +873,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         logger.info("Sending shutting down operations to all members...");
 
         Collection<Member> members = getMembers(NON_LOCAL_MEMBER_SELECTOR);
-        final long timeout = node.groupProperties.getNanos(GroupProperty.CLUSTER_SHUTDOWN_TIMEOUT_SECONDS);
-        final long startTime = System.nanoTime();
+        long timeout = node.groupProperties.getNanos(GroupProperty.CLUSTER_SHUTDOWN_TIMEOUT_SECONDS);
+        long startTime = System.nanoTime();
 
         while ((System.nanoTime() - startTime) < timeout && !members.isEmpty()) {
             for (Member member : members) {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -51,12 +51,7 @@ public class TcpIpJoiner extends AbstractJoiner {
 
     public TcpIpJoiner(Node node) {
         super(node);
-        int tryCount = node.groupProperties.getInteger(GroupProperty.TCP_JOIN_PORT_TRY_COUNT);
-        if (tryCount <= 0) {
-            throw new IllegalArgumentException(String.format("%s should be greater than zero! Current value: %d",
-                    GroupProperty.TCP_JOIN_PORT_TRY_COUNT, tryCount));
-        }
-        maxPortTryCount = tryCount;
+        maxPortTryCount = node.groupProperties.getInteger(GroupProperty.TCP_JOIN_PORT_TRY_COUNT);
     }
 
     public boolean isClaimingMaster() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -355,7 +355,8 @@ public enum GroupProperty implements HazelcastProperty {
      * <p/>
      * The default is -1 indicating there is no detection.
      */
-    SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS("hazelcast.slow.invocation.detector.threshold.millis", -1, MILLISECONDS),
+    SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS("hazelcast.slow.invocation.detector.threshold.millis", -1, MILLISECONDS,
+            DISABLEABLE.YES),
 
     LOCK_MAX_LEASE_TIME_SECONDS("hazelcast.lock.max.lease.time.seconds", Long.MAX_VALUE, SECONDS),
 
@@ -492,7 +493,7 @@ public enum GroupProperty implements HazelcastProperty {
      * <p/>
      * The feature can be disabled by setting its value to <tt>-1</tt> (which is the default value).
      */
-    QUERY_RESULT_SIZE_LIMIT("hazelcast.query.result.size.limit", -1),
+    QUERY_RESULT_SIZE_LIMIT("hazelcast.query.result.size.limit", -1, DISABLEABLE.YES),
 
     /**
      * Maximum value of local partitions to trigger local pre-check for {@link TruePredicate} query operations on maps.
@@ -508,7 +509,7 @@ public enum GroupProperty implements HazelcastProperty {
      *
      * @see #QUERY_RESULT_SIZE_LIMIT
      */
-    QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK("hazelcast.query.max.local.partition.limit.for.precheck", 3),
+    QUERY_MAX_LOCAL_PARTITION_LIMIT_FOR_PRE_CHECK("hazelcast.query.max.local.partition.limit.for.precheck", 3, DISABLEABLE.YES),
 
     /**
      * Type of Query Optimizer.
@@ -554,6 +555,8 @@ public enum GroupProperty implements HazelcastProperty {
     private final String defaultValue;
     private final TimeUnit timeUnit;
     private final GroupProperty parent;
+    private DISABLEABLE disablable = DISABLEABLE.NO;
+    private enum DISABLEABLE { YES, NO }
 
     GroupProperty(String name) {
         this(name, (String) null);
@@ -572,7 +575,7 @@ public enum GroupProperty implements HazelcastProperty {
     }
 
     GroupProperty(String name, String defaultValue) {
-        this(name, defaultValue, null);
+        this(name, defaultValue, null, DISABLEABLE.NO);
     }
 
     GroupProperty(String name, Integer defaultValue, TimeUnit timeUnit) {
@@ -584,11 +587,49 @@ public enum GroupProperty implements HazelcastProperty {
     }
 
     GroupProperty(String name, String defaultValue, TimeUnit timeUnit) {
-        this(name, defaultValue, timeUnit, null);
+        this(name, defaultValue, timeUnit, null, DISABLEABLE.NO);
     }
 
     GroupProperty(String name, GroupProperty groupProperty) {
         this(name, groupProperty.getDefaultValue(), groupProperty.timeUnit, groupProperty);
+    }
+
+    GroupProperty(String name, boolean defaultValue, DISABLEABLE disablable) {
+        this(name, defaultValue ? "true" : "false", disablable);
+    }
+
+    GroupProperty(String name, Integer defaultValue, DISABLEABLE disablable) {
+        this(name, String.valueOf(defaultValue), disablable);
+    }
+
+    GroupProperty(String name, Byte defaultValue, DISABLEABLE disablable) {
+        this(name, String.valueOf(defaultValue), disablable);
+    }
+
+    GroupProperty(String name, String defaultValue, DISABLEABLE disablable) {
+        this(name, defaultValue, null, disablable);
+    }
+
+    GroupProperty(String name, Integer defaultValue, TimeUnit timeUnit, DISABLEABLE disablable) {
+        this(name, String.valueOf(defaultValue), timeUnit, disablable);
+    }
+
+    GroupProperty(String name, Long defaultValue, TimeUnit timeUnit, DISABLEABLE disablable) {
+        this(name, Long.toString(defaultValue), timeUnit, disablable);
+    }
+
+    GroupProperty(String name, String defaultValue, TimeUnit timeUnit, DISABLEABLE disablable) {
+        this(name, defaultValue, timeUnit, null, disablable);
+    }
+
+    GroupProperty(String name, String defaultValue, TimeUnit timeUnit, GroupProperty parent, DISABLEABLE disablable) {
+        this.disablable = disablable;
+        checkHasText(name, "The property name cannot be null or empty!");
+
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.timeUnit = timeUnit;
+        this.parent = parent;
     }
 
     GroupProperty(String name, String defaultValue, TimeUnit timeUnit, GroupProperty parent) {
@@ -646,5 +687,10 @@ public enum GroupProperty implements HazelcastProperty {
     @Override
     public String toString() {
         return name;
+    }
+
+    @Override
+    public boolean isDisablable() {
+        return DISABLEABLE.YES == disablable;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastProperty.java
@@ -80,4 +80,9 @@ public interface HazelcastProperty {
      * Clears the environmental value of the property.
      */
     String clearSystemProperty();
+
+    /**
+     * @return true if setting `-1` to property means feature is disabled
+     */
+    boolean isDisablable();
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
@@ -33,8 +33,6 @@ import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
 
 public class LifecycleServiceImpl implements LifecycleService {
 
-    public static final int DEFAULT_GRACEFUL_SHUTDOWN_WAIT = 30;
-
     private final HazelcastInstanceImpl instance;
     private final ConcurrentMap<String, LifecycleListener> lifecycleListeners
             = new ConcurrentHashMap<String, LifecycleListener>();
@@ -97,8 +95,7 @@ public class LifecycleServiceImpl implements LifecycleService {
     }
 
     private static int getShutdownTimeoutSeconds(Node node) {
-        int gracefulShutdownMaxWaitSeconds = node.groupProperties.getSeconds(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT);
-        return Math.min(DEFAULT_GRACEFUL_SHUTDOWN_WAIT, gracefulShutdownMaxWaitSeconds);
+        return node.groupProperties.getSeconds(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -65,8 +65,8 @@ import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.util.UuidUtil;
 import com.hazelcast.util.PhoneHome;
+import com.hazelcast.util.UuidUtil;
 
 import java.lang.reflect.Constructor;
 import java.nio.channels.ServerSocketChannel;
@@ -152,6 +152,7 @@ public class Node {
 
         String loggingType = groupProperties.getString(GroupProperty.LOGGING_TYPE);
         loggingService = new LoggingServiceImpl(config.getGroupConfig().getName(), loggingType, buildInfo);
+        groupProperties.setLogger(loggingService.getLogger(GroupProperties.class));
         final AddressPicker addressPicker = nodeContext.createAddressPicker(this);
         try {
             addressPicker.pickAddress();

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -194,8 +194,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         memberGroupFactory = MemberGroupFactoryFactory.newMemberGroupFactory(node.getConfig().getPartitionGroupConfig());
         partitionStateGenerator = new PartitionStateGeneratorImpl();
 
-        long intervalMillis = node.groupProperties.getMillis(GroupProperty.PARTITION_MIGRATION_INTERVAL);
-        partitionMigrationInterval = (intervalMillis > 0 ? intervalMillis : 0);
+        partitionMigrationInterval = node.groupProperties.getMillis(GroupProperty.PARTITION_MIGRATION_INTERVAL);
 
         partitionMigrationTimeout = node.groupProperties.getMillis(GroupProperty.PARTITION_MIGRATION_TIMEOUT);
 
@@ -227,8 +226,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             }
         });
 
-        long definedBackupSyncCheckInterval = node.groupProperties.getSeconds(GroupProperty.PARTITION_BACKUP_SYNC_INTERVAL);
-        backupSyncCheckInterval = definedBackupSyncCheckInterval > 0 ? definedBackupSyncCheckInterval : 1;
+        backupSyncCheckInterval = node.groupProperties.getSeconds(GroupProperty.PARTITION_BACKUP_SYNC_INTERVAL);
         maxParallelReplications = node.groupProperties.getInteger(GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS);
         replicaSyncProcessLock = new Semaphore(maxParallelReplications);
         nodeEngine.getMetricsRegistry().scanAndRegister(this, "partitions");
@@ -274,9 +272,6 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         migrationThread.start();
 
         int partitionTableSendInterval = node.groupProperties.getSeconds(GroupProperty.PARTITION_TABLE_SEND_INTERVAL);
-        if (partitionTableSendInterval <= 0) {
-            partitionTableSendInterval = 1;
-        }
         ExecutionService executionService = nodeEngine.getExecutionService();
         executionService.scheduleAtFixedRate(new SendPartitionRuntimeStateTask(),
                 partitionTableSendInterval, partitionTableSendInterval, TimeUnit.SECONDS);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
@@ -111,16 +111,12 @@ public class BackpressureRegulator {
     }
 
     private int getSyncWindow(GroupProperties props) {
-        int syncWindow = props.getInteger(BACKPRESSURE_SYNCWINDOW);
-        if (enabled && syncWindow <= 0) {
-            throw new IllegalArgumentException("Can't have '" + BACKPRESSURE_SYNCWINDOW + "' with a value smaller than 1");
-        }
-        return syncWindow;
+        return props.getInteger(BACKPRESSURE_SYNCWINDOW);
     }
 
     private int getBackoffTimeoutMs(GroupProperties props) {
         int backoffTimeoutMs = (int) props.getMillis(BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS);
-        if (enabled && backoffTimeoutMs < 0) {
+        if (enabled) {
             throw new IllegalArgumentException("Can't have '" + BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS
                     + "' with a value smaller than 0");
         }
@@ -129,11 +125,6 @@ public class BackpressureRegulator {
 
     private int getMaxConcurrentInvocations(GroupProperties props) {
         int invocationsPerPartition = props.getInteger(BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION);
-        if (invocationsPerPartition < 1) {
-            throw new IllegalArgumentException("Can't have '" + BACKPRESSURE_MAX_CONCURRENT_INVOCATIONS_PER_PARTITION
-                    + "' with a value smaller than 1");
-        }
-
         return (partitionCount + 1) * invocationsPerPartition;
     }
 
@@ -172,7 +163,7 @@ public class BackpressureRegulator {
      * <p/>
      * Once and a while for every BackupAwareOperation with one or more async backups, these async backups are transformed
      * into a sync backup.
-     *
+     * <p/>
      * For {@link com.hazelcast.spi.UrgentSystemOperation} no sync will be forced.
      *
      * @param backupAwareOp The BackupAwareOperation to check.


### PR DESCRIPTION
`get` methods of Hazelcast properties made return the default
value in case a negative value is configured.

Advantages of this change:
1) I see some places when a a property is negative, a different
hardcoded default value is used instead of one in the Properties
file. This way, same mistake won't be happening again.

2) There are lots of places that there are no check to if a value
is negative. This way all will be checked, a log will be printed
and it will fallback to default value,

3) There are places that negative value checked and correct value
is used, but this is code repeation. This logic to one place to
prevent code repetation.

4) Before this change, in some places we convert to defualt value
silently, in some places we throw exception when a negative value
configured. This change will make the behavuour consistent across
all propreties so that potential confusing behaviour for our users
is eliminated.