### PR TITLE
Invalid partition id should not crash partition threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
@@ -154,8 +154,8 @@ public abstract class OperationThread extends HazelcastManagedThread {
     private void processPartitionSpecificRunnable(PartitionSpecificRunnable runnable) {
         processedPartitionSpecificRunnableCount.inc();
 
-        currentOperationRunner = getOperationRunner(runnable.getPartitionId());
         try {
+            currentOperationRunner = getOperationRunner(runnable.getPartitionId());
             currentOperationRunner.run(runnable);
         } catch (Throwable e) {
             inspectOutputMemoryError(e);
@@ -179,8 +179,8 @@ public abstract class OperationThread extends HazelcastManagedThread {
     private void processPacket(Packet packet) {
         processedPacketCount.inc();
 
-        currentOperationRunner = getOperationRunner(packet.getPartitionId());
         try {
+            currentOperationRunner = getOperationRunner(packet.getPartitionId());
             currentOperationRunner.run(packet);
         } catch (Throwable e) {
             inspectOutputMemoryError(e);
@@ -193,8 +193,8 @@ public abstract class OperationThread extends HazelcastManagedThread {
     private void processOperation(Operation operation) {
         processedOperationsCount.inc();
 
-        currentOperationRunner = getOperationRunner(operation.getPartitionId());
         try {
+            currentOperationRunner = getOperationRunner(operation.getPartitionId());
             currentOperationRunner.run(operation);
         } catch (Throwable e) {
             inspectOutputMemoryError(e);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunnerFactory;
 import com.hazelcast.test.AssertTask;
@@ -15,6 +16,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -71,6 +73,70 @@ public class OperationThreadTest extends AbstractClassicOperationExecutorTest {
 
         int normalSize = operationThread.normalPendingCount();
         assertEquals(Integer.MAX_VALUE, normalSize);
+    }
+
+    @Test
+    public void executeOperation_withInvalid_partitionId() {
+        final int partitionId = Integer.MAX_VALUE;
+        Operation operation = new DummyPartitionOperation(partitionId);
+        testExecute_withInvalid_partitionId(operation);
+    }
+
+    @Test
+    public void executePartitionSpecificRunnable_withInvalid_partitionId() {
+        final int partitionId = Integer.MAX_VALUE;
+        testExecute_withInvalid_partitionId(new PartitionSpecificRunnable() {
+            @Override
+            public int getPartitionId() {
+                return partitionId;
+            }
+            @Override
+            public void run() {
+            }
+        });
+    }
+
+    @Test
+    public void executePacket_withInvalid_partitionId() {
+        final int partitionId = Integer.MAX_VALUE;
+        Operation operation = new DummyPartitionOperation(partitionId);
+        Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
+        packet.setHeader(Packet.HEADER_OP);
+
+        testExecute_withInvalid_partitionId(packet);
+    }
+
+    private void testExecute_withInvalid_partitionId(Object task) {
+        handlerFactory = mock(OperationRunnerFactory.class);
+        OperationRunner handler = mock(OperationRunner.class);
+        when(handlerFactory.createGenericRunner()).thenReturn(handler);
+        when(handlerFactory.createPartitionRunner(anyInt())).thenReturn(handler);
+
+        initExecutor();
+
+        if (task instanceof Operation) {
+            executor.execute((Operation) task);
+        } else if (task instanceof PartitionSpecificRunnable) {
+            executor.execute((PartitionSpecificRunnable) task);
+        } else if (task instanceof Packet) {
+            executor.execute((Packet) task);
+        } else {
+            fail("invalid task!");
+        }
+
+        final Runnable emptyRunnable = new Runnable() {
+            @Override
+            public void run() {
+            }
+        };
+        executor.runOnAllPartitionThreads(emptyRunnable);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(0, executor.getPriorityOperationExecutorQueueSize());
+            }
+        });
     }
 
     private PartitionOperationThread createNewOperationThread(ScheduleQueue mockScheduleQueue) {


### PR DESCRIPTION
When an operation, a partition-specific-runnable or a packet with an
invalid partition id (greater than max partition id) is submitted to
operation executor, it causes partition operation thread to crash with
ArrayIndexOutOfBoundsException. After that point, no task can be executed
on any that thread and also thread's task queue can lead to oome.

Even this can be considered a security failure, one can send a corrupted
client message to a server and server becomes stuck.

see zendesk tickets: 1361 & 1370