### PR TITLE
[Backport] Invalid partition id should not crash partition threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
@@ -125,8 +125,8 @@ public abstract class OperationThread extends HazelcastManagedThread {
     }
 
     private void processPartitionSpecificRunnable(PartitionSpecificRunnable runnable) {
-        currentOperationRunner = getOperationRunner(runnable.getPartitionId());
         try {
+            currentOperationRunner = getOperationRunner(runnable.getPartitionId());
             currentOperationRunner.run(runnable);
         } catch (Throwable e) {
             inspectOutputMemoryError(e);
@@ -137,8 +137,8 @@ public abstract class OperationThread extends HazelcastManagedThread {
     }
 
     private void processPacket(Packet packet) {
-        currentOperationRunner = getOperationRunner(packet.getPartitionId());
         try {
+            currentOperationRunner = getOperationRunner(packet.getPartitionId());
             currentOperationRunner.run(packet);
         } catch (Throwable e) {
             inspectOutputMemoryError(e);
@@ -149,8 +149,8 @@ public abstract class OperationThread extends HazelcastManagedThread {
     }
 
     private void processOperation(Operation operation) {
-        currentOperationRunner = getOperationRunner(operation.getPartitionId());
         try {
+            currentOperationRunner = getOperationRunner(operation.getPartitionId());
             currentOperationRunner.run(operation);
         } catch (Throwable e) {
             inspectOutputMemoryError(e);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunnerFactory;
 import com.hazelcast.test.AssertTask;
@@ -14,6 +15,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -48,6 +50,68 @@ public class OperationThreadTest extends AbstractClassicOperationExecutorTest {
             @Override
             public void run() throws Exception {
                 assertEquals(oldCount + 1, OutOfMemoryErrorDispatcher.getOutOfMemoryErrorCount());
+            }
+        });
+    }
+
+    @Test
+    public void executeOperation_withInvalid_partitionId() {
+        final int partitionId = Integer.MAX_VALUE;
+        Operation operation = new DummyPartitionOperation(partitionId);
+        testExecute_withInvalid_partitionId(operation);
+    }
+
+    @Test
+    public void executePartitionSpecificRunnable_withInvalid_partitionId() {
+        final int partitionId = Integer.MAX_VALUE;
+        testExecute_withInvalid_partitionId(new PartitionSpecificRunnable() {
+            @Override
+            public int getPartitionId() {
+                return partitionId;
+            }
+            @Override
+            public void run() {
+            }
+        });
+    }
+
+    @Test
+    public void executePacket_withInvalid_partitionId() {
+        final int partitionId = Integer.MAX_VALUE;
+        Operation operation = new DummyPartitionOperation(partitionId);
+        Packet packet = new Packet(serializationService.toData(operation), operation.getPartitionId());
+        packet.setHeader(Packet.HEADER_OP);
+
+        testExecute_withInvalid_partitionId(packet);
+    }
+
+    private void testExecute_withInvalid_partitionId(Object task) {
+        handlerFactory = mock(OperationRunnerFactory.class);
+        OperationRunner handler = mock(OperationRunner.class);
+        when(handlerFactory.createGenericRunner()).thenReturn(handler);
+        when(handlerFactory.createPartitionRunner(anyInt())).thenReturn(handler);
+
+        initExecutor();
+
+        if (task instanceof Operation) {
+            executor.execute((Operation) task);
+        } else if (task instanceof PartitionSpecificRunnable) {
+            executor.execute((PartitionSpecificRunnable) task);
+        } else if (task instanceof Packet) {
+            executor.execute((Packet) task);
+        } else {
+            fail("invalid task!");
+        }
+
+        final int threadCount = executor.getPartitionOperationThreadCount();
+        for (int i = 0; i < threadCount; i++) {
+            executor.execute(new DummyPartitionOperation(i));
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(0, executor.getOperationExecutorQueueSize());
             }
         });
     }


### PR DESCRIPTION
When an operation, a partition-specific-runnable or a packet with an
invalid partition id (greater than max partition id) is submitted to
operation executor, it causes partition operation thread to crash with
ArrayIndexOutOfBoundsException. After that point, no task can be executed
on any that thread and also thread's task queue can lead to oome.

Even this can be considered a security failure, one can send a corrupted
client message to a server and server becomes stuck.

Backport of https://github.com/hazelcast/hazelcast/pull/7334