### PR TITLE
[3.6.1] Add support for setAsync 

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -91,6 +91,7 @@
     <suppress checks="JavadocVariable" files="com/hazelcast/core/"/>
     <suppress checks="MethodCount" files="com/hazelcast/core/HazelcastInstance"/>
     <suppress checks="MethodCount" files="com/hazelcast/core/IMap"/>
+    <suppress checks="FileLengthCheck" files="com/hazelcast/core/IMap"/>
 
     <!-- Config -->
     <suppress checks="MethodCount" files="com/hazelcast/config/Config"/>

--- a/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client-legacy/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -158,6 +158,12 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
+    protected Future<Void> setAsyncInternal(long ttl, TimeUnit timeunit, Data keyData, Data valueData) {
+        invalidateNearCache(keyData);
+        return super.setAsyncInternal(ttl, timeunit, keyData, valueData);
+    }
+
+    @Override
     protected Future<V> removeAsyncInternal(Data keyData) {
         invalidateNearCache(keyData);
         return super.removeAsyncInternal(keyData);

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -32,6 +32,8 @@ import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -254,11 +256,10 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testAsyncPutWithTtl() throws Exception {
         IMap<String, String> map = createMap();
         final CountDownLatch latch = new CountDownLatch(1);
-        map.addEntryListener(new EntryAdapter<String, String>() {
+        map.addEntryListener(new EntryEvictedListener<String, String>() {
             public void entryEvicted(EntryEvent<String, String> event) {
                 latch.countDown();
             }
@@ -269,6 +270,33 @@ public class ClientMapTest extends HazelcastTestSupport {
         assertEquals("value1", map.get("key"));
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNull(map.get("key"));
+    }
+
+    @Test
+    public void testAsyncSet() throws Exception {
+        IMap<String, String> map = createMap();
+        fillMap(map);
+        Future<Void> future = map.setAsync("key3", "value");
+        future.get();
+        assertEquals("value", map.get("key3"));
+    }
+
+    @Test
+    public void testAsyncSetWithTtl() throws Exception {
+        IMap<String, String> map = createMap();
+        final CountDownLatch latch = new CountDownLatch(1);
+        map.addEntryListener(new EntryEvictedListener<String, String>() {
+            public void entryEvicted(EntryEvent<String, String> event) {
+                latch.countDown();
+            }
+        }, true);
+
+        Future<Void> future = map.setAsync("key", "value1", 3, TimeUnit.SECONDS);
+        future.get();
+        assertEquals("value1", map.get("key"));
+
+        assertOpenEventually(latch);
         assertNull(map.get("key"));
     }
 
@@ -816,13 +844,12 @@ public class ClientMapTest extends HazelcastTestSupport {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testEntryListenerWithPredicateOnDeleteOperation() throws Exception {
         IMap<String, String> serverMap = server.getMap("A");
         IMap<String, String> clientMap = client.getMap("A");
 
         final CountDownLatch latch = new CountDownLatch(1);
-        clientMap.addEntryListener(new EntryAdapter<String, String>() {
+        clientMap.addEntryListener(new EntryRemovedListener<String, String>() {
             @Override
             public void entryRemoved(EntryEvent<String, String> event) {
                 latch.countDown();

--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -233,6 +233,27 @@ public class ClientMapNearCacheTest {
     }
 
     @Test
+    public void testAfterSetAsyncNearCacheIsInvalidated() throws InterruptedException {
+        int mapSize = 1000;
+        String mapName = randomMapName();
+        hazelcastFactory.newHazelcastInstance(newConfig());
+        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationAndCacheLocalEntriesEnabledNearCacheConfig(mapName));
+
+        final IMap<Integer, Integer> clientMap = client.getMap(mapName);
+        populateNearCache(clientMap, mapSize);
+
+        for (int i = 0; i < mapSize; i++) {
+            clientMap.setAsync(i, i, 1, TimeUnit.SECONDS);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            public void run() throws Exception {
+                assertThatOwnedEntryCountEquals(clientMap, 0);
+            }
+        });
+    }
+
+    @Test
     public void testAfterRemoveAsyncNearCacheIsInvalidated() {
         int mapSize = 1000;
         String mapName = randomMapName();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -158,6 +158,12 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
+    protected Future<Void> setAsyncInternal(long ttl, TimeUnit timeunit, Data keyData, Data valueData) {
+        invalidateNearCache(keyData);
+        return super.setAsyncInternal(ttl, timeunit, keyData, valueData);
+    }
+
+    @Override
     protected Future<V> removeAsyncInternal(Data keyData) {
         invalidateNearCache(keyData);
         return super.removeAsyncInternal(keyData);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.map.listener.EntryEvictedListener;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -269,6 +270,33 @@ public class ClientMapTest extends HazelcastTestSupport {
         assertEquals("value1", map.get("key"));
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertNull(map.get("key"));
+    }
+
+    @Test
+    public void testAsyncSet() throws Exception {
+        IMap<String, String> map = createMap();
+        fillMap(map);
+        Future<Void> future = map.setAsync("key3", "value");
+        future.get();
+        assertEquals("value", map.get("key3"));
+    }
+
+    @Test
+    public void testAsyncSetWithTtl() throws Exception {
+        IMap<String, String> map = createMap();
+        final CountDownLatch latch = new CountDownLatch(1);
+        map.addEntryListener(new EntryEvictedListener<String, String>() {
+            public void entryEvicted(EntryEvent<String, String> event) {
+                latch.countDown();
+            }
+        }, true);
+
+        Future<Void> future = map.setAsync("key", "value1", 3, TimeUnit.SECONDS);
+        future.get();
+        assertEquals("value1", map.get("key"));
+
+        assertOpenEventually(latch);
         assertNull(map.get("key"));
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -233,6 +233,27 @@ public class ClientMapNearCacheTest {
     }
 
     @Test
+    public void testAfterSetAsyncNearCacheIsInvalidated() throws InterruptedException {
+        int mapSize = 1000;
+        String mapName = randomMapName();
+        hazelcastFactory.newHazelcastInstance(newConfig());
+        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationAndCacheLocalEntriesEnabledNearCacheConfig(mapName));
+
+        final IMap<Integer, Integer> clientMap = client.getMap(mapName);
+        populateNearCache(clientMap, mapSize);
+
+        for (int i = 0; i < mapSize; i++) {
+            clientMap.setAsync(i, i, 1, TimeUnit.SECONDS);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            public void run() throws Exception {
+                assertThatOwnedEntryCountEquals(clientMap, 0);
+            }
+        });
+    }
+
+    @Test
     public void testAfterRemoveAsyncNearCacheIsInvalidated() {
         int mapSize = 1000;
         String mapName = randomMapName();

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -401,14 +401,9 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
      * defined in the <tt>key</tt>'s class.
      * <p/>
-     * <p><b>Warning 2:</b></p>
-     * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
      *
      * @param key      the key of the map entry.
      * @param value    the new value of the map entry.
-     * @param ttl      maximum time for this entry to stay in the map.
-     *                 0 means infinite.
-     * @param timeunit time unit for the ttl.
      * @return Future on which to block.
      * @throws NullPointerException if the specified key or value is null.
      * @see java.util.concurrent.Future

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -375,6 +375,89 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
     Future<V> putAsync(K key, V value, long ttl, TimeUnit timeunit);
 
     /**
+     * Asynchronously puts the given key and value.
+     * the entry lives forever.
+     * Similar to the put operation except that set
+     * doesn't return the old value, which is more efficient.
+     * <pre>{@code Future<Void> future = map.setAsync(key, value);
+     * // do some other stuff, when ready get the result
+     * future.get();
+     * }</pre>
+     * Future.get() will block until the actual map.get() completes.
+     * If your application requires a timely response,
+     * then you can use Future.get(timeout, timeunit).
+     * <pre>{@code
+     * try{
+     *     Future<Void> future = map.setAsync(key, newValue);
+     *     future.get(40, TimeUnit.MILLISECOND);
+     * }catch (TimeoutException t) {
+     *     // time wasn't enough
+     * }
+     * }</pre>
+     * ExecutionException is never thrown.
+     * <p/>
+     * <p><b>Warning 1:</b></p>
+     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
+     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
+     * defined in the <tt>key</tt>'s class.
+     * <p/>
+     * <p><b>Warning 2:</b></p>
+     * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
+     *
+     * @param key      the key of the map entry.
+     * @param value    the new value of the map entry.
+     * @param ttl      maximum time for this entry to stay in the map.
+     *                 0 means infinite.
+     * @param timeunit time unit for the ttl.
+     * @return Future on which to block.
+     * @throws NullPointerException if the specified key or value is null.
+     * @see java.util.concurrent.Future
+     */
+    Future<Void> setAsync(K key, V value);
+
+    /**
+     * Asynchronously puts the given key and value into this map with a given ttl (time to live) value.
+     * Entry will expire and get evicted after the ttl. If ttl is 0, then
+     * the entry lives forever.
+     * Similar to the put operation except that set
+     * doesn't return the old value, which is more efficient.
+     * <pre>{@code Future<Void> future = map.setAsync(key, value, ttl, timeunit);
+     * // do some other stuff, when ready get the result
+     * future.get();
+     * }</pre>
+     * Future.get() will block until the actual map.get() completes.
+     * If your application requires a timely response,
+     * then you can use Future.get(timeout, timeunit).
+     * <pre>{@code
+     * try{
+     *     Future<Void> future = map.setAsync(key, newValue, ttl, timeunit);
+     *     future.get(40, TimeUnit.MILLISECOND);
+     * }catch (TimeoutException t) {
+     *     // time wasn't enough
+     * }
+     * }</pre>
+     * ExecutionException is never thrown.
+     * <p/>
+     * <p><b>Warning 1:</b></p>
+     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
+     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
+     * defined in the <tt>key</tt>'s class.
+     * <p/>
+     * <p><b>Warning 2:</b></p>
+     * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
+     *
+     * @param key      the key of the map entry.
+     * @param value    the new value of the map entry.
+     * @param ttl      maximum time for this entry to stay in the map.
+     *                 0 means infinite.
+     * @param timeunit time unit for the ttl.
+     * @return Future on which to block.
+     * @throws NullPointerException if the specified key or value is null.
+     * @see java.util.concurrent.Future
+     */
+    Future<Void> setAsync(K key, V value, long ttl, TimeUnit timeunit);
+
+    /**
      * Asynchronously removes the given key.
      * <p/>
      * <p><b>Warning:</b></p>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -277,18 +277,34 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
-    public Future putAsync(K key, V value) {
+    public Future<V> putAsync(K key, V value) {
         return putAsync(key, value, -1, TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public ICompletableFuture putAsync(K key, V value, long ttl, TimeUnit timeunit) {
+    public ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit timeunit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
         Data k = toData(key, partitionStrategy);
         Data v = toData(value);
         return new DelegatingFuture<V>(putAsyncInternal(k, v, ttl, timeunit),
+                getNodeEngine().getSerializationService());
+    }
+
+    @Override
+    public Future<Void> setAsync(K key, V value) {
+        return setAsync(key, value, -1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
+
+        Data k = toData(key, partitionStrategy);
+        Data v = toData(value);
+        return new DelegatingFuture<Void>(setAsyncInternal(k, v, ttl, timeunit),
                 getNodeEngine().getSerializationService());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -154,6 +154,12 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
+    protected ICompletableFuture<Data> setAsyncInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+        invalidateCache(key);
+        return super.setAsyncInternal(key, value, ttl, timeunit);
+    }
+
+    @Override
     protected boolean replaceInternal(Data key, Data expect, Data update) {
         invalidateCache(key);
         return super.replaceInternal(key, expect, update);

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLocalInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLocalInvalidationTest.java
@@ -261,6 +261,26 @@ public class NearCacheLocalInvalidationTest extends HazelcastTestSupport {
         }
     }
 
+    @Test
+    public void testSetAsync() {
+        final IMap<String, String> map = hcInstance.getMap(getMapName());
+        for (int k = 0; k < numIterations; k++) {
+            String key = "setasync_" + String.valueOf(k);
+            String value = "merhaba-" + key;
+            // test
+            String value0 = map.get(key); // this brings the NULL_OBJECT into the NearCache
+            Future<Void> future = map.setAsync(key, value);
+            try {
+                future.get();
+            } catch (Exception e) {
+                fail("Exception in future.get(): " + e.getMessage());
+            }
+            String value2 = map.get(key); // here we _might_ still see the NULL_OBJECT
+            // assert
+            assertNull(value0);
+            assertEquals(value, value2);
+        }
+    }
 
     @Test
     public void testEvict() {


### PR DESCRIPTION
Backport of #7206 to hazelcast:maintenance-3.x in anticipation of the 3.6.1 release. Refer to #7206 for comments relating to the changes in this PR.

Implements #6726 for 3.6 users.