### PR TITLE
Remove logging of client requests failures

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -184,8 +184,6 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     }
 
     public void handleClientMessage(ClientMessage clientMessage, Connection connection) {
-
-        //TODO: FIXME
         int partitionId = clientMessage.getPartitionId();
         final MessageTask messageTask = messageTaskFactory.create(clientMessage, connection);
         if (partitionId < 0) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAllPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAllPartitionsMessageTask.java
@@ -33,17 +33,12 @@ public abstract class AbstractAllPartitionsMessageTask<P> extends AbstractMessag
     }
 
     @Override
-    protected void processMessage() {
+    protected void processMessage() throws Exception {
         ClientEndpoint endpoint = getEndpoint();
         OperationFactory operationFactory = new OperationFactoryWrapper(createOperationFactory(), endpoint.getUuid());
-        final InternalOperationService operationService = nodeEngine.getOperationService();
-        try {
-            Map<Integer, Object> map = operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
-            sendResponse(reduce(map));
-        } catch (Exception e) {
-            clientEngine.getLogger(getClass()).warning(e);
-            sendClientMessage(e);
-        }
+        InternalOperationService operationService = nodeEngine.getOperationService();
+        Map<Integer, Object> map = operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
+        sendResponse(reduce(map));
     }
 
     protected abstract OperationFactory createOperationFactory();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractCallableMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractCallableMessageTask.java
@@ -30,15 +30,9 @@ public abstract class AbstractCallableMessageTask<P>
         super(clientMessage, node, connection);
     }
 
-    @Override
-    public final void processMessage() {
-        try {
-            Object result = call();
-            sendResponse(result);
-        } catch (Exception e) {
-            clientEngine.getLogger(getClass()).warning(e);
-            sendClientMessage(e);
-        }
+    public final void processMessage() throws Exception {
+        Object result = call();
+        sendResponse(result);
     }
 
     protected abstract Object call() throws Exception;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
@@ -53,6 +53,6 @@ public abstract class AbstractInvocationMessageTask<P> extends AbstractMessageTa
 
     @Override
     public void onFailure(Throwable t) {
-        sendClientMessage(t);
+        handleProcessingFailure(t);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -99,7 +99,6 @@ public abstract class AbstractMessageTask<P>
             }
 
         } catch (Throwable e) {
-            logProcessingFailure(e);
             handleProcessingFailure(e);
         }
     }
@@ -108,7 +107,7 @@ public abstract class AbstractMessageTask<P>
         return false;
     }
 
-    private void initializeAndProcessMessage() {
+    private void initializeAndProcessMessage() throws Throwable {
         if (!node.joined()) {
             throw new HazelcastInstanceNotActiveException("Hazelcast instance is not ready yet!");
         }
@@ -144,17 +143,18 @@ public abstract class AbstractMessageTask<P>
     }
 
     private void logProcessingFailure(Throwable throwable) {
-        Level level = nodeEngine.isRunning() ? Level.SEVERE : Level.FINEST;
-        if (logger.isLoggable(level)) {
+        if (logger.isLoggable(Level.FINEST)) {
             if (parameters == null) {
-                logger.log(level, throwable.getMessage(), throwable);
+                logger.log(Level.FINEST, throwable.getMessage(), throwable);
             } else {
-                logger.log(level, "While executing request: " + parameters + " -> " + throwable.getMessage(), throwable);
+                logger.log(Level.FINEST, "While executing request: " + parameters
+                        + " -> " + throwable.getMessage(), throwable);
             }
         }
     }
 
-    private void handleProcessingFailure(Throwable throwable) {
+    protected void handleProcessingFailure(Throwable throwable) {
+        logProcessingFailure(throwable);
         if (endpoint != null) {
             sendClientMessage(throwable);
         }
@@ -190,7 +190,7 @@ public abstract class AbstractMessageTask<P>
         }
     }
 
-    protected abstract void processMessage();
+    protected abstract void processMessage() throws Throwable;
 
     protected void sendResponse(Object response) {
         ClientMessage clientMessage = encodeResponse(response);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
@@ -77,7 +77,7 @@ public abstract class AbstractPartitionMessageTask<P>
     @Override
     public void onFailure(Throwable t) {
         beforeResponse();
-        sendClientMessage(t);
+        handleProcessingFailure(t);
         afterResponse();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
@@ -48,7 +48,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.mapreduce.impl.MapReduceUtil.executeOperation;
@@ -177,11 +176,7 @@ public abstract class AbstractMapReduceTask<Parameters>
 
     @Override
     public void onFailure(Throwable t) {
-        Throwable throwable = t;
-        if (throwable instanceof ExecutionException) {
-            throwable = throwable.getCause();
-        }
-        sendClientMessage(throwable);
+        handleProcessingFailure(t);
     }
 
     @Override


### PR DESCRIPTION
These exceptions are already send to client and handled on client
side.
 I found a couple of places where try catch is used but actually not needed. And instead of deleting the logging. I made all logged in FINEST level. 

Backport of https://github.com/hazelcast/hazelcast/pull/7356