### PR TITLE
[3.6] ILock expiry operation should be able run both owner and backup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
@@ -63,7 +63,6 @@ public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data
         try {
             submit(operation, key);
         } catch (Throwable t) {
-            ILogger logger = nodeEngine.getLogger(getClass());
             logger.warning(t);
         }
     }
@@ -77,6 +76,7 @@ public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data
         OperationAccessor.setCallerAddress(operation, nodeEngine.getThisAddress());
         operation.setCallerUuid(nodeEngine.getLocalMember().getUuid());
         operation.setOperationResponseHandler(unlockResponseHandler);
+        operation.setValidateTarget(false);
         operation.setAsyncBackup(true);
 
         operationService.executeOperation(operation);


### PR DESCRIPTION
UnlockIfLeaseExpiredOperation runs on both owner and backup nodes. When expiry
isn't triggered on a backup and owner dies just around expiry time, before sending
unlocking backup operation, lock remains as locked even though it's supposed to be expired.
That's why `Operation.validateTarget` is set to false. Otherwise it doesn't
run on backup node and logs a `WrongTargetException`.