### PR TITLE
Improved BufferPoolThreadLocal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocal.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/bufferpool/BufferPoolThreadLocal.java
@@ -16,47 +16,97 @@
 
 package com.hazelcast.internal.serialization.impl.bufferpool;
 
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.BufferObjectDataOutput;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
 
-import java.util.concurrent.ConcurrentMap;
+import java.lang.ref.WeakReference;
+import java.util.Map;
+
+import static com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType.STRONG;
+import static com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType.WEAK;
 
 /**
- * A thread-local like structure for {@link BufferPoolImpl}.
+ * A thread-local for {@link BufferPool}.
  *
- * The reason not a regular ThreadLocal is being used is that the pooled instances should be
- * pooled per HZ instance because:
- * - buffers can contain references to hz instance specifics
- * - buffers for a given hz instance should be cleanable when the instance shuts down and we don't
- * want to have memory leaks.
+ * The BufferPoolThreadLocal is not assigned to a static field, but as a member field of the SerializationService-instance.
+ * is unlike the common use of a ThreadLocal where it assigned to a static field. The reason behind this is that the BufferPool
+ * instance belongs to a specific SerializationService instance (the buffer pool has buffers tied to a particular
+ * SerializationService instance). By creating a ThreadLocal per SerializationService-instance, we obtain 'BufferPool per thread
+ * per SerializationService-instance' semantics.
+ *
+ * <h1>BufferPool is tied to SerializationService-instance</h1>
+ * The BufferPool contains e.g. {@link BufferObjectDataOutput} instances that have a reference to a specific
+ * SerializationService-instance. So as long as there is a strong reference to the BufferPool, there is a strong reference
+ * to the SerializationService-instance.
+ *
+ * <h1>The problem with regular ThreadLocals</h1>
+ * In the Thread.threadLocal-map only the key (the ThreadLocal) is wrapped in a WeakReference. So when the ThreadLocal-instance
+ * dies, the WeakReference prevents a strong reference to the ThreadLocal and potentially at some point in the future, the map
+ * entry with the null valued WeakReference-key and the strong reference to the the value removed. The problem is we have
+ * no control when this happens and we could end up with a memory leak because there are strong references to e.g. the
+ * SerializationService.
+ *
+ * <h1>BufferPoolThreadLocal wraps BufferPool also in WeakReference</h1>
+ * To prevent this memory leak, the value (the BufferPool) in the Thread.threadLocals-map is also wrapped in a WeakReference
+ * So if there is no strong reference to the BufferPool, the BufferPool is gc'ed. Even though there might by some empty key/value
+ * WeakReferences in the Thread.threadLocal-map.
+ *
+ * <h1>Strong references to the BufferPools</h1>
+ * To prevent the BufferPool wrapped in a WeakReference to be gc'ed as soon as it is created, the BufferPool is also stored
+ * in the BufferPoolThreadLocal in a ConcurrentReferenceHashMap with a weak reference for the key (the thread) and a
+ * strong reference to the value (BufferPool):
+ *
+ * This gives us the following behavior:
+ * <ol>
+ * <li>
+ * As soon as the Thread, having the ThreadLocal in its Thread.threadLocals-map, dies, the Entry with the Thread as key
+ * will be removed from the ConcurrentReferenceHashMap at some point.
+ * </li>
+ * <li>
+ * As soon as the SerializationService is collected, the BufferPoolThreadLocal is collected. And because of this, there
+ * are no strong references to the BufferPool instances, and they get collected as well.
+ * </li>
+ * </ol>
+ * So it can be that a Thread in its Thread.threadLocal-map will for some time have an empty weak-reference as key and value. But
+ * there won't be any references to the BufferPool/SerializationService.
+ *
+ * <h1>Performance</h1>
+ * The Performance of using a ThreadLocal in combination with a WeakReference is almost the same as using a ThreadLocal without
+ * WeakReference. There is an extra pointer indirection and some additional pressure on the gc system since it needs to deal with
+ * the WeakReferences, but the number of threads is limited.
  */
 public final class BufferPoolThreadLocal {
 
-    private static final float LOAD_FACTOR = 0.91f;
-
-    private final ConcurrentMap<Thread, BufferPool> pools;
+    private final ThreadLocal<WeakReference<BufferPool>> threadLocal = new ThreadLocal<WeakReference<BufferPool>>();
     private final SerializationService serializationService;
     private final BufferPoolFactory bufferPoolFactory;
+    private final Map<Thread, BufferPool> strongReferences = new ConcurrentReferenceHashMap<Thread, BufferPool>(WEAK, STRONG);
 
     public BufferPoolThreadLocal(SerializationService serializationService, BufferPoolFactory bufferPoolFactory) {
         this.serializationService = serializationService;
         this.bufferPoolFactory = bufferPoolFactory;
-        int initialCapacity = Runtime.getRuntime().availableProcessors();
-        this.pools = new ConcurrentReferenceHashMap<Thread, BufferPool>(initialCapacity, LOAD_FACTOR, 1);
     }
 
     public BufferPool get() {
-        Thread t = Thread.currentThread();
-        BufferPool pool = pools.get(t);
-        if (pool == null) {
-            pool = bufferPoolFactory.create(serializationService);
-            pools.put(t, pool);
+        WeakReference<BufferPool> ref = threadLocal.get();
+        if (ref == null) {
+            BufferPool pool = bufferPoolFactory.create(serializationService);
+            ref = new WeakReference<BufferPool>(pool);
+            strongReferences.put(Thread.currentThread(), pool);
+            threadLocal.set(ref);
+            return pool;
+        } else {
+            BufferPool pool = ref.get();
+            if (pool == null) {
+                throw new HazelcastInstanceNotActiveException();
+            }
+            return pool;
         }
-
-        return pool;
     }
 
     public void clear() {
-        pools.clear();
+        strongReferences.clear();
     }
 }


### PR DESCRIPTION
The previous implementation was very inefficient due to ConcurrentReferenceHashMap. The new implementation relies on a ThreadLocal followed by a WeakReference on the happy path. 

On my machine the following test:
```
 @Test
    public void testLong() {
        Long value = new Long(234533455);

        long startMs = System.currentTimeMillis();
        for (int k = 0; k < iterations; k++) {
            Data data = serializationService.toData(value);
            serializationService.toObject(data);

            if(k%10000000==0){
                System.out.println("at:"+k);
            }
        }
        long durationMs = System.currentTimeMillis() - startMs;
        double performance = (1000.0 * iterations) / durationMs;
        System.out.println("Performance: " + performance + " serializations/second");
    }
```

 gives the following performance improvements:

before:
Performance: 3.674.107 serializations/second

after:
Performance 5.081.817 serializations/second

That is a 38% performance improvement

This week I'll prepare another PR that pushes it to 6M serialization/seconds by improving serializer lookup. 