### PR TITLE
Moved evicting entries to the end of the loadRecordOrNull method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -356,10 +356,10 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (value != null) {
             record = createRecord(value, DEFAULT_TTL, getNow());
             storage.put(key, record);
-            evictEntries(Clock.currentTimeMillis());
             if (!backup) {
                 saveIndex(record, null);
             }
+            evictEntries(Clock.currentTimeMillis());
         }
         return record;
     }


### PR DESCRIPTION
Purpose of this change is that if the loaded entry is picked for eviction, we add the index regardless of the eviction. With this PR, eviction happens at the end so that it can clear indexes of the evicted entry