### PR TITLE
Introduce a way to test hearbeat features of client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -50,7 +50,8 @@ import static com.hazelcast.client.config.ClientProperty.MAX_CONCURRENT_INVOCATI
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.onOutOfMemory;
 
 
-abstract class ClientInvocationServiceSupport implements ClientInvocationService, ConnectionListener {
+abstract class ClientInvocationServiceSupport implements ClientInvocationService, ConnectionListener
+        , ConnectionHeartbeatListener {
 
     private static final int WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED = 10;
     private static final int WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD = 5000;
@@ -81,6 +82,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         executionService = client.getClientExecutionService();
         clientListenerService = (ClientListenerServiceImpl) client.getListenerService();
         connectionManager.addConnectionListener(this);
+        connectionManager.addConnectionHeartbeatListener(this);
         partitionService = client.getClientPartitionService();
         clientExceptionFactory = initClientExceptionFactory();
         responseThread = new ResponseThread(client.getThreadGroup(), client.getName() + ".response-",
@@ -183,6 +185,16 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
 
     @Override
     public void connectionRemoved(Connection connection) {
+        cleanConnectionResources((ClientConnection) connection);
+    }
+
+    @Override
+    public void heartBeatStarted(Connection connection) {
+
+    }
+
+    @Override
+    public void heartBeatStopped(Connection connection) {
         cleanConnectionResources((ClientConnection) connection);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.heartbeat;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientProperty;
+import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.spi.impl.ConnectionHeartbeatListener;
+import com.hazelcast.client.test.TestClientRegistry;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.client.util.ClientDelegatingFuture;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientHeartbeatTest extends HazelcastTestSupport {
+    TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testHeartbeatStoppedEvent() throws InterruptedException {
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.HEARTBEAT_TIMEOUT, "3000");
+        clientConfig.setProperty(ClientProperty.HEARTBEAT_INTERVAL, "500");
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
+        ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        connectionManager.addConnectionHeartbeatListener(new ConnectionHeartbeatListener() {
+            @Override
+            public void heartBeatStarted(Connection connection) {
+            }
+
+            @Override
+            public void heartBeatStopped(Connection connection) {
+                countDownLatch.countDown();
+            }
+        });
+
+        blockMessagesFromInstance(instance, client);
+        assertOpenEventually(countDownLatch);
+    }
+
+    @Test(expected = TargetDisconnectedException.class)
+    public void testInvocation_whenHeartbeatStopped() throws InterruptedException {
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.HEARTBEAT_TIMEOUT, "3000");
+        clientConfig.setProperty(ClientProperty.HEARTBEAT_INTERVAL, "500");
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
+
+        String keyOwnedByInstance2 = generateKeyOwnedBy(instance2);
+        IMap map = client.getMap(randomString());
+        map.put(keyOwnedByInstance2, randomString());
+        blockMessagesFromInstance(instance2, client);
+        map.put(keyOwnedByInstance2, randomString());
+    }
+
+    @Test
+    public void testAsyncInvocation_whenHeartbeatStopped() throws InterruptedException {
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.HEARTBEAT_TIMEOUT, "3000");
+        clientConfig.setProperty(ClientProperty.HEARTBEAT_INTERVAL, "500");
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+        HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
+
+        IMap map = client.getMap(randomString());
+        String keyOwnedByInstance2 = generateKeyOwnedBy(instance2);
+        map.put(keyOwnedByInstance2, randomString());
+        blockMessagesFromInstance(instance2, client);
+        ClientDelegatingFuture future = (ClientDelegatingFuture) map.putAsync(keyOwnedByInstance2, randomString());
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        future.andThen(new ExecutionCallback() {
+            @Override
+            public void onResponse(Object response) {
+
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                if (t.getCause() instanceof TargetDisconnectedException) {
+                    countDownLatch.countDown();
+                }
+            }
+        });
+        assertOpenEventually(countDownLatch);
+    }
+
+    private void blockMessagesFromInstance(HazelcastInstance instance, HazelcastInstance client) {
+        HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
+        ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
+        Address address = instance.getCluster().getLocalMember().getAddress();
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).block(address);
+    }
+
+    private void unblockMessagesFromInstance(HazelcastInstance instance, HazelcastInstance client) {
+        HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
+        ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
+        Address address = instance.getCluster().getLocalMember().getAddress();
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).unblock(address);
+    }
+
+    private HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {
+        HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
+        return clientProxy.client;
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionServiceLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionServiceLiteMemberTest.java
@@ -19,8 +19,7 @@ import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientPartitionServiceLiteMemberTest
-        extends TestHazelcastFactory {
+public class ClientPartitionServiceLiteMemberTest {
 
     private TestHazelcastFactory factory;
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -49,6 +49,10 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
 
 public class TestClientRegistry {
@@ -96,10 +100,11 @@ public class TestClientRegistry {
     }
 
 
-    private class MockClientConnectionManager extends ClientConnectionManagerImpl {
+    public class MockClientConnectionManager extends ClientConnectionManagerImpl {
 
         private final Address clientAddress;
         private final HazelcastClientInstanceImpl client;
+        private final Map<Address, State> stateMap = new ConcurrentHashMap<Address, State>();
 
         public MockClientConnectionManager(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
                                            Address clientAddress) {
@@ -135,17 +140,47 @@ public class TestClientRegistry {
                 }
                 Node node = TestUtil.getNode(instance);
                 return new MockedClientConnection(client, connectionIdGen.incrementAndGet(),
-                        node.nodeEngine, address, clientAddress);
+                        node.nodeEngine, address, clientAddress, stateMap);
             } catch (Exception e) {
                 throw ExceptionUtil.rethrow(e, IOException.class);
             }
         }
 
+        /**
+         * Stores incoming messages from address to a temporary queue
+         * When unblocked first this queue will be processed after that new messages will be consumed
+         *
+         * @param address
+         */
+        public void block(Address address) {
+            stateMap.put(address, State.BLOCKING);
+        }
 
+        /**
+         * Drops incoming messages from address
+         *
+         * @param address
+         */
+        public void drop(Address address) {
+            stateMap.put(address, State.DROPPING);
+        }
+
+        /**
+         * Removes the filter that is put by either block or drop
+         * Consumes from the temporary queue if there is anything then continues to normal behaviour
+         *
+         * @param address
+         */
+        public void unblock(Address address) {
+            stateMap.remove(address);
+        }
     }
 
+    enum State {
+        BLOCKING, DROPPING
+    }
 
-    private class MockedClientConnection extends ClientConnection {
+    public class MockedClientConnection extends ClientConnection {
         private volatile long lastReadTime;
         private volatile long lastWriteTime;
         private final NodeEngineImpl serverNodeEngine;
@@ -153,12 +188,16 @@ public class TestClientRegistry {
         private final Address localAddress;
         private final Connection serverSideConnection;
 
+        private final Queue<ClientMessage> incomingMessages = new ConcurrentLinkedQueue<ClientMessage>();
+        private final Map<Address, State> stateMap;
+
         public MockedClientConnection(HazelcastClientInstanceImpl client, int connectionId, NodeEngineImpl serverNodeEngine,
-                                      Address address, Address localAddress) throws IOException {
+                                      Address address, Address localAddress, Map<Address, State> stateMap) throws IOException {
             super(client, connectionId);
             this.serverNodeEngine = serverNodeEngine;
             this.remoteAddress = address;
             this.localAddress = localAddress;
+            this.stateMap = stateMap;
             this.serverSideConnection = new MockedNodeConnection(connectionId, remoteAddress,
                     localAddress, serverNodeEngine, this);
         }
@@ -169,8 +208,25 @@ public class TestClientRegistry {
         }
 
         void handleClientMessage(ClientMessage clientMessage) {
+            if (getState() == State.DROPPING) {
+                return;
+            }
+
+            if (getState() == State.BLOCKING) {
+                incomingMessages.add(clientMessage);
+                return;
+            }
+            ClientMessage message;
+            while ((message = incomingMessages.poll()) != null) {
+                lastReadTime = System.currentTimeMillis();
+                getConnectionManager().handleClientMessage(message, this);
+            }
             lastReadTime = System.currentTimeMillis();
             getConnectionManager().handleClientMessage(clientMessage, this);
+        }
+
+        private State getState() {
+            return stateMap.get(remoteAddress);
         }
 
         @Override


### PR DESCRIPTION
This is currently only avaliable for mocked network tests.
One bug fixed and related tests are added.

Fixed bug is related to async invocations made from client.
ClientHeartbat check was used to be made from only `future.get` .
When user does not call `future.get` method, heartbeat never kicks
in to make the waiting party free. Related logic is moved to
lientInvocationServiceSupport via ConnectionHeartbeatListener.