### PR TITLE
Backport: Aligns `SerializationConfig`s default values in `hazelcast-spring.xsd` with Java API

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.6.xsd
@@ -1986,9 +1986,9 @@
             </xs:simpleType>
         </xs:attribute>
         <xs:attribute name="portable-version" use="optional" type="xs:string"/>
-        <xs:attribute name="check-class-def-errors" use="optional" type="xs:string" default="false"/>
+        <xs:attribute name="check-class-def-errors" use="optional" type="xs:string" default="true"/>
         <xs:attribute name="enable-compression" use="optional" type="xs:string" default="false"/>
-        <xs:attribute name="enable-shared-object" use="optional" type="xs:string" default="false"/>
+        <xs:attribute name="enable-shared-object" use="optional" type="xs:string" default="true"/>
         <xs:attribute name="allow-unsafe" use="optional" type="xs:string" default="false"/>
     </xs:complexType>
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -91,6 +91,9 @@ public class TestClientApplicationContext {
     @Resource(name = "client6")
     private HazelcastClientProxy client6;
 
+    @Resource(name = "client7-empty-serialization-config")
+    private HazelcastClientProxy client7;
+
     @Resource(name = "instance")
     private HazelcastInstance instance;
 
@@ -271,6 +274,20 @@ public class TestClientApplicationContext {
         assertEquals("atomicReference", atomicReference.getName());
         assertEquals("countDownLatch", countDownLatch.getName());
         assertEquals("semaphore", semaphore.getName());
+    }
+
+    @Test
+    public void testDefaultSerializationConfig() {
+        ClientConfig config7 = client7.getClientConfig();
+        final SerializationConfig serConf = config7.getSerializationConfig();
+
+        assertEquals(ByteOrder.BIG_ENDIAN, serConf.getByteOrder());
+        assertEquals(false, serConf.isAllowUnsafe());
+        assertEquals(true, serConf.isCheckClassDefErrors());
+        assertEquals(false, serConf.isEnableCompression());
+        assertEquals(true, serConf.isEnableSharedObject());
+        assertEquals(false, serConf.isUseNativeByteOrder());
+        assertEquals(0, serConf.getPortableVersion());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -217,6 +217,24 @@
 
     </hz:client>
 
+    <hz:client id="client7-empty-serialization-config" credentials-ref="credentials">
+        <hz:network connection-attempt-limit="3"
+                    connection-attempt-period="3000"
+                    connection-timeout="1000"
+                    redo-operation="false"
+                    smart-routing="false">
+
+            <hz:member>127.0.0.1:5700</hz:member>
+            <hz:member>127.0.0.1:5701</hz:member>
+            <hz:socket-options buffer-size="32"
+                               keep-alive="false"
+                               linger-seconds="3"
+                               reuse-address="false"
+                               tcp-no-delay="false"/>
+        </hz:network>
+        <hz:serialization></hz:serialization>
+    </hz:client>
+
     <bean id="credentials" class="com.hazelcast.security.UsernamePasswordCredentials">
         <property name="username" value="spring-group"/>
         <property name="password" value="spring-group-pass"/>


### PR DESCRIPTION
Backport: https://github.com/hazelcast/hazelcast/pull/7379
resolves #5815