### PR TITLE
Client txn deserialization on server-side fix

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
@@ -20,6 +20,9 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.SampleObjects;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -35,6 +38,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -545,5 +549,58 @@ public class ClientTxnMapTest {
         final TransactionalMap<Object, Object> txMap = context.getMap(mapName);
 
         txMap.values(null);
+    }
+
+    @Test
+    public void testPutDoesNotDeserializeOnServerSide(){
+        String name = randomString();
+        client.getMap(name).put(5, new DeserializeOnceObject(5));
+        TransactionContext context = client.newTransactionContext();
+        context.beginTransaction();
+        TransactionalMap<Integer, DeserializeOnceObject> map = context.getMap(name);
+        map.put(5, new DeserializeOnceObject(6));
+        context.commitTransaction();
+    }
+
+    private static class DeserializeOnceObject implements DataSerializable {
+
+        private int amount;
+
+        private static AtomicBoolean readCalled = new AtomicBoolean(false);
+
+        public DeserializeOnceObject() {
+        }
+
+        public DeserializeOnceObject(int amount) {
+            this.amount = amount;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeInt(amount);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            if (!readCalled.compareAndSet(false, true)) {
+                throw new AssertionError("Read called more than once!!!");
+            }
+            amount = in.readInt();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof DeserializeOnceObject)) return false;
+
+            DeserializeOnceObject that = (DeserializeOnceObject) o;
+
+            return amount == that.amount;
+        }
+
+        @Override
+        public int hashCode() {
+            return amount;
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XATransactionCreateMessageTask.java
@@ -40,7 +40,7 @@ public class XATransactionCreateMessageTask
     protected Object call() throws Exception {
         ClientEndpoint endpoint = getEndpoint();
         XAService xaService = getService(getServiceName());
-        TransactionContext context = xaService.newXATransactionContext(parameters.xid, (int) parameters.timeout);
+        TransactionContext context = xaService.newXATransactionContext(parameters.xid, (int) parameters.timeout, true);
         TransactionAccessor.getTransaction(context).begin();
         endpoint.setTransactionContext(context);
         return context.getTxnId();

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
@@ -23,10 +23,10 @@ import com.hazelcast.collection.impl.txncollection.operations.CollectionReserveR
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnAddOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnRemoveOperation;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.TransactionalDistributedObject;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.impl.Transaction;
@@ -40,17 +40,15 @@ import java.util.concurrent.Future;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
-public abstract class AbstractTransactionalCollectionProxy<S extends RemoteService, E> extends AbstractDistributedObject<S> {
+public abstract class AbstractTransactionalCollectionProxy<S extends RemoteService, E> extends TransactionalDistributedObject<S> {
 
     protected final String name;
-    protected final Transaction tx;
     protected final int partitionId;
     protected final Set<Long> itemIdSet = new HashSet<Long>();
 
     public AbstractTransactionalCollectionProxy(String name, Transaction tx, NodeEngine nodeEngine, S service) {
-        super(nodeEngine, service);
+        super(nodeEngine, service, tx);
         this.name = name;
-        this.tx = tx;
         this.partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.collection.impl.txnqueue;
 
+import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.EmptyStatement;
@@ -80,7 +80,7 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport i
 
         checkTransactionState();
         Data data = pollInternal(unit.toMillis(timeout));
-        return getNodeEngine().toObject(data);
+        return (E) toObjectIfNeeded(data);
     }
 
     @Override
@@ -100,7 +100,7 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport i
 
         checkTransactionState();
         Data data = peekInternal(unit.toMillis(timeout));
-        return getNodeEngine().toObject(data);
+        return (E) toObjectIfNeeded(data);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.collection.impl.txnqueue;
 
-import com.hazelcast.config.QueueConfig;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.collection.impl.queue.QueueItem;
 import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.collection.impl.queue.operations.SizeOperation;
@@ -26,11 +24,13 @@ import com.hazelcast.collection.impl.txnqueue.operations.TxnPeekOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnPollOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnReserveOfferOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnReservePollOperation;
-import com.hazelcast.spi.AbstractDistributedObject;
+import com.hazelcast.config.QueueConfig;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.TransactionalDistributedObject;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionalObject;
@@ -45,11 +45,10 @@ import java.util.concurrent.Future;
 /**
  * Provides support for proxy of the Transactional Queue.
  */
-public abstract class TransactionalQueueProxySupport extends AbstractDistributedObject<QueueService>
+public abstract class TransactionalQueueProxySupport extends TransactionalDistributedObject<QueueService>
         implements TransactionalObject {
 
     protected final String name;
-    protected final Transaction tx;
     protected final int partitionId;
     protected final QueueConfig config;
     private final LinkedList<QueueItem> offeredQueue = new LinkedList<QueueItem>();
@@ -57,9 +56,8 @@ public abstract class TransactionalQueueProxySupport extends AbstractDistributed
 
     protected TransactionalQueueProxySupport(NodeEngine nodeEngine, QueueService service, String name,
                                              Transaction tx) {
-        super(nodeEngine, service);
+        super(nodeEngine, service, tx);
         this.name = name;
-        this.tx = tx;
         partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
         config = nodeEngine.getConfig().findQueueConfig(name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -23,6 +23,7 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultCollection;
+import com.hazelcast.map.impl.tx.TxnValueWrapper.Type;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
@@ -45,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.Preconditions.checkNotInstanceOf;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Proxy implementation of {@link com.hazelcast.core.TransactionalMap} interface.
@@ -64,7 +66,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
         TxnValueWrapper valueWrapper = txMap.get(keyData);
         if (valueWrapper != null) {
-            return (valueWrapper.type != TxnValueWrapper.Type.REMOVED);
+            return (valueWrapper.type != Type.REMOVED);
         }
         return containsKeyInternal(keyData);
     }
@@ -75,9 +77,9 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         int currentSize = sizeInternal();
         for (Map.Entry<Data, TxnValueWrapper> entry : txMap.entrySet()) {
             TxnValueWrapper wrapper = entry.getValue();
-            if (wrapper.type == TxnValueWrapper.Type.NEW) {
+            if (wrapper.type == Type.NEW) {
                 currentSize++;
-            } else if (wrapper.type == TxnValueWrapper.Type.REMOVED) {
+            } else if (wrapper.type == Type.REMOVED) {
                 VersionedValue versionedValue = valueMap.get(entry.getKey());
                 if (versionedValue != null && versionedValue.value != null) {
                     currentSize--;
@@ -104,7 +106,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         if (currentValue != null) {
             return checkIfRemoved(currentValue);
         }
-        return mapServiceContext.toObject(getInternal(keyData));
+        return toObjectIfNeeded(getInternal(keyData));
     }
 
     @Override
@@ -119,26 +121,12 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
             return checkIfRemoved(currentValue);
         }
 
-        return mapServiceContext.toObject(getForUpdateInternal(keyData));
+        return toObjectIfNeeded(getForUpdateInternal(keyData));
     }
 
     @Override
     public Object put(Object key, Object value) {
-        checkTransactionState();
-        MapService service = getService();
-        MapServiceContext mapServiceContext = service.getMapServiceContext();
-        Data keyData = mapServiceContext.toData(key, partitionStrategy);
-        Object valueBeforeTxn = mapServiceContext.toObject(putInternal(keyData, mapServiceContext.toData(value)));
-
-        TxnValueWrapper currentValue = txMap.get(keyData);
-        if (value != null) {
-            TxnValueWrapper wrapper = valueBeforeTxn == null
-                    ? new TxnValueWrapper(value, TxnValueWrapper.Type.NEW)
-                    : new TxnValueWrapper(value, TxnValueWrapper.Type.UPDATED);
-
-            txMap.put(keyData, wrapper);
-        }
-        return currentValue == null ? valueBeforeTxn : checkIfRemoved(currentValue);
+        return put(key, value, -1, MILLISECONDS);
     }
 
     @Override
@@ -147,13 +135,12 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
-        Object valueBeforeTxn = mapServiceContext.toObject(putInternal(keyData, mapServiceContext.toData(value), ttl, timeUnit));
+        Object valueBeforeTxn = toObjectIfNeeded(putInternal(keyData, mapServiceContext.toData(value), ttl, timeUnit));
 
         TxnValueWrapper currentValue = txMap.get(keyData);
         if (value != null) {
-            TxnValueWrapper wrapper = valueBeforeTxn == null
-                    ? new TxnValueWrapper(value, TxnValueWrapper.Type.NEW)
-                    : new TxnValueWrapper(value, TxnValueWrapper.Type.UPDATED);
+            Type type = valueBeforeTxn == null ? Type.NEW : Type.UPDATED;
+            TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
             txMap.put(keyData, wrapper);
         }
         return currentValue == null ? valueBeforeTxn : checkIfRemoved(currentValue);
@@ -165,11 +152,10 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
-        Data dataBeforeTxn = putInternal(keyData, mapServiceContext.toData(value));
+        Data dataBeforeTxn = putInternal(keyData, mapServiceContext.toData(value), -1, MILLISECONDS);
         if (value != null) {
-            TxnValueWrapper wrapper = (dataBeforeTxn == null)
-                    ? new TxnValueWrapper(value, TxnValueWrapper.Type.NEW)
-                    : new TxnValueWrapper(value, TxnValueWrapper.Type.UPDATED);
+            Type type = dataBeforeTxn == null ? Type.NEW : Type.UPDATED;
+            TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
             txMap.put(keyData, wrapper);
         }
     }
@@ -183,20 +169,20 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         TxnValueWrapper wrapper = txMap.get(keyData);
         boolean haveTxnPast = wrapper != null;
         if (haveTxnPast) {
-            if (wrapper.type != TxnValueWrapper.Type.REMOVED) {
+            if (wrapper.type != Type.REMOVED) {
                 return wrapper.value;
             }
-            putInternal(keyData, mapServiceContext.toData(value));
-            txMap.put(keyData, new TxnValueWrapper(value, TxnValueWrapper.Type.NEW));
+            putInternal(keyData, mapServiceContext.toData(value), -1, MILLISECONDS);
+            txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
             return null;
         } else {
             Data oldValue
                     = putIfAbsentInternal(keyData,
                     mapServiceContext.toData(value));
             if (oldValue == null) {
-                txMap.put(keyData, new TxnValueWrapper(value, TxnValueWrapper.Type.NEW));
+                txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
             }
-            return mapServiceContext.toObject(oldValue);
+            return toObjectIfNeeded(oldValue);
         }
     }
 
@@ -210,18 +196,18 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         TxnValueWrapper wrapper = txMap.get(keyData);
         boolean haveTxnPast = wrapper != null;
         if (haveTxnPast) {
-            if (wrapper.type == TxnValueWrapper.Type.REMOVED) {
+            if (wrapper.type == Type.REMOVED) {
                 return null;
             }
-            putInternal(keyData, mapServiceContext.toData(value));
-            txMap.put(keyData, new TxnValueWrapper(value, TxnValueWrapper.Type.UPDATED));
+            putInternal(keyData, mapServiceContext.toData(value), -1, MILLISECONDS);
+            txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
             return wrapper.value;
         } else {
             Data oldValue = replaceInternal(keyData, mapServiceContext.toData(value));
             if (oldValue != null) {
-                txMap.put(keyData, new TxnValueWrapper(value, TxnValueWrapper.Type.UPDATED));
+                txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
             }
-            return mapServiceContext.toObject(oldValue);
+            return toObjectIfNeeded(oldValue);
         }
     }
 
@@ -238,14 +224,14 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
             if (!wrapper.value.equals(oldValue)) {
                 return false;
             }
-            putInternal(keyData, mapServiceContext.toData(newValue));
-            txMap.put(keyData, new TxnValueWrapper(wrapper.value, TxnValueWrapper.Type.UPDATED));
+            putInternal(keyData, mapServiceContext.toData(newValue), -1, MILLISECONDS);
+            txMap.put(keyData, new TxnValueWrapper(wrapper.value, Type.UPDATED));
             return true;
         } else {
             boolean success = replaceIfSameInternal(keyData,
                     mapServiceContext.toData(oldValue), mapServiceContext.toData(newValue));
             if (success) {
-                txMap.put(keyData, new TxnValueWrapper(newValue, TxnValueWrapper.Type.UPDATED));
+                txMap.put(keyData, new TxnValueWrapper(newValue, Type.UPDATED));
             }
             return success;
         }
@@ -265,7 +251,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
         boolean removed = removeIfSameInternal(keyData, value);
         if (removed) {
-            txMap.put(keyData, new TxnValueWrapper(value, TxnValueWrapper.Type.REMOVED));
+            txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
         }
         return removed;
     }
@@ -276,11 +262,11 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
-        Object valueBeforeTxn = mapServiceContext.toObject(removeInternal(keyData));
+        Object valueBeforeTxn = toObjectIfNeeded(removeInternal(keyData));
 
         TxnValueWrapper wrapper = null;
         if (valueBeforeTxn != null || txMap.containsKey(keyData)) {
-            wrapper = txMap.put(keyData, new TxnValueWrapper(valueBeforeTxn, TxnValueWrapper.Type.REMOVED));
+            wrapper = txMap.put(keyData, new TxnValueWrapper(valueBeforeTxn, Type.REMOVED));
         }
         return wrapper == null ? valueBeforeTxn : checkIfRemoved(wrapper);
     }
@@ -294,7 +280,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
         Data data = removeInternal(keyData);
         if (data != null || txMap.containsKey(keyData)) {
-            txMap.put(keyData, new TxnValueWrapper(mapServiceContext.toObject(data), TxnValueWrapper.Type.REMOVED));
+            txMap.put(keyData, new TxnValueWrapper(toObjectIfNeeded(data), Type.REMOVED));
         }
     }
 
@@ -324,9 +310,9 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         Extractors extractors = mapServiceContext.getExtractors(name);
         for (Map.Entry<Data, TxnValueWrapper> entry : txMap.entrySet()) {
             Data keyData = entry.getKey();
-            if (!TxnValueWrapper.Type.REMOVED.equals(entry.getValue().type)) {
+            if (!Type.REMOVED.equals(entry.getValue().type)) {
                 Object value = (entry.getValue().value instanceof Data)
-                        ? mapServiceContext.toObject(entry.getValue().value) : entry.getValue().value;
+                        ? toObjectIfNeeded(entry.getValue().value) : entry.getValue().value;
 
                 QueryableEntry queryEntry = new CachedQueryEntry(serializationService, keyData, value, extractors);
                 // apply predicate on txMap
@@ -372,8 +358,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
         // iterate over the txMap and see if the values are updated or removed
         for (Map.Entry<Data, TxnValueWrapper> entry : txMap.entrySet()) {
-            boolean isRemoved = TxnValueWrapper.Type.REMOVED.equals(entry.getValue().type);
-            boolean isUpdated = TxnValueWrapper.Type.UPDATED.equals(entry.getValue().type);
+            boolean isRemoved = Type.REMOVED.equals(entry.getValue().type);
+            boolean isUpdated = Type.UPDATED.equals(entry.getValue().type);
 
             Object keyObject = serializationService.toObject(entry.getKey());
             if (isRemoved) {
@@ -400,7 +386,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
     private Object checkIfRemoved(TxnValueWrapper wrapper) {
         checkTransactionState();
-        return wrapper == null || wrapper.type == TxnValueWrapper.Type.REMOVED ? null : wrapper.value;
+        return wrapper == null || wrapper.type == Type.REMOVED ? null : wrapper.value;
     }
 
     private void removeFromResultSet(QueryResultCollection<Map.Entry> queryResultSet, List<Object> valueSet,

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
@@ -56,7 +56,7 @@ public class TransactionalMultiMapProxy<K, V> extends TransactionalMultiMapProxy
         Collection<MultiMapRecord> coll = getInternal(dataKey);
         Collection<V> collection = new ArrayList<V>(coll.size());
         for (MultiMapRecord record : coll) {
-            collection.add((V) getNodeEngine().toObject(record.getObject()));
+            collection.add((V) toObjectIfNeeded(record.getObject()));
         }
         return collection;
     }
@@ -76,7 +76,7 @@ public class TransactionalMultiMapProxy<K, V> extends TransactionalMultiMapProxy
         Collection<MultiMapRecord> coll = removeAllInternal(dataKey);
         Collection<V> result = new ArrayList<V>(coll.size());
         for (MultiMapRecord record : coll) {
-            result.add((V) getNodeEngine().toObject(record.getObject()));
+            result.add((V) toObjectIfNeeded(record.getObject()));
         }
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
@@ -24,9 +24,9 @@ import com.hazelcast.multimap.impl.operations.GetAllOperation;
 import com.hazelcast.multimap.impl.operations.MultiMapOperationFactory;
 import com.hazelcast.multimap.impl.operations.MultiMapResponse;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.TransactionalDistributedObject;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
@@ -44,12 +44,11 @@ import java.util.concurrent.Future;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
-public abstract class TransactionalMultiMapProxySupport extends AbstractDistributedObject<MultiMapService>
+public abstract class TransactionalMultiMapProxySupport extends TransactionalDistributedObject<MultiMapService>
         implements TransactionalObject {
 
     private static final double TIMEOUT_EXTEND_MULTIPLIER = 1.5;
     protected final String name;
-    protected final Transaction tx;
     protected final MultiMapConfig config;
 
     private final Map<Data, Collection<MultiMapRecord>> txMap = new HashMap<Data, Collection<MultiMapRecord>>();
@@ -58,9 +57,8 @@ public abstract class TransactionalMultiMapProxySupport extends AbstractDistribu
                                                 MultiMapService service,
                                                 String name,
                                                 Transaction tx) {
-        super(nodeEngine, service);
+        super(nodeEngine, service, tx);
         this.name = name;
-        this.tx = tx;
         this.config = nodeEngine.getConfig().findMultiMapConfig(name);
     }
 
@@ -92,7 +90,7 @@ public abstract class TransactionalMultiMapProxySupport extends AbstractDistribu
         } else {
             logRecord = (MultiMapTransactionLogRecord) tx.get(getRecordLogKey(key));
         }
-        MultiMapRecord record = new MultiMapRecord(config.isBinary() ? value : getNodeEngine().toObject(value));
+        MultiMapRecord record = new MultiMapRecord(config.isBinary() ? value : toObjectIfNeeded(value));
         if (coll.add(record)) {
             if (recordId == -1) {
                 recordId = nextId(key);
@@ -125,7 +123,7 @@ public abstract class TransactionalMultiMapProxySupport extends AbstractDistribu
         } else {
             logRecord = (MultiMapTransactionLogRecord) tx.get(getRecordLogKey(key));
         }
-        MultiMapRecord record = new MultiMapRecord(config.isBinary() ? value : getNodeEngine().toObject(value));
+        MultiMapRecord record = new MultiMapRecord(config.isBinary() ? value : toObjectIfNeeded(value));
         Iterator<MultiMapRecord> iterator = coll.iterator();
         long recordId = -1;
         while (iterator.hasNext()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.transaction.impl.Transaction;
+
+/**
+ * To centralize de-serialization for transactional proxies
+ */
+public abstract class TransactionalDistributedObject<S extends RemoteService> extends AbstractDistributedObject<S> {
+
+    protected final Transaction tx;
+
+    protected TransactionalDistributedObject(NodeEngine nodeEngine, S service, Transaction tx) {
+        super(nodeEngine, service);
+        this.tx = tx;
+    }
+
+    public Object toObjectIfNeeded(Object data) {
+        if (tx.isOriginatedFromClient()) {
+            return data;
+        }
+        return getNodeEngine().toObject(data);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/Transaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/Transaction.java
@@ -53,4 +53,6 @@ public interface Transaction {
     TransactionLogRecord get(Object key);
 
     String getOwnerUuid();
+
+    boolean isOriginatedFromClient();
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
@@ -50,9 +50,9 @@ final class TransactionContextImpl implements TransactionContext {
             = new HashMap<TransactionalObjectKey, TransactionalObject>(2);
 
     TransactionContextImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngineImpl nodeEngine,
-                           TransactionOptions options, String ownerUuid) {
+                           TransactionOptions options, String ownerUuid, boolean originatedFromClient) {
         this.nodeEngine = nodeEngine;
-        this.transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, ownerUuid);
+        this.transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, ownerUuid, originatedFromClient);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -88,9 +88,15 @@ public class TransactionImpl implements Transaction {
     private long startTime;
     private Address[] backupAddresses = EMPTY_ADDRESSES;
     private boolean backupLogsCreated;
+    private boolean originatedFromClient;
 
     public TransactionImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngine nodeEngine,
                            TransactionOptions options, String txOwnerUuid) {
+        this(transactionManagerService, nodeEngine, options, txOwnerUuid, false);
+    }
+
+    public TransactionImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngine nodeEngine,
+                           TransactionOptions options, String txOwnerUuid, boolean originatedFromClient) {
         this.transactionLog = new TransactionLog();
         this.transactionManagerService = transactionManagerService;
         this.nodeEngine = nodeEngine;
@@ -104,6 +110,7 @@ public class TransactionImpl implements Transaction {
         this.logger = nodeEngine.getLogger(getClass());
         this.rollbackExceptionHandler = logAllExceptions(logger, "Error during rollback!", WARNING);
         this.rollbackTxExceptionHandler = logAllExceptions(logger, "Error during tx rollback backup!", WARNING);
+        this.originatedFromClient = originatedFromClient;
     }
 
     // used by tx backups
@@ -139,6 +146,10 @@ public class TransactionImpl implements Transaction {
     @Override
     public String getOwnerUuid() {
         return txOwnerUuid;
+    }
+
+    public boolean isOriginatedFromClient() {
+        return originatedFromClient;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
@@ -91,7 +91,8 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
     public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException {
         checkNotNull(task, "TransactionalTask is required!");
 
-        final TransactionContextImpl context = new TransactionContextImpl(this, nodeEngine, options, null);
+
+        TransactionContext context = newTransactionContext(options);
         context.beginTransaction();
         try {
             T value = task.execute(context);
@@ -114,12 +115,12 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
 
     @Override
     public TransactionContext newTransactionContext(TransactionOptions options) {
-        return new TransactionContextImpl(this, nodeEngine, options, null);
+        return new TransactionContextImpl(this, nodeEngine, options, null, false);
     }
 
     @Override
     public TransactionContext newClientTransactionContext(TransactionOptions options, String clientUuid) {
-        return new TransactionContextImpl(this, nodeEngine, options, clientUuid);
+        return new TransactionContextImpl(this, nodeEngine, options, clientUuid, true);
     }
 
     /**
@@ -340,8 +341,8 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
         final String callerUuid;
         final long timeoutMillis;
         final long startTime;
-        volatile State state;
         final boolean allowedDuringPassiveState;
+        volatile State state;
 
         private TxBackupLog(List<TransactionLogRecord> records, String callerUuid, State state,
                             long timeoutMillis, long startTime, boolean allowedDuringPassiveState) {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -107,7 +107,7 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
 
     private TransactionContext createTransactionContext(Xid xid) {
         XAService xaService = getService();
-        TransactionContext context = xaService.newXATransactionContext(xid, timeoutInSeconds.get());
+        TransactionContext context = xaService.newXATransactionContext(xid, timeoutInSeconds.get(), false);
         getTransaction(context).begin();
         return context;
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
@@ -82,8 +82,8 @@ public class XAService implements ManagedService, RemoteService, MigrationAwareS
     public void destroyDistributedObject(String objectName) {
     }
 
-    public TransactionContext newXATransactionContext(Xid xid, int timeout) {
-        return new XATransactionContextImpl(nodeEngine, xid, null, timeout);
+    public TransactionContext newXATransactionContext(Xid xid, int timeout, boolean originatedFromClient) {
+        return new XATransactionContextImpl(nodeEngine, xid, null, timeout, originatedFromClient);
     }
 
     public void putTransaction(XATransaction transaction) {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
@@ -46,9 +46,10 @@ public class XATransactionContextImpl implements TransactionContext {
     private final Map<TransactionalObjectKey, TransactionalObject> txnObjectMap
             = new HashMap<TransactionalObjectKey, TransactionalObject>(2);
 
-    public XATransactionContextImpl(NodeEngineImpl nodeEngine, Xid xid, String txOwnerUuid, int timeout) {
+    public XATransactionContextImpl(NodeEngineImpl nodeEngine, Xid xid, String txOwnerUuid,
+                                    int timeout, boolean originatedFromClient) {
         this.nodeEngine = nodeEngine;
-        this.transaction = new XATransaction(nodeEngine, xid, txOwnerUuid, timeout);
+        this.transaction = new XATransaction(nodeEngine, xid, txOwnerUuid, timeout, originatedFromClient);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/impl/AdvancedClusterStateTest.java
@@ -638,6 +638,11 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
         @Override
         public String getOwnerUuid() {return tx.getOwnerUuid();}
+
+        @Override
+        public boolean isOriginatedFromClient() {
+            return tx.isOriginatedFromClient();
+        }
     }
 
     public static void changeClusterStateEventually(HazelcastInstance hz, ClusterState newState) {

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionContextImpl_backupLogsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionContextImpl_backupLogsTest.java
@@ -68,7 +68,7 @@ public class TransactionContextImpl_backupLogsTest extends HazelcastTestSupport 
     public void assertBackupLogCreationForced(String serviceName) {
         TransactionOptions options = new TransactionOptions();
 
-        TransactionContextImpl txContext = new TransactionContextImpl(localTxManager, localNodeEngine, options, ownerUuid);
+        TransactionContextImpl txContext = new TransactionContextImpl(localTxManager, localNodeEngine, options, ownerUuid, false);
         txContext.beginTransaction();
 
         TransactionalObject result = txContext.getTransactionalObject(serviceName, "foo");
@@ -90,7 +90,7 @@ public class TransactionContextImpl_backupLogsTest extends HazelcastTestSupport 
     public void assertBackupLogCreationNotForced(String serviceName) {
         TransactionOptions options = new TransactionOptions();
 
-        TransactionContextImpl txContext = new TransactionContextImpl(localTxManager, localNodeEngine, options, ownerUuid);
+        TransactionContextImpl txContext = new TransactionContextImpl(localTxManager, localNodeEngine, options, ownerUuid, false);
         txContext.beginTransaction();
 
         TransactionalObject result = txContext.getTransactionalObject(serviceName, "foo");


### PR DESCRIPTION
Client transaction mechanism relies on server-side transaction mechanism, client transaction proxies basically delegates calls to server-side transaction proxies. Because of this design values are deserialized on server-side. 
For example a call to `TransactionalMap.put` from client side, sends a message to the server which calls the server-side transactional-map-proxy's `put` method. And server-side transactional-map-proxy deserializes the value before returning.

The aim of this PR is to mark transactional-proxies on server-side which are created by clients, so that deserialization of the values can be bypassed for those proxies. In order to achieve that first I've centralized transactional-proxies by extending them from `TransactionalDistributedObject`. In this class we check if the proxy originated from client and bypass the deserialization.

PS: This PR may affect the performance positively since we are removing deserialization/serialization cycle.