### PR TITLE
Fixes concurrent store operation occurence probability upon IMap#flush

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFlushMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFlushMessageTask.java
@@ -18,29 +18,43 @@ package com.hazelcast.client.impl.protocol.task.map;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapFlushCodec;
+import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.operation.MapOperationProvider;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
-import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ProxyService;
 
 import java.security.Permission;
-import java.util.Map;
+
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 public class MapFlushMessageTask
-        extends AbstractMapAllPartitionsMessageTask<MapFlushCodec.RequestParameters> {
+        extends AbstractCallableMessageTask<MapFlushCodec.RequestParameters> {
 
     public MapFlushMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected OperationFactory createOperationFactory() {
-        MapOperationProvider operationProvider = getOperationProvider(parameters.name);
-        return operationProvider.createMapFlushOperationFactory(parameters.name);
+    protected Object call() throws Exception {
+        MapService mapService = getService(SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+        ProxyService proxyService = nodeEngine.getProxyService();
+        DistributedObject distributedObject = proxyService.getDistributedObject(SERVICE_NAME, parameters.name);
+
+        MapProxyImpl mapProxy = (MapProxyImpl) distributedObject;
+        mapProxy.flush();
+
+        return null;
     }
+
 
     @Override
     protected MapFlushCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
@@ -52,14 +66,10 @@ public class MapFlushMessageTask
         return MapFlushCodec.encodeResponse();
     }
 
-    @Override
-    protected Object reduce(Map<Integer, Object> map) {
-        return MapFlushCodec.encodeResponse();
-    }
 
     @Override
     public String getServiceName() {
-        return MapService.SERVICE_NAME;
+        return SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/EmptyMapDataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/EmptyMapDataStore.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.map.impl.mapstore;
 
-import com.hazelcast.nio.serialization.Data;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -73,8 +71,13 @@ class EmptyMapDataStore implements MapDataStore {
     }
 
     @Override
-    public Collection<Data> flush() {
-        return Collections.emptyList();
+    public void softFlush() {
+
+    }
+
+    @Override
+    public void hardFlush() {
+
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/MapDataStore.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.map.impl.mapstore;
 
-import com.hazelcast.nio.serialization.Data;
-
 import java.util.Collection;
 import java.util.Map;
 
@@ -64,11 +62,25 @@ public interface MapDataStore<K, V> {
     boolean isPostProcessingMapStore();
 
     /**
-     * Flushes all keys in this map-store.
+     * Only marks this {@link MapDataStore} as flushable. Flush means storing entries from write-behind-queue into map-store
+     * regardless of the scheduled store-time. Actual flushing is done by another thread than partition-operation thread
+     * which runs {@link com.hazelcast.map.impl.mapstore.writebehind.StoreWorker}.
      *
-     * @return flushed {@link com.hazelcast.nio.serialization.Data} keys list.
+     * @see com.hazelcast.map.impl.operation.MapFlushOperation
      */
-    Collection<Data> flush();
+    void softFlush();
+
+    /**
+     * Flushes write-behind-queue into map-store in calling thread.
+     *
+     * After calling of this method, all elements in the {@link com.hazelcast.map.impl.mapstore.writebehind.WriteBehindQueue}
+     * of this {@link MapDataStore} should be in map-store regardless of the scheduled store-time.
+     *
+     * The only call to this method is in node-shutdown.
+     *
+     * @see com.hazelcast.map.impl.MapManagedService#shutdown(boolean)
+     */
+    void hardFlush();
 
     /**
      * Flushes the supplied key to the map-store.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindProcessor.java
@@ -42,10 +42,15 @@ public interface WriteBehindProcessor<E> {
 
     void addStoreListener(StoreListener storeListener);
 
-    Collection flush(WriteBehindQueue queue);
+    /**
+     * Flushes supplied {@link WriteBehindQueue} to map-store.
+     *
+     * @param queue supplied {@link WriteBehindQueue} for flush.
+     */
+    void flush(WriteBehindQueue queue);
 
     /**
-     * Flush a key directly to map store.
+     * Flushes a key directly to map store.
      *
      * @param key to be flushed.
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writethrough/WriteThroughStore.java
@@ -21,9 +21,6 @@ import com.hazelcast.map.impl.MapStoreWrapper;
 import com.hazelcast.map.impl.mapstore.AbstractMapDataStore;
 import com.hazelcast.nio.serialization.Data;
 
-import java.util.Collection;
-import java.util.Collections;
-
 /**
  * Write through map data store implementation.
  * Created per map.
@@ -81,8 +78,13 @@ public class WriteThroughStore extends AbstractMapDataStore<Data, Object> {
     }
 
     @Override
-    public Collection<Data> flush() {
-        return Collections.emptyList();
+    public void softFlush() {
+        // Only write-behind configured map-stores are flushable.
+    }
+
+    @Override
+    public void hardFlush() {
+        // Only write-behind configured map-stores are flushable.
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/CheckIfPartitionFlushedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/CheckIfPartitionFlushedOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.impl.mapstore.MapDataStore;
+import com.hazelcast.map.impl.mapstore.writebehind.WriteBehindStore;
+import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ReadonlyOperation;
+
+public class CheckIfPartitionFlushedOperation extends MapOperation implements PartitionAwareOperation, ReadonlyOperation {
+
+    private boolean isFlushed = true;
+
+    public CheckIfPartitionFlushedOperation() {
+    }
+
+    public CheckIfPartitionFlushedOperation(String name) {
+        super(name);
+    }
+
+    @Override
+    public void run() {
+        RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), name);
+
+        MapDataStore mapDataStore = recordStore.getMapDataStore();
+        if (!(mapDataStore instanceof WriteBehindStore)) {
+            return;
+        }
+
+        WriteBehindStore store = (WriteBehindStore) mapDataStore;
+        isFlushed = 0 == store.getNumberOfEntriesToFlush();
+    }
+
+    @Override
+    public Object getResponse() {
+        return isFlushed;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/CheckIfPartitionFlushedOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/CheckIfPartitionFlushedOperationFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+
+import java.io.IOException;
+
+public class CheckIfPartitionFlushedOperationFactory implements OperationFactory {
+
+    private String name;
+
+    public CheckIfPartitionFlushedOperationFactory() {
+    }
+
+    public CheckIfPartitionFlushedOperationFactory(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public Operation createOperation() {
+        return new CheckIfPartitionFlushedOperation(name);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(name);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        name = in.readUTF();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushBackupOperation.java
@@ -36,6 +36,6 @@ public class MapFlushBackupOperation extends MapOperation implements BackupOpera
     @Override
     public void run() throws Exception {
         RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), name);
-        recordStore.getMapDataStore().clear();
+        recordStore.softFlush();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFlushOperation.java
@@ -38,7 +38,7 @@ public class MapFlushOperation extends MapOperation implements BackupAwareOperat
     @Override
     public void run() {
         RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), name);
-        recordStore.flush();
+        recordStore.softFlush();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -54,6 +54,10 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
 
     private Map<String, Set<RecordReplicationInfo>> data;
     private Map<String, Collection<DelayedEntry>> delayedEntries;
+    /**
+     * @see WriteBehindStore#flushCounter
+     */
+    private Map<String, Integer> flushCounters;
 
     public MapReplicationOperation() {
     }
@@ -87,6 +91,7 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
     }
 
     private void readDelayedEntries(PartitionContainer container) {
+        flushCounters = new HashMap<String, Integer>(container.getMaps().size());
         delayedEntries = new HashMap<String, Collection<DelayedEntry>>(container.getMaps().size());
         for (Entry<String, RecordStore> entry : container.getMaps().entrySet()) {
             RecordStore recordStore = entry.getValue();
@@ -94,13 +99,15 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
             if (!mapContainer.getMapStoreContext().isWriteBehindMapStoreEnabled()) {
                 continue;
             }
-            final WriteBehindQueue<DelayedEntry> writeBehindQueue = ((WriteBehindStore) recordStore.getMapDataStore())
-                    .getWriteBehindQueue();
-            final Collection<DelayedEntry> delayedEntries = writeBehindQueue.asList();
-            if (delayedEntries != null && delayedEntries.size() == 0) {
+            WriteBehindStore mapDataStore = (WriteBehindStore) recordStore.getMapDataStore();
+            WriteBehindQueue<DelayedEntry> writeBehindQueue = mapDataStore.getWriteBehindQueue();
+            Collection<DelayedEntry> entries = writeBehindQueue.asList();
+            if (entries != null && entries.size() == 0) {
                 continue;
             }
-            this.delayedEntries.put(entry.getKey(), delayedEntries);
+            String mapName = entry.getKey();
+            delayedEntries.put(mapName, entries);
+            flushCounters.put(mapName, mapDataStore.getNumberOfEntriesToFlush());
         }
     }
 
@@ -126,9 +133,11 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
         }
 
         for (Entry<String, Collection<DelayedEntry>> entry : delayedEntries.entrySet()) {
-            RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), entry.getKey());
+            String mapName = entry.getKey();
+            RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), mapName);
             WriteBehindStore mapDataStore = (WriteBehindStore) recordStore.getMapDataStore();
             mapDataStore.clear();
+            mapDataStore.setNumberOfEntriesToFlush(flushCounters.get(mapName));
 
             Collection<DelayedEntry> replicatedEntries = entry.getValue();
             for (DelayedEntry delayedEntry : replicatedEntries) {
@@ -173,6 +182,13 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
             }
             delayedEntries.put(mapName, delayedEntriesList);
         }
+        int counterSize = in.readInt();
+        flushCounters = new HashMap<String, Integer>(counterSize);
+        for (int i = 0; i < counterSize; i++) {
+            String mapName = in.readUTF();
+            int count = in.readInt();
+            flushCounters.put(mapName, count);
+        }
     }
 
     @Override
@@ -201,6 +217,12 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
                 out.writeLong(e.getStoreTime());
                 out.writeInt(e.getPartitionId());
             }
+        }
+
+        out.writeInt(flushCounters.size());
+        for (Entry<String, Integer> entry : flushCounters.entrySet()) {
+            out.writeUTF(entry.getKey());
+            out.writeInt(entry.getValue());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -229,7 +229,10 @@ public interface RecordStore<R extends Record> {
 
     MapContainer getMapContainer();
 
-    void flush();
+    /**
+     * @see MapDataStore#softFlush()
+     */
+    void softFlush();
 
     /**
      * Clears internal partition data.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/TemporaryBlockerMapStore.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/TemporaryBlockerMapStore.java
@@ -1,0 +1,28 @@
+package com.hazelcast.map.impl.mapstore.writebehind;
+
+import com.hazelcast.core.MapStoreAdapter;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
+
+public class TemporaryBlockerMapStore extends MapStoreAdapter<String, String> {
+
+    private final int blockStoreOperationSeconds;
+    private final AtomicInteger storeOperationCount = new AtomicInteger(0);
+
+    public TemporaryBlockerMapStore(int blockStoreOperationSeconds) {
+        this.blockStoreOperationSeconds = blockStoreOperationSeconds;
+    }
+
+    @Override
+    public void store(String key, String value) {
+        storeOperationCount.incrementAndGet();
+
+        sleepSeconds(blockStoreOperationSeconds);
+    }
+
+    public int getStoreOperationCount() {
+        return storeOperationCount.get();
+    }
+}


### PR DESCRIPTION
- With this PR partition threads will not be blocked by IMap#flush operations any more (previously IMap#flush operations were executed in partition threads.) What we do now is, marking recordstores write-behind-queues as flushable by calling IMap#flush and periodically checking if the write-behind-queues are all flushed. This periodic check will be done from user thread by calling `CheckIfPartitionFlushedOperation`.

- Also this PR includes some changes to reduce code complexity.

closes https://github.com/hazelcast/hazelcast/issues/3338