### PR TITLE
Renamed HazelcastInstanceFactory to HazelcastInstanceManager

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/CacheClientListenerTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.Hazelcast;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -41,7 +41,7 @@ public class CacheClientListenerTest extends CacheListenerTest {
     @After
     public void cleanup() {
         HazelcastClient.shutdownAll();
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheConfigTest.java
@@ -26,7 +26,7 @@ import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -86,7 +86,7 @@ public class ClientCacheConfigTest {
     @After
     public void tearDown() {
         HazelcastClient.shutdownAll();
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastInstanceDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastInstanceDefinitionParser.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spring;
 
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
@@ -64,7 +64,7 @@ public class HazelcastInstanceDefinitionParser extends AbstractHazelcastBeanDefi
 
         public SpringXmlBuilder(ParserContext parserContext) {
             this.parserContext = parserContext;
-            this.builder = BeanDefinitionBuilder.rootBeanDefinition(HazelcastInstanceFactory.class);
+            this.builder = BeanDefinitionBuilder.rootBeanDefinition(HazelcastInstanceManager.class);
             this.builder.setFactoryMethod("newHazelcastInstance");
             this.builder.setDestroyMethodName("shutdown");
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
@@ -95,7 +95,7 @@ public final class HazelcastServerCachingProvider
                 Config config = new XmlConfigBuilder(configURL).build();
                 config.setClassLoader(theClassLoader);
                 config.setInstanceName(configURL.toString());
-                return HazelcastInstanceFactory.getOrCreateHazelcastInstance(config);
+                return HazelcastInstanceManager.getOrCreateHazelcastInstance(config);
             } catch (Exception e) {
                 throw ExceptionUtil.rethrow(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/core/Hazelcast.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Hazelcast.java
@@ -17,7 +17,7 @@
 package com.hazelcast.core;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 
 import java.util.Set;
@@ -38,7 +38,7 @@ public final class Hazelcast {
      * @see #newHazelcastInstance(Config)
      */
     public static void shutdownAll() {
-        HazelcastInstanceFactory.shutdownAll();
+        HazelcastInstanceManager.shutdownAll();
     }
 
     /**
@@ -55,7 +55,7 @@ public final class Hazelcast {
      * @see #getHazelcastInstanceByName(String)
      */
     public static HazelcastInstance newHazelcastInstance(Config config) {
-        return HazelcastInstanceFactory.newHazelcastInstance(config);
+        return HazelcastInstanceManager.newHazelcastInstance(config);
     }
 
     /**
@@ -84,7 +84,7 @@ public final class Hazelcast {
      * @see #getHazelcastInstanceByName(String)
      */
     public static HazelcastInstance newHazelcastInstance() {
-        return HazelcastInstanceFactory.newHazelcastInstance(null);
+        return HazelcastInstanceManager.newHazelcastInstance(null);
     }
 
     /**
@@ -99,7 +99,7 @@ public final class Hazelcast {
      * @see #shutdownAll()
      */
     public static HazelcastInstance getHazelcastInstanceByName(String instanceName) {
-        return HazelcastInstanceFactory.getHazelcastInstance(instanceName);
+        return HazelcastInstanceManager.getHazelcastInstance(instanceName);
     }
 
     /**
@@ -113,7 +113,7 @@ public final class Hazelcast {
      * @throws IllegalArgumentException if the instance name of the config is null or empty.
      */
     public static HazelcastInstance getOrCreateHazelcastInstance(Config config) {
-        return HazelcastInstanceFactory.getOrCreateHazelcastInstance(config);
+        return HazelcastInstanceManager.getOrCreateHazelcastInstance(config);
     }
 
 
@@ -129,7 +129,7 @@ public final class Hazelcast {
      * @see #shutdownAll()
      */
     public static Set<HazelcastInstance> getAllHazelcastInstances() {
-        return HazelcastInstanceFactory.getAllHazelcastInstances();
+        return HazelcastInstanceManager.getAllHazelcastInstances();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceManager.java
@@ -46,14 +46,14 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 @SuppressWarnings("SynchronizationOnStaticField")
 @PrivateApi
-public final class HazelcastInstanceFactory {
+public final class HazelcastInstanceManager {
 
     private static final int ADDITIONAL_SLEEP_SECONDS_FOR_NON_FIRST_MEMBERS = 4;
 
     private static final ConcurrentMap<String, InstanceFuture> INSTANCE_MAP = new ConcurrentHashMap<String, InstanceFuture>(5);
     private static final AtomicInteger FACTORY_ID_GEN = new AtomicInteger();
 
-    private HazelcastInstanceFactory() {
+    private HazelcastInstanceManager() {
     }
 
     public static Set<HazelcastInstance> getAllHazelcastInstances() {
@@ -155,7 +155,7 @@ public final class HazelcastInstanceFactory {
         HazelcastInstanceProxy proxy;
         try {
             if (classLoader == null) {
-                Thread.currentThread().setContextClassLoader(HazelcastInstanceFactory.class.getClassLoader());
+                Thread.currentThread().setContextClassLoader(HazelcastInstanceManager.class.getClassLoader());
             }
             HazelcastInstanceImpl hazelcastInstance = new HazelcastInstanceImpl(instanceName, config, nodeContext);
             OutOfMemoryErrorDispatcher.registerServer(hazelcastInstance);

--- a/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
@@ -89,7 +89,7 @@ public class LifecycleServiceImpl implements LifecycleService {
             if (node != null) {
                 final NodeShutdownLatch shutdownLatch = new NodeShutdownLatch(node);
                 node.shutdown(false);
-                HazelcastInstanceFactory.remove(instance);
+                HazelcastInstanceManager.remove(instance);
                 shutdownLatch.await(getShutdownTimeoutSeconds(node), TimeUnit.SECONDS);
             }
             fireLifecycleEvent(SHUTDOWN);
@@ -113,7 +113,7 @@ public class LifecycleServiceImpl implements LifecycleService {
             if (node != null) {
                 node.shutdown(true);
             }
-            HazelcastInstanceFactory.remove(instance);
+            HazelcastInstanceManager.remove(instance);
             fireLifecycleEvent(SHUTDOWN);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
@@ -46,7 +46,7 @@ final class NodeShutdownLatch {
         members.remove(localMember);
 
         if (!members.isEmpty()) {
-            for (HazelcastInstanceImpl instance : HazelcastInstanceFactory.getInstanceImpls(members)) {
+            for (HazelcastInstanceImpl instance : HazelcastInstanceManager.getInstanceImpls(members)) {
                 if (instance.node.isRunning()) {
                     try {
                         ClusterServiceImpl clusterService = instance.node.clusterService;

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheCreationTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
@@ -52,7 +52,7 @@ public class CacheCreationTest {
     @Before
     @After
     public void killAllHazelcastInstances() throws Exception {
-        HazelcastInstanceFactory.shutdownAll();
+        HazelcastInstanceManager.shutdownAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheQuorumConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheQuorumConfigTest.java
@@ -1,27 +1,19 @@
 package com.hazelcast.cache;
 
 import com.hazelcast.config.CacheSimpleConfig;
-import com.hazelcast.config.CacheSimpleEntryListenerConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.QuorumConfig;
-import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.XmlConfigBuilder;
-import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import javax.cache.Caching;
 import java.io.IOException;
 import java.net.URL;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/hazelcast/src/test/java/com/hazelcast/cache/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/config/CacheConfigTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.spi.NodeEngine;
@@ -84,7 +84,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
     @Before
     @After
     public void cleanup() {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
         Caching.getCachingProvider().close();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheSplitBrainTest.java
@@ -13,7 +13,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
@@ -42,7 +42,7 @@ public class CacheSplitBrainTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -70,7 +70,7 @@ public class JoinStressTest extends HazelcastTestSupport {
     @Before
     @After
     public void tearDown() throws Exception {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
@@ -8,7 +8,7 @@ import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.Node;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -33,7 +33,7 @@ public class LiteMemberJoinTest {
     @Before
     @After
     public void cleanup() {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
@@ -56,7 +56,7 @@ public class MemberListTest {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     /*

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
@@ -10,7 +10,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -30,7 +30,7 @@ public class MulticastJoinTest extends AbstractJoinTest {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -31,7 +31,7 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.DefaultNodeContext;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.merge.PassThroughMergePolicy;
@@ -64,7 +64,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.hazelcast.cluster.ClusterState.ACTIVE;
 import static com.hazelcast.cluster.ClusterState.FROZEN;
 import static com.hazelcast.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
-import static com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance;
+import static com.hazelcast.instance.HazelcastInstanceManager.newHazelcastInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -76,7 +76,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.Cluster;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
@@ -52,7 +52,7 @@ public class SystemClockChangeTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws Exception {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
         shutdownIsolatedNode();
         resetClock();
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -43,7 +43,7 @@ public class TcpIpJoinTest extends AbstractJoinTest {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -12,7 +12,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
@@ -36,7 +36,7 @@ public class ListSplitBrainTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.shutdownAll();
+        HazelcastInstanceManager.shutdownAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -10,7 +10,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
@@ -33,7 +33,7 @@ public class QueueSplitBrainTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.shutdownAll();
+        HazelcastInstanceManager.shutdownAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
@@ -10,7 +10,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
@@ -32,7 +32,7 @@ public class CountDownLatchSplitBrainTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.shutdownAll();
+        HazelcastInstanceManager.shutdownAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
@@ -10,7 +10,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -33,7 +33,7 @@ public class LockSplitBrainTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.shutdownAll();
+        HazelcastInstanceManager.shutdownAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
@@ -10,7 +10,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -34,7 +34,7 @@ public class SemaphoreSplitBrainTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.shutdownAll();
+        HazelcastInstanceManager.shutdownAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/instance/MulticastLoopbackModeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MulticastLoopbackModeTest.java
@@ -88,7 +88,7 @@ public class MulticastLoopbackModeTest extends HazelcastTestSupport {
 
 	@After
 	public void tearDownTests() {
-		HazelcastInstanceFactory.terminateAll();
+		HazelcastInstanceManager.terminateAll();
 		if (multicastGroup == null) {
 			System.clearProperty("hazelcast.multicast.group");
 		} else {
@@ -103,10 +103,10 @@ public class MulticastLoopbackModeTest extends HazelcastTestSupport {
 		multicastConfig.setEnabled(true);
 		multicastConfig.setLoopbackModeEnabled(loopbackMode);
 
-		hz1 = HazelcastInstanceFactory.newHazelcastInstance(config);
+		hz1 = HazelcastInstanceManager.newHazelcastInstance(config);
 		assertNotNull("Cannot create the first HazelcastInstance", hz1);
 
-		hz2 = HazelcastInstanceFactory.newHazelcastInstance(config);
+		hz2 = HazelcastInstanceManager.newHazelcastInstance(config);
 		assertNotNull("Cannot create the second HazelcastInstance", hz2);
 	}
 

--- a/hazelcast/src/test/java/com/hazelcast/map/BackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BackupTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.test.AssertTask;
@@ -56,7 +56,7 @@ public class BackupTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
@@ -11,7 +11,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.map.merge.HigherHitsMapMergePolicy;
 import com.hazelcast.map.merge.LatestUpdateMapMergePolicy;
 import com.hazelcast.map.merge.PassThroughMergePolicy;
@@ -40,7 +40,7 @@ public class MergePolicyTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerMemoryLeakTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.internal.ascii.HTTPCommunicator;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
 import com.hazelcast.test.AssertTask;
@@ -42,7 +42,7 @@ public class IOBalancerMemoryLeakTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThreadingModel;
@@ -56,7 +56,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Repeat(25)

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionControlledIdTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionControlledIdTest.java
@@ -41,7 +41,7 @@ import com.hazelcast.core.IdGenerator;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.core.PartitioningStrategy;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.nio.serialization.Data;
@@ -92,7 +92,7 @@ public class PartitionControlledIdTest extends HazelcastTestSupport {
 
     @AfterClass
     public static void killHazelcastInstances() {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     private HazelcastInstance getHazelcastInstance(String partitionKey) {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadQuorumTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.QuorumConfig;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.quorum.PartitionedCluster;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -95,7 +95,7 @@ public class CacheReadQuorumTest {
 
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheReadWriteQuorumTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.QuorumConfig;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.quorum.PartitionedCluster;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -101,7 +101,7 @@ public class CacheReadWriteQuorumTest extends HazelcastTestSupport {
 
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheWriteQuorumTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.QuorumConfig;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.quorum.PartitionedCluster;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -101,7 +101,7 @@ public class CacheWriteQuorumTest {
 
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadQuorumTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.quorum.map;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.quorum.PartitionedCluster;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -78,7 +78,7 @@ public class MapReadQuorumTest {
 
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapReadWriteQuorumTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.quorum.map;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.quorum.PartitionedCluster;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -81,7 +81,7 @@ public class MapReadWriteQuorumTest {
 
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/MapWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/MapWriteQuorumTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.quorum.map;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.quorum.PartitionedCluster;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumType;
@@ -83,7 +83,7 @@ public class MapWriteQuorumTest {
 
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadQuorumTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.quorum.map;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.quorum.PartitionedCluster;
 import com.hazelcast.quorum.QuorumType;
@@ -89,7 +89,7 @@ public class TransactionalMapReadQuorumTest {
 
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapReadWriteQuorumTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.quorum.map;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.quorum.PartitionedCluster;
 import com.hazelcast.quorum.QuorumType;
@@ -90,7 +90,7 @@ public class TransactionalMapReadWriteQuorumTest {
 
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/map/TransactionalMapWriteQuorumTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.quorum.map;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.TransactionalMap;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.quorum.PartitionedCluster;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastTestRunner;
@@ -89,7 +89,7 @@ public class TransactionalMapWriteQuorumTest {
 
     @AfterClass
     public static void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapMergePolicyTest.java
@@ -27,7 +27,7 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.replicatedmap.merge.HigherHitsMapMergePolicy;
 import com.hazelcast.replicatedmap.merge.LatestUpdateMapMergePolicy;
 import com.hazelcast.replicatedmap.merge.PassThroughMergePolicy;
@@ -53,7 +53,7 @@ public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.replicatedmap;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import java.util.ArrayList;
@@ -70,7 +70,7 @@ public class ReplicatedMapWriteOrderTest extends ReplicatedMapBaseTest {
 
     @After
     public void setUp() throws Exception {
-        HazelcastInstanceFactory.terminateAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -23,7 +23,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.core.PartitionService;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.metrics.MetricsRegistry;
@@ -538,7 +538,7 @@ public abstract class HazelcastTestSupport {
     }
 
     public static boolean isAllInSafeState() {
-        Set<HazelcastInstance> nodeSet = HazelcastInstanceFactory.getAllHazelcastInstances();
+        Set<HazelcastInstance> nodeSet = HazelcastInstanceManager.getAllHazelcastInstances();
         return isAllInSafeState(nodeSet);
     }
 
@@ -552,7 +552,7 @@ public abstract class HazelcastTestSupport {
     }
 
     public static void waitAllForSafeState() {
-        waitAllForSafeState(HazelcastInstanceFactory.getAllHazelcastInstances());
+        waitAllForSafeState(HazelcastInstanceManager.getAllHazelcastInstances());
     }
 
     public static void waitAllForSafeState(Collection<HazelcastInstance> instances) {

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperty;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.NodeContext;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.mocknetwork.TestNodeRegistry;
@@ -109,9 +109,9 @@ public class TestHazelcastInstanceFactory {
         if (mockNetwork) {
             init(config);
             NodeContext nodeContext = registry.createNodeContext(pickAddress());
-            return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
+            return HazelcastInstanceManager.newHazelcastInstance(config, instanceName, nodeContext);
         }
-        return HazelcastInstanceFactory.newHazelcastInstance(config);
+        return HazelcastInstanceManager.newHazelcastInstance(config);
     }
 
     /**
@@ -134,7 +134,7 @@ public class TestHazelcastInstanceFactory {
         if (mockNetwork) {
             init(config);
             NodeContext nodeContext = registry.createNodeContext(address);
-            return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
+            return HazelcastInstanceManager.newHazelcastInstance(config, instanceName, nodeContext);
         }
         throw new UnsupportedOperationException("Explicit address is only available for mock network setup!");
     }
@@ -188,7 +188,7 @@ public class TestHazelcastInstanceFactory {
             return registry.getInstance(address);
         }
 
-        Set<HazelcastInstance> instances = HazelcastInstanceFactory.getAllHazelcastInstances();
+        Set<HazelcastInstance> instances = HazelcastInstanceManager.getAllHazelcastInstances();
         for (HazelcastInstance instance : instances) {
             if (address.equals(getAddress(instance))) {
                 return instance;
@@ -209,7 +209,7 @@ public class TestHazelcastInstanceFactory {
         if (mockNetwork) {
             registry.terminate();
         } else {
-            HazelcastInstanceFactory.terminateAll();
+            HazelcastInstanceManager.terminateAll();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/HazelcastInstanceManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/HazelcastInstanceManagerTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeContext;
 import com.hazelcast.instance.NodeExtension;
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.doThrow;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
+public class HazelcastInstanceManagerTest extends HazelcastTestSupport {
 
     @Test
     public void testTestHazelcastInstanceFactory() {
@@ -115,7 +115,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
 
-        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+        HazelcastInstanceManager.newHazelcastInstance(config, randomString(), context);
     }
 
     @Test(expected = ExpectedRuntimeException.class)
@@ -132,7 +132,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
 
-        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+        HazelcastInstanceManager.newHazelcastInstance(config, randomString(), context);
     }
 
     @Test(expected = ExpectedRuntimeException.class)
@@ -149,7 +149,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
 
-        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+        HazelcastInstanceManager.newHazelcastInstance(config, randomString(), context);
     }
 
     @Test(expected = ExpectedRuntimeException.class)
@@ -175,7 +175,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
 
-        HazelcastInstance instance = HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+        HazelcastInstance instance = HazelcastInstanceManager.newHazelcastInstance(config, randomString(), context);
         try {
             instance.getLifecycleService().terminate();
         } catch (ExpectedRuntimeException expected) {
@@ -199,7 +199,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
 
-        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+        HazelcastInstanceManager.newHazelcastInstance(config, randomString(), context);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -224,6 +224,6 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
 
-        HazelcastInstanceFactory.newHazelcastInstance(config, randomString(), context);
+        HazelcastInstanceManager.newHazelcastInstance(config, randomString(), context);
     }
 }


### PR DESCRIPTION
A factory creates objects and doesn't track them. The current implementation
is more of a manager since it manages a lot of access and lifecycle methods.

This renaming if pre-work for JET integration; to prevent making this PR
too large.