### PR TITLE
SimpleEntry from SupplierConsumingMapper extracted into a top-level class

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
@@ -197,8 +197,8 @@ public class DistinctValuesAggregation<Key, Value, DistinctType>
         @Override
         public void map(Key key, Value value, Context<Integer, DistinctType> context) {
             int mappingKey = key();
-            entry.key = key;
-            entry.value = value;
+            entry.setKey(key);
+            entry.setValue(value);
             DistinctType valueOut = supplier.apply(entry);
             if (valueOut != null) {
                 context.emit(mappingKey, valueOut);
@@ -237,32 +237,4 @@ public class DistinctValuesAggregation<Key, Value, DistinctType>
         }
     }
 
-    /**
-     * Internal implementation of an map entry with changeable value to prevent
-     * to much object allocation while supplying
-     *
-     * @param <K> key type
-     * @param <V> value type
-     */
-    private static final class SimpleEntry<K, V>
-            implements Map.Entry<K, V> {
-
-        private K key;
-        private V value;
-
-        @Override
-        public K getKey() {
-            return key;
-        }
-
-        @Override
-        public V getValue() {
-            return value;
-        }
-
-        @Override
-        public V setValue(V value) {
-            throw new UnsupportedOperationException();
-        }
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.mapreduce.aggregation.impl;
+
+import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.getters.Extractors;
+
+import java.util.Collections;
+
+/**
+ * Internal implementation of an map entry with changeable value to prevent
+ * to much object allocation while supplying
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+final class SimpleEntry<K, V>
+        extends QueryableEntry<K, V> {
+
+    private K key;
+    private V value;
+
+    public SimpleEntry() {
+        this.extractors = new Extractors(Collections.<MapAttributeConfig>emptyList());
+    }
+
+    @Override
+    public K getKey() {
+        return key;
+    }
+
+    @Override
+    public Data getKeyData() {
+        // not used in map-reduce
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Data getValueData() {
+        // not used in map-reduce
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Object getTargetObject(boolean key) {
+        return key ? this.key : this.value;
+    }
+
+    @Override
+    public V getValue() {
+        return value;
+    }
+
+    @Override
+    public V setValue(V newValue) {
+        V oldValue = this.value;
+        this.value = newValue;
+        return oldValue;
+    }
+
+    void setKey(K key) {
+        this.key = key;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
@@ -16,20 +16,15 @@
 
 package com.hazelcast.mapreduce.aggregation.impl;
 
-import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.mapreduce.Context;
 import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.aggregation.Supplier;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.query.impl.getters.Extractors;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
-import java.util.Collections;
 
 /**
  * The default mapper implementation for most (but not DistinctValues) aggregations.
@@ -55,8 +50,8 @@ class SupplierConsumingMapper<Key, ValueIn, ValueOut>
 
     @Override
     public void map(Key key, ValueIn value, Context<Key, ValueOut> context) {
-        entry.key = key;
-        entry.value = value;
+        entry.setKey(key);
+        entry.setValue(value);
         ValueOut valueOut = supplier.apply(entry);
         if (valueOut != null) {
             context.emit(key, valueOut);
@@ -85,60 +80,6 @@ class SupplierConsumingMapper<Key, ValueIn, ValueOut>
             throws IOException {
 
         supplier = in.readObject();
-    }
-
-    /**
-     * Internal implementation of an map entry with changeable value to prevent
-     * to much object allocation while supplying.
-     * Extends QueryableEntry in order to provide Extractable logic
-     *
-     * @param <K> key type
-     * @param <V> value type
-     * @see com.hazelcast.query.impl.QueryableEntry
-     * @see com.hazelcast.query.impl.Extractable
-     */
-    private static final class SimpleEntry<K, V> extends QueryableEntry<K, V> {
-
-        private K key;
-        private V value;
-
-        public SimpleEntry() {
-            this.extractors = new Extractors(Collections.<MapAttributeConfig>emptyList());
-        }
-
-        @Override
-        public V getValue() {
-            return value;
-        }
-
-        @Override
-        public V setValue(V value) {
-            this.value = value;
-            return value;
-        }
-
-        @Override
-        public K getKey() {
-            return this.key;
-        }
-
-        @Override
-        public Data getKeyData() {
-            // not used in map-reduce
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Data getValueData() {
-            // not used in map-reduce
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        protected Object getTargetObject(boolean key) {
-            return key ? this.key : this.value;
-        }
-
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
@@ -494,7 +494,7 @@ public final class HashUtil {
      * keys are nearly-ordered by their hashed values so when adding one container's
      * values to the other, the number of collisions can skyrocket into the worst case
      * possible.
-     * <p/>
+     * <p/>f
      * <p>If it is known that hash containers will not be added to each other
      * (will be used for counting only, for example) then some speed can be gained by
      * not perturbing keys before hashing and returning a value of zero for all possible

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/DistinctAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/DistinctAggregationTest.java
@@ -1,0 +1,74 @@
+package com.hazelcast.mapreduce.aggregation;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.Set;
+
+import static com.hazelcast.mapreduce.aggregation.Aggregations.distinctValues;
+import static com.hazelcast.mapreduce.aggregation.Supplier.fromPredicate;
+import static com.hazelcast.query.Predicates.equal;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DistinctAggregationTest extends AbstractAggregationTest {
+
+    @Test
+    public void testDistinctAggregationWithPredicates() {
+        String mapName = randomMapName();
+        IMap<Integer, Car> map = HAZELCAST_INSTANCE.getMap(mapName);
+
+        Car vw1999 = Car.newCar(1999, "VW");
+        Car bmw2000 = Car.newCar(2000, "BMW");
+        Car vw2000 = Car.newCar(2000, "VW");
+
+        map.put(0, vw1999);
+        map.put(1, bmw2000);
+        map.put(2, vw2000);
+
+        Supplier<Integer, Car, Car> supplier = fromPredicate(equal("buildYear", 2000));
+        Aggregation<Integer, Car, Set<Car>> aggregation = distinctValues();
+        Set<Car> cars = map.aggregate(supplier, aggregation);
+
+        assertThat(cars, containsInAnyOrder(bmw2000, vw2000));
+    }
+
+    private static class Car implements Serializable {
+        private int buildYear;
+        private String brand;
+
+        private static Car newCar(int buildYear, String brand) {
+            Car car = new Car();
+            car.buildYear = buildYear;
+            car.brand = brand;
+            return car;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Car)) return false;
+
+            Car car = (Car) o;
+
+            if (buildYear != car.buildYear) return false;
+            return brand.equals(car.brand);
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = buildYear;
+            result = 31 * result + brand.hashCode();
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
 Fixes #7398
 The SimpleEntry is now re-used in DistinctValuesAggregation.

 It removes code duplication and fixes ClassCastException as the old inner class
 used in DistinctValuesAggregation didn't implement the interface QueryEngine
 expects.