### PR TITLE
JMX Enhancements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -291,6 +291,7 @@ public enum GroupProperty implements HazelcastProperty {
 
     ENABLE_JMX("hazelcast.jmx", false),
     ENABLE_JMX_DETAILED("hazelcast.jmx.detailed", false),
+    JMX_UPDATE_INTERVAL_SECONDS("hazelcast.jmx.update.interval.seconds", 5, SECONDS),
 
     MC_MAX_VISIBLE_INSTANCE_COUNT("hazelcast.mc.max.visible.instance.count", 100),
     MC_MAX_VISIBLE_SLOW_OPERATION_COUNT("hazelcast.mc.max.visible.slow.operations.count", 10),

--- a/hazelcast/src/main/java/com/hazelcast/jmx/HazelcastMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/HazelcastMBean.java
@@ -16,11 +16,8 @@
 
 package com.hazelcast.jmx;
 
-import java.lang.management.ManagementFactory;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Map;
+import com.hazelcast.instance.GroupProperty;
+
 import javax.management.Attribute;
 import javax.management.AttributeList;
 import javax.management.AttributeNotFoundException;
@@ -36,6 +33,11 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
 
 /**
  * Base class for beans registered to JMX by Hazelcast.
@@ -47,14 +49,19 @@ public abstract class HazelcastMBean<T> implements DynamicMBean, MBeanRegistrati
     protected HashMap<String, BeanInfo> attributeMap = new HashMap<String, BeanInfo>();
     protected HashMap<String, BeanInfo> operationMap = new HashMap<String, BeanInfo>();
 
+    protected final long updateIntervalSec;
+
     final T managedObject;
     final ManagementService service;
+
     String description;
     ObjectName objectName;
+
 
     protected HazelcastMBean(T managedObject, ManagementService service) {
         this.managedObject = managedObject;
         this.service = service;
+        updateIntervalSec = service.instance.node.groupProperties.getLong(GroupProperty.JMX_UPDATE_INTERVAL_SECONDS);
     }
 
     public void register(HazelcastMBean mbean) {

--- a/hazelcast/src/main/java/com/hazelcast/jmx/LocalStatsDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/LocalStatsDelegate.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jmx;
+
+import com.hazelcast.jmx.suppliers.StatsSupplier;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Provides LocalStats for {@link MapMBean}, {@link MultiMapMBean}, {@link QueueMBean}
+ * So that statistics are only created in given internal
+ * @param <T> LocalStats type
+ */
+public class LocalStatsDelegate<T> {
+
+    private volatile T localStats;
+    private final StatsSupplier<T> supplier;
+    private final long intervalMs;
+    private final AtomicLong lastUpdated = new AtomicLong(0);
+    private final AtomicBoolean inProgress = new AtomicBoolean(false);
+
+    public LocalStatsDelegate(StatsSupplier<T> supplier, long intervalSec) {
+        this.supplier = supplier;
+        this.intervalMs = TimeUnit.SECONDS.toMillis(intervalSec);
+        localStats = supplier.getEmpty();
+    }
+
+    public T getLocalStats() {
+        long delta = System.currentTimeMillis() - lastUpdated.get();
+        if (delta > intervalMs) {
+            if (inProgress.compareAndSet(false, true)) {
+                try {
+                    localStats = supplier.get();
+                    lastUpdated.set(System.currentTimeMillis());
+                } finally {
+                    inProgress.set(false);
+                }
+            }
+        }
+        return localStats;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jmx/MapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/MapMBean.java
@@ -17,6 +17,9 @@
 package com.hazelcast.jmx;
 
 import com.hazelcast.core.IMap;
+import com.hazelcast.jmx.suppliers.LocalMapStatsSupplier;
+import com.hazelcast.jmx.suppliers.StatsSupplier;
+import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.SqlPredicate;
 
@@ -29,154 +32,157 @@ import java.util.Set;
  */
 @ManagedDescription("IMap")
 public class MapMBean extends HazelcastMBean<IMap> {
+    private final LocalStatsDelegate<LocalMapStats> localMapStatsDelegate;
 
     protected MapMBean(IMap managedObject, ManagementService service) {
         super(managedObject, service);
         objectName = service.createObjectName("IMap", managedObject.getName());
+        StatsSupplier<LocalMapStats> localMapStatsSupplier = new LocalMapStatsSupplier(managedObject);
+        this.localMapStatsDelegate = new LocalStatsDelegate<LocalMapStats>(localMapStatsSupplier, updateIntervalSec);
     }
 
     @ManagedAnnotation("localOwnedEntryCount")
     @ManagedDescription("number of entries owned on this member")
     public long getLocalOwnedEntryCount() {
-        return managedObject.getLocalMapStats().getOwnedEntryCount();
+        return localMapStatsDelegate.getLocalStats().getOwnedEntryCount();
     }
 
     @ManagedAnnotation("localBackupEntryCount")
     @ManagedDescription("the number of backup entries hold on this member")
     public long getLocalBackupEntryCount() {
-        return managedObject.getLocalMapStats().getBackupEntryCount();
+        return localMapStatsDelegate.getLocalStats().getBackupEntryCount();
     }
 
     @ManagedAnnotation("localBackupCount")
     @ManagedDescription("the number of backups per entry on this member")
     public int getLocalBackupCount() {
-        return managedObject.getLocalMapStats().getBackupCount();
+        return localMapStatsDelegate.getLocalStats().getBackupCount();
     }
 
     @ManagedAnnotation("localOwnedEntryMemoryCost")
     @ManagedDescription("memory cost (number of bytes) of owned entries on this member")
     public long getLocalOwnedEntryMemoryCost() {
-        return managedObject.getLocalMapStats().getOwnedEntryMemoryCost();
+        return localMapStatsDelegate.getLocalStats().getOwnedEntryMemoryCost();
     }
 
     @ManagedAnnotation("localBackupEntryMemoryCost")
     @ManagedDescription("memory cost (number of bytes) of backup entries on this member.")
     public long getLocalBackupEntryMemoryCost() {
-        return managedObject.getLocalMapStats().getBackupEntryMemoryCost();
+        return localMapStatsDelegate.getLocalStats().getBackupEntryMemoryCost();
     }
 
     @ManagedAnnotation("localCreationTime")
     @ManagedDescription("the creation time of this map on this member.")
     public long getLocalCreationTime() {
-        return managedObject.getLocalMapStats().getCreationTime();
+        return localMapStatsDelegate.getLocalStats().getCreationTime();
     }
 
     @ManagedAnnotation("localLastAccessTime")
     @ManagedDescription("the last access (read) time of the locally owned entries.")
     public long getLocalLastAccessTime() {
-        return managedObject.getLocalMapStats().getLastAccessTime();
+        return localMapStatsDelegate.getLocalStats().getLastAccessTime();
     }
 
     @ManagedAnnotation("localLastUpdateTime")
     @ManagedDescription("the last update time of the locally owned entries.")
     public long getLocalLastUpdateTime() {
-        return managedObject.getLocalMapStats().getLastUpdateTime();
+        return localMapStatsDelegate.getLocalStats().getLastUpdateTime();
     }
 
     @ManagedAnnotation("localHits")
     @ManagedDescription("the number of hits (reads) of the locally owned entries.")
     public long getLocalHits() {
-        return managedObject.getLocalMapStats().getHits();
+        return localMapStatsDelegate.getLocalStats().getHits();
     }
 
     @ManagedAnnotation("localLockedEntryCount")
     @ManagedDescription("the number of currently locked locally owned keys.")
     public long getLocalLockedEntryCount() {
-        return managedObject.getLocalMapStats().getLockedEntryCount();
+        return localMapStatsDelegate.getLocalStats().getLockedEntryCount();
     }
 
     @ManagedAnnotation("localDirtyEntryCount")
     @ManagedDescription("the number of entries that the member owns and are dirty on this member")
     public long getLocalDirtyEntryCount() {
-        return managedObject.getLocalMapStats().getDirtyEntryCount();
+        return localMapStatsDelegate.getLocalStats().getDirtyEntryCount();
     }
 
     @ManagedAnnotation("localPutOperationCount")
     @ManagedDescription("the number of put operations on this member")
     public long getLocalPutOperationCount() {
-        return managedObject.getLocalMapStats().getPutOperationCount();
+        return localMapStatsDelegate.getLocalStats().getPutOperationCount();
     }
 
     @ManagedAnnotation("localGetOperationCount")
     @ManagedDescription("number of get operations on this member")
     public long getLocalGetOperationCount() {
-        return managedObject.getLocalMapStats().getGetOperationCount();
+        return localMapStatsDelegate.getLocalStats().getGetOperationCount();
     }
 
     @ManagedAnnotation("localRemoveOperationCount")
     @ManagedDescription("number of remove operations on this member")
     public long getLocalRemoveOperationCount() {
-        return managedObject.getLocalMapStats().getRemoveOperationCount();
+        return localMapStatsDelegate.getLocalStats().getRemoveOperationCount();
     }
 
     @ManagedAnnotation("localTotalPutLatency")
     @ManagedDescription("the total latency of put operations. To get the average latency, divide to number of puts")
     public long getLocalTotalPutLatency() {
-        return managedObject.getLocalMapStats().getTotalPutLatency();
+        return localMapStatsDelegate.getLocalStats().getTotalPutLatency();
     }
 
     @ManagedAnnotation("localTotalGetLatency")
     @ManagedDescription("the total latency of get operations. To get the average latency, divide to number of gets")
     public long getLocalTotalGetLatency() {
-        return managedObject.getLocalMapStats().getTotalGetLatency();
+        return localMapStatsDelegate.getLocalStats().getTotalGetLatency();
     }
 
     @ManagedAnnotation("localTotalRemoveLatency")
     @ManagedDescription("the total latency of remove operations. To get the average latency, divide to number of gets")
     public long getLocalTotalRemoveLatency() {
-        return managedObject.getLocalMapStats().getTotalRemoveLatency();
+        return localMapStatsDelegate.getLocalStats().getTotalRemoveLatency();
     }
 
     @ManagedAnnotation("localMaxPutLatency")
     @ManagedDescription("the maximum latency of put operations. To get the average latency, divide to number of puts")
     public long getLocalMaxPutLatency() {
-        return managedObject.getLocalMapStats().getMaxPutLatency();
+        return localMapStatsDelegate.getLocalStats().getMaxPutLatency();
     }
 
     @ManagedAnnotation("localMaxGetLatency")
     @ManagedDescription("the maximum latency of get operations. To get the average latency, divide to number of gets")
     public long getLocalMaxGetLatency() {
-        return managedObject.getLocalMapStats().getMaxGetLatency();
+        return localMapStatsDelegate.getLocalStats().getMaxGetLatency();
     }
 
     @ManagedAnnotation("localMaxRemoveLatency")
     @ManagedDescription("the maximum latency of remove operations. To get the average latency, divide to number of gets")
     public long getMaxRemoveLatency() {
-        return managedObject.getLocalMapStats().getMaxRemoveLatency();
+        return localMapStatsDelegate.getLocalStats().getMaxRemoveLatency();
     }
 
     @ManagedAnnotation("localEventOperationCount")
     @ManagedDescription("number of events received on this member")
     public long getLocalEventOperationCount() {
-        return managedObject.getLocalMapStats().getEventOperationCount();
+        return localMapStatsDelegate.getLocalStats().getEventOperationCount();
     }
 
     @ManagedAnnotation("localOtherOperationCount")
     @ManagedDescription("the total number of other operations on this member")
     public long getLocalOtherOperationCount() {
-        return managedObject.getLocalMapStats().getOtherOperationCount();
+        return localMapStatsDelegate.getLocalStats().getOtherOperationCount();
     }
 
     @ManagedAnnotation("localTotal")
     @ManagedDescription("the total number of operations on this member")
     public long localTotal() {
-        return managedObject.getLocalMapStats().total();
+        return localMapStatsDelegate.getLocalStats().total();
     }
 
     @ManagedAnnotation("localHeapCost")
     @ManagedDescription("the total heap cost of map, near cache and heap cost")
     public long localHeapCost() {
-        return managedObject.getLocalMapStats().getHeapCost();
+        return localMapStatsDelegate.getLocalStats().getHeapCost();
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/jmx/MultiMapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/MultiMapMBean.java
@@ -17,6 +17,9 @@
 package com.hazelcast.jmx;
 
 import com.hazelcast.core.MultiMap;
+import com.hazelcast.jmx.suppliers.LocalMultiMapStatsSupplier;
+import com.hazelcast.jmx.suppliers.StatsSupplier;
+import com.hazelcast.monitor.LocalMultiMapStats;
 
 /**
  * Management bean for {@link com.hazelcast.core.MultiMap}
@@ -24,147 +27,151 @@ import com.hazelcast.core.MultiMap;
 @ManagedDescription("MultiMap")
 public class MultiMapMBean extends HazelcastMBean<MultiMap> {
 
-    protected MultiMapMBean(MultiMap managedObject, ManagementService service) {
+    private final LocalStatsDelegate<LocalMultiMapStats> localMultiMapStatsDelegate;
+
+    protected MultiMapMBean(final MultiMap managedObject, ManagementService service) {
         super(managedObject, service);
         objectName = service.createObjectName("MultiMap", managedObject.getName());
+        StatsSupplier<LocalMultiMapStats> localMultiMapStatsSupplier = new LocalMultiMapStatsSupplier(managedObject);
+        localMultiMapStatsDelegate = new LocalStatsDelegate<LocalMultiMapStats>(localMultiMapStatsSupplier, updateIntervalSec);
     }
 
     @ManagedAnnotation("localOwnedEntryCount")
     @ManagedDescription("number of entries owned on this member")
     public long getLocalOwnedEntryCount() {
-        return managedObject.getLocalMultiMapStats().getOwnedEntryCount();
+        return localMultiMapStatsDelegate.getLocalStats().getOwnedEntryCount();
     }
 
     @ManagedAnnotation("localBackupEntryCount")
     @ManagedDescription("the number of backup entries hold on this member")
     public long getLocalBackupEntryCount() {
-        return managedObject.getLocalMultiMapStats().getBackupEntryCount();
+        return localMultiMapStatsDelegate.getLocalStats().getBackupEntryCount();
     }
 
     @ManagedAnnotation("localBackupCount")
     @ManagedDescription("the number of backups per entry on this member")
     public int getLocalBackupCount() {
-        return managedObject.getLocalMultiMapStats().getBackupCount();
+        return localMultiMapStatsDelegate.getLocalStats().getBackupCount();
     }
 
     @ManagedAnnotation("localOwnedEntryMemoryCost")
     @ManagedDescription("memory cost (number of bytes) of owned entries on this member")
     public long getLocalOwnedEntryMemoryCost() {
-        return managedObject.getLocalMultiMapStats().getOwnedEntryMemoryCost();
+        return localMultiMapStatsDelegate.getLocalStats().getOwnedEntryMemoryCost();
     }
 
     @ManagedAnnotation("localBackupEntryMemoryCost")
     @ManagedDescription("memory cost (number of bytes) of backup entries on this member.")
     public long getLocalBackupEntryMemoryCost() {
-        return managedObject.getLocalMultiMapStats().getBackupEntryMemoryCost();
+        return localMultiMapStatsDelegate.getLocalStats().getBackupEntryMemoryCost();
     }
 
     @ManagedAnnotation("localCreationTime")
     @ManagedDescription("the creation time of this map on this member.")
     public long getLocalCreationTime() {
-        return managedObject.getLocalMultiMapStats().getCreationTime();
+        return localMultiMapStatsDelegate.getLocalStats().getCreationTime();
     }
 
     @ManagedAnnotation("localLastAccessTime")
     @ManagedDescription("the last access (read) time of the locally owned entries.")
     public long getLocalLastAccessTime() {
-        return managedObject.getLocalMultiMapStats().getLastAccessTime();
+        return localMultiMapStatsDelegate.getLocalStats().getLastAccessTime();
     }
 
     @ManagedAnnotation("localLastUpdateTime")
     @ManagedDescription("the last update time of the locally owned entries.")
     public long getLocalLastUpdateTime() {
-        return managedObject.getLocalMultiMapStats().getLastUpdateTime();
+        return localMultiMapStatsDelegate.getLocalStats().getLastUpdateTime();
     }
 
     @ManagedAnnotation("localHits")
     @ManagedDescription("the number of hits (reads) of the locally owned entries.")
     public long getLocalHits() {
-        return managedObject.getLocalMultiMapStats().getHits();
+        return localMultiMapStatsDelegate.getLocalStats().getHits();
     }
 
     @ManagedAnnotation("localLockedEntryCount")
     @ManagedDescription("the number of currently locked locally owned keys.")
     public long getLocalLockedEntryCount() {
-        return managedObject.getLocalMultiMapStats().getLockedEntryCount();
+        return localMultiMapStatsDelegate.getLocalStats().getLockedEntryCount();
     }
 
     @ManagedAnnotation("localDirtyEntryCount")
     @ManagedDescription("the number of entries that the member owns and are dirty on this member")
     public long getLocalDirtyEntryCount() {
-        return managedObject.getLocalMultiMapStats().getDirtyEntryCount();
+        return localMultiMapStatsDelegate.getLocalStats().getDirtyEntryCount();
     }
 
     @ManagedAnnotation("localPutOperationCount")
     @ManagedDescription("the number of put operations on this member")
     public long getLocalPutOperationCount() {
-        return managedObject.getLocalMultiMapStats().getPutOperationCount();
+        return localMultiMapStatsDelegate.getLocalStats().getPutOperationCount();
     }
 
     @ManagedAnnotation("localGetOperationCount")
     @ManagedDescription("number of get operations on this member")
     public long getLocalGetOperationCount() {
-        return managedObject.getLocalMultiMapStats().getGetOperationCount();
+        return localMultiMapStatsDelegate.getLocalStats().getGetOperationCount();
     }
 
     @ManagedAnnotation("localRemoveOperationCount")
     @ManagedDescription("number of remove operations on this member")
     public long getLocalRemoveOperationCount() {
-        return managedObject.getLocalMultiMapStats().getRemoveOperationCount();
+        return localMultiMapStatsDelegate.getLocalStats().getRemoveOperationCount();
     }
 
     @ManagedAnnotation("localTotalPutLatency")
     @ManagedDescription("the total latency of put operations. To get the average latency, divide to number of puts")
     public long getLocalTotalPutLatency() {
-        return managedObject.getLocalMultiMapStats().getTotalPutLatency();
+        return localMultiMapStatsDelegate.getLocalStats().getTotalPutLatency();
     }
 
     @ManagedAnnotation("localTotalGetLatency")
     @ManagedDescription("the total latency of get operations. To get the average latency, divide to number of gets")
     public long getLocalTotalGetLatency() {
-        return managedObject.getLocalMultiMapStats().getTotalGetLatency();
+        return localMultiMapStatsDelegate.getLocalStats().getTotalGetLatency();
     }
 
     @ManagedAnnotation("localTotalRemoveLatency")
     @ManagedDescription("the total latency of remove operations. To get the average latency, divide to number of gets")
     public long getLocalTotalRemoveLatency() {
-        return managedObject.getLocalMultiMapStats().getTotalRemoveLatency();
+        return localMultiMapStatsDelegate.getLocalStats().getTotalRemoveLatency();
     }
 
     @ManagedAnnotation("localMaxPutLatency")
     @ManagedDescription("the maximum latency of put operations. To get the average latency, divide to number of puts")
     public long getLocalMaxPutLatency() {
-        return managedObject.getLocalMultiMapStats().getMaxPutLatency();
+        return localMultiMapStatsDelegate.getLocalStats().getMaxPutLatency();
     }
 
     @ManagedAnnotation("localMaxGetLatency")
     @ManagedDescription("the maximum latency of get operations. To get the average latency, divide to number of gets")
     public long getLocalMaxGetLatency() {
-        return managedObject.getLocalMultiMapStats().getMaxGetLatency();
+        return localMultiMapStatsDelegate.getLocalStats().getMaxGetLatency();
     }
 
     @ManagedAnnotation("localMaxRemoveLatency")
     @ManagedDescription("the maximum latency of remove operations. To get the average latency, divide to number of gets")
     public long getMaxRemoveLatency() {
-        return managedObject.getLocalMultiMapStats().getMaxRemoveLatency();
+        return localMultiMapStatsDelegate.getLocalStats().getMaxRemoveLatency();
     }
 
     @ManagedAnnotation("localEventOperationCount")
     @ManagedDescription("number of events received on this member")
     public long getLocalEventOperationCount() {
-        return managedObject.getLocalMultiMapStats().getEventOperationCount();
+        return localMultiMapStatsDelegate.getLocalStats().getEventOperationCount();
     }
 
     @ManagedAnnotation("localOtherOperationCount")
     @ManagedDescription("the total number of other operations on this member")
     public long getLocalOtherOperationCount() {
-        return managedObject.getLocalMultiMapStats().getOtherOperationCount();
+        return localMultiMapStatsDelegate.getLocalStats().getOtherOperationCount();
     }
 
     @ManagedAnnotation("localTotal")
     @ManagedDescription("the total number of operations on this member")
     public long localTotal() {
-        return managedObject.getLocalMultiMapStats().total();
+        return localMultiMapStatsDelegate.getLocalStats().total();
     }
 
     @ManagedAnnotation("name")

--- a/hazelcast/src/main/java/com/hazelcast/jmx/QueueMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/QueueMBean.java
@@ -19,6 +19,9 @@ package com.hazelcast.jmx;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.core.IQueue;
+import com.hazelcast.jmx.suppliers.LocalQueueStatsSupplier;
+import com.hazelcast.jmx.suppliers.StatsSupplier;
+import com.hazelcast.monitor.LocalQueueStats;
 
 /**
  * Management bean for {@link com.hazelcast.core.IQueue}
@@ -26,75 +29,79 @@ import com.hazelcast.core.IQueue;
 @ManagedDescription("IQueue")
 public class QueueMBean extends HazelcastMBean<IQueue> {
 
+    private final LocalStatsDelegate<LocalQueueStats> localQueueStatsDelegate;
+
     protected QueueMBean(IQueue managedObject, ManagementService service) {
         super(managedObject, service);
         objectName = service.createObjectName("IQueue", managedObject.getName());
+        StatsSupplier<LocalQueueStats> localQueueStatsSupplier = new LocalQueueStatsSupplier(managedObject);
+        localQueueStatsDelegate = new LocalStatsDelegate<LocalQueueStats>(localQueueStatsSupplier, updateIntervalSec);
     }
 
     @ManagedAnnotation("localOwnedItemCount")
     @ManagedDescription("the number of owned items in this member.")
     public long getLocalOwnedItemCount() {
-        return managedObject.getLocalQueueStats().getOwnedItemCount();
+        return localQueueStatsDelegate.getLocalStats().getOwnedItemCount();
     }
 
     @ManagedAnnotation("localBackupItemCount")
     @ManagedDescription("the number of backup items in this member.")
     public long getLocalBackupItemCount() {
-        return managedObject.getLocalQueueStats().getBackupItemCount();
+        return localQueueStatsDelegate.getLocalStats().getBackupItemCount();
     }
 
     @ManagedAnnotation("localMinAge")
     @ManagedDescription("the min age of the items in this member.")
     public long getLocalMinAge() {
-        return managedObject.getLocalQueueStats().getMinAge();
+        return localQueueStatsDelegate.getLocalStats().getMinAge();
     }
 
     @ManagedAnnotation("localMaxAge")
     @ManagedDescription("the max age of the items in this member.")
     public long getLocalMaxAge() {
-        return managedObject.getLocalQueueStats().getMaxAge();
+        return localQueueStatsDelegate.getLocalStats().getMaxAge();
     }
 
     @ManagedAnnotation("localAvgAge")
     @ManagedDescription("the average age of the items in this member.")
     public long getLocalAvgAge() {
-        return managedObject.getLocalQueueStats().getAvgAge();
+        return localQueueStatsDelegate.getLocalStats().getAvgAge();
     }
 
     @ManagedAnnotation("localOfferOperationCount")
     @ManagedDescription("the number of offer/put/add operations in this member")
     public long getLocalOfferOperationCount() {
-        return managedObject.getLocalQueueStats().getOfferOperationCount();
+        return localQueueStatsDelegate.getLocalStats().getOfferOperationCount();
     }
 
     @ManagedAnnotation("localRejectedOfferOperationCount")
     @ManagedDescription("the number of rejected offers in this member")
     public long getLocalRejectedOfferOperationCount() {
-        return managedObject.getLocalQueueStats().getRejectedOfferOperationCount();
+        return localQueueStatsDelegate.getLocalStats().getRejectedOfferOperationCount();
     }
 
     @ManagedAnnotation("localPollOperationCount")
     @ManagedDescription("the number of poll/take/remove operations in this member")
     public long getLocalPollOperationCount() {
-        return managedObject.getLocalQueueStats().getPollOperationCount();
+        return localQueueStatsDelegate.getLocalStats().getPollOperationCount();
     }
 
     @ManagedAnnotation("localEmptyPollOperationCount")
     @ManagedDescription("number of null returning poll operations in this member")
     public long getLocalEmptyPollOperationCount() {
-        return managedObject.getLocalQueueStats().getEmptyPollOperationCount();
+        return localQueueStatsDelegate.getLocalStats().getEmptyPollOperationCount();
     }
 
     @ManagedAnnotation("localOtherOperationsCount")
     @ManagedDescription("number of other operations in this member")
     public long getLocalOtherOperationsCount() {
-        return managedObject.getLocalQueueStats().getOtherOperationsCount();
+        return localQueueStatsDelegate.getLocalStats().getOtherOperationsCount();
     }
 
     @ManagedAnnotation("localEventOperationCount")
     @ManagedDescription("number of event operations in this member")
     public long getLocalEventOperationCount() {
-        return managedObject.getLocalQueueStats().getEventOperationCount();
+        return localQueueStatsDelegate.getLocalStats().getEventOperationCount();
     }
 
     @ManagedAnnotation("name")

--- a/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/LocalMapStatsSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/LocalMapStatsSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jmx.suppliers;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+
+/**
+ * Implementation of {@link StatsSupplier} for {@link LocalMapStats}
+ */
+public class LocalMapStatsSupplier implements StatsSupplier<LocalMapStats> {
+
+    private final IMap map;
+
+    public LocalMapStatsSupplier(IMap map) {
+        this.map = map;
+    }
+
+    @Override
+    public LocalMapStats getEmpty() {
+        return new LocalMapStatsImpl();
+    }
+
+    @Override
+    public LocalMapStats get() {
+        return map.getLocalMapStats();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/LocalMultiMapStatsSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/LocalMultiMapStatsSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jmx.suppliers;
+
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.monitor.LocalMultiMapStats;
+import com.hazelcast.monitor.impl.LocalMultiMapStatsImpl;
+
+/**
+ * Implementation of {@link StatsSupplier} for {@link LocalMultiMapStats}
+ */
+public class LocalMultiMapStatsSupplier implements StatsSupplier<LocalMultiMapStats> {
+
+    private final MultiMap multiMap;
+
+    public LocalMultiMapStatsSupplier(MultiMap multiMap) {
+        this.multiMap = multiMap;
+    }
+
+    @Override
+    public LocalMultiMapStats getEmpty() {
+        return new LocalMultiMapStatsImpl();
+    }
+
+    @Override
+    public LocalMultiMapStats get() {
+        return multiMap.getLocalMultiMapStats();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/LocalQueueStatsSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/LocalQueueStatsSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jmx.suppliers;
+
+import com.hazelcast.core.IQueue;
+import com.hazelcast.monitor.LocalQueueStats;
+import com.hazelcast.monitor.impl.LocalQueueStatsImpl;
+
+/**
+ * Implementation of {@link StatsSupplier} for {@link LocalQueueStats}
+ */
+public class LocalQueueStatsSupplier implements StatsSupplier<LocalQueueStats> {
+
+    private final IQueue queue;
+
+    public LocalQueueStatsSupplier(IQueue queue) {
+        this.queue = queue;
+    }
+
+    @Override
+    public LocalQueueStats getEmpty() {
+        return new LocalQueueStatsImpl();
+    }
+
+    @Override
+    public LocalQueueStats get() {
+        return queue.getLocalQueueStats();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/StatsSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/StatsSupplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jmx.suppliers;
+
+/**
+ * Interface used in MBeans for retrieving the Local Stats
+ * @param <T> LocalStats type
+ */
+public interface StatsSupplier<T> {
+
+    T getEmpty();
+    T get();
+}

--- a/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/jmx/suppliers/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains Hazelcast management bean stat providers.
+ */
+
+package com.hazelcast.jmx.suppliers;

--- a/hazelcast/src/test/java/com/hazelcast/jmx/LocalStatsDelegateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/jmx/LocalStatsDelegateTest.java
@@ -1,0 +1,165 @@
+package com.hazelcast.jmx;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.jmx.suppliers.LocalMapStatsSupplier;
+import com.hazelcast.jmx.suppliers.StatsSupplier;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.UuidUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class LocalStatsDelegateTest extends HazelcastTestSupport {
+
+    private AtomicBoolean done;
+    private HazelcastInstance hz;
+
+    @Before
+    public void setUp() {
+        hz = createHazelcastInstance();
+        done = new AtomicBoolean(false);
+    }
+
+    @Test
+    public void testMapStats_Created_OnlyOnce_InGivenInternal() throws InterruptedException {
+        final IMap<Object, Object> trial = hz.getMap("trial");
+
+        final StatsSupplier<LocalMapStats> statsSupplier = new LocalMapStatsSupplier(trial);
+        final LocalStatsDelegate localStatsDelegate = new LocalStatsDelegate<LocalMapStats>(statsSupplier, 60);
+
+        Thread mapStatsThread1 = new Thread(new MapStatsThread(localStatsDelegate, done, 100));
+        Thread mapStatsThread2 = new Thread(new MapStatsThread(localStatsDelegate, done, 90));
+
+        mapStatsThread1.start();
+        mapStatsThread2.start();
+
+        Thread mapPutThread = new Thread(new MapPutThread(trial, done));
+        mapPutThread.start();
+
+        sleepSeconds(30);
+
+        done.set(true);
+
+        mapStatsThread1.join();
+        mapStatsThread2.join();
+        mapPutThread.join();
+    }
+
+    /**
+     * In this test, map entry count is incrementing steadily. Thus, we expect OwnedEntryCount
+     * to increase as well. Since the interval value for generating new map stats is 5 seconds,
+     * we assert for greater or equal.
+     */
+    @Test
+    @Category(NightlyTest.class)
+    public void stressTest() throws InterruptedException {
+        final IMap<Object, Object> trial = hz.getMap("trial");
+
+        final StatsSupplier<LocalMapStats> statsSupplier = new LocalMapStatsSupplier(trial);
+        final LocalStatsDelegate localStatsDelegate = new LocalStatsDelegate<LocalMapStats>(statsSupplier, 5);
+
+        Thread mapStatsThread1 = new Thread(new MapStatsThread(localStatsDelegate, done, true, 100));
+        Thread mapStatsThread2 = new Thread(new MapStatsThread(localStatsDelegate, done, true, 80));
+
+        mapStatsThread1.start();
+        mapStatsThread2.start();
+
+        Thread mapPutThread = new Thread(new MapPutThread(trial, done));
+        mapPutThread.start();
+
+        sleepSeconds(60);
+
+        done.set(true);
+
+        mapStatsThread1.join();
+        mapStatsThread2.join();
+        mapPutThread.join();
+    }
+
+    private void assertGreaterThanOrEqualTo(long leftHand, long rightHand) {
+        boolean correct = false;
+
+        if (leftHand >= rightHand || leftHand == rightHand) {
+            correct = true;
+        }
+        assertTrue(leftHand + " is less than " + rightHand, correct);
+    }
+
+    private class MapPutThread implements Runnable {
+        private IMap map;
+        private AtomicBoolean done;
+
+        public MapPutThread(IMap map, AtomicBoolean done) {
+            this.map = map;
+            this.done = done;
+        }
+
+        @Override
+        public void run() {
+            while (!done.get()) {
+                String randomString = UuidUtil.newUnsecureUuidString();
+                map.put(randomString, randomString);
+                sleepMillis(10);
+            }
+        }
+    }
+
+    private class MapStatsThread implements Runnable {
+        private LocalStatsDelegate localStatsDelegate;
+        private AtomicBoolean done;
+
+        private boolean stress = false;
+
+        private int sleepMs;
+
+        public MapStatsThread(LocalStatsDelegate localMapStatsDelegate, AtomicBoolean done, int sleepMs) {
+            this.localStatsDelegate = localMapStatsDelegate;
+            this.done = done;
+            this.sleepMs = sleepMs;
+        }
+
+        public MapStatsThread(LocalStatsDelegate localMapStatsDelegate, AtomicBoolean done, boolean stress, int sleepMs) {
+            this.localStatsDelegate = localMapStatsDelegate;
+            this.done = done;
+            this.stress = stress;
+            this.sleepMs = sleepMs;
+        }
+
+        @Override
+        public void run() {
+            LocalMapStats localMapStats = (LocalMapStats) localStatsDelegate.getLocalStats();
+            long previous = localMapStats.getOwnedEntryCount();
+            long current = previous;
+
+            while (!done.get()) {
+                if (stress) {
+                    assertGreaterThanOrEqualTo(current, previous);
+                } else {
+                    assertEquals(current, previous);
+                }
+                previous = current;
+                localMapStats = (LocalMapStats) localStatsDelegate.getLocalStats();
+                current = localMapStats.getOwnedEntryCount();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(sleepMs);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Gets rid of the JMX stat collecting overhead. Stats are created for given distributed object type for once in given interval. Before it was every time there was a method call.

Logic reviewed and approved here: https://github.com/hazelcast/hazelcast/pull/7327

Please comment on compatibility.