### PR TITLE
Litter reduction in MethodProbe

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -44,6 +44,8 @@ import static java.lang.String.format;
  */
 abstract class MethodProbe implements ProbeFunction {
 
+    private static final Object[] EMPTY_ARGS = new Object[0];
+
     final Method method;
     final Probe probe;
     final int type;
@@ -98,21 +100,21 @@ abstract class MethodProbe implements ProbeFunction {
         public long get(S source) throws Exception {
             switch (type) {
                 case TYPE_PRIMITIVE_LONG:
-                    return ((Number) method.invoke(source)).longValue();
+                    return ((Number) method.invoke(source, EMPTY_ARGS)).longValue();
                 case TYPE_LONG_NUMBER:
-                    Number longNumber = (Number) method.invoke(source);
+                    Number longNumber = (Number) method.invoke(source, EMPTY_ARGS);
                     return longNumber == null ? 0 : longNumber.longValue();
                 case TYPE_MAP:
-                    Map<?, ?> map = (Map<?, ?>) method.invoke(source);
+                    Map<?, ?> map = (Map<?, ?>) method.invoke(source, EMPTY_ARGS);
                     return map == null ? 0 : map.size();
                 case TYPE_COLLECTION:
-                    Collection<?> collection = (Collection<?>) method.invoke(source);
+                    Collection<?> collection = (Collection<?>) method.invoke(source, EMPTY_ARGS);
                     return collection == null ? 0 : collection.size();
                 case TYPE_COUNTER:
-                    Counter counter = (Counter) method.invoke(source);
+                    Counter counter = (Counter) method.invoke(source, EMPTY_ARGS);
                     return counter == null ? 0 : counter.get();
                 case TYPE_SEMAPHORE:
-                    Semaphore semaphore = (Semaphore) method.invoke(source);
+                    Semaphore semaphore = (Semaphore) method.invoke(source, EMPTY_ARGS);
                     return semaphore == null ? 0 : semaphore.availablePermits();
                 default:
                     throw new IllegalStateException("Unrecognized type:" + type);
@@ -131,7 +133,7 @@ abstract class MethodProbe implements ProbeFunction {
             switch (type) {
                 case TYPE_DOUBLE_PRIMITIVE:
                 case TYPE_DOUBLE_NUMBER:
-                    Number result = (Number) method.invoke(source);
+                    Number result = (Number) method.invoke(source, EMPTY_ARGS);
                     return result == null ? 0 : result.doubleValue();
                 default:
                     throw new IllegalStateException("Unrecognized type:" + type);


### PR DESCRIPTION
After doing some allocation analysis in JProfiler, it became clear that litter was being created
when calling Method.invoke(source) without an arguments array. The litter created is an empty var-args array.

After adding an explicit empty varargs array, no more litter was visible.

Very strange that the JIT doesn't optimize for this. Another option is that either JProfiler is lying or the JVM behaves differently when a profiler is connected.

Anyhow.. it should not do any harm. 