### PR TITLE
Renamed OperationSystemMetricSet

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -24,7 +24,7 @@ import com.hazelcast.internal.metrics.ProbeFunction;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.metricsets.ClassLoadingMetricSet;
 import com.hazelcast.internal.metrics.metricsets.GarbageCollectionMetricSet;
-import com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricsSet;
+import com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet;
 import com.hazelcast.internal.metrics.metricsets.RuntimeMetricSet;
 import com.hazelcast.internal.metrics.metricsets.ThreadMetricSet;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
@@ -84,7 +84,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
 
         RuntimeMetricSet.register(this);
         GarbageCollectionMetricSet.register(this);
-        OperatingSystemMetricsSet.register(this);
+        OperatingSystemMetricSet.register(this);
         ThreadMetricSet.register(this);
         ClassLoadingMetricSet.register(this);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
@@ -30,11 +30,11 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 /**
  * A Metric set for exposing {@link java.lang.management.OperatingSystemMXBean} metrics.
  */
-public final class OperatingSystemMetricsSet {
+public final class OperatingSystemMetricSet {
 
     private static final double PERCENTAGE_MULTIPLIER = 100d;
 
-    private OperatingSystemMetricsSet() {
+    private OperatingSystemMetricSet() {
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
@@ -2,7 +2,6 @@ package com.hazelcast.internal.metrics.metricsets;
 
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.LongGauge;
-import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -17,7 +16,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
-import static com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricsSet.registerMethod;
+import static com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet.registerMethod;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -38,7 +37,7 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
 
     @Test
     public void utilityConstructor(){
-        assertUtilityConstructor(OperatingSystemMetricsSet.class);
+        assertUtilityConstructor(OperatingSystemMetricSet.class);
     }
 
     @Test


### PR DESCRIPTION
Original name was OperatingSystemMetricsSet (metrics). This is not in line with the other
metricset implementations.