### PR TITLE
Avoid unnecessary HashSets in ClientMapProxy.convertKeysToData and MapGetAllMessageTask

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -966,21 +966,21 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             return;
         }
 
-        Set<Data> dataKeys = convertKeysToData(keys);
+        List<Data> dataKeys = convertKeysToData(keys);
         loadAllInternal(replaceExistingValues, dataKeys);
     }
 
-    protected void loadAllInternal(boolean replaceExistingValues, Set<Data> dataKeys) {
+    protected void loadAllInternal(boolean replaceExistingValues, List<Data> dataKeys) {
         ClientMessage request = MapLoadGivenKeysCodec.encodeRequest(name, dataKeys, replaceExistingValues);
         invoke(request);
     }
 
     // todo duplicate code.
-    private <K> Set<Data> convertKeysToData(Set<K> keys) {
+    private List<Data> convertKeysToData(Set<K> keys) {
         if (keys == null || keys.isEmpty()) {
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
-        final Set<Data> dataKeys = new HashSet<Data>(keys.size());
+        final List<Data> dataKeys = new ArrayList<Data>(keys.size());
         for (K key : keys) {
             checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -44,7 +44,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -238,7 +237,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected void loadAllInternal(boolean replaceExistingValues, Set<Data> dataKeys) {
+    protected void loadAllInternal(boolean replaceExistingValues, List<Data> dataKeys) {
         invalidateNearCache(dataKeys);
         super.loadAllInternal(replaceExistingValues, dataKeys);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetAllMessageTask.java
@@ -24,14 +24,11 @@ import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.GetAllOperation;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.Operation;
 
 import java.security.Permission;
-import java.util.HashSet;
-import java.util.Map;
 
 public class MapGetAllMessageTask
         extends AbstractPartitionMessageTask<MapGetAllCodec.RequestParameters> {
@@ -58,7 +55,7 @@ public class MapGetAllMessageTask
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
-        return MapGetAllCodec.encodeResponse(new HashSet<Map.Entry<Data, Data>>(((MapEntries) response).entries()));
+        return MapGetAllCodec.encodeResponse(((MapEntries) response).entries());
     }
 
     @Override


### PR DESCRIPTION
@cangencer noted on [gitter](https://gitter.im/hazelcast/hazelcast?at=56825e120199d70069e00edf) that ClientMapProxy.convertKeysToData should return an ArrayList instead of a HashSet, to avoid unneeded hashing. Further, MapGetAllMessageTask had an unnecessary HashSet which should be removed.

This PR ratifies this.