### PR TITLE
Cluster clock fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterClock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterClock.java
@@ -25,8 +25,6 @@ public interface ClusterClock {
      */
     long getClusterTime();
 
-    long getClusterTimeDiff();
-
     /**
      * Returns the cluster  up-time in milliseconds.
      * When first node in cluster becomes master, its clusterTime value is saved as

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
@@ -28,7 +28,7 @@ public class ClusterClockImpl implements ClusterClock {
 
     private final ILogger logger;
 
-    private volatile long clusterTimeDiff = Long.MAX_VALUE;
+    private volatile long clusterTimeDiff;
     private volatile long clusterStartTime = Long.MIN_VALUE;
 
     public ClusterClockImpl(ILogger logger) {
@@ -38,25 +38,24 @@ public class ClusterClockImpl implements ClusterClock {
     @Probe(name = "clusterTime")
     @Override
     public long getClusterTime() {
-        return Clock.currentTimeMillis() + ((clusterTimeDiff == Long.MAX_VALUE) ? 0 : clusterTimeDiff);
+        return Clock.currentTimeMillis() + clusterTimeDiff;
     }
 
     public void setMasterTime(long masterTime) {
         long diff = masterTime - Clock.currentTimeMillis();
+        setClusterTimeDiff(diff);
+    }
+
+    void setClusterTimeDiff(long diff) {
         if (logger.isFinestEnabled()) {
             logger.finest("Setting cluster time diff to " + diff + "ms.");
         }
         this.clusterTimeDiff = diff;
     }
 
-    void reset() {
-        this.clusterTimeDiff = Long.MAX_VALUE;
-    }
-
     @Probe(name = "clusterTimeDiff", level = MANDATORY)
-    @Override
-    public long getClusterTimeDiff() {
-        return (clusterTimeDiff == Long.MAX_VALUE) ? 0 : clusterTimeDiff;
+    long getClusterTimeDiff() {
+        return clusterTimeDiff;
     }
 
     @Probe(name = "clusterUpTime")

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -58,7 +58,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
-import com.hazelcast.util.Clock;
 import com.hazelcast.util.executor.ExecutorType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -291,7 +290,6 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
         if (node.isMaster()) {
             clusterHeartbeatManager.resetMemberMasterConfirmations();
-            clusterClock.reset();
         } else {
             clusterHeartbeatManager.sendMasterConfirmation();
         }
@@ -351,7 +349,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                 if (member == null) {
                     member = createMember(memberInfo, scopeId);
                     newMembers.add(member);
-                    long now = Clock.currentTimeMillis();
+                    long now = clusterClock.getClusterTime();
                     clusterHeartbeatManager.onHeartbeat(member, now);
                     clusterHeartbeatManager.acceptMasterConfirmation(member, now);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
@@ -17,11 +17,12 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.cluster.MemberInfo;
-import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.MemberInfo;
+import com.hazelcast.internal.cluster.impl.ClusterClockImpl;
+import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -101,7 +102,9 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
     private void initClusterStates(ClusterServiceImpl clusterService) {
         clusterService.initialClusterState(clusterState);
         clusterService.setClusterId(clusterId);
-        clusterService.getClusterClock().setClusterStartTime(clusterStartTime);
+        ClusterClockImpl clusterClock = clusterService.getClusterClock();
+        clusterClock.setClusterStartTime(clusterStartTime);
+        clusterClock.setMasterTime(masterTime);
     }
 
     private void processPartitionState() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberInfoUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberInfoUpdateOperation.java
@@ -54,7 +54,6 @@ public class MemberInfoUpdateOperation extends AbstractClusterOperation implemen
     protected final void processMemberUpdate() {
         if (isValid()) {
             final ClusterServiceImpl clusterService = getService();
-            clusterService.getClusterClock().setMasterTime(masterTime);
             clusterService.updateMembers(memberInfos);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/JumpingSystemClock.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/JumpingSystemClock.java
@@ -25,15 +25,18 @@ import java.util.concurrent.TimeUnit;
  * @author mdogan 18/12/14
  */
 class JumpingSystemClock extends Clock.ClockImpl {
-    public static final int JUMP_AFTER_SECONDS = 30;
 
-    private final long jumpAfter = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(JUMP_AFTER_SECONDS);
+    public static final String JUMP_AFTER_SECONDS_PROPERTY = "com.hazelcast.clock.jump.after";
+
+    private final long jumpAfter;
     private final long jumpOffset;
 
     public JumpingSystemClock() {
         String clockOffset = System.getProperty(Clock.HAZELCAST_CLOCK_OFFSET);
+        String jumpAfterSeconds = System.getProperty(JUMP_AFTER_SECONDS_PROPERTY);
         try {
-            this.jumpOffset = Long.parseLong(clockOffset);
+            jumpOffset = Long.parseLong(clockOffset);
+            jumpAfter = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(Integer.parseInt(jumpAfterSeconds));
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
@@ -22,13 +22,16 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceManager;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.FilteringClassLoader;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -37,7 +40,6 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.cluster.JumpingSystemClock.JUMP_AFTER_SECONDS;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -47,7 +49,21 @@ import static org.junit.Assert.assertEquals;
 @Category(NightlyTest.class)
 public class SystemClockChangeTest extends HazelcastTestSupport {
 
+    private static final int JUMP_AFTER_SECONDS = 15;
+
     private Object isolatedNode;
+
+    @BeforeClass
+    public static void setSystemProps() {
+        System.setProperty(GroupProperty.HEARTBEAT_INTERVAL_SECONDS.getName(), "1");
+        System.setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName(), "10");
+    }
+
+    @AfterClass
+    public static void clearSystemProps() {
+        System.clearProperty(GroupProperty.HEARTBEAT_INTERVAL_SECONDS.getName());
+        System.clearProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName());
+    }
 
     @Before
     @After
@@ -62,92 +78,147 @@ public class SystemClockChangeTest extends HazelcastTestSupport {
             Class<?> instanceClass = isolatedNode.getClass();
             Method shutdown = instanceClass.getMethod("shutdown");
             shutdown.invoke(isolatedNode);
+            isolatedNode = null;
         }
     }
 
     @Test
-    public void testCluster_whenMasterClockJumpsForward() throws Exception {
-        setClock(TimeUnit.MINUTES.toMillis(30));
-        HazelcastInstance hz = startNode();
-
-        resetClock();
+    public void testCluster_whenMasterClockIsBehind() throws Exception {
+        setClockOffset(TimeUnit.MINUTES.toMillis(-60));
         isolatedNode = startIsolatedNode();
 
-        assertClusterSizeAlways(2, hz, TimeUnit.SECONDS.toMillis(JUMP_AFTER_SECONDS * 2));
+        resetClock();
+        HazelcastInstance hz = startNode();
+
+        assertClusterSize(2, hz);
+        assertClusterTime(getClusterTime(isolatedNode), hz);
+    }
+
+    @Test
+    public void testCluster_whenMasterClockIsAhead() throws Exception {
+        setClockOffset(TimeUnit.MINUTES.toMillis(60));
+        isolatedNode = startIsolatedNode();
+
+        resetClock();
+        HazelcastInstance hz = startNode();
+
+        assertClusterSize(2, hz);
+        assertClusterTime(getClusterTime(isolatedNode), hz);
+    }
+
+    @Test
+    public void testCluster_whenMasterChanges() throws Exception {
+        setClockOffset(TimeUnit.MINUTES.toMillis(60));
+        isolatedNode = startIsolatedNode();
+
+        resetClock();
+        HazelcastInstance hz1 = startNode();
+        HazelcastInstance hz2 = startNode();
+
+        assertClusterSizeEventually(3, hz1);
+        assertClusterSizeEventually(3, hz2);
+
+        shutdownIsolatedNode();
+
+        assertClusterSizeEventually(2, hz1);
+        assertClusterSizeEventually(2, hz2);
+
+        assertClusterTime(hz1.getCluster().getClusterTime(), hz2);
+    }
+
+    @Test
+    public void testCluster_whenMasterClockJumpsForward() throws Exception {
+        setJumpingClock(TimeUnit.MINUTES.toMillis(30));
+        isolatedNode = startIsolatedNode();
+
+        resetClock();
+        HazelcastInstance hz = startNode();
+
+        assertClusterSizeAlways(2, hz);
         assertClusterTime(hz.getCluster().getClusterTime(), isolatedNode);
     }
 
     @Test
     public void testCluster_whenMasterClockJumpsBackward() throws Exception {
-        setClock(TimeUnit.MINUTES.toMillis(-30));
-        HazelcastInstance hz = startNode();
-
-        resetClock();
+        setJumpingClock(TimeUnit.MINUTES.toMillis(-30));
         isolatedNode = startIsolatedNode();
 
-        assertClusterSizeAlways(2, hz, TimeUnit.SECONDS.toMillis(JUMP_AFTER_SECONDS * 2));
+        resetClock();
+        HazelcastInstance hz = startNode();
+
+        assertClusterSizeAlways(2, hz);
         assertClusterTime(hz.getCluster().getClusterTime(), isolatedNode);
     }
 
     @Test
     public void testCluster_whenSlaveClockJumpsForward() throws Exception {
-        isolatedNode = startIsolatedNode();
-
-        setClock(TimeUnit.MINUTES.toMillis(30));
         HazelcastInstance hz = startNode();
 
-        assertClusterSizeAlways(2, hz, TimeUnit.SECONDS.toMillis(JUMP_AFTER_SECONDS * 2));
+        setJumpingClock(TimeUnit.MINUTES.toMillis(30));
+        isolatedNode = startIsolatedNode();
+
+        assertClusterSizeAlways(2, hz);
         assertClusterTime(System.currentTimeMillis(), hz);
+        assertClusterTime(System.currentTimeMillis(), isolatedNode);
     }
 
     @Test
     public void testCluster_whenSlaveClockJumpsBackward() throws Exception {
-        isolatedNode = startIsolatedNode();
-
-        setClock(TimeUnit.MINUTES.toMillis(-30));
         HazelcastInstance hz = startNode();
 
-        assertClusterSizeAlways(2, hz, TimeUnit.SECONDS.toMillis(JUMP_AFTER_SECONDS * 2));
+        setJumpingClock(TimeUnit.MINUTES.toMillis(-30));
+        isolatedNode = startIsolatedNode();
+
+        assertClusterSizeAlways(2, hz);
         assertClusterTime(System.currentTimeMillis(), hz);
+        assertClusterTime(System.currentTimeMillis(), isolatedNode);
     }
 
     private void assertClusterTime(long expected, HazelcastInstance hz) {
-        assertEquals("Cluster time should be equal to master time!",
+        assertEquals("Cluster time should be (approx.) equal to master time!",
                 expected, hz.getCluster().getClusterTime(), 1000d);
     }
 
     private void assertClusterTime(long expected, Object hz) throws Exception {
+        assertEquals("Cluster time should be (approx.) equal to master time!", expected,
+                getClusterTime(hz), 1000d);
+    }
+
+    private long getClusterTime(Object hz) throws Exception {
         Method getCluster = hz.getClass().getMethod("getCluster");
         Object cluster = getCluster.invoke(hz);
         Method getClusterTime = cluster.getClass().getMethod("getClusterTime");
-        Number clusterTime = (Number) getClusterTime.invoke(cluster);
-
-        assertEquals("Cluster time should be equal to master time!", expected,
-                clusterTime.doubleValue(), 1000d);
+        return ((Number) getClusterTime.invoke(cluster)).longValue();
     }
 
-    private void assertClusterSizeAlways(int expected, HazelcastInstance hz, long timeoutMillis) {
-        Cluster cluster = hz.getCluster();
-        while (timeoutMillis > 0) {
-            assertEquals("Cluster should be stable when system clock changes!", expected, cluster.getMembers().size());
-            sleepSeconds(1);
-            timeoutMillis -= 1000;
-        }
+    private void assertClusterSizeAlways(final int expected, HazelcastInstance hz) {
+        final Cluster cluster = hz.getCluster();
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("Cluster should be stable when system clock changes!", expected, cluster.getMembers().size());
+            }
+        }, JUMP_AFTER_SECONDS * 2);
     }
 
-    private void setClock(long offset) {
+    private void setClockOffset(long offset) {
+        System.setProperty(Clock.HAZELCAST_CLOCK_OFFSET, String.valueOf(offset));
+    }
+
+    private void setJumpingClock(long offset) {
         System.setProperty(Clock.HAZELCAST_CLOCK_IMPL, JumpingSystemClock.class.getName());
         System.setProperty(Clock.HAZELCAST_CLOCK_OFFSET, String.valueOf(offset));
+        System.setProperty(JumpingSystemClock.JUMP_AFTER_SECONDS_PROPERTY, String.valueOf(JUMP_AFTER_SECONDS));
     }
 
     private void resetClock() {
         System.clearProperty(Clock.HAZELCAST_CLOCK_IMPL);
         System.clearProperty(Clock.HAZELCAST_CLOCK_OFFSET);
+        System.clearProperty(JumpingSystemClock.JUMP_AFTER_SECONDS_PROPERTY);
     }
 
     private static HazelcastInstance startNode() throws Exception {
         Config config = new Config();
-        config.setProperty(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS, "10");
         return Hazelcast.newHazelcastInstance(config);
     }
 
@@ -162,8 +233,6 @@ public class SystemClockChangeTest extends HazelcastTestSupport {
             Object config = configClazz.newInstance();
             Method setClassLoader = configClazz.getDeclaredMethod("setClassLoader", ClassLoader.class);
             setClassLoader.invoke(config, cl);
-            Method setProperty = configClazz.getDeclaredMethod("setProperty", String.class, String.class);
-            setProperty.invoke(config, GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "10");
 
             Class<?> hazelcastClazz = cl.loadClass("com.hazelcast.core.Hazelcast");
             Method newHazelcastInstance = hazelcastClazz.getDeclaredMethod("newHazelcastInstance", configClazz);


### PR DESCRIPTION
- Cluster clock is set/updated during join and on every heartbeat.
- Cluster clock is adjusted locally when a clock jump is detected. So, even system clock
changes on master, cluster clock remains unchanged (in a small interval, a few ms to a few sec).
- With these changes, no need to take clock-jump into account while checking heartbeat
 and master-confirmation timeouts.

Fixes https://github.com/hazelcast/hazelcast/issues/7408