### PR TITLE
Hazelcast support for Spring Transaction API #611

### DIFF
--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -158,6 +158,12 @@
                     <version>${org.springframework.version}</version>
                     <scope>provided</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-tx</artifactId>
+                    <version>${org.springframework.version}</version>
+                    <scope>provided</scope>
+                </dependency>
 
                 <!--TEST DEPENDENCIES-->
                 <dependency>
@@ -176,12 +182,6 @@
                 <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-test</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-tx</artifactId>
                     <version>${org.springframework.version}</version>
                     <scope>test</scope>
                 </dependency>
@@ -226,6 +226,12 @@
                     <version>${org.springframework.version}</version>
                     <scope>provided</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-tx</artifactId>
+                    <version>${org.springframework.version}</version>
+                    <scope>provided</scope>
+                </dependency>
 
                 <!--TEST DEPENDENCIES-->
                 <dependency>
@@ -250,12 +256,6 @@
                 <dependency>
                     <groupId>org.springframework</groupId>
                     <artifactId>spring-test</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-tx</artifactId>
                     <version>${org.springframework.version}</version>
                     <scope>test</scope>
                 </dependency>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.transaction;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.transaction.TransactionContext;
+import org.springframework.transaction.CannotCreateTransactionException;
+import org.springframework.transaction.NoTransactionException;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+import org.springframework.transaction.support.ResourceTransactionManager;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * {@link org.springframework.transaction.PlatformTransactionManager} implementation
+ * for a single {@link HazelcastInstance}. Binds a Hazelcast {@link TransactionContext}
+ * from the instance to the thread (as it is already bounded by Hazelcast itself) and makes it available for access.
+ * <p><i>Note:</i> This transaction manager doesn't supports nested transactions, since
+ * Hazelcast doesn't support them either.
+ *
+ * @author Balint Krivan
+ * @see #getTransactionContext(HazelcastInstance)
+ * @see #getTransactionContext()
+ */
+public class HazelcastTransactionManager extends AbstractPlatformTransactionManager implements ResourceTransactionManager {
+
+    private HazelcastInstance hazelcastInstance;
+
+
+    public HazelcastTransactionManager(HazelcastInstance hazelcastInstance) {
+        this.hazelcastInstance = hazelcastInstance;
+    }
+
+
+    /**
+     * Returns the transaction context for the given Hazelcast instance bounded to the current thread.
+     *
+     * @throws NoTransactionException if the transaction context cannot be found
+     */
+    public static TransactionContext getTransactionContext(HazelcastInstance hazelcastInstance) {
+        TransactionContextHolder transactionContextHolder =
+                (TransactionContextHolder) TransactionSynchronizationManager.getResource(hazelcastInstance);
+        if (transactionContextHolder == null) {
+            throw new NoTransactionException("No TransactionContext with actual transaction available for current thread");
+        }
+        return transactionContextHolder.getContext();
+    }
+
+    /**
+     * Returns the transaction context
+     *
+     * @throws NoTransactionException if the transaction context cannot be found
+     */
+    public TransactionContext getTransactionContext() {
+        return getTransactionContext(this.hazelcastInstance);
+    }
+
+    @Override
+    public Object getResourceFactory() {
+        return hazelcastInstance;
+    }
+
+
+    @Override
+    protected Object doGetTransaction() throws TransactionException {
+        HazelcastTransactionObject txObject = new HazelcastTransactionObject();
+
+        TransactionContextHolder transactionContextHolder =
+                (TransactionContextHolder) TransactionSynchronizationManager.getResource(hazelcastInstance);
+        if (transactionContextHolder != null) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Found thread-bound TransactionContext [" + transactionContextHolder.getContext() + "]");
+            }
+            txObject.setTransactionContextHolder(transactionContextHolder, false);
+        }
+
+        return txObject;
+    }
+
+    @Override
+    protected boolean isExistingTransaction(Object transaction) throws TransactionException {
+        return ((HazelcastTransactionObject) transaction).hasTransaction();
+    }
+
+    @Override
+    protected void doBegin(Object transaction, TransactionDefinition definition) throws TransactionException {
+        HazelcastTransactionObject txObject = (HazelcastTransactionObject) transaction;
+
+        try {
+            if (txObject.getTransactionContextHolder() == null) {
+                TransactionContext transactionContext = hazelcastInstance.newTransactionContext();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Opened new TransactionContext [" + transactionContext + "]");
+                }
+                txObject.setTransactionContextHolder(new TransactionContextHolder(transactionContext), true);
+            }
+
+            txObject.getTransactionContextHolder().beginTransaction();
+
+            if (txObject.isNewTransactionContextHolder()) {
+                TransactionSynchronizationManager.bindResource(hazelcastInstance, txObject.getTransactionContextHolder());
+            }
+        } catch (Throwable ex) {
+            closeTransactionContextAfterFailedBegin(txObject);
+            throw new CannotCreateTransactionException("Could not begin Hazelcast transaction", ex);
+        }
+    }
+
+    private void closeTransactionContextAfterFailedBegin(HazelcastTransactionObject txObject) {
+        if (txObject.isNewTransactionContextHolder()) {
+            TransactionContext context = txObject.getTransactionContextHolder().getContext();
+            try {
+                context.rollbackTransaction();
+            } catch (Throwable ex) {
+                logger.debug("Could not rollback Hazelcast transaction after failed transaction begin", ex);
+            }
+            txObject.setTransactionContextHolder(null, false);
+        }
+    }
+
+    @Override
+    protected void doCommit(DefaultTransactionStatus status) throws TransactionException {
+        HazelcastTransactionObject txObject = (HazelcastTransactionObject) status.getTransaction();
+        if (status.isDebug()) {
+            logger.debug("Committing Hazelcast transaction on TransactionContext ["
+                    + txObject.getTransactionContextHolder().getContext() + "]");
+        }
+
+        try {
+            txObject.getTransactionContextHolder().getContext().commitTransaction();
+        } catch (com.hazelcast.transaction.TransactionException ex) {
+            throw new TransactionSystemException("Could not commit Hazelcast transaction", ex);
+        }
+    }
+
+    @Override
+    protected void doRollback(DefaultTransactionStatus status) throws TransactionException {
+        HazelcastTransactionObject txObject = (HazelcastTransactionObject) status.getTransaction();
+        if (status.isDebug()) {
+            logger.debug("Rolling back Hazelcast transaction on TransactionContext ["
+                    + txObject.getTransactionContextHolder().getContext() + "]");
+        }
+
+        TransactionContext tx = txObject.getTransactionContextHolder().getContext();
+        tx.rollbackTransaction();
+    }
+
+    @Override
+    protected void doCleanupAfterCompletion(Object transaction) {
+        HazelcastTransactionObject txObject = (HazelcastTransactionObject) transaction;
+
+        if (txObject.isNewTransactionContextHolder()) {
+            TransactionSynchronizationManager.unbindResourceIfPossible(hazelcastInstance);
+        }
+
+        txObject.getTransactionContextHolder().clear();
+    }
+
+
+    private class HazelcastTransactionObject {
+
+        private TransactionContextHolder transactionContextHolder;
+        private boolean newTransactionContextHolder;
+
+        public void setTransactionContextHolder(TransactionContextHolder transactionContextHolder,
+                                                boolean newTransactionContextHolder) {
+            this.transactionContextHolder = transactionContextHolder;
+            this.newTransactionContextHolder = newTransactionContextHolder;
+        }
+
+        public TransactionContextHolder getTransactionContextHolder() {
+            return transactionContextHolder;
+        }
+
+        public boolean isNewTransactionContextHolder() {
+            return newTransactionContextHolder;
+        }
+
+        public boolean hasTransaction() {
+            return this.transactionContextHolder != null && this.transactionContextHolder.isTransactionActive();
+        }
+    }
+}

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/ManagedTransactionalTaskContext.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/ManagedTransactionalTaskContext.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.transaction;
+
+import com.hazelcast.core.TransactionalList;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.core.TransactionalMultiMap;
+import com.hazelcast.core.TransactionalQueue;
+import com.hazelcast.core.TransactionalSet;
+import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionalObject;
+import com.hazelcast.transaction.TransactionalTaskContext;
+
+/**
+ * {@link TransactionalTaskContext} proxying implementation to make the one created by {@link HazelcastTransactionManager}
+ * available to actual business logic. Useful when the transaction is managed declaratively using
+ * {@link org.springframework.transaction.annotation.Transactional @Transactional} annotations with AOP.
+ *
+ * @author Balint Krivan
+ * @see HazelcastTransactionManager
+ */
+public class ManagedTransactionalTaskContext implements TransactionalTaskContext {
+
+    private final HazelcastTransactionManager hzTxMgr;
+
+
+    public ManagedTransactionalTaskContext(HazelcastTransactionManager hzTxMgr) {
+        this.hzTxMgr = hzTxMgr;
+    }
+
+
+    @Override
+    public <K, V> TransactionalMap<K, V> getMap(String name) {
+        return transactionContext().getMap(name);
+    }
+
+    @Override
+    public <E> TransactionalQueue<E> getQueue(String name) {
+        return transactionContext().getQueue(name);
+    }
+
+    @Override
+    public <K, V> TransactionalMultiMap<K, V> getMultiMap(String name) {
+        return transactionContext().getMultiMap(name);
+    }
+
+    @Override
+    public <E> TransactionalList<E> getList(String name) {
+        return transactionContext().getList(name);
+    }
+
+    @Override
+    public <E> TransactionalSet<E> getSet(String name) {
+        return transactionContext().getSet(name);
+    }
+
+    @Override
+    public <T extends TransactionalObject> T getTransactionalObject(String serviceName, String name) {
+        return transactionContext().getTransactionalObject(serviceName, name);
+    }
+
+    private TransactionContext transactionContext() {
+        return hzTxMgr.getTransactionContext();
+    }
+}

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/TransactionContextHolder.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/TransactionContextHolder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring.transaction;
+
+import com.hazelcast.transaction.TransactionContext;
+
+/**
+ * Holder wrapping a Hazelcast TransactionContext.
+ * HazelcastTransactionManager binds instances of this class to the thread, for a given HazelcastInstance.
+ *
+ * @author Balint Krivan
+ * @see HazelcastTransactionManager
+ */
+class TransactionContextHolder {
+
+    private final TransactionContext transactionContext;
+    private boolean transactionActive;
+
+
+    public TransactionContextHolder(TransactionContext transactionContext) {
+        this.transactionContext = transactionContext;
+    }
+
+
+    public boolean isTransactionActive() {
+        return transactionActive;
+    }
+
+    public TransactionContext getContext() {
+        return transactionContext;
+    }
+
+    /**
+     * @see TransactionContext#beginTransaction()
+     */
+    public void beginTransaction() {
+        transactionContext.beginTransaction();
+        transactionActive = true;
+    }
+
+    public void clear() {
+        transactionActive = false;
+    }
+}

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/package-info.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains Hazelcast transaction classes for Spring Transaction API.
+ */
+package com.hazelcast.spring.transaction;

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyObject.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyObject.java
@@ -1,0 +1,35 @@
+package com.hazelcast.spring.transaction;
+
+import java.io.Serializable;
+
+public class DummyObject implements Serializable {
+
+    private Long id;
+    private String string;
+
+
+    public DummyObject() {
+    }
+
+    public DummyObject(long id, String string) {
+        this.id = id;
+        this.string = string;
+    }
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    public void setString(String string) {
+        this.string = string;
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
@@ -1,0 +1,28 @@
+package com.hazelcast.spring.transaction;
+
+import com.hazelcast.transaction.TransactionalTaskContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OtherServiceBeanWithTransactionalContext {
+
+    TransactionalTaskContext transactionalContext;
+
+
+    public OtherServiceBeanWithTransactionalContext(TransactionalTaskContext transactionalContext) {
+        this.transactionalContext = transactionalContext;
+    }
+
+
+    @Transactional
+    public void put(DummyObject object) {
+        transactionalContext.getMap("dummyObjectMap").put(object.getId(), object);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void putInNewTransaction(DummyObject object) {
+        put(object);
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
@@ -1,0 +1,37 @@
+package com.hazelcast.spring.transaction;
+
+import com.hazelcast.transaction.TransactionalTaskContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ServiceBeanWithTransactionalContext {
+
+    TransactionalTaskContext transactionalContext;
+    OtherServiceBeanWithTransactionalContext otherService;
+
+    public ServiceBeanWithTransactionalContext(TransactionalTaskContext transactionalContext,
+                                               OtherServiceBeanWithTransactionalContext otherService) {
+        this.transactionalContext = transactionalContext;
+        this.otherService = otherService;
+    }
+
+
+    public void put(DummyObject object) {
+        transactionalContext.getMap("dummyObjectMap").put(object.getId(), object);
+    }
+
+    public void putWithException(DummyObject object) {
+        put(object);
+        throw new RuntimeException("oops, let's rollback!");
+    }
+
+    public void putUsingOtherBean_sameTransaction(DummyObject object) {
+        otherService.put(object);
+    }
+
+    public void putUsingOtherBean_newTransaction(DummyObject object) {
+        otherService.putInNewTransaction(object);
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -1,0 +1,129 @@
+package com.hazelcast.spring.transaction;
+
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionalTaskContext;
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.NoTransactionException;
+import org.springframework.transaction.TransactionSuspensionNotSupportedException;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(CustomSpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"transaction-applicationContext-hazelcast.xml"})
+@Category(QuickTest.class)
+public class TestSpringManagedHazelcastTransaction {
+
+    @BeforeClass
+    @AfterClass
+    public static void cleanup() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Autowired
+    ServiceBeanWithTransactionalContext service;
+
+    @Autowired
+    TransactionalTaskContext transactionalContext;
+
+    @Autowired
+    HazelcastInstance instance;
+
+
+    /**
+     * Tests that transactionalContext cannot be accessed when there is no transaction.
+     */
+    @Test
+    public void noTransactionContextWhenNoTransaction() {
+        // given
+        expectedException.expect(NoTransactionException.class);
+
+        // when
+        transactionalContext.getMap("magic");
+    }
+
+    /**
+     * Tests that transactionContext is accessible when there is a transaction.
+     */
+    @Test
+    @Transactional
+    public void noExceptionWhenTransaction() {
+        // when
+        TransactionalMap<Object, Object> magic = transactionalContext.getMap("magic");
+
+        // then
+        Assert.assertNotNull(magic);
+    }
+
+    /**
+     * Tests that transaction will be committed if everything works fine.
+     */
+    @Test
+    public void transactionalServiceBeanInvocation_commit() {
+        // when
+        service.put(new DummyObject(1L, "magic"));
+
+        // then
+        Assert.assertEquals(1L, instance.getMap("dummyObjectMap").size());
+    }
+
+    /**
+     * Tests that transaction will be rollbacked if there is an exception.
+     */
+    @Test
+    public void transactionalServiceBeanInvocation_rollback() {
+        // when
+        RuntimeException expectedEx = null;
+
+        try {
+            service.putWithException(new DummyObject(1L, "magic"));
+        } catch (RuntimeException ex) {
+            expectedEx = ex;
+        } finally {
+            // then
+            Assert.assertNotNull(expectedEx);
+            Assert.assertEquals(0L, instance.getMap("dummyObjectMap").size());
+        }
+    }
+
+    /**
+     * Tests that if propagation is set to {@link org.springframework.transaction.annotation.Propagation#REQUIRED REQUIRED},
+     * then the same transaction will be used.
+     */
+    @Test
+    public void transactionalServiceBeanInvocation_nestedWithPropagationRequired() {
+        // when
+        service.putUsingOtherBean_sameTransaction(new DummyObject(1L, "magic"));
+
+        // then
+        Assert.assertEquals(1L, instance.getMap("dummyObjectMap").size());
+    }
+
+    /**
+     * Tests that if propagation is set to {@link org.springframework.transaction.annotation.Propagation#REQUIRES_NEW REQUIRES_NEW},
+     * then an exception will be thrown, since Hazelcast doesn't support nested transaction, so {@link HazelcastTransactionManager}
+     * doesn't support transaction suspension.
+     */
+    @Test
+    public void transactionalServiceBeanInvocation_nestedWithPropagationRequiresNew() {
+        // given
+        expectedException.expect(TransactionSuspensionNotSupportedException.class);
+
+        // when
+        service.putUsingOtherBean_newTransaction(new DummyObject(1L, "magic"));
+    }
+}

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/transaction/transaction-applicationContext-hazelcast.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.hazelcast.com/schema/spring
+		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd">
+
+    <tx:annotation-driven transaction-manager="transactionManager"/>
+
+    <bean id="transactionManager" class="com.hazelcast.spring.transaction.HazelcastTransactionManager">
+        <constructor-arg ref="instance"/>
+    </bean>
+
+    <bean id="transactionalContext" class="com.hazelcast.spring.transaction.ManagedTransactionalTaskContext">
+        <constructor-arg ref="transactionManager"/>
+    </bean>
+
+    <bean id="otherService" class="com.hazelcast.spring.transaction.OtherServiceBeanWithTransactionalContext">
+        <constructor-arg ref="transactionalContext"/>
+    </bean>
+
+    <bean id="service" class="com.hazelcast.spring.transaction.ServiceBeanWithTransactionalContext">
+        <constructor-arg ref="transactionalContext"/>
+        <constructor-arg ref="otherService"/>
+    </bean>
+
+    <hz:hazelcast id="instance" lazy-init="true" scope="singleton">
+        <hz:config>
+            <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
+            <hz:network port="5701" port-auto-increment="false">
+                <hz:join>
+                    <hz:multicast enabled="false"/>
+                    <hz:tcp-ip enabled="true">
+                        <hz:interface>127.0.0.1:5701</hz:interface>
+                        <hz:interface>127.0.0.1:5702</hz:interface>
+                    </hz:tcp-ip>
+                </hz:join>
+                <hz:interfaces enabled="true">
+                    <hz:interface>127.0.0.1</hz:interface>
+                </hz:interfaces>
+            </hz:network>
+        </hz:config>
+    </hz:hazelcast>
+
+    <hz:client id="client" lazy-init="true" scope="prototype">
+        <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
+        <hz:network connection-attempt-limit="3"
+                    connection-attempt-period="3000"
+                    connection-timeout="1000"
+                    redo-operation="true"
+                    smart-routing="true">
+
+            <hz:member>127.0.0.1:5701</hz:member>
+
+            <hz:socket-options buffer-size="32"
+                               keep-alive="false"
+                               linger-seconds="3"
+                               reuse-address="false"
+                               tcp-no-delay="false"/>
+        </hz:network>
+    </hz:client>
+</beans>


### PR DESCRIPTION
An `AbstractPlatformTransactionManager` implementation called `HazelcastTransactionManager` is provided with some tests to solve #611. Also there is a `TransactionalTaskContext` implementation, which can be used to acquire transactional objects (like `TransactionalMap`) from the context in a spring-way.