### PR TITLE
Renamed to InternalClusterService

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientInternalClusterServiceMemberListTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientInternalClusterServiceMemberListTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientClusterServiceMemberListTest {
+public class ClientInternalClusterServiceMemberListTest {
 
     private Config liteConfig = new Config().setLiteMember(true);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEngine.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.client;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.instance.MemberImpl;
@@ -41,7 +41,7 @@ public interface ClientEngine {
 
     InternalPartitionService getPartitionService();
 
-    ClusterService getClusterService();
+    InternalClusterService getClusterService();
 
     EventService getEventService();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -28,7 +28,7 @@ import com.hazelcast.client.impl.protocol.ClientExceptionFactory;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.MessageTaskFactory;
 import com.hazelcast.client.impl.protocol.task.MessageTask;
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientListener;
@@ -178,7 +178,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     }
 
     @Override
-    public ClusterService getClusterService() {
+    public InternalClusterService getClusterService() {
         return nodeEngine.getClusterService();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientAddDistributedObjectListenerCodec;
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.core.DistributedObjectEvent;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.instance.Node;
@@ -114,7 +114,7 @@ public class AddDistributedObjectListenerMessageTask
             return false;
         }
 
-        ClusterService clusterService = clientEngine.getClusterService();
+        InternalClusterService clusterService = clientEngine.getClusterService();
         boolean currentMemberIsMaster = clusterService.getMasterAddress().equals(clientEngine.getThisAddress());
         if (parameters.localOnly && !currentMemberIsMaster) {
             //if client registered localOnly, only master is allowed to send request

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
@@ -19,9 +19,9 @@ package com.hazelcast.client.impl.protocol.task;
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientAddMembershipListenerCodec;
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.cluster.MemberAttributeOperationType;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.core.InitialMembershipEvent;
 import com.hazelcast.core.InitialMembershipListener;
 import com.hazelcast.core.MemberAttributeEvent;
@@ -42,8 +42,8 @@ public class AddMembershipListenerMessageTask
 
     @Override
     protected Object call() {
-        String serviceName = ClusterServiceImpl.SERVICE_NAME;
-        ClusterServiceImpl service = getService(serviceName);
+        String serviceName = InternalClusterServiceImpl.SERVICE_NAME;
+        InternalClusterServiceImpl service = getService(serviceName);
         ClientEndpoint endpoint = getEndpoint();
         String registrationId = service.addMembershipListener(new MembershipListenerImpl(endpoint));
         endpoint.addListenerDestroyAction(serviceName, serviceName, registrationId);
@@ -62,7 +62,7 @@ public class AddMembershipListenerMessageTask
 
     @Override
     public String getServiceName() {
-        return ClusterServiceImpl.SERVICE_NAME;
+        return InternalClusterServiceImpl.SERVICE_NAME;
     }
 
     @Override
@@ -94,7 +94,7 @@ public class AddMembershipListenerMessageTask
 
         @Override
         public void init(InitialMembershipEvent membershipEvent) {
-            ClusterService service = getService(ClusterServiceImpl.SERVICE_NAME);
+            InternalClusterService service = getService(InternalClusterServiceImpl.SERVICE_NAME);
             Collection members = service.getMemberImpls();
             ClientMessage eventMessage = ClientAddMembershipListenerCodec.encodeMemberListEvent(members);
             sendClientMessage(endpoint.getUuid(), eventMessage);
@@ -146,7 +146,7 @@ public class AddMembershipListenerMessageTask
                 return false;
             }
 
-            ClusterService clusterService = clientEngine.getClusterService();
+            InternalClusterService clusterService = clientEngine.getClusterService();
             boolean currentMemberIsMaster = clusterService.getMasterAddress().equals(clientEngine.getThisAddress());
             if (parameters.localOnly && !currentMemberIsMaster) {
                 //if client registered localOnly, only master is allowed to send request

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.impl.protocol.task.mapreduce;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.JobTrackerConfig;
 import com.hazelcast.core.ExecutionCallback;
@@ -65,7 +65,7 @@ public abstract class AbstractMapReduceTask<Parameters>
         MapReduceService mapReduceService = getService(MapReduceService.SERVICE_NAME);
         NodeEngine nodeEngine = mapReduceService.getNodeEngine();
 
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
         if (clusterService.getSize(MemberSelectors.DATA_MEMBER_SELECTOR) == 0) {
             throw new IllegalStateException("Could not register map reduce job since there are no nodes owning a partition");
         }
@@ -117,7 +117,7 @@ public abstract class AbstractMapReduceTask<Parameters>
 
         final KeyPredicate predicate = getPredicate();
 
-        final ClusterService clusterService = nodeEngine.getClusterService();
+        final InternalClusterService clusterService = nodeEngine.getClusterService();
         for (Member member : clusterService.getMembers(KeyValueJobOperation.MEMBER_SELECTOR)) {
             Operation operation = new KeyValueJobOperation(name, jobId, chunkSize, keyValueSource, mapper, combinerFactory,
                     reducerFactory, communicateStats, topologyChangedStrategy);

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -19,7 +19,7 @@ package com.hazelcast.instance;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.internal.cluster.Joiner;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ConfigCheck;
 import com.hazelcast.internal.cluster.impl.DiscoveryJoiner;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
@@ -100,7 +100,7 @@ public class Node {
 
     public final InternalPartitionServiceImpl partitionService;
 
-    public final ClusterServiceImpl clusterService;
+    public final InternalClusterServiceImpl clusterService;
 
     public final MulticastService multicastService;
 
@@ -184,7 +184,7 @@ public class Node {
             clientEngine = new ClientEngineImpl(this);
             connectionManager = nodeContext.createConnectionManager(this, serverSocketChannel);
             partitionService = new InternalPartitionServiceImpl(this);
-            clusterService = new ClusterServiceImpl(this);
+            clusterService = new InternalClusterServiceImpl(this);
             textCommandService = new TextCommandServiceImpl(this);
             nodeExtension.printNodeInfo();
             multicastService = createMulticastService(addressPicker.getBindAddress(), this, config, logger);
@@ -284,7 +284,7 @@ public class Node {
         return serializationService;
     }
 
-    public ClusterServiceImpl getClusterService() {
+    public InternalClusterServiceImpl getClusterService() {
         return clusterService;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeShutdownLatch.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.instance;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
@@ -50,7 +50,7 @@ final class NodeShutdownLatch {
             for (HazelcastInstanceImpl instance : HazelcastInstanceManager.getInstanceImpls(members)) {
                 if (instance.node.isRunning()) {
                     try {
-                        ClusterServiceImpl clusterService = instance.node.clusterService;
+                        InternalClusterServiceImpl clusterService = instance.node.clusterService;
                         final String id = clusterService.addMembershipListener(new ShutdownMembershipListener());
                         registrations.put(id, instance);
                     } catch (Throwable ignored) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.ascii.rest;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.instance.GroupProperty;
@@ -76,7 +76,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String res = "{\"status\":\"${STATUS}\",\"state\":\"${STATE}\"}";
         try {
             Node node = textCommandService.getNode();
-            ClusterService clusterService = node.getClusterService();
+            InternalClusterService clusterService = node.getClusterService();
             GroupConfig groupConfig = node.getConfig().getGroupConfig();
             if (!(groupConfig.getName().equals(groupName) && groupConfig.getPassword().equals(groupPass))) {
                 res = res.replace("${STATUS}", "forbidden");
@@ -116,7 +116,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String res = "{\"status\":\"${STATUS}\",\"state\":\"${STATE}\"}";
         try {
             Node node = textCommandService.getNode();
-            ClusterService clusterService = node.getClusterService();
+            InternalClusterService clusterService = node.getClusterService();
             GroupConfig groupConfig = node.getConfig().getGroupConfig();
             if (!(groupConfig.getName().equals(groupName) && groupConfig.getPassword().equals(groupPass))) {
                 res = res.replace("${STATUS}", "forbidden");
@@ -162,7 +162,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String res = "{\"status\":\"${STATUS}\"}";
         try {
             Node node = textCommandService.getNode();
-            ClusterService clusterService = node.getClusterService();
+            InternalClusterService clusterService = node.getClusterService();
             GroupConfig groupConfig = node.getConfig().getGroupConfig();
             if (!(groupConfig.getName().equals(groupName) && groupConfig.getPassword().equals(groupPass))) {
                 res = res.replace("${STATUS}", "forbidden");

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/InternalClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/InternalClusterService.java
@@ -30,7 +30,7 @@ import java.util.Collection;
  * <p/>
  * This API is an internal API; the end user will use the {@link com.hazelcast.core.Cluster} interface.
  */
-public interface ClusterService extends CoreService, Cluster {
+public interface InternalClusterService extends CoreService, Cluster {
 
     /**
      * Gets the member for the given address.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.internal.cluster.Joiner;
 import com.hazelcast.internal.cluster.impl.operations.JoinCheckOperation;
@@ -59,7 +59,7 @@ public abstract class AbstractJoiner implements Joiner {
     protected final ConcurrentMap<Address, Boolean> blacklistedAddresses = new ConcurrentHashMap<Address, Boolean>();
     protected final Config config;
     protected final Node node;
-    protected final ClusterServiceImpl clusterService;
+    protected final InternalClusterServiceImpl clusterService;
     protected final ClusterJoinManager clusterJoinManager;
     protected final ILogger logger;
 
@@ -281,7 +281,7 @@ public abstract class AbstractJoiner implements Joiner {
         }
 
         NodeEngine nodeEngine = node.nodeEngine;
-        Future f = nodeEngine.getOperationService().createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,
+        Future f = nodeEngine.getOperationService().createInvocationBuilder(InternalClusterServiceImpl.SERVICE_NAME,
                 new JoinCheckOperation(node.createSplitBrainJoinMessage()), target)
                 .setTryCount(1).invoke();
         try {
@@ -301,7 +301,7 @@ public abstract class AbstractJoiner implements Joiner {
     }
 
     protected void startClusterMerge(final Address targetAddress) {
-        ClusterServiceImpl clusterService = node.clusterService;
+        InternalClusterServiceImpl clusterService = node.clusterService;
 
         if (!prepareClusterState(clusterService)) {
             return;
@@ -312,7 +312,7 @@ public abstract class AbstractJoiner implements Joiner {
         for (Member member : memberList) {
             if (!member.localMember()) {
                 Operation op = new MergeClustersOperation(targetAddress);
-                operationService.invokeOnTarget(ClusterServiceImpl.SERVICE_NAME, op, member.getAddress());
+                operationService.invokeOnTarget(InternalClusterServiceImpl.SERVICE_NAME, op, member.getAddress());
             }
         }
 
@@ -322,7 +322,7 @@ public abstract class AbstractJoiner implements Joiner {
         operationService.runOperationOnCallingThread(mergeClustersOperation);
     }
 
-    private boolean prepareClusterState(ClusterServiceImpl clusterService) {
+    private boolean prepareClusterState(InternalClusterServiceImpl clusterService) {
         if (!preCheckClusterState(clusterService)) {
             return false;
         }
@@ -355,7 +355,7 @@ public abstract class AbstractJoiner implements Joiner {
         return false;
     }
 
-    private boolean preCheckClusterState(final ClusterService clusterService) {
+    private boolean preCheckClusterState(final InternalClusterService clusterService) {
         final ClusterState initialState = clusterService.getClusterState();
         if (initialState != ClusterState.ACTIVE) {
             logger.warning("Could not prepare cluster state since it has been changed to " + initialState);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -41,8 +41,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.EXECUTOR_NAME;
-import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.createMemberInfoList;
+import static com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl.EXECUTOR_NAME;
+import static com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl.createMemberInfoList;
 import static java.lang.String.format;
 
 /**
@@ -69,7 +69,7 @@ public class ClusterHeartbeatManager {
     private final ILogger logger;
     private final Node node;
     private final NodeEngineImpl nodeEngine;
-    private final ClusterServiceImpl clusterService;
+    private final InternalClusterServiceImpl clusterService;
     private final ClusterClockImpl clusterClock;
 
     private final ConcurrentMap<MemberImpl, Long> heartbeatTimes = new ConcurrentHashMap<MemberImpl, Long>();
@@ -86,7 +86,7 @@ public class ClusterHeartbeatManager {
     @Probe(name = "lastHeartBeat")
     private volatile long lastHeartBeat;
 
-    public ClusterHeartbeatManager(Node node, ClusterServiceImpl clusterService) {
+    public ClusterHeartbeatManager(Node node, InternalClusterServiceImpl clusterService) {
         this.node = node;
         this.clusterService = clusterService;
         this.nodeEngine = node.getNodeEngine();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -56,7 +56,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.logging.Level;
 
-import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.createMemberInfoList;
+import static com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl.createMemberInfoList;
 import static com.hazelcast.internal.cluster.impl.operations.FinalizeJoinOperation.FINALIZE_JOIN_MAX_TIMEOUT;
 import static com.hazelcast.internal.cluster.impl.operations.FinalizeJoinOperation.FINALIZE_JOIN_TIMEOUT_FACTOR;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
@@ -80,7 +80,7 @@ public class ClusterJoinManager {
     private final ILogger logger;
     private final Node node;
     private final NodeEngineImpl nodeEngine;
-    private final ClusterServiceImpl clusterService;
+    private final InternalClusterServiceImpl clusterService;
     private final Lock clusterServiceLock;
     private final ClusterClockImpl clusterClock;
     private final ClusterStateManager clusterStateManager;
@@ -94,7 +94,7 @@ public class ClusterJoinManager {
     private long timeToStartJoin;
     private boolean joinInProgress;
 
-    public ClusterJoinManager(Node node, ClusterServiceImpl clusterService, Lock clusterServiceLock) {
+    public ClusterJoinManager(Node node, InternalClusterServiceImpl clusterService, Lock clusterServiceLock) {
         this.node = node;
         this.clusterService = clusterService;
         this.clusterServiceLock = clusterServiceLock;
@@ -522,7 +522,7 @@ public class ClusterJoinManager {
 
     private Future invokeClusterOperation(Operation op, Address target) {
         return nodeEngine.getOperationService()
-                .createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME, op, target)
+                .createInvocationBuilder(InternalClusterServiceImpl.SERVICE_NAME, op, target)
                 .setTryCount(CLUSTER_OPERATION_RETRY_COUNT).invoke();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 
-import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.SERVICE_NAME;
+import static com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl.SERVICE_NAME;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/InternalClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/InternalClusterServiceImpl.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.MemberAttributeOperationType;
 import com.hazelcast.internal.cluster.MemberInfo;
@@ -85,7 +85,7 @@ import static java.lang.String.format;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 
-public class ClusterServiceImpl implements ClusterService, ConnectionListener, ManagedService,
+public class InternalClusterServiceImpl implements InternalClusterService, ConnectionListener, ManagedService,
         EventPublishingService<MembershipEvent, MembershipListener>, TransactionalService {
 
     public static final String SERVICE_NAME = "hz:core:clusterService";
@@ -129,12 +129,12 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     private String clusterId;
 
-    public ClusterServiceImpl(Node node) {
+    public InternalClusterServiceImpl(Node node) {
 
         this.node = node;
         nodeEngine = node.nodeEngine;
 
-        logger = node.getLogger(ClusterService.class.getName());
+        logger = node.getLogger(InternalClusterService.class.getName());
         clusterClock = new ClusterClockImpl(logger);
 
         thisAddress = node.getThisAddress();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -192,7 +192,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             }
             if (node.getConnectionManager().getConnection(address) != null) {
                 Future future = node.nodeEngine.getOperationService()
-                        .createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,
+                        .createInvocationBuilder(InternalClusterServiceImpl.SERVICE_NAME,
                                 new MasterClaimOperation(), address).setTryCount(1).invoke();
                 responses.add(future);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AbstractClusterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/AbstractClusterOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.spi.AbstractOperation;
 
 abstract class AbstractClusterOperation extends AbstractOperation implements JoinOperation {
@@ -28,6 +28,6 @@ abstract class AbstractClusterOperation extends AbstractOperation implements Joi
 
     @Override
     public final String getServiceName() {
-        return ClusterServiceImpl.SERVICE_NAME;
+        return InternalClusterServiceImpl.SERVICE_NAME;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ClusterStateManager;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -54,7 +54,7 @@ public class ChangeClusterStateOperation extends AbstractOperation implements Al
 
     @Override
     public void run() throws Exception {
-        ClusterServiceImpl service = getService();
+        InternalClusterServiceImpl service = getService();
         ClusterStateManager clusterStateManager = service.getClusterStateManager();
         getLogger().info("Changing cluster state state to " + newState + ", Initiator: " + initiator);
         clusterStateManager.commitClusterState(newState, initiator, txnId);
@@ -76,7 +76,7 @@ public class ChangeClusterStateOperation extends AbstractOperation implements Al
 
     @Override
     public String getServiceName() {
-        return ClusterServiceImpl.SERVICE_NAME;
+        return InternalClusterServiceImpl.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.cluster.impl.operations;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
@@ -76,7 +76,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
             return;
         }
 
-        final ClusterServiceImpl clusterService = getService();
+        final InternalClusterServiceImpl clusterService = getService();
         final NodeEngineImpl nodeEngine = clusterService.getNodeEngine();
 
         if (nodeEngine.getNode().joined()) {
@@ -98,7 +98,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         runPostJoinOp();
     }
 
-    private void initClusterStates(ClusterServiceImpl clusterService) {
+    private void initClusterStates(InternalClusterServiceImpl clusterService) {
         clusterService.initialClusterState(clusterState);
         clusterService.setClusterId(clusterId);
         clusterService.getClusterClock().setClusterStartTime(clusterStartTime);
@@ -110,7 +110,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         }
 
         partitionRuntimeState.setEndpoint(getCallerAddress());
-        ClusterServiceImpl clusterService = getService();
+        InternalClusterServiceImpl clusterService = getService();
         Node node = clusterService.getNodeEngine().getNode();
         node.partitionService.processPartitionRuntimeState(partitionRuntimeState);
     }
@@ -120,7 +120,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
             return;
         }
 
-        ClusterServiceImpl clusterService = getService();
+        InternalClusterServiceImpl clusterService = getService();
         NodeEngineImpl nodeEngine = clusterService.getNodeEngine();
         InternalOperationService operationService = nodeEngine.getOperationService();
 
@@ -132,7 +132,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
     }
 
     private void sendPostJoinOperations() {
-        final ClusterServiceImpl clusterService = getService();
+        final InternalClusterServiceImpl clusterService = getService();
         final NodeEngineImpl nodeEngine = clusterService.getNodeEngine();
 
         // Post join operations must be lock free; means no locks at all;
@@ -145,7 +145,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
             for (Member member : members) {
                 if (!member.localMember()) {
                     PostJoinOperation operation = new PostJoinOperation(postJoinOperations);
-                    operationService.createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,
+                    operationService.createInvocationBuilder(InternalClusterServiceImpl.SERVICE_NAME,
                             operation, member.getAddress()).setTryCount(100).invoke();
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
@@ -40,7 +40,7 @@ public final class HeartbeatOperation extends AbstractClusterOperation
 
     @Override
     public void run() {
-        ClusterServiceImpl service = getService();
+        InternalClusterServiceImpl service = getService();
         MemberImpl member = service.getMember(getCallerAddress());
         if (member == null) {
             ILogger logger = getLogger();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinCheckOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
@@ -45,7 +45,7 @@ public class JoinCheckOperation extends AbstractOperation implements JoinOperati
 
     @Override
     public void run() {
-        ClusterServiceImpl service = getService();
+        InternalClusterServiceImpl service = getService();
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         Node node = nodeEngine.getNode();
 
@@ -77,7 +77,7 @@ public class JoinCheckOperation extends AbstractOperation implements JoinOperati
     private boolean masterCheck(Node node) {
         ILogger logger = getLogger();
         Address caller = getCallerAddress();
-        ClusterServiceImpl service = getService();
+        InternalClusterServiceImpl service = getService();
 
         if (node.isMaster()) {
             if (service.getMember(caller) != null) {
@@ -98,7 +98,7 @@ public class JoinCheckOperation extends AbstractOperation implements JoinOperati
     @Override
     public void afterRun() throws Exception {
         if (removeCaller) {
-            ClusterServiceImpl service = getService();
+            InternalClusterServiceImpl service = getService();
             Address caller = getCallerAddress();
             service.removeAddress(caller);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.JoinRequest;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -36,7 +36,7 @@ public class JoinRequestOperation extends AbstractClusterOperation implements Jo
 
     @Override
     public void run() {
-        ClusterServiceImpl cm = getService();
+        InternalClusterServiceImpl cm = getService();
         cm.getClusterJoinManager().handleJoinRequest(request, getConnection());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ClusterStateManager;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.Address;
@@ -62,7 +62,7 @@ public class LockClusterStateOperation extends AbstractOperation implements Allo
 
     @Override
     public void run() throws Exception {
-        ClusterServiceImpl service = getService();
+        InternalClusterServiceImpl service = getService();
         ClusterStateManager clusterStateManager = service.getClusterStateManager();
         ClusterState state = clusterStateManager.getState();
         if (state == ClusterState.IN_TRANSITION) {
@@ -94,7 +94,7 @@ public class LockClusterStateOperation extends AbstractOperation implements Allo
 
     @Override
     public String getServiceName() {
-        return ClusterServiceImpl.SERVICE_NAME;
+        return InternalClusterServiceImpl.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterConfirmationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterConfirmationOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -45,7 +45,7 @@ public class MasterConfirmationOperation extends AbstractClusterOperation implem
             return;
         }
 
-        final ClusterServiceImpl clusterService = getService();
+        final InternalClusterServiceImpl clusterService = getService();
         final ILogger logger = getLogger();
         final MemberImpl member = clusterService.getMember(endpoint);
         if (member == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterDiscoveryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterDiscoveryOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -36,7 +36,7 @@ public class MasterDiscoveryOperation extends AbstractClusterOperation implement
 
     @Override
     public void run() {
-        ClusterServiceImpl cm = getService();
+        InternalClusterServiceImpl cm = getService();
         cm.getClusterJoinManager().answerMasterQuestion(joinMessage, getConnection());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberAttributeChangedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberAttributeChangedOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.cluster.MemberAttributeOperationType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -42,7 +42,7 @@ public class MemberAttributeChangedOperation extends AbstractClusterOperation {
 
     @Override
     public void run() throws Exception {
-        final ClusterServiceImpl cs = getService();
+        final InternalClusterServiceImpl cs = getService();
         cs.updateMemberAttribute(getCallerUuid(), operationType, key, value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberInfoUpdateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberInfoUpdateOperation.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ObjectDataInput;
@@ -53,14 +53,14 @@ public class MemberInfoUpdateOperation extends AbstractClusterOperation implemen
 
     protected final void processMemberUpdate() {
         if (isValid()) {
-            final ClusterServiceImpl clusterService = getService();
+            final InternalClusterServiceImpl clusterService = getService();
             clusterService.getClusterClock().setMasterTime(masterTime);
             clusterService.updateMembers(memberInfos);
         }
     }
 
     protected final boolean isValid() {
-        final ClusterServiceImpl clusterService = getService();
+        final InternalClusterServiceImpl clusterService = getService();
         final Connection conn = getConnection();
         final Address masterAddress = conn != null ? conn.getEndPoint() : null;
         boolean isLocal = conn == null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberRemoveOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -38,7 +38,7 @@ public class MemberRemoveOperation extends AbstractClusterOperation implements A
 
     @Override
     public void run() {
-        final ClusterServiceImpl clusterService = getService();
+        final InternalClusterServiceImpl clusterService = getService();
         final Address caller = getCallerAddress();
         ILogger logger = getLogger();
         if (caller != null

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/RollbackClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/RollbackClusterStateOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ClusterStateManager;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.Address;
@@ -46,7 +46,7 @@ public class RollbackClusterStateOperation extends AbstractOperation implements 
 
     @Override
     public void run() throws Exception {
-        ClusterServiceImpl service = getService();
+        InternalClusterServiceImpl service = getService();
         ClusterStateManager clusterStateManager = service.getClusterStateManager();
         getLogger().info("Rolling back cluster state! Initiator: " + initiator);
         response = clusterStateManager.rollbackClusterState(txnId);
@@ -59,7 +59,7 @@ public class RollbackClusterStateOperation extends AbstractOperation implements 
 
     @Override
     public String getServiceName() {
-        return ClusterServiceImpl.SERVICE_NAME;
+        return InternalClusterServiceImpl.SERVICE_NAME;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SetMasterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SetMasterOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -36,7 +36,7 @@ public class SetMasterOperation extends AbstractClusterOperation implements Join
 
     @Override
     public void run() {
-        ClusterServiceImpl clusterService = getService();
+        InternalClusterServiceImpl clusterService = getService();
         clusterService.getClusterJoinManager().handleMaster(masterAddress, getCallerAddress());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ShutdownNodeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ShutdownNodeOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -31,7 +31,7 @@ public class ShutdownNodeOperation
 
     @Override
     public void run() {
-        final ClusterServiceImpl clusterService = getService();
+        final InternalClusterServiceImpl clusterService = getService();
         final ILogger logger = getLogger();
 
         final ClusterState clusterState = clusterService.getClusterState();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/TriggerMemberListPublishOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/TriggerMemberListPublishOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 
 /**
  * Requests member list publish from master node
@@ -28,7 +28,7 @@ public class TriggerMemberListPublishOperation extends AbstractClusterOperation 
 
     @Override
     public void run() throws Exception {
-        final ClusterServiceImpl clusterService = getService();
+        final InternalClusterServiceImpl clusterService = getService();
         clusterService.sendMemberListToMember(getCallerAddress());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.cache.impl.nearcache.NearCache;
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
 import com.hazelcast.map.impl.record.Record;
@@ -59,7 +59,7 @@ public class LocalMapStatsProvider {
 
     protected final MapServiceContext mapServiceContext;
     protected final NearCacheProvider nearCacheProvider;
-    protected final ClusterService clusterService;
+    protected final InternalClusterService clusterService;
     protected final InternalPartitionService partitionService;
     protected final ILogger logger;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/AbstractNearCacheInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/AbstractNearCacheInvalidator.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.nearcache;
 
 import com.hazelcast.cache.impl.nearcache.NearCache;
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.operation.MapOperation;
@@ -40,7 +40,7 @@ public abstract class AbstractNearCacheInvalidator implements NearCacheInvalidat
 
     protected final EventService eventService;
     protected final OperationService operationService;
-    protected final ClusterService clusterService;
+    protected final InternalClusterService clusterService;
     protected final MapServiceContext mapServiceContext;
     protected final NearCacheProvider nearCacheProvider;
     protected final NodeEngine nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map.impl.query;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.serialization.SerializationService;
@@ -88,7 +88,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
     protected final InternalPartitionService partitionService;
     protected final QueryOptimizer queryOptimizer;
     protected final OperationService operationService;
-    protected final ClusterService clusterService;
+    protected final InternalClusterService clusterService;
     protected final LocalMapStatsProvider localMapStatsProvider;
     protected final boolean parallelEvaluation;
     protected final ManagedExecutorService executor;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceService.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JobTrackerConfig;
 import com.hazelcast.core.DistributedObject;
@@ -76,7 +76,7 @@ public class MapReduceService
     private final ConcurrentMap<JobSupervisorKey, JobSupervisor> jobSupervisors;
 
     private final InternalPartitionService partitionService;
-    private final ClusterService clusterService;
+    private final InternalClusterService clusterService;
 
     private final NodeEngineImpl nodeEngine;
     private final Config config;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.mapreduce.JobPartitionState;
@@ -219,7 +219,7 @@ public final class MapReduceUtil {
     public static <V> V executeOperation(Operation operation, Address address, MapReduceService mapReduceService,
                                          NodeEngine nodeEngine) {
 
-        ClusterService cs = nodeEngine.getClusterService();
+        InternalClusterService cs = nodeEngine.getClusterService();
         OperationService os = nodeEngine.getOperationService();
         boolean returnsResponse = operation.returnsResponse();
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce.impl.task;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.mapreduce.JobPartitionState;
@@ -490,7 +490,7 @@ public class JobSupervisor {
         public void run() {
             Object finalResult = null;
             try {
-                ClusterService clusterService = nodeEngine.getClusterService();
+                InternalClusterService clusterService = nodeEngine.getClusterService();
                 final Collection<Member> members = clusterService.getMembers(DATA_MEMBER_SELECTOR);
                 List<Map> results = MapReduceUtil.executeOperation(members, operationFactory, mapReduceService, nodeEngine);
                 boolean reducedResult = configuration.getReducerFactory() != null;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueJob.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueJob.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce.impl.task;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.JobTrackerConfig;
 import com.hazelcast.core.Member;
@@ -57,7 +57,7 @@ public class KeyValueJob<KeyIn, ValueIn>
 
     @Override
     protected <T> JobCompletableFuture<T> invoke(Collator collator) {
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
         if (clusterService.getSize(MemberSelectors.DATA_MEMBER_SELECTOR) == 0) {
             throw new IllegalStateException("Could not register map reduce job since there are no nodes owning a partition");
         }
@@ -85,7 +85,7 @@ public class KeyValueJob<KeyIn, ValueIn>
             topologyChangedStrategy = config.getTopologyChangedStrategy();
         }
 
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
         for (Member member : clusterService.getMembers(KeyValueJobOperation.MEMBER_SELECTOR)) {
             Operation operation = new KeyValueJobOperation<KeyIn, ValueIn>(name, jobId, chunkSize, keyValueSource, mapper,
                     combinerFactory, reducerFactory, communicateStats, topologyChangedStrategy);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.multimap.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.IMapEvent;
@@ -38,10 +38,10 @@ class MultiMapEventsDispatcher {
 
     private final ILogger logger = Logger.getLogger(MultiMapEventsDispatcher.class);
 
-    private final ClusterService clusterService;
+    private final InternalClusterService clusterService;
     private final MultiMapService multiMapService;
 
-    public MultiMapEventsDispatcher(MultiMapService multiMapService, ClusterService clusterService) {
+    public MultiMapEventsDispatcher(MultiMapService multiMapService, InternalClusterService clusterService) {
         this.multiMapService = multiMapService;
         this.clusterService = clusterService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.multimap.impl;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStoreInfo;
 import com.hazelcast.config.MultiMapConfig;
@@ -301,7 +301,7 @@ public class MultiMapService implements ManagedService, RemoteService, Migration
         long backupEntryCount = 0;
         long hits = 0;
         long lockedEntryCount = 0;
-        ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngine.getClusterService();
+        InternalClusterServiceImpl clusterService = (InternalClusterServiceImpl) nodeEngine.getClusterService();
 
         Address thisAddress = clusterService.getThisAddress();
         for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {

--- a/hazelcast/src/main/java/com/hazelcast/partition/InternalPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/InternalPartition.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.partition;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.nio.Address;
 
 /**
@@ -42,7 +42,7 @@ public interface InternalPartition {
      * Checks if the partition is local.
      *
      * A partition is local if and only if the {@link #getOwnerOrNull()} returns the same address as 'this' address of the
-     * {@link ClusterService#getThisAddress()}. If the address is null or a different address, false
+     * {@link InternalClusterService#getThisAddress()}. If the address is null or a different address, false
      * is returned.
      *
      * @return true if local, false otherwise.

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -18,7 +18,7 @@ package com.hazelcast.partition.impl;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.internal.cluster.MemberInfo;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
@@ -325,7 +325,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     private boolean isClusterFormedByOnlyLiteMembers() {
-        final ClusterServiceImpl clusterService = node.getClusterService();
+        final InternalClusterServiceImpl clusterService = node.getClusterService();
         return clusterService.getMembers(DATA_MEMBER_SELECTOR).isEmpty();
     }
 
@@ -664,7 +664,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             PartitionStateOperation op = new PartitionStateOperation(partitionState);
 
             OperationService operationService = nodeEngine.getOperationService();
-            final ClusterServiceImpl clusterService = node.clusterService;
+            final InternalClusterServiceImpl clusterService = node.clusterService;
             for (MemberImpl member : members) {
                 if (!(member.localMember() || clusterService.isMemberRemovedWhileClusterIsNotActive(member.getAddress()))) {
                     try {
@@ -708,7 +708,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     private List<Future> firePartitionStateOperation(Collection<MemberImpl> members,
                                                      PartitionRuntimeState partitionState,
                                                      OperationService operationService) {
-        final ClusterServiceImpl clusterService = node.clusterService;
+        final InternalClusterServiceImpl clusterService = node.clusterService;
         List<Future> calls = new ArrayList<Future>(members.size());
         for (MemberImpl member : members) {
             if (!(member.localMember() || clusterService.isMemberRemovedWhileClusterIsNotActive(member.getAddress()))) {
@@ -825,7 +825,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
     private void searchUnknownAddressesInPartitionTable(Address sender, Set<Address> unknownAddresses, int partitionId,
                                                         PartitionInfo partitionInfo) {
-        final ClusterServiceImpl clusterService = node.clusterService;
+        final InternalClusterServiceImpl clusterService = node.clusterService;
         final ClusterState clusterState = clusterService.getClusterState();
         for (int index = 0; index < InternalPartition.MAX_REPLICA_COUNT; index++) {
             Address address = partitionInfo.getReplicaAddress(index);
@@ -1401,7 +1401,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     private boolean checkClusterStateForReplicaSync(final Address address) {
-        final ClusterServiceImpl clusterService = node.clusterService;
+        final InternalClusterServiceImpl clusterService = node.clusterService;
         final ClusterState clusterState = clusterService.getClusterState();
 
         if (clusterState == ClusterState.ACTIVE || clusterState == ClusterState.IN_TRANSITION) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.replicatedmap.impl;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ListenerConfig;
@@ -83,7 +83,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
     private final NodeEngine nodeEngine;
     private final PartitionContainer[] partitionContainers;
     private final InternalPartitionServiceImpl partitionService;
-    private final ClusterServiceImpl clusterService;
+    private final InternalClusterServiceImpl clusterService;
     private final OperationService operationService;
     private final ReplicatedMapEventPublishingService eventPublishingService;
     private final MergePolicyProvider mergePolicyProvider;
@@ -102,7 +102,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
         this.nodeEngine = nodeEngine;
         this.config = nodeEngine.getConfig();
         this.partitionService = (InternalPartitionServiceImpl) nodeEngine.getPartitionService();
-        this.clusterService = (ClusterServiceImpl) nodeEngine.getClusterService();
+        this.clusterService = (InternalClusterServiceImpl) nodeEngine.getClusterService();
         this.operationService = nodeEngine.getOperationService();
         this.partitionContainers = new PartitionContainer[nodeEngine.getPartitionService().getPartitionCount()];
         this.eventPublishingService = new ReplicatedMapEventPublishingService(this);

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spi;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
@@ -57,7 +57,7 @@ public interface NodeEngine {
      *
      * @return the ClusterService.
      */
-    ClusterService getClusterService();
+    InternalClusterService getClusterService();
 
     /**
      * Gets the InternalPartitionService.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spi.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
@@ -214,7 +214,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     @Override
-    public ClusterService getClusterService() {
+    public InternalClusterService getClusterService() {
         return node.getClusterService();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
@@ -301,7 +301,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
 
         invTarget = getTarget();
 
-        final ClusterService clusterService = nodeEngine.getClusterService();
+        final InternalClusterService clusterService = nodeEngine.getClusterService();
         if (invTarget == null) {
             remote = false;
             notifyWithExceptionWhenTargetIsNull();
@@ -332,7 +332,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
 
     private void notifyWithExceptionWhenTargetIsNull() {
         Address thisAddress = nodeEngine.getThisAddress();
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
 
         if (!nodeEngine.isRunning()) {
             notify(new HazelcastInstanceNotActiveException());

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -18,7 +18,7 @@ package com.hazelcast.spi.impl.servicemanager.impl;
 
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.impl.ClientEngineImpl;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
@@ -115,7 +115,7 @@ public final class ServiceManagerImpl implements ServiceManager {
         logger.finest("Registering core services...");
 
         Node node = nodeEngine.getNode();
-        registerService(ClusterServiceImpl.SERVICE_NAME, node.getClusterService());
+        registerService(InternalClusterServiceImpl.SERVICE_NAME, node.getClusterService());
         registerService(InternalPartitionService.SERVICE_NAME, node.getPartitionService());
         registerService(ProxyServiceImpl.SERVICE_NAME, nodeEngine.getProxyService());
         registerService(TransactionManagerServiceImpl.SERVICE_NAME, nodeEngine.getTransactionManagerService());

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.topic.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.config.TopicConfig;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Message;
@@ -119,7 +119,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
     @Override
     public void dispatchEvent(Object event, Object listener) {
         TopicEvent topicEvent = (TopicEvent) event;
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
         MemberImpl member = clusterService.getMember(topicEvent.publisherAddress);
         if (member == null) {
             member = new MemberImpl(topicEvent.publisherAddress, false);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerRunner.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.topic.impl.reliable;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
@@ -45,7 +45,7 @@ class ReliableMessageListenerRunner<E> implements ExecutionCallback<ReadResultSe
     private final Ringbuffer<ReliableTopicMessage> ringbuffer;
     private final String topicName;
     private final SerializationService serializationService;
-    private final ClusterService clusterService;
+    private final InternalClusterService clusterService;
     private final ILogger logger;
     private final String id;
     private final ReliableTopicProxy<E> proxy;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.transaction.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -333,7 +333,7 @@ public class TransactionImpl implements Transaction {
         }
 
         OperationService operationService = nodeEngine.getOperationService();
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
         List<Future> futures = new ArrayList<Future>(backupAddresses.length);
         for (Address backupAddress : backupAddresses) {
             if (clusterService.getMember(backupAddress) != null) {
@@ -406,7 +406,7 @@ public class TransactionImpl implements Transaction {
         }
 
         OperationService operationService = nodeEngine.getOperationService();
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
         List<Future> futures = new ArrayList<Future>(backupAddresses.length);
         for (Address backupAddress : backupAddresses) {
             if (clusterService.getMember(backupAddress) != null) {
@@ -424,7 +424,7 @@ public class TransactionImpl implements Transaction {
         }
 
         OperationService operationService = nodeEngine.getOperationService();
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
         for (Address backupAddress : backupAddresses) {
             if (clusterService.getMember(backupAddress) != null) {
                 try {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.transaction.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.MemberImpl;
@@ -278,7 +278,7 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
         // This should be cleaned up because this is quite a complex approach since it depends on
         // the number of members in the cluster and creates litter.
 
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
         List<MemberImpl> members = new ArrayList<MemberImpl>(clusterService.getMemberImpls());
         members.remove(nodeEngine.getLocalMember());
         int c = Math.min(members.size(), durability);

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.transaction.impl.xa;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
@@ -231,7 +231,7 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
         NodeEngine nodeEngine = getNodeEngine();
         XAService xaService = getService();
         OperationService operationService = nodeEngine.getOperationService();
-        ClusterService clusterService = nodeEngine.getClusterService();
+        InternalClusterService clusterService = nodeEngine.getClusterService();
         Collection<Member> memberList = clusterService.getMembers();
         List<InternalCompletableFuture<SerializableList>> futureList
                 = new ArrayList<InternalCompletableFuture<SerializableList>>();

--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.util;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.instance.GroupProperty;
@@ -131,7 +131,7 @@ public final class PhoneHome {
 
         //Calculate native memory usage from native memory config
         NativeMemoryConfig memoryConfig = hazelcastNode.getConfig().getNativeMemoryConfig();
-        final ClusterServiceImpl clusterService = hazelcastNode.getClusterService();
+        final InternalClusterServiceImpl clusterService = hazelcastNode.getClusterService();
         long totalNativeMemorySize = clusterService.getSize(DATA_MEMBER_SELECTOR)
                 * memoryConfig.getSize().bytes();
         String nativeMemoryParameter = (isEnterprise)

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
@@ -1,7 +1,7 @@
 package com.hazelcast.cluster;
 
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
@@ -61,7 +61,7 @@ public class ClusterInfoTest extends HazelcastTestSupport {
         Node node3 = TestUtil.getNode(h3);
 
         //All nodes should have same startTime
-        final ClusterServiceImpl clusterService = node1.getClusterService();
+        final InternalClusterServiceImpl clusterService = node1.getClusterService();
         long node1ClusterStartTime = clusterService.getClusterClock().getClusterStartTime();
         long clusterUpTime = clusterService.getClusterClock().getClusterUpTime();
         String node1ClusterId = clusterService.getClusterId();
@@ -91,7 +91,7 @@ public class ClusterInfoTest extends HazelcastTestSupport {
         assertClusterSizeEventually(3, h3);
 
         Node node1 = TestUtil.getNode(h1);
-        final ClusterServiceImpl clusterService = node1.getClusterService();
+        final InternalClusterServiceImpl clusterService = node1.getClusterService();
         long node1ClusterStartTime = clusterService.getClusterClock().getClusterStartTime();
         long clusterUpTime = clusterService.getClusterClock().getClusterUpTime();
         String node1ClusterId = clusterService.getClusterId();

--- a/hazelcast/src/test/java/com/hazelcast/cluster/InternalClusterServiceMemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/InternalClusterServiceMemberListTest.java
@@ -4,7 +4,7 @@ import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClusterServiceMemberListTest
+public class InternalClusterServiceMemberListTest
         extends HazelcastTestSupport {
 
     private Config liteConfig = new Config().setLiteMember(true);
@@ -83,7 +83,7 @@ public class ClusterServiceMemberListTest
 
     private void verifyMembersFromLiteMember(final HazelcastInstance instance) {
         final Member localMember = getLocalMember(instance);
-        final ClusterService clusterService = getClusterService(instance);
+        final InternalClusterService clusterService = getClusterService(instance);
         final Collection<Member> liteMembers = clusterService.getMembers(LITE_MEMBER_SELECTOR);
         final Collection<Member> dataMembers = clusterService.getMembers(DATA_MEMBER_SELECTOR);
 
@@ -99,7 +99,7 @@ public class ClusterServiceMemberListTest
 
     private void verifyMembersFromDataMember(final HazelcastInstance instance) {
         final Member localMember = getLocalMember(instance);
-        final ClusterService clusterService = getClusterService(instance);
+        final InternalClusterService clusterService = getClusterService(instance);
         final Collection<Member> liteMembers = clusterService.getMembers(LITE_MEMBER_SELECTOR);
         final Collection<Member> dataMembers = clusterService.getMembers(DATA_MEMBER_SELECTOR);
 
@@ -114,7 +114,7 @@ public class ClusterServiceMemberListTest
     }
 
     private void verifySizeFromLiteMember(final HazelcastInstance instance) {
-        final ClusterService clusterService = getClusterService(instance);
+        final InternalClusterService clusterService = getClusterService(instance);
 
         assertEquals(1, clusterService.getSize(MemberSelectors.LITE_MEMBER_SELECTOR));
         assertEquals(2, clusterService.getSize(MemberSelectors.DATA_MEMBER_SELECTOR));
@@ -123,7 +123,7 @@ public class ClusterServiceMemberListTest
     }
 
     private void verifySizeFromDataMember(final HazelcastInstance instance) {
-        final ClusterService clusterService = getClusterService(instance);
+        final InternalClusterService clusterService = getClusterService(instance);
 
         assertEquals(1, clusterService.getSize(MemberSelectors.LITE_MEMBER_SELECTOR));
         assertEquals(2, clusterService.getSize(MemberSelectors.DATA_MEMBER_SELECTOR));

--- a/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
@@ -1,6 +1,6 @@
 package com.hazelcast.cluster;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.NetworkConfig;
@@ -158,7 +158,7 @@ public class LiteMemberJoinTest {
         final Node node1 = getNode(instance1);
         final Node node2 = getNode(instance2);
 
-        final ClusterServiceImpl clusterService = node1.getClusterService();
+        final InternalClusterServiceImpl clusterService = node1.getClusterService();
         clusterService.merge(node2.address);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -84,7 +84,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         }
 
         HazelcastInstance hz = instances[instances.length - 1];
-        ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz);
+        InternalClusterServiceImpl clusterService = (InternalClusterServiceImpl) getClusterService(hz);
         Collection<Member> initialMembers = new ArrayList<Member>(clusterService.getMembers());
         initialMembers.remove(clusterService.getLocalMember());
 
@@ -100,7 +100,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         }
 
         HazelcastInstance hz = instances[instances.length - 1];
-        ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz);
+        InternalClusterServiceImpl clusterService = (InternalClusterServiceImpl) getClusterService(hz);
         Collection<Member> initialMembers = new ArrayList<Member>(clusterService.getMembers());
 
         MemberImpl fakeMember = new MemberImpl((MemberImpl) clusterService.getLocalMember());
@@ -389,7 +389,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         final InternalPartitionService partitionService = getNode(hz1).getPartitionService();
         final int initialPartitionStateVersion = partitionService.getPartitionStateVersion();
 
-        final ClusterServiceImpl cluster = getNode(hz2).getClusterService();
+        final InternalClusterServiceImpl cluster = getNode(hz2).getClusterService();
         final ClusterState newState = ClusterState.PASSIVE;
 
         final Future future = spawn(new Runnable() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -60,7 +60,7 @@ public class ClusterStateManagerTest {
 
     private final Node node = mock(Node.class);
     private final InternalPartitionService partitionService = mock(InternalPartitionService.class);
-    private final ClusterServiceImpl clusterService = mock(ClusterServiceImpl.class);
+    private final InternalClusterServiceImpl clusterService = mock(InternalClusterServiceImpl.class);
     private final Lock lock = mock(Lock.class);
 
     private ClusterStateManager clusterStateManager;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MemberLeftException;
@@ -100,7 +100,7 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
         splitAction.run(node1, node2, node3);
 
         // Let node3 detect the split and merge it back to other two.
-        ClusterServiceImpl clusterService3 = node3.getClusterService();
+        InternalClusterServiceImpl clusterService3 = node3.getClusterService();
         clusterService3.merge(node1.address);
 
         assertClusterSizeEventually(3, hz1);
@@ -170,7 +170,7 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
         });
 
         // Let node3 detect the split and merge it back to other two.
-        ClusterServiceImpl clusterService3 = node3.getClusterService();
+        InternalClusterServiceImpl clusterService3 = node3.getClusterService();
         clusterService3.merge(node1.address);
 
         assertEquals(4, node1.getClusterService().getSize());

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
@@ -1,6 +1,6 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
@@ -39,7 +39,7 @@ public class OperationRunnerImplTest extends HazelcastTestSupport {
     private HazelcastInstance remote;
     private OperationRunnerImpl operationRunner;
     private OperationServiceImpl operationService;
-    private ClusterService clusterService;
+    private InternalClusterService clusterService;
     private OperationResponseHandler responseHandler;
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.test;
 
-import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.InternalClusterService;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastInstance;
@@ -182,7 +182,7 @@ public abstract class HazelcastTestSupport {
         return node.connectionManager;
     }
 
-    public static ClusterService getClusterService(HazelcastInstance hz) {
+    public static InternalClusterService getClusterService(HazelcastInstance hz) {
         Node node = getNode(hz);
         return node.clusterService;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -17,7 +17,7 @@
 
 package com.hazelcast.test.mocknetwork;
 
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.InternalClusterServiceImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -103,7 +103,7 @@ public class MockConnectionManager implements ConnectionManager {
             if (nodeEngine != null && nodeEngine.isRunning()) {
                 nodeEngine.getExecutionService().execute(ExecutionService.SYSTEM_EXECUTOR, new Runnable() {
                     public void run() {
-                        ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngine.getClusterService();
+                        InternalClusterServiceImpl clusterService = (InternalClusterServiceImpl) nodeEngine.getClusterService();
                         clusterService.removeAddress(node.getThisAddress());
                     }
                 });


### PR DESCRIPTION
The com.hazelcast.internal.cluster.ClusterService has been renamed to InternalClusterService.

The reason behind this rename is that we already have a public com.hazelcast.core.ClusterService
and having a second class with the same name is confusing (especially with code completion).

Also internally it is confusing to have 2 interfaces with the same name, but different purposes.

Apart from that there is a naming schema that for internal API's, especially in case of name
conflicts, we use the Internal prefix. For example:
* InternalOperationService
* InternalPartitionService
* InternalEventService