### PR TITLE
AbstractSupplyingMapper for easier custom aggregations #7477

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/AbstractSupplyingMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/AbstractSupplyingMapper.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.mapreduce.aggregation;
+
+import com.hazelcast.mapreduce.Context;
+import com.hazelcast.mapreduce.Mapper;
+import com.hazelcast.mapreduce.aggregation.impl.SimpleEntry;
+import com.hazelcast.mapreduce.impl.task.DefaultContext;
+
+/**
+ * Base class for mapper implementations used in aggregations.
+ *
+ * @param <KeyIn>    the input key type
+ * @param <ValueIn>  the input value type
+ * @param <KeyOut>   the output key type
+ * @param <ValueOut> the output value type
+ */
+public abstract class AbstractSupplyingMapper<KeyIn, ValueIn, KeyOut, ValueOut>
+        implements Mapper<KeyIn, ValueIn, KeyOut, ValueOut> {
+
+    protected Supplier<KeyIn, ValueIn, ValueOut> supplier;
+
+    private transient SimpleEntry<KeyIn, ValueIn> entry = new SimpleEntry<KeyIn, ValueIn>();
+
+    public AbstractSupplyingMapper() {
+    }
+
+    public AbstractSupplyingMapper(Supplier<KeyIn, ValueIn, ValueOut> supplier) {
+        this.supplier = supplier;
+    }
+
+    @Override
+    public final void map(KeyIn key, ValueIn value, Context<KeyOut, ValueOut> context) {
+        entry.setKey(key);
+        entry.setValue(value);
+        entry.setSerializationService(((DefaultContext) context).getSerializationService());
+        ValueOut supplied = supplier.apply(entry);
+        mapSupplied(key, supplied, context);
+    }
+
+    /**
+     * This method is called for each {@link #map} after the {@link Supplier} has been applied to the key-value pair.
+     *
+     * @param key      key to map
+     * @param supplied supplied value
+     * @param context  Context to be used for emitting values
+     */
+    protected abstract void mapSupplied(KeyIn key, ValueOut supplied, Context<KeyOut, ValueOut> context);
+}

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
@@ -31,7 +31,7 @@ import java.util.Collections;
  * @param <K> key type
  * @param <V> value type
  */
-final class SimpleEntry<K, V>
+public final class SimpleEntry<K, V>
         extends QueryableEntry<K, V> {
 
     private K key;
@@ -75,11 +75,11 @@ final class SimpleEntry<K, V>
         return oldValue;
     }
 
-    void setKey(K key) {
+    public void setKey(K key) {
         this.key = key;
     }
 
-    void setSerializationService(InternalSerializationService serializationService) {
+    public void setSerializationService(InternalSerializationService serializationService) {
         this.serializationService = serializationService;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
@@ -17,9 +17,8 @@
 package com.hazelcast.mapreduce.aggregation.impl;
 
 import com.hazelcast.mapreduce.Context;
-import com.hazelcast.mapreduce.Mapper;
+import com.hazelcast.mapreduce.aggregation.AbstractSupplyingMapper;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.mapreduce.impl.task.DefaultContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -36,27 +35,19 @@ import java.io.IOException;
  */
 @SuppressFBWarnings("SE_NO_SERIALVERSIONID")
 class SupplierConsumingMapper<Key, ValueIn, ValueOut>
-        implements Mapper<Key, ValueIn, Key, ValueOut>, IdentifiedDataSerializable {
-
-    private transient SimpleEntry<Key, ValueIn> entry = new SimpleEntry<Key, ValueIn>();
-
-    private Supplier<Key, ValueIn, ValueOut> supplier;
+        extends AbstractSupplyingMapper<Key, ValueIn, Key, ValueOut> implements IdentifiedDataSerializable {
 
     SupplierConsumingMapper() {
     }
 
     SupplierConsumingMapper(Supplier<Key, ValueIn, ValueOut> supplier) {
-        this.supplier = supplier;
+        super(supplier);
     }
 
     @Override
-    public void map(Key key, ValueIn value, Context<Key, ValueOut> context) {
-        entry.setKey(key);
-        entry.setValue(value);
-        entry.setSerializationService(((DefaultContext) context).getSerializationService());
-        ValueOut valueOut = supplier.apply(entry);
-        if (valueOut != null) {
-            context.emit(key, valueOut);
+    protected void mapSupplied(Key key, ValueOut supplied, Context<Key, ValueOut> context) {
+        if (supplied != null) {
+            context.emit(key, supplied);
         }
     }
 


### PR DESCRIPTION
A `Mapper` abstract implementation which wraps a `Supplier` instance for custom `Aggregation` implementations and in the `#map()` method it extracts the supplied value and delegates the emission to the actual implementation. The `SupplierConsumingMapper` is a straight-forward implementation of it, because it doesn't modify the key of the entries, it just emits the supplied values to the context with the same keys before.

The purpose of this class is that a custom aggregation shouldn't need to create intermediate `SimpleEntry`-like instances just to get the supplied values, but it should be handled by Hazelcast itself.

This PR fixes #7477.
