### PR TITLE
Prevent blocking for Transactions (Map/MultiMap)

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -171,6 +171,7 @@
     <!-- Transaction -->
     <suppress checks="JavadocMethod" files="com/hazelcast/transaction/"/>
     <suppress checks="JavadocType" files="com/hazelcast/transaction/"/>
+    <suppress checks="MethodCount" files="com/hazelcast/transaction/impl/TransactionImpl"/>
 
     <!-- Security -->
     <suppress checks="JavadocMethod" files="com/hazelcast/security/"/>

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
@@ -30,6 +30,8 @@ public interface LockResource {
 
     boolean isTransactional();
 
+    boolean shouldBlockReads();
+
     long getThreadId();
 
     int getLockCount();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -42,6 +42,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
     private long expirationTime = -1;
     private long acquireTime = -1L;
     private boolean transactional;
+    private boolean blockReads;
     private Map<String, ConditionInfo> conditions;
     private List<ConditionKey> signalKeys;
     private List<AwaitOperation> expiredAwaitOps;
@@ -74,7 +75,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         return (this.threadId == threadId && owner != null && owner.equals(this.owner));
     }
 
-    boolean lock(String owner, long threadId, long referenceId, long leaseTime, boolean transactional) {
+    boolean lock(String owner, long threadId, long referenceId, long leaseTime, boolean transactional, boolean blockReads) {
         if (lockCount == 0) {
             this.owner = owner;
             this.threadId = threadId;
@@ -83,6 +84,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
             acquireTime = Clock.currentTimeMillis();
             setExpirationTime(leaseTime);
             this.transactional = transactional;
+            this.blockReads = blockReads;
             return true;
         } else if (isLockedBy(owner, threadId)) {
             if (!transactional && this.referenceId == referenceId) {
@@ -92,16 +94,25 @@ final class LockResourceImpl implements DataSerializable, LockResource {
             lockCount++;
             setExpirationTime(leaseTime);
             this.transactional = transactional;
+            this.blockReads = blockReads;
             return true;
         }
         return false;
     }
 
+    /**
+     * This method is used to extend the already locked resource in prepare phase of the transactions
+     * It also mark the resource true for blocking the reads
+     * @param caller
+     * @param threadId
+     * @param leaseTime
+     * @return
+     */
     boolean extendLeaseTime(String caller, long threadId, long leaseTime) {
         if (!isLockedBy(caller, threadId)) {
             return false;
         }
-
+        this.blockReads = true;
         if (expirationTime < Long.MAX_VALUE) {
             setExpirationTime(expirationTime - Clock.currentTimeMillis() + leaseTime);
         }
@@ -255,6 +266,8 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         acquireTime = -1L;
         cancelEviction();
         version = 0;
+        transactional = false;
+        blockReads = false;
     }
 
     void cancelEviction() {
@@ -275,6 +288,11 @@ final class LockResourceImpl implements DataSerializable, LockResource {
     @Override
     public boolean isTransactional() {
         return transactional;
+    }
+
+    @Override
+    public boolean shouldBlockReads() {
+        return blockReads;
     }
 
     @Override
@@ -331,6 +349,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         out.writeLong(expirationTime);
         out.writeLong(acquireTime);
         out.writeBoolean(transactional);
+        out.writeBoolean(blockReads);
 
         int conditionCount = getConditionCount();
         out.writeInt(conditionCount);
@@ -378,6 +397,7 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         expirationTime = in.readLong();
         acquireTime = in.readLong();
         transactional = in.readBoolean();
+        blockReads = in.readBoolean();
 
         int len = in.readInt();
         if (len > 0) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -24,7 +24,7 @@ public interface LockStore {
 
     boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime);
 
-    boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime);
+    boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime, boolean blockReads);
 
     boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime);
 
@@ -40,7 +40,7 @@ public interface LockStore {
 
     boolean canAcquireLock(Data key, String caller, long threadId);
 
-    boolean isTransactionallyLocked(Data key);
+    boolean shouldBlockReads(Data key);
 
     Set<Data> getLockedKeys();
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -68,7 +68,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     public boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
         leaseTime = getLeaseTime(leaseTime);
         LockResourceImpl lock = getLock(key);
-        return lock.lock(caller, threadId, referenceId, leaseTime, false);
+        return lock.lock(caller, threadId, referenceId, leaseTime, false, false);
     }
 
     private long getLeaseTime(long leaseTime) {
@@ -84,9 +84,9 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime, boolean blockReads) {
         LockResourceImpl lock = getLock(key);
-        return lock.lock(caller, threadId, referenceId, leaseTime, true);
+        return lock.lock(caller, threadId, referenceId, leaseTime, true, blockReads);
     }
 
     @Override
@@ -148,9 +148,9 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean isTransactionallyLocked(Data key) {
+    public boolean shouldBlockReads(Data key) {
         LockResourceImpl lock = locks.get(key);
-        return lock != null && lock.isTransactional() && lock.isLocked();
+        return lock != null && lock.shouldBlockReads() && lock.isLocked();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
@@ -39,9 +39,9 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime, boolean blockReads) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, leaseTime);
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, leaseTime, blockReads);
     }
 
     @Override
@@ -93,9 +93,9 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean isTransactionallyLocked(Data key) {
+    public boolean shouldBlockReads(Data key) {
         LockStore lockStore = getLockStoreOrNull();
-        return lockStore != null && lockStore.isTransactionallyLocked(key);
+        return lockStore != null && lockStore.shouldBlockReads(key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -171,8 +171,8 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
 
     @Override
     public MapOperation createTxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, String
-            ownerUuid, boolean shouldLoad) {
-        return new TxnLockAndGetOperation(name, dataKey, timeout, ttl, ownerUuid, shouldLoad);
+            ownerUuid, boolean shouldLoad, boolean blockReads) {
+        return new TxnLockAndGetOperation(name, dataKey, timeout, ttl, ownerUuid, shouldLoad, blockReads);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -78,7 +78,7 @@ public interface MapOperationProvider {
     MapOperation createTxnDeleteOperation(String name, Data dataKey, long version);
 
     MapOperation createTxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, String ownerUuid,
-                                              boolean shouldLoad);
+                                              boolean shouldLoad, boolean blockReads);
 
     MapOperation createTxnSetOperation(String name, Data dataKey, Data value, long version, long ttl);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -149,9 +149,9 @@ public abstract class MapOperationProviderDelegator implements MapOperationProvi
     }
 
     @Override
-    public MapOperation createTxnLockAndGetOperation(String name, Data dataKey,
-                                                     long timeout, long ttl, String ownerUuid, boolean shouldLoad) {
-        return getDelegate().createTxnLockAndGetOperation(name, dataKey, timeout, ttl, ownerUuid, shouldLoad);
+    public MapOperation createTxnLockAndGetOperation(String name, Data dataKey, long timeout,
+                                                     long ttl, String ownerUuid, boolean shouldLoad, boolean blockReads) {
+        return getDelegate().createTxnLockAndGetOperation(name, dataKey, timeout, ttl, ownerUuid, shouldLoad, blockReads);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -301,9 +301,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl, boolean blockReads) {
         checkIfLoaded();
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl, blockReads);
     }
 
     @Override
@@ -330,7 +330,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     @Override
     public boolean isTransactionallyLocked(Data key) {
-        return lockStore != null && lockStore.isTransactionallyLocked(key);
+        return lockStore != null && lockStore.shouldBlockReads(key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -201,7 +201,7 @@ public interface RecordStore<R extends Record> {
 
     int size();
 
-    boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl);
+    boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl, boolean blockReads);
 
     boolean extendLock(Data key, String caller, long threadId, long ttl);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -29,6 +29,7 @@ import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.TransactionalDistributedObject;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
+import com.hazelcast.transaction.TransactionOptions.TransactionType;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.ExceptionUtil;
@@ -258,8 +259,9 @@ public abstract class TransactionalMapProxySupport
             return versionedValue;
         }
         NodeEngine nodeEngine = getNodeEngine();
+        boolean blockReads = tx.getTransactionType() == TransactionType.ONE_PHASE;
         MapOperation operation = operationProvider.createTxnLockAndGetOperation(name, key, timeout, timeout,
-                tx.getOwnerUuid(), shouldLoad);
+                tx.getOwnerUuid(), shouldLoad, blockReads);
         operation.setThreadId(ThreadUtil.getThreadId());
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -46,7 +46,7 @@ public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements B
 
     @Override
     public void run() throws Exception {
-        if (!recordStore.txnLock(getKey(), lockOwner, lockThreadId, getCallId(), LOCK_TTL_MILLIS)) {
+        if (!recordStore.txnLock(getKey(), lockOwner, lockThreadId, getCallId(), LOCK_TTL_MILLIS, true)) {
             throw new TransactionException("Lock is not owned by the transaction! Caller: " + lockOwner
                     + ", Owner: " + recordStore.getLockOwnerInfo(getKey()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -70,11 +70,11 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     }
 
     public boolean isTransactionallyLocked(Data key) {
-        return lockStore != null && lockStore.isTransactionallyLocked(key);
+        return lockStore != null && lockStore.shouldBlockReads(key);
     }
 
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl) {
-        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl);
+    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl, boolean blockReads) {
+        return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl, blockReads);
     }
 
     public boolean unlock(Data key, String caller, long threadId, long referenceId) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.TransactionalDistributedObject;
 import com.hazelcast.transaction.TransactionNotActiveException;
+import com.hazelcast.transaction.TransactionOptions.TransactionType;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.ExceptionUtil;
@@ -258,7 +259,8 @@ public abstract class TransactionalMultiMapProxySupport extends TransactionalDis
 
     private MultiMapResponse lockAndGet(Data key, long timeout, long ttl) {
         final NodeEngine nodeEngine = getNodeEngine();
-        TxnLockAndGetOperation operation = new TxnLockAndGetOperation(name, key, timeout, ttl, getThreadId());
+        boolean blockReads = tx.getTransactionType() == TransactionType.ONE_PHASE;
+        TxnLockAndGetOperation operation = new TxnLockAndGetOperation(name, key, timeout, ttl, getThreadId(), blockReads);
         try {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             final OperationService operationService = nodeEngine.getOperationService();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
@@ -45,7 +45,7 @@ public class TxnPrepareBackupOperation extends MultiMapKeyBasedOperation impleme
     @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        if (!container.txnLock(dataKey, caller, threadId, getCallId(), ttl + LOCK_EXTENSION_TIME_IN_MILLIS)) {
+        if (!container.txnLock(dataKey, caller, threadId, getCallId(), ttl + LOCK_EXTENSION_TIME_IN_MILLIS, true)) {
             throw new TransactionException(
                     "Lock is not owned by the transaction! -> " + container.getLockOwnerInfo(dataKey)
             );

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/Transaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/Transaction.java
@@ -17,20 +17,9 @@
 package com.hazelcast.transaction.impl;
 
 import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions.TransactionType;
 
 public interface Transaction {
-
-    enum State {
-        NO_TXN,
-        ACTIVE,
-        PREPARING,
-        PREPARED,
-        COMMITTING,
-        COMMITTED,
-        COMMIT_FAILED,
-        ROLLING_BACK,
-        ROLLED_BACK
-    }
 
     void begin() throws IllegalStateException;
 
@@ -55,4 +44,18 @@ public interface Transaction {
     String getOwnerUuid();
 
     boolean isOriginatedFromClient();
+
+    TransactionType getTransactionType();
+
+    enum State {
+        NO_TXN,
+        ACTIVE,
+        PREPARING,
+        PREPARED,
+        COMMITTING,
+        COMMITTED,
+        COMMIT_FAILED,
+        ROLLING_BACK,
+        ROLLED_BACK
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -79,10 +79,9 @@ public class TransactionImpl implements Transaction {
     private final TransactionType transactionType;
     private final boolean checkThreadAccess;
     private final ILogger logger;
-    private Long threadId;
-
     private final String txOwnerUuid;
     private final TransactionLog transactionLog;
+    private Long threadId;
     private long timeoutMillis;
     private State state = NO_TXN;
     private long startTime;
@@ -238,10 +237,10 @@ public class TransactionImpl implements Transaction {
 
     /**
      * Checks if this Transaction needs to be prepared.
-     *
+     * <p>
      * Preparing a transaction costs time since the backup log potentially needs to be copied and
      * each logrecord needs to prepare its content (e.g. by acquiring locks). This takes time.
-     *
+     * <p>
      * If a transaction is local or if there is 1 or 0 items in the transaction log, instead of
      * preparing, we are just going to try to commit. If the lock is still acquired, the write
      * succeeds, and if the lock isn't acquired, the write fails; the same effect as a prepare
@@ -348,7 +347,7 @@ public class TransactionImpl implements Transaction {
     /**
      * Some data-structures like the Transaction List rely on (empty) backup logs to be created before any change on the
      * data-structure is made. That is why when such a data-structure is loaded, it should the creation.
-     *
+     * <p>
      * Not every data-structure, e.g. the Transactional Map, relies on it and in some cases can even skip it.
      */
     public void ensureBackupLogsExist() {
@@ -457,6 +456,11 @@ public class TransactionImpl implements Transaction {
 
     protected PurgeTxBackupLogOperation createPurgeTxBackupLogOperation() {
         return new PurgeTxBackupLogOperation(txnId);
+    }
+
+    @Override
+    public TransactionType getTransactionType() {
+        return transactionType;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
+import com.hazelcast.transaction.TransactionOptions.TransactionType;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.transaction.impl.TransactionLog;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
@@ -59,7 +60,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * XA {@link Transaction} implementation.
- *
+ * <p>
  * This class does not need to be thread-safe, it is only used via XAResource
  * All visibility guarantees handled by XAResource
  */
@@ -227,6 +228,11 @@ public final class XATransaction implements Transaction {
     @Override
     public State getState() {
         return state;
+    }
+
+    @Override
+    public TransactionType getTransactionType() {
+        return TransactionType.TWO_PHASE;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
@@ -397,39 +397,39 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testIsTransactionallyLocked_whenLockDoesNotExist_thenReturnFalse() {
-        boolean locked = lockStore.isTransactionallyLocked(key);
+    public void testIsBlockReads_whenLockDoesNotExist_thenReturnFalse() {
+        boolean locked = lockStore.shouldBlockReads(key);
         assertFalse(locked);
     }
 
     @Test
-    public void testIsTransactionallyLocked_whenNonTxnLocked_thenReturnFalse() {
+    public void testIsIsBlockReads_whenNonTxnLocked_thenReturnFalse() {
         lock();
-        boolean locked = lockStore.isTransactionallyLocked(key);
+        boolean locked = lockStore.shouldBlockReads(key);
         assertFalse(locked);
     }
 
     @Test
-    public void testIsTransactionallyLocked_whenTxnLocked_thenReturnTrue() {
+    public void testIsBlockReads_whenTxnLocked_thenReturnTrue() {
         txnLock();
-        boolean locked = lockStore.isTransactionallyLocked(key);
+        boolean locked = lockStore.shouldBlockReads(key);
         assertTrue(locked);
     }
 
     @Test
-    public void testIsTransactionallyLocked_whenTxnLockedAndUnlocked_thenReturnFalse() {
+    public void testIsBlockReads_whenTxnLockedAndUnlocked_thenReturnFalse() {
         txnLockAndIncreaseReferenceId();
         unlock();
-        boolean locked = lockStore.isTransactionallyLocked(key);
+        boolean locked = lockStore.shouldBlockReads(key);
         assertFalse(locked);
     }
 
     @Test
-    public void testIsTransactionallyLocked_whenTxnLockedAndAttemptedToLockFromAnotherThread_thenReturnTrue() {
+    public void testIsBlockReads_whenTxnLockedAndAttemptedToLockFromAnotherThread_thenReturnTrue() {
         txnLockAndIncreaseReferenceId();
         threadId++;
         lockAndIncreaseReferenceId();
-        boolean locked = lockStore.isTransactionallyLocked(key);
+        boolean locked = lockStore.shouldBlockReads(key);
         assertTrue(locked);
     }
 
@@ -439,7 +439,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     }
 
     private boolean txnLock() {
-        return lockStore.txnLock(key, callerId, threadId, referenceId, leaseTime);
+        return lockStore.txnLock(key, callerId, threadId, referenceId, leaseTime, true);
     }
 
     private boolean unlock() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -40,6 +40,7 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.transaction.TransactionOptions.TransactionType;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
@@ -660,6 +661,11 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         @Override
         public String getOwnerUuid() {
             return tx.getOwnerUuid();
+        }
+
+        @Override
+        public TransactionType getTransactionType() {
+            return tx.getTransactionType();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapTransactionTest.java
@@ -26,9 +26,11 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.IMap;
+import com.hazelcast.core.IQueue;
 import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.core.TransactionalMap;
+import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.properties.GroupProperty;
@@ -54,6 +56,7 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
@@ -68,7 +71,10 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -89,6 +95,60 @@ public class MapTransactionTest extends HazelcastTestSupport {
 
     private final TransactionOptions options = new TransactionOptions()
             .setTransactionType(TransactionOptions.TransactionType.TWO_PHASE);
+
+    @Test
+    public void testTransactionAtomicity_withMapAndQueue() throws ExecutionException, InterruptedException {
+        final HazelcastInstance instance = createHazelcastInstance();
+
+        Future<Object> future = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                IQueue<Object> queue = instance.getQueue("queue");
+                IMap<Object, Object> map = instance.getMap("map");
+                Object item = queue.take();
+                return map.get(item);
+            }
+        });
+        TransactionOptions options = new TransactionOptions().setTransactionType(TransactionOptions.TransactionType.ONE_PHASE);
+        TransactionContext context = instance.newTransactionContext(options);
+        context.beginTransaction();
+
+        TransactionalQueue<Object> queue = context.getQueue("queue");
+        TransactionalMap<Object, Object> map = context.getMap("map");
+
+        queue.offer("item-99");
+        for (int i = 0; i < 100; i++) {
+            map.put("item-" + i, "value");
+        }
+
+        context.commitTransaction();
+
+        assertEquals("value", future.get());
+    }
+
+    @Test
+    public void testNotToBlockReads() throws ExecutionException, InterruptedException {
+        final HazelcastInstance instance = createHazelcastInstance();
+
+        TransactionContext context = instance.newTransactionContext();
+        context.beginTransaction();
+
+        TransactionalMap<Object, Object> map = context.getMap("map");
+
+        map.put("key", "value");
+
+        Future<Object> future = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                IMap<Object, Object> map = instance.getMap("map");
+                return map.get("key");
+            }
+        });
+
+        assertNull(future.get());
+
+        context.commitTransaction();
+    }
 
     //unfortunately the bug can't be detected by a unit test since the exception is thrown in a background thread (and logged)
     @Test
@@ -746,60 +806,6 @@ public class MapTransactionTest extends HazelcastTestSupport {
         assertEquals("2", map2.get("2"));
     }
 
-    @Test(expected = OperationTimeoutException.class)
-    public void test_containsKey_throwsException_whenKeyLockedInTxn() throws TransactionException, InterruptedException {
-        final String mapName = "default";
-
-        Config config = getConfig();
-        final HazelcastInstance instance = createHazelcastInstance(config);
-        final IMap map = instance.getMap(mapName);
-        map.put(1, 1);
-
-        final CountDownLatch latch = new CountDownLatch(1);
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                instance.executeTransaction(options, new TransactionalTask<Boolean>() {
-                    public Boolean execute(TransactionalTaskContext context) throws TransactionException {
-                        TransactionalMap<Object, Object> txMap = context.getMap(mapName);
-                        txMap.getForUpdate(1);
-
-                        latch.countDown();
-                        sleepSeconds(Integer.MAX_VALUE);
-                        return null;
-                    }
-                });
-
-            }
-        }).start();
-
-        assertOpenEventually(latch);
-
-        // this is used to set wait-timeout for contains-key operation.
-        MapProxyImpl mapProxy = (MapProxyImpl) map;
-        MapOperationProvider operationProvider
-                = ((MapService) mapProxy.getService()).getMapServiceContext().getMapOperationProvider(mapName);
-        mapProxy.setOperationProvider(new WaitTimeoutSetterMapOperationProvider(operationProvider));
-
-        map.containsKey(1);
-    }
-
-    private static class WaitTimeoutSetterMapOperationProvider extends DefaultMapOperationProvider {
-
-        private final MapOperationProvider operationProvider;
-
-        public WaitTimeoutSetterMapOperationProvider(MapOperationProvider operationProvider) {
-            this.operationProvider = operationProvider;
-        }
-
-        @Override
-        public MapOperation createContainsKeyOperation(String name, Data dataKey) {
-            MapOperation containsKeyOperation = operationProvider.createContainsKeyOperation(name, dataKey);
-            containsKeyOperation.setWaitTimeout(TimeUnit.SECONDS.toMillis(3));
-            return containsKeyOperation;
-        }
-    }
-
     @Test
     public void testTxnContainsKey() throws TransactionException {
         Config config = getConfig();
@@ -819,7 +825,6 @@ public class MapTransactionTest extends HazelcastTestSupport {
         });
         assertTrue(b);
     }
-
 
     @Test
     public void testTxnReplace2() throws TransactionException {
@@ -870,7 +875,6 @@ public class MapTransactionTest extends HazelcastTestSupport {
 
         inst.shutdown();
     }
-
 
     @Test
     // TODO: @mm - Review following case...
@@ -1232,7 +1236,6 @@ public class MapTransactionTest extends HazelcastTestSupport {
 
     }
 
-
     @Test(expected = IllegalArgumentException.class)
     public void testValuesWithPagingPredicate() throws TransactionException {
         final int nodeCount = 1;
@@ -1403,7 +1406,6 @@ public class MapTransactionTest extends HazelcastTestSupport {
         });
     }
 
-
     @Test
     public void testGetForUpdate_LoadsKeyFromMapLoader_whenKeyDoesNotExistsInDb() {
         final String mapName = randomMapName();
@@ -1425,7 +1427,6 @@ public class MapTransactionTest extends HazelcastTestSupport {
             }
         });
     }
-
 
     @Test
     public void testGetForUpdate_LoadsKeyFromMapLoader_whenKeyExistsInDb() {
@@ -1493,6 +1494,22 @@ public class MapTransactionTest extends HazelcastTestSupport {
                 return null;
             }
         });
+    }
+
+    private static class WaitTimeoutSetterMapOperationProvider extends DefaultMapOperationProvider {
+
+        private final MapOperationProvider operationProvider;
+
+        public WaitTimeoutSetterMapOperationProvider(MapOperationProvider operationProvider) {
+            this.operationProvider = operationProvider;
+        }
+
+        @Override
+        public MapOperation createContainsKeyOperation(String name, Data dataKey) {
+            MapOperation containsKeyOperation = operationProvider.createContainsKeyOperation(name, dataKey);
+            containsKeyOperation.setWaitTimeout(TimeUnit.SECONDS.toMillis(3));
+            return containsKeyOperation;
+        }
     }
 
 }


### PR DESCRIPTION
Previously read operations were blocked if an entry is locked transactionaly. 
I've introduced a `blockReads` field on Lock, it is set to true on `prepare` phase of the transaction and cleared on `commit/rollback` phase of the transaction (while unlocking).
Now read operations are checking `blockReads` field to block/wait instead of `transactional` field.

One thing to remember, since `ONE_PHASE` transactions do not have a `prepare` phase, the old behavior is not changed.