### PR TITLE
Make TranscationalMapProxy generic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -51,9 +51,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 /**
  * Proxy implementation of {@link com.hazelcast.core.TransactionalMap} interface.
  */
-public class TransactionalMapProxy extends TransactionalMapProxySupport implements TransactionalMap {
+public class TransactionalMapProxy<K, V> extends TransactionalMapProxySupport implements TransactionalMap<K, V> {
 
-    private final Map<Data, TxnValueWrapper> txMap = new HashMap<Data, TxnValueWrapper>();
+    private final Map<Data, TxnValueWrapper<V>> txMap = new HashMap<Data, TxnValueWrapper<V>>();
 
     public TransactionalMapProxy(String name, MapService mapService, NodeEngine nodeEngine, Transaction transaction) {
         super(name, mapService, nodeEngine, transaction);
@@ -64,7 +64,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkTransactionState();
         Data keyData = getService().getMapServiceContext().toData(key, partitionStrategy);
 
-        TxnValueWrapper valueWrapper = txMap.get(keyData);
+        TxnValueWrapper<V> valueWrapper = txMap.get(keyData);
         if (valueWrapper != null) {
             return (valueWrapper.type != Type.REMOVED);
         }
@@ -75,8 +75,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     public int size() {
         checkTransactionState();
         int currentSize = sizeInternal();
-        for (Map.Entry<Data, TxnValueWrapper> entry : txMap.entrySet()) {
-            TxnValueWrapper wrapper = entry.getValue();
+        for (Map.Entry<Data, TxnValueWrapper<V>> entry : txMap.entrySet()) {
+            TxnValueWrapper<V> wrapper = entry.getValue();
             if (wrapper.type == Type.NEW) {
                 currentSize++;
             } else if (wrapper.type == Type.REMOVED) {
@@ -96,13 +96,13 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     }
 
     @Override
-    public Object get(Object key) {
+    public V get(Object key) {
         checkTransactionState();
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
 
-        TxnValueWrapper currentValue = txMap.get(keyData);
+        TxnValueWrapper<V> currentValue = txMap.get(keyData);
         if (currentValue != null) {
             return checkIfRemoved(currentValue);
         }
@@ -110,13 +110,13 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     }
 
     @Override
-    public Object getForUpdate(Object key) {
+    public V getForUpdate(Object key) {
         checkTransactionState();
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
 
-        TxnValueWrapper currentValue = txMap.get(keyData);
+        TxnValueWrapper<V> currentValue = txMap.get(keyData);
         if (currentValue != null) {
             return checkIfRemoved(currentValue);
         }
@@ -125,29 +125,29 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     }
 
     @Override
-    public Object put(Object key, Object value) {
+    public V put(K key, V value) {
         return put(key, value, -1, MILLISECONDS);
     }
 
     @Override
-    public Object put(Object key, Object value, long ttl, TimeUnit timeUnit) {
+    public V put(K key, V value, long ttl, TimeUnit timeUnit) {
         checkTransactionState();
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
-        Object valueBeforeTxn = toObjectIfNeeded(putInternal(keyData, mapServiceContext.toData(value), ttl, timeUnit));
+        V valueBeforeTxn = toObjectIfNeeded(putInternal(keyData, mapServiceContext.toData(value), ttl, timeUnit));
 
-        TxnValueWrapper currentValue = txMap.get(keyData);
+        TxnValueWrapper<V> currentValue = txMap.get(keyData);
         if (value != null) {
             Type type = valueBeforeTxn == null ? Type.NEW : Type.UPDATED;
-            TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
+            TxnValueWrapper<V> wrapper = new TxnValueWrapper<V>(value, type);
             txMap.put(keyData, wrapper);
         }
         return currentValue == null ? valueBeforeTxn : checkIfRemoved(currentValue);
     }
 
     @Override
-    public void set(Object key, Object value) {
+    public void set(K key, V value) {
         checkTransactionState();
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
@@ -155,83 +155,83 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         Data dataBeforeTxn = putInternal(keyData, mapServiceContext.toData(value), -1, MILLISECONDS);
         if (value != null) {
             Type type = dataBeforeTxn == null ? Type.NEW : Type.UPDATED;
-            TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
+            TxnValueWrapper<V> wrapper = new TxnValueWrapper<V>(value, type);
             txMap.put(keyData, wrapper);
         }
     }
 
     @Override
-    public Object putIfAbsent(Object key, Object value) {
+    public V putIfAbsent(K key, V value) {
         checkTransactionState();
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
-        TxnValueWrapper wrapper = txMap.get(keyData);
+        TxnValueWrapper<V> wrapper = txMap.get(keyData);
         boolean haveTxnPast = wrapper != null;
         if (haveTxnPast) {
             if (wrapper.type != Type.REMOVED) {
                 return wrapper.value;
             }
             putInternal(keyData, mapServiceContext.toData(value), -1, MILLISECONDS);
-            txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
+            txMap.put(keyData, new TxnValueWrapper<V>(value, Type.NEW));
             return null;
         } else {
             Data oldValue
                     = putIfAbsentInternal(keyData,
                     mapServiceContext.toData(value));
             if (oldValue == null) {
-                txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
+                txMap.put(keyData, new TxnValueWrapper<V>(value, Type.NEW));
             }
             return toObjectIfNeeded(oldValue);
         }
     }
 
     @Override
-    public Object replace(Object key, Object value) {
+    public V replace(K key, V value) {
         checkTransactionState();
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
 
-        TxnValueWrapper wrapper = txMap.get(keyData);
+        TxnValueWrapper<V> wrapper = txMap.get(keyData);
         boolean haveTxnPast = wrapper != null;
         if (haveTxnPast) {
             if (wrapper.type == Type.REMOVED) {
                 return null;
             }
             putInternal(keyData, mapServiceContext.toData(value), -1, MILLISECONDS);
-            txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
+            txMap.put(keyData, new TxnValueWrapper<V>(value, Type.UPDATED));
             return wrapper.value;
         } else {
             Data oldValue = replaceInternal(keyData, mapServiceContext.toData(value));
             if (oldValue != null) {
-                txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
+                txMap.put(keyData, new TxnValueWrapper<V>(value, Type.UPDATED));
             }
             return toObjectIfNeeded(oldValue);
         }
     }
 
     @Override
-    public boolean replace(Object key, Object oldValue, Object newValue) {
+    public boolean replace(K key, V oldValue, V newValue) {
         checkTransactionState();
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
 
-        TxnValueWrapper wrapper = txMap.get(keyData);
+        TxnValueWrapper<V> wrapper = txMap.get(keyData);
         boolean haveTxnPast = wrapper != null;
         if (haveTxnPast) {
             if (!wrapper.value.equals(oldValue)) {
                 return false;
             }
             putInternal(keyData, mapServiceContext.toData(newValue), -1, MILLISECONDS);
-            txMap.put(keyData, new TxnValueWrapper(wrapper.value, Type.UPDATED));
+            txMap.put(keyData, new TxnValueWrapper<V>(wrapper.value, Type.UPDATED));
             return true;
         } else {
             boolean success = replaceIfSameInternal(keyData,
                     mapServiceContext.toData(oldValue), mapServiceContext.toData(newValue));
             if (success) {
-                txMap.put(keyData, new TxnValueWrapper(newValue, Type.UPDATED));
+                txMap.put(keyData, new TxnValueWrapper<V>(newValue, Type.UPDATED));
             }
             return success;
         }
@@ -244,29 +244,29 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
 
-        TxnValueWrapper wrapper = txMap.get(keyData);
+        TxnValueWrapper<V> wrapper = txMap.get(keyData);
         if (wrapper != null && !isEquals(wrapper.value, value)) {
             return false;
         }
 
         boolean removed = removeIfSameInternal(keyData, value);
         if (removed) {
-            txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
+            txMap.put(keyData, new TxnValueWrapper<V>((V) value, Type.REMOVED));
         }
         return removed;
     }
 
     @Override
-    public Object remove(Object key) {
+    public V remove(Object key) {
         checkTransactionState();
         MapService service = getService();
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
-        Object valueBeforeTxn = toObjectIfNeeded(removeInternal(keyData));
+        V valueBeforeTxn = toObjectIfNeeded(removeInternal(keyData));
 
-        TxnValueWrapper wrapper = null;
+        TxnValueWrapper<V> wrapper = null;
         if (valueBeforeTxn != null || txMap.containsKey(keyData)) {
-            wrapper = txMap.put(keyData, new TxnValueWrapper(valueBeforeTxn, Type.REMOVED));
+            wrapper = txMap.put(keyData, new TxnValueWrapper<V>(valueBeforeTxn, Type.REMOVED));
         }
         return wrapper == null ? valueBeforeTxn : checkIfRemoved(wrapper);
     }
@@ -280,19 +280,19 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         Data keyData = mapServiceContext.toData(key, partitionStrategy);
         Data data = removeInternal(keyData);
         if (data != null || txMap.containsKey(keyData)) {
-            txMap.put(keyData, new TxnValueWrapper(toObjectIfNeeded(data), Type.REMOVED));
+            V value = toObjectIfNeeded(data);
+            txMap.put(keyData, new TxnValueWrapper<V>(value, Type.REMOVED));
         }
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public Set<Object> keySet() {
+    public Set<K> keySet() {
         return keySet(TruePredicate.INSTANCE);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public Set keySet(Predicate predicate) {
+    public Set<K> keySet(Predicate predicate) {
         checkTransactionState();
         checkNotNull(predicate, "Predicate should not be null!");
         checkNotInstanceOf(PagingPredicate.class, predicate, "Paging is not supported for Transactional queries!");
@@ -303,21 +303,21 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         SerializationService serializationService = getNodeEngine().getSerializationService();
 
         QueryResult result = queryEngine.invokeQueryAllPartitions(name, predicate, IterationType.KEY);
-        Set<Object> queryResult = new QueryResultCollection(serializationService, IterationType.KEY, false, true, result);
+        Set<K> queryResult = new QueryResultCollection<K>(serializationService, IterationType.KEY, false, true, result);
 
         // TODO: Can't we just use the original set?
-        Set<Object> keySet = new HashSet<Object>(queryResult);
+        Set<K> keySet = new HashSet<K>(queryResult);
         Extractors extractors = mapServiceContext.getExtractors(name);
-        for (Map.Entry<Data, TxnValueWrapper> entry : txMap.entrySet()) {
+        for (Map.Entry<Data, TxnValueWrapper<V>> entry : txMap.entrySet()) {
             Data keyData = entry.getKey();
             if (!Type.REMOVED.equals(entry.getValue().type)) {
-                Object value = (entry.getValue().value instanceof Data)
-                        ? toObjectIfNeeded(entry.getValue().value) : entry.getValue().value;
+                V value = (entry.getValue().value instanceof Data)
+                        ? (V) toObjectIfNeeded(entry.getValue().value) : entry.getValue().value;
 
-                QueryableEntry queryEntry = new CachedQueryEntry(serializationService, keyData, value, extractors);
+                QueryableEntry<K, V> queryEntry = new CachedQueryEntry<K, V>(serializationService, keyData, value, extractors);
                 // apply predicate on txMap
                 if (predicate.apply(queryEntry)) {
-                    Object keyObject = serializationService.toObject(keyData);
+                    K keyObject = serializationService.toObject(keyData);
                     keySet.add(keyObject);
                 }
             } else {
@@ -330,14 +330,12 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public Collection<Object> values() {
+    public Collection<V> values() {
         return values(TruePredicate.INSTANCE);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public Collection values(Predicate predicate) {
+    public Collection<V> values(Predicate predicate) {
         checkTransactionState();
         checkNotNull(predicate, "Predicate can not be null!");
         checkNotInstanceOf(PagingPredicate.class, predicate, "Paging is not supported for Transactional queries");
@@ -348,28 +346,28 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         SerializationService serializationService = getNodeEngine().getSerializationService();
 
         QueryResult result = queryEngine.invokeQueryAllPartitions(name, predicate, IterationType.ENTRY);
-        QueryResultCollection<Map.Entry> queryResult
-                = new QueryResultCollection<Map.Entry>(serializationService, IterationType.ENTRY, false, true, result);
+        QueryResultCollection<Map.Entry<K, V>> queryResult
+                = new QueryResultCollection<Map.Entry<K, V>>(serializationService, IterationType.ENTRY, false, true, result);
 
         // TODO: Can't we just use the original set?
-        List<Object> valueSet = new ArrayList<Object>();
-        Set<Object> keyWontBeIncluded = new HashSet<Object>();
+        List<V> valueSet = new ArrayList<V>();
+        Set<K> keyWontBeIncluded = new HashSet<K>();
         Extractors extractors = mapServiceContext.getExtractors(name);
 
         // iterate over the txMap and see if the values are updated or removed
-        for (Map.Entry<Data, TxnValueWrapper> entry : txMap.entrySet()) {
+        for (Map.Entry<Data, TxnValueWrapper<V>> entry : txMap.entrySet()) {
             boolean isRemoved = Type.REMOVED.equals(entry.getValue().type);
             boolean isUpdated = Type.UPDATED.equals(entry.getValue().type);
 
-            Object keyObject = serializationService.toObject(entry.getKey());
+            K keyObject = serializationService.toObject(entry.getKey());
             if (isRemoved) {
                 keyWontBeIncluded.add(keyObject);
             } else {
                 if (isUpdated) {
                     keyWontBeIncluded.add(keyObject);
                 }
-                Object entryValue = entry.getValue().value;
-                QueryableEntry queryEntry = new CachedQueryEntry(serializationService, entry.getKey(), entryValue, extractors);
+                V entryValue = entry.getValue().value;
+                QueryableEntry<K, V> queryEntry = new CachedQueryEntry<K, V>(serializationService, entry.getKey(), entryValue, extractors);
                 if (predicate.apply(queryEntry)) {
                     valueSet.add(queryEntry.getValue());
                 }
@@ -384,14 +382,14 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         return "TransactionalMap" + "{name='" + name + '\'' + '}';
     }
 
-    private Object checkIfRemoved(TxnValueWrapper wrapper) {
+    private V checkIfRemoved(TxnValueWrapper<V> wrapper) {
         checkTransactionState();
         return wrapper == null || wrapper.type == Type.REMOVED ? null : wrapper.value;
     }
 
-    private void removeFromResultSet(QueryResultCollection<Map.Entry> queryResultSet, List<Object> valueSet,
-                                     Set<Object> keyWontBeIncluded) {
-        for (Map.Entry entry : queryResultSet) {
+    private void removeFromResultSet(QueryResultCollection<Map.Entry<K, V>> queryResultSet, List<V> valueSet,
+                                     Set<K> keyWontBeIncluded) {
+        for (Map.Entry<K, V> entry : queryResultSet) {
             if (keyWontBeIncluded.contains(entry.getKey())) {
                 continue;
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
@@ -19,12 +19,12 @@ package com.hazelcast.map.impl.tx;
 /**
  * Wrapper for value objects with type information.
  */
-public class TxnValueWrapper {
+public class TxnValueWrapper<V> {
 
-    Object value;
+    V value;
     Type type;
 
-    public TxnValueWrapper(Object value, Type type) {
+    public TxnValueWrapper(V value, Type type) {
         this.value = value;
         this.type = type;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnValueWrapper.java
@@ -19,12 +19,12 @@ package com.hazelcast.map.impl.tx;
 /**
  * Wrapper for value objects with type information.
  */
-public class TxnValueWrapper<V> {
+public class TxnValueWrapper {
 
-    V value;
+    Object value;
     Type type;
 
-    public TxnValueWrapper(V value, Type type) {
+    public TxnValueWrapper(Object value, Type type) {
         this.value = value;
         this.type = type;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -24,21 +24,21 @@ import com.hazelcast.query.impl.getters.Extractors;
 /**
  * Entry of the Query.
  */
-public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
+public class CachedQueryEntry extends QueryableEntry {
 
     private Data keyData;
-    private K keyObject;
+    private Object keyObject;
     private Data valueData;
-    private V valueObject;
+    private Object valueObject;
 
     public CachedQueryEntry() {
     }
 
-    public CachedQueryEntry(SerializationService serializationService, Data key, V value, Extractors extractors) {
+    public CachedQueryEntry(SerializationService serializationService, Data key, Object value, Extractors extractors) {
         init(serializationService, key, value, extractors);
     }
 
-    public void init(SerializationService serializationService, Data key, V value, Extractors extractors) {
+    public void init(SerializationService serializationService, Data key, Object value, Extractors extractors) {
         if (key == null) {
             throw new IllegalArgumentException("keyData cannot be null");
         }
@@ -57,7 +57,7 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
     }
 
     @Override
-    public K getKey() {
+    public Object getKey() {
         if (keyObject == null) {
             keyObject = serializationService.toObject(keyData);
         }
@@ -65,7 +65,7 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
     }
 
     @Override
-    public V getValue() {
+    public Object getValue() {
         if (valueObject == null) {
             valueObject = serializationService.toObject(valueData);
         }
@@ -114,7 +114,7 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
     }
 
     @Override
-    public V setValue(V value) {
+    public Object setValue(Object value) {
         throw new UnsupportedOperationException();
     }
 
@@ -126,7 +126,7 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        CachedQueryEntry<K, V> that = (CachedQueryEntry<K, V>) o;
+        CachedQueryEntry that = (CachedQueryEntry) o;
         if (!keyData.equals(that.keyData)) {
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -24,21 +24,21 @@ import com.hazelcast.query.impl.getters.Extractors;
 /**
  * Entry of the Query.
  */
-public class CachedQueryEntry extends QueryableEntry {
+public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
 
     private Data keyData;
-    private Object keyObject;
+    private K keyObject;
     private Data valueData;
-    private Object valueObject;
+    private V valueObject;
 
     public CachedQueryEntry() {
     }
 
-    public CachedQueryEntry(SerializationService serializationService, Data key, Object value, Extractors extractors) {
+    public CachedQueryEntry(SerializationService serializationService, Data key, V value, Extractors extractors) {
         init(serializationService, key, value, extractors);
     }
 
-    public void init(SerializationService serializationService, Data key, Object value, Extractors extractors) {
+    public void init(SerializationService serializationService, Data key, V value, Extractors extractors) {
         if (key == null) {
             throw new IllegalArgumentException("keyData cannot be null");
         }
@@ -57,7 +57,7 @@ public class CachedQueryEntry extends QueryableEntry {
     }
 
     @Override
-    public Object getKey() {
+    public K getKey() {
         if (keyObject == null) {
             keyObject = serializationService.toObject(keyData);
         }
@@ -65,7 +65,7 @@ public class CachedQueryEntry extends QueryableEntry {
     }
 
     @Override
-    public Object getValue() {
+    public V getValue() {
         if (valueObject == null) {
             valueObject = serializationService.toObject(valueData);
         }
@@ -114,7 +114,7 @@ public class CachedQueryEntry extends QueryableEntry {
     }
 
     @Override
-    public Object setValue(Object value) {
+    public V setValue(V value) {
         throw new UnsupportedOperationException();
     }
 
@@ -126,7 +126,7 @@ public class CachedQueryEntry extends QueryableEntry {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        CachedQueryEntry that = (CachedQueryEntry) o;
+        CachedQueryEntry<K, V> that = (CachedQueryEntry<K, V>) o;
         if (!keyData.equals(that.keyData)) {
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
@@ -32,9 +32,9 @@ public abstract class TransactionalDistributedObject<S extends RemoteService> ex
         this.tx = tx;
     }
 
-    public <T> T toObjectIfNeeded(Object data) {
+    public Object toObjectIfNeeded(Object data) {
         if (tx.isOriginatedFromClient()) {
-            return (T) data;
+            return data;
         }
         return getNodeEngine().toObject(data);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
@@ -32,9 +32,9 @@ public abstract class TransactionalDistributedObject<S extends RemoteService> ex
         this.tx = tx;
     }
 
-    public Object toObjectIfNeeded(Object data) {
+    public <T> T toObjectIfNeeded(Object data) {
         if (tx.isOriginatedFromClient()) {
-            return data;
+            return (T) data;
         }
         return getNodeEngine().toObject(data);
     }


### PR DESCRIPTION
* Introduce generic parameters to TxnValueWrapper and CachedQueryEntry.
* Introduce a generic cast for toObjectIfNeeded. Given most callers of
this method will be casting to desired type anyway, it makes sense to do
so.
* Convert all Object types in TransactionalMapProxy to K/V generics
where appropriate

Implements #7484.