### PR TITLE
Moved util.counters to internal.util.counters

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -370,7 +370,7 @@
     <suppress checks="Header|IllegalImport" files="com/hazelcast/util/HashUtil"/>
     <suppress checks="MagicNumber" files="com/hazelcast/util/QuickMath"/>
     <suppress checks="NPathComplexity|CyclomaticComplexity" files="com/hazelcast/client/util/ClientDelegatingFuture"/>
-    <suppress checks="IllegalImport|InnerAssignment" files="com/hazelcast/util/counters/SwCounter"/>
+    <suppress checks="IllegalImport|InnerAssignment" files="com/hazelcast/internal/util/counters/SwCounter"/>
     <suppress checks="JavadocMethod" files="com/hazelcast/util/executor/"/>
     <suppress checks="JavadocType" files="com/hazelcast/util/executor/"/>
     <suppress checks="JavadocVariable" files="com/hazelcast/util/executor/"/>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -26,7 +26,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.util.counters.MwCounter;
+import com.hazelcast.internal.util.counters.MwCounter;
 
 import javax.security.auth.login.LoginException;
 import java.util.Collection;
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static com.hazelcast.util.counters.MwCounter.newMwCounter;
+import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 
 /**
  * Manages and stores {@link com.hazelcast.client.impl.ClientEndpointImpl}s.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
@@ -46,7 +46,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <li>double</li>
  * <li>{@link java.util.concurrent.atomic.AtomicInteger}</li>
  * <li>{@link java.util.concurrent.atomic.AtomicLong}</li>
- * <li>{@link com.hazelcast.util.counters.Counter}</li>
+ * <li>{@link com.hazelcast.internal.util.counters.Counter}</li>
  * <li>{@link Byte}</li>
  * <li>{@link Short}</li>
  * <li>{@link Integer}</li>

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeFunction;
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 
 import java.lang.reflect.Field;
 import java.util.Collection;

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeFunction;
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 
 import java.lang.reflect.Method;
 import java.util.Collection;

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeUtils.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.metrics.impl;
 
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/Counter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/Counter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.util.counters;
+package com.hazelcast.internal.util.counters;
 
 /**
  * A Counter keeps track of a long value.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/MwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/MwCounter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.util.counters;
+package com.hazelcast.internal.util.counters;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/SwCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/SwCounter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.util.counters;
+package com.hazelcast.internal.util.counters;
 
 import com.hazelcast.nio.UnsafeHelper;
 import sun.misc.Unsafe;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/counters/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/counters/package-info.java
@@ -17,4 +17,4 @@
 /**
  * Provides various counter implementations.
  */
-package com.hazelcast.util.counters;
+package com.hazelcast.internal.util.counters;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberReadHandler.java
@@ -18,7 +18,7 @@ package com.hazelcast.nio.tcp;
 
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.impl.packetdispatcher.PacketDispatcher;
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 
 import java.nio.ByteBuffer;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketReader.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 
 /**
  * The SocketReader is responsible for reading data from the socket, on behalf of a connection, into a

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -35,7 +35,7 @@ import com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
-import com.hazelcast.util.counters.MwCounter;
+import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.util.executor.StripedRunnable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
@@ -57,7 +57,7 @@ import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static com.hazelcast.util.counters.MwCounter.newMwCounter;
+import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 
 public class TcpIpConnectionManager implements ConnectionManager, PacketHandler {
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
-import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.internal.util.counters.SwCounter;
 
 import java.io.IOException;
 import java.nio.channels.CancelledKeyException;
@@ -30,7 +30,7 @@ import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -25,8 +25,8 @@ import com.hazelcast.nio.tcp.ReadHandler;
 import com.hazelcast.nio.tcp.SocketReader;
 import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.TcpIpConnection;
-import com.hazelcast.util.counters.Counter;
-import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.internal.util.counters.Counter;
+import com.hazelcast.internal.util.counters.SwCounter;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -41,7 +41,7 @@ import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
 import static com.hazelcast.nio.Protocols.CLUSTER;
 import static com.hazelcast.util.Clock.currentTimeMillis;
 import static com.hazelcast.util.StringUtil.bytesToString;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 
 /**
  * A {@link SocketReader} tailored for non blocking IO.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -25,7 +25,7 @@ import com.hazelcast.nio.tcp.NewClientWriteHandler;
 import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.WriteHandler;
-import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.internal.util.counters.SwCounter;
 
 import java.io.IOException;
 import java.net.SocketException;
@@ -45,7 +45,7 @@ import static com.hazelcast.nio.Protocols.CLUSTER;
 import static com.hazelcast.util.Clock.currentTimeMillis;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.StringUtil.stringToBytes;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static java.lang.Math.max;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
@@ -25,13 +25,13 @@ import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketReader;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketWriter;
-import com.hazelcast.util.counters.MwCounter;
-import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.internal.util.counters.MwCounter;
+import com.hazelcast.internal.util.counters.SwCounter;
 
 import static com.hazelcast.instance.GroupProperty.IO_BALANCER_INTERVAL_SECONDS;
 import static com.hazelcast.instance.GroupProperty.IO_THREAD_COUNT;
-import static com.hazelcast.util.counters.MwCounter.newMwCounter;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 
 /**
  * It attempts to detect and fix a selector imbalance problem.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
@@ -27,8 +27,8 @@ import com.hazelcast.nio.tcp.SocketChannelWrapper;
 import com.hazelcast.nio.tcp.SocketReader;
 import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.TcpIpConnection;
-import com.hazelcast.util.counters.Counter;
-import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.internal.util.counters.Counter;
+import com.hazelcast.internal.util.counters.SwCounter;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -40,7 +40,7 @@ import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
 import static com.hazelcast.nio.Protocols.CLUSTER;
 import static com.hazelcast.util.StringUtil.bytesToString;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
@@ -28,7 +28,7 @@ import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.WriteHandler;
 import com.hazelcast.util.EmptyStatement;
-import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.internal.util.counters.SwCounter;
 
 import java.io.IOException;
 import java.net.SocketException;
@@ -43,7 +43,7 @@ import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
 import static com.hazelcast.nio.Protocols.CLUSTER;
 import static com.hazelcast.util.StringUtil.stringToBytes;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static java.lang.System.currentTimeMillis;
 
 public class SpinningSocketWriter extends AbstractHandler implements SocketWriter {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -40,7 +40,7 @@ import com.hazelcast.spi.impl.eventservice.impl.operations.RegistrationOperation
 import com.hazelcast.spi.impl.eventservice.impl.operations.SendEventOperation;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.UuidUtil;
-import com.hazelcast.util.counters.MwCounter;
+import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.util.executor.StripedExecutor;
 
 import java.io.Closeable;
@@ -59,7 +59,7 @@ import java.util.logging.Level;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
-import static com.hazelcast.util.counters.MwCounter.newMwCounter;
+import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 
 public class EventServiceImpl implements InternalEventService {
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
@@ -24,13 +24,13 @@ import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
-import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.util.executor.HazelcastManagedThread;
 
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMemoryError;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 
 /**
  * The OperationThread is responsible for processing operations, packets containing operations and runnable's.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -29,7 +29,7 @@ import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
-import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.internal.util.counters.SwCounter;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -39,7 +39,7 @@ import java.util.logging.Level;
 
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMemoryError;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.INFO;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -28,8 +28,8 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutRespons
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
-import com.hazelcast.util.counters.MwCounter;
-import com.hazelcast.util.counters.SwCounter;
+import com.hazelcast.internal.util.counters.MwCounter;
+import com.hazelcast.internal.util.counters.SwCounter;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -39,8 +39,8 @@ import java.util.concurrent.ConcurrentMap;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.spi.Operation.CALL_ID_LOCAL_SKIPPED;
 import static com.hazelcast.spi.OperationAccessor.setCallId;
-import static com.hazelcast.util.counters.MwCounter.newMwCounter;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 
 /**
  * The InvocationsRegistry is responsible for the registration of all pending invocations. Using the InvocationRegistry the

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -51,7 +51,7 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutRespons
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
@@ -65,7 +65,7 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmpty
 import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
 import static com.hazelcast.spi.impl.operationutil.Operations.isMigrationOperation;
 import static com.hazelcast.spi.impl.operationutil.Operations.isWanReplicationOperation;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -48,7 +48,7 @@ import com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperat
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
 import com.hazelcast.util.EmptyStatement;
-import com.hazelcast.util.counters.MwCounter;
+import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.util.executor.ExecutorType;
 import com.hazelcast.util.executor.ManagedExecutorService;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -37,7 +37,7 @@ import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.FutureUtil.ExceptionHandler;
 import com.hazelcast.util.UuidUtil;
-import com.hazelcast.util.counters.MwCounter;
+import com.hazelcast.internal.util.counters.MwCounter;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,7 +55,7 @@ import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static com.hazelcast.util.counters.MwCounter.newMwCounter;
+import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 
 public class ProxyServiceImpl
         implements InternalProxyService, PostJoinAwareService, EventPublishingService<DistributedObjectEventPacket, Object> {

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/FieldProbeTest.java
@@ -7,7 +7,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.metrics.impl.FieldProbe.createFieldProbe;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
@@ -6,7 +6,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.metrics.impl.MethodProbe.createMethodProbe;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedFieldsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedFieldsTest.java
@@ -2,7 +2,7 @@ package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.LongGauge;
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RegisterAnnotatedMethodsTest.java
@@ -2,7 +2,7 @@ package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.LongGauge;
-import com.hazelcast.util.counters.Counter;
+import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
 
 //todo: testing of null return value

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/counters/MwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/counters/MwCounterTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.util.counters;
+package com.hazelcast.internal.util.counters;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -7,34 +7,32 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static org.junit.Assert.assertEquals;
 
-/**
- * If Unsafe is available, this will trigger the testing of the {@link SwCounter.UnsafeSwCounter} class. Otherwise
- * the {@link SwCounter.SafeSwCounter} is tested.
- */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class SwCounterTest {
-
-    private SwCounter counter;
+public class MwCounterTest {
+    private MwCounter counter;
 
     @Before
     public void setup() {
-        counter = newSwCounter();
+        counter = newMwCounter();
     }
 
     @Test
     public void inc() {
-        assertEquals(1, counter.inc());
+        counter.inc();
+        assertEquals(1, counter.get());
     }
 
     @Test
     public void inc_withAmount() {
-        assertEquals(10, counter.inc(10));
-        assertEquals(10, counter.inc(0));
-        assertEquals(0, counter.inc(-10));
+        counter.inc(10);
+        assertEquals(10, counter.get());
+
+        counter.inc(0);
+        assertEquals(10, counter.get());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SafeSwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SafeSwCounterTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.util.counters;
+package com.hazelcast.internal.util.counters;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -7,17 +7,16 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.util.counters.MwCounter.newMwCounter;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class MwCounterTest {
-    private MwCounter counter;
+public class SafeSwCounterTest {
+    private SwCounter.SafeSwCounter counter;
 
     @Before
     public void setup() {
-        counter = newMwCounter();
+        counter = new SwCounter.SafeSwCounter(0);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SwCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/counters/SwCounterTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.util.counters;
+package com.hazelcast.internal.util.counters;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -7,31 +7,34 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static org.junit.Assert.assertEquals;
 
+/**
+ * If Unsafe is available, this will trigger the testing of the {@link SwCounter.UnsafeSwCounter} class. Otherwise
+ * the {@link SwCounter.SafeSwCounter} is tested.
+ */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class SafeSwCounterTest {
-    private SwCounter.SafeSwCounter counter;
+public class SwCounterTest {
+
+    private SwCounter counter;
 
     @Before
     public void setup() {
-        counter = new SwCounter.SafeSwCounter(0);
+        counter = newSwCounter();
     }
 
     @Test
     public void inc() {
-        counter.inc();
-        assertEquals(1, counter.get());
+        assertEquals(1, counter.inc());
     }
 
     @Test
     public void inc_withAmount() {
-        counter.inc(10);
-        assertEquals(10, counter.get());
-
-        counter.inc(0);
-        assertEquals(10, counter.get());
+        assertEquals(10, counter.inc(10));
+        assertEquals(10, counter.inc(0));
+        assertEquals(0, counter.inc(-10));
     }
 
     @Test


### PR DESCRIPTION
The com.hazelcast.util package is internal API so should be moved to com.hazelcast.internal.util. This is one of many smaller pr's.