### PR TITLE
Fixed test failure on MetricsPluginTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/MetricsPluginTest.java
@@ -5,6 +5,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -54,14 +55,14 @@ public class MetricsPluginTest extends AbstractPerformanceMonitorPluginTest {
             }
         });
 
-        plugin.run(logWriter);
-
-        try {
-            assertContains("broken=java.lang.RuntimeException:error");
-        } catch (Throwable t) {
-            // this is a hack to figure out which probes are really available.
-            throw new Exception("existing probes:"+metricsRegistry.getNames(), t);
-        }
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                logWriter.clean();
+                plugin.run(logWriter);
+                assertContains("broken=java.lang.RuntimeException:error");
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
the problem is that rending the probes is eventually consistent due to the internals
of MetricsRegistry being eventually consistent. So eventually the right probes are
seen; but doesn't need to be immediately.

This cases the problematic probe not to be seen.