### PR TITLE
PerformanceMonitor should not rely on NodeEngineImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -121,10 +121,13 @@ public class NodeEngineImpl implements NodeEngine {
                 operationService,
                 eventService,
                 wanReplicationService,
-                new ConnectionManagerPacketHandler()
-        );
+                new ConnectionManagerPacketHandler());
         this.quorumService = new QuorumServiceImpl(this);
-        this.performanceMonitor = new PerformanceMonitor(this);
+        this.performanceMonitor = new PerformanceMonitor(
+                node.hazelcastInstance,
+                loggingService.getLogger(PerformanceMonitor.class),
+                node.getHazelcastThreadGroup(),
+                node.groupProperties);
     }
 
      class ConnectionManagerPacketHandler implements PacketHandler {

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceMonitorTest.java
@@ -2,6 +2,8 @@ package com.hazelcast.internal.monitors;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -30,7 +32,12 @@ public class PerformanceMonitorTest extends HazelcastTestSupport {
 
     private PerformanceMonitor newPerformanceMonitor(Config config) {
         HazelcastInstance hz = createHazelcastInstance(config);
-        return new PerformanceMonitor(getNodeEngineImpl(hz));
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(hz);
+        return new PerformanceMonitor(
+                hz,
+                Logger.getLogger(PerformanceMonitor.class),
+                nodeEngineImpl.getNode().getHazelcastThreadGroup(),
+                nodeEngineImpl.getNode().groupProperties);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
This is needed refactoring to let the client make use of the PerformanceMonitor.