### PR TITLE
Cleanup HazelcastProperties

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperties.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperties.java
@@ -122,11 +122,6 @@ public class ClientProperties extends HazelcastProperties {
      * @param config {@link Config} used to configure the {@link ClientProperty} values.
      */
     public ClientProperties(ClientConfig config) {
-        initProperties(config.getProperties(), ClientProperty.values());
-    }
-
-    @Override
-    protected String[] createProperties() {
-        return new String[ClientProperty.values().length];
+        super(config.getProperties(), ClientProperty.values());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -18,8 +18,6 @@ package com.hazelcast.instance;
 
 import com.hazelcast.config.Config;
 
-import static com.hazelcast.util.Preconditions.checkNotNull;
-
 /**
  * Container for configured Hazelcast properties ({@see GroupProperty}).
  * <p/>
@@ -263,12 +261,6 @@ public class GroupProperties extends HazelcastProperties {
      * @param config {@link Config} used to configure the {@link GroupProperty} values.
      */
     public GroupProperties(Config config) {
-        checkNotNull(config);
-        initProperties(config.getProperties(), GroupProperty.values());
-    }
-
-    @Override
-    protected String[] createProperties() {
-        return new String[GroupProperty.values().length];
+        super(config.getProperties(), GroupProperty.values());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/ConfigPropertiesPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/ConfigPropertiesPlugin.java
@@ -23,7 +23,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import static java.util.Collections.sort;
 
@@ -32,9 +31,9 @@ import static java.util.Collections.sort;
  */
 public class ConfigPropertiesPlugin extends PerformanceMonitorPlugin {
 
-    private final Properties properties;
+    private final HazelcastProperties properties;
     private final ILogger logger;
-    private final List keyList = new ArrayList();
+    private final List<String> keyList = new ArrayList<String>();
 
     public ConfigPropertiesPlugin(NodeEngineImpl nodeEngine) {
         this(nodeEngine.getLogger(ConfigPropertiesPlugin.class), nodeEngine.getNode().getGroupProperties());
@@ -42,7 +41,7 @@ public class ConfigPropertiesPlugin extends PerformanceMonitorPlugin {
 
     public ConfigPropertiesPlugin(ILogger logger, HazelcastProperties properties) {
         this.logger = logger;
-        this.properties = properties.getProperties();
+        this.properties = properties;
     }
 
     @Override
@@ -62,10 +61,9 @@ public class ConfigPropertiesPlugin extends PerformanceMonitorPlugin {
         sort(keyList);
 
         writer.startSection("ConfigProperties");
-        for (Object key : keyList) {
-            String keyString = (String) key;
-            String value = (String) properties.get(keyString);
-            writer.writeKeyValueEntry(keyString, value);
+        for (String key : keyList) {
+            String value = properties.get(key);
+            writer.writeKeyValueEntry(key, value);
         }
         writer.endSection();
     }

--- a/hazelcast/src/test/java/com/hazelcast/instance/HazelcastPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/HazelcastPropertiesTest.java
@@ -1,0 +1,75 @@
+package com.hazelcast.instance;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HazelcastPropertiesTest {
+
+    @Test
+    public void testNullProperties() {
+        HazelcastProperties properties = new HazelcastPropertiesImpl(null);
+
+        assertTrue(properties.keySet().isEmpty());
+    }
+
+    @Test
+    public void testKeySet_whenPropertiesAvailable() {
+        Properties props = new Properties();
+        props.setProperty("key1", "value1");
+        props.setProperty("key2", "value2");
+        HazelcastProperties properties = new HazelcastPropertiesImpl(props);
+
+        assertEquals(props.keySet(), properties.keySet());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testKeySet_isImmutable() {
+        HazelcastProperties properties = new HazelcastPropertiesImpl(null);
+
+        properties.keySet().remove("foo");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGet_whenKeyNull() {
+        HazelcastProperties properties = new HazelcastPropertiesImpl(null);
+
+        properties.get(null);
+    }
+
+    @Test
+    public void testGet_whenKeyNotExisting() {
+        Properties props = new Properties();
+        props.setProperty("key1", "value1");
+        props.setProperty("key2", "value2");
+        HazelcastProperties properties = new HazelcastPropertiesImpl(props);
+
+        assertNull(properties.get("nonexistingkey"));
+    }
+
+    @Test
+    public void testGet_whenKeyExisting() {
+        Properties props = new Properties();
+        props.setProperty("key1", "value1");
+        props.setProperty("key2", "value2");
+        HazelcastProperties properties = new HazelcastPropertiesImpl(props);
+
+        assertEquals("value1", properties.get("key1"));
+    }
+
+    class HazelcastPropertiesImpl extends HazelcastProperties {
+        public HazelcastPropertiesImpl(Properties properties) {
+            super(properties, GroupProperty.values());
+        }
+    }
+}


### PR DESCRIPTION
Removed the need to create an array by letting the subclass implement a method.
Everything is now done through the constructor.

The HazelcastProperties now also have abilit to ask the keyset + value. This is
useful to determine the content of the HazelcastProperties.

Fixed the ConfigPropertiesPlugin to make use of these new methods.