### PR TITLE
Adds Metrics and PerformanceLog to the client.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -148,11 +148,14 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 client.getName() + ".ClientInSelector",
                 loggingService.getLogger(NonBlockingIOThread.class),
                 OUT_OF_MEMORY_HANDLER);
+        client.getMetricsRegistry().scanAndRegister(inputThread, "tcp." + inputThread.getName());
+
         outputThread = new ClientNonBlockingOutputThread(
                 client.getThreadGroup(),
                 client.getName() + ".ClientOutSelector",
                 loggingService.getLogger(ClientNonBlockingOutputThread.class),
                 OUT_OF_MEMORY_HANDLER);
+        client.getMetricsRegistry().scanAndRegister(outputThread, "tcp." + outputThread.getName());
     }
 
     private SocketInterceptor initSocketInterceptor(SocketInterceptorConfig sic) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -28,6 +28,8 @@ import com.hazelcast.client.spi.ClientInvocationService;
 import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.Connection;
@@ -58,6 +60,8 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     protected ClientListenerServiceImpl clientListenerService;
     protected final ILogger invocationLogger;
     private ResponseThread responseThread;
+
+    @Probe(name = "pendingCalls", level = ProbeLevel.MANDATORY)
     private ConcurrentMap<Long, ClientInvocation> callIdMap
             = new ConcurrentHashMap<Long, ClientInvocation>();
 
@@ -70,6 +74,8 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         int maxAllowedConcurrentInvocations = client.getClientProperties().getInteger(MAX_CONCURRENT_INVOCATIONS);
         callIdSequence = new CallIdSequence.CallIdSequenceFailFast(maxAllowedConcurrentInvocations);
         invocationLogger = client.getLoggingService().getLogger(ClientInvocationService.class);
+
+        client.getMetricsRegistry().scanAndRegister(this, "invocations");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperties.java
@@ -18,6 +18,7 @@ package com.hazelcast.instance;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.internal.properties.GroupProperty;
+import com.hazelcast.internal.monitors.PerformanceMonitor;
 
 /**
  * Container for configured Hazelcast properties.
@@ -37,16 +38,16 @@ public class GroupProperties extends HazelcastProperties {
     @Deprecated
     public static final String PROP_HEALTH_MONITORING_DELAY_SECONDS = GroupProperty.HEALTH_MONITORING_DELAY_SECONDS.getName();
     @Deprecated
-    public static final String PROP_PERFORMANCE_MONITOR_ENABLED = GroupProperty.PERFORMANCE_MONITOR_ENABLED.getName();
+    public static final String PROP_PERFORMANCE_MONITOR_ENABLED = PerformanceMonitor.ENABLED.getName();
     @Deprecated
     public static final String PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB
-            = GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB.getName();
+            = PerformanceMonitor.MAX_ROLLED_FILE_SIZE_MB.getName();
     @Deprecated
     public static final String PROP_PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT
-            = GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT.getName();
+            = PerformanceMonitor.MAX_ROLLED_FILE_COUNT.getName();
     @Deprecated
     public static final String PROP_PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT
-            = GroupProperty.PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT.getName();
+            = PerformanceMonitor.HUMAN_FRIENDLY_FORMAT.getName();
     @Deprecated
     public static final String PROP_PHONE_HOME_ENABLED = GroupProperty.PHONE_HOME_ENABLED.getName();
     @Deprecated

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
@@ -120,7 +120,7 @@ public class HealthMonitor {
                     node.getHazelcastThreadGroup().getThreadNamePrefix("HealthMonitor"));
             setDaemon(true);
             this.delaySeconds = delaySeconds;
-            this.performanceLogHint = node.getGroupProperties().getBoolean(GroupProperty.PERFORMANCE_MONITOR_ENABLED);
+            this.performanceLogHint = node.getGroupProperties().getBoolean(PerformanceMonitor.ENABLED);
         }
 
         @Override
@@ -167,7 +167,7 @@ public class HealthMonitor {
 
             logger.info(String.format("The HealthMonitor has detected a high load on the system. For more detailed information,%s"
                             + "enable the PerformanceMonitor by adding the property -D%s=true",
-                    LINE_SEPARATOR, GroupProperty.PERFORMANCE_MONITOR_ENABLED));
+                    LINE_SEPARATOR, PerformanceMonitor.ENABLED));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/MetricsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/MetricsPlugin.java
@@ -19,15 +19,28 @@ package com.hazelcast.internal.monitors;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
 import com.hazelcast.internal.properties.HazelcastProperties;
+import com.hazelcast.internal.properties.HazelcastProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_METRICS_PERIOD_SECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * A {@link PerformanceMonitorPlugin} that displays the content of the {@link MetricsRegistry}.
  */
 public class MetricsPlugin extends PerformanceMonitorPlugin {
+    /**
+     * The period in seconds the PerformanceMonitor MetricsPlugin runs.
+     *
+     * The MetricsPlugin does nothing more than frequently writing the content of the MetricsRegistry
+     * to the logfile. For debugging purposes make sure the {@link #PERFORMANCE_METRICS_LEVEL} is set to debug.
+     *
+     * This plugin is very cheap to use.
+     *
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERIOD_SECONDS
+            = new HazelcastProperty("hazelcast.performance.monitor.metrics.period.seconds", 60, SECONDS);
 
     private final MetricsRegistry metricsRegistry;
     private final long periodMillis;
@@ -35,13 +48,13 @@ public class MetricsPlugin extends PerformanceMonitorPlugin {
     private final ProbeRendererImpl probeRenderer = new ProbeRendererImpl();
 
     public MetricsPlugin(NodeEngineImpl nodeEngine) {
-        this(nodeEngine.getMetricsRegistry(), nodeEngine.getLogger(MetricsPlugin.class), nodeEngine.getNode().groupProperties);
+        this(nodeEngine.getLogger(MetricsPlugin.class), nodeEngine.getMetricsRegistry(), nodeEngine.getNode().groupProperties);
     }
 
-    public MetricsPlugin(MetricsRegistry metricsRegistry, ILogger logger, HazelcastProperties properties) {
+    public MetricsPlugin(ILogger logger, MetricsRegistry metricsRegistry, HazelcastProperties properties) {
         this.metricsRegistry = metricsRegistry;
         this.logger = logger;
-        this.periodMillis = properties.getMillis(PERFORMANCE_MONITOR_METRICS_PERIOD_SECONDS);
+        this.periodMillis = properties.getMillis(PERIOD_SECONDS);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/OverloadedConnectionsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/OverloadedConnectionsPlugin.java
@@ -17,9 +17,11 @@
 package com.hazelcast.internal.monitors;
 
 import com.hazelcast.internal.properties.GroupProperties;
+import com.hazelcast.internal.properties.HazelcastProperty;
+import com.hazelcast.nio.OutboundFrame;
+
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ConnectionManager;
-import com.hazelcast.nio.OutboundFrame;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
@@ -37,11 +39,9 @@ import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
 
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_PERIOD_SECONDS;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_SAMPLES;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_THRESHOLD;
 import static java.lang.Math.min;
 import static java.util.Collections.emptySet;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * The OverloadedConnectionsPlugin checks all the connections and samples the content of the packet
@@ -52,6 +52,34 @@ import static java.util.Collections.emptySet;
  * plugin is disabled by default.
  */
 public class OverloadedConnectionsPlugin extends PerformanceMonitorPlugin {
+
+    /**
+     * The period in seconds the PerformanceMonitor OverloadedConnectionPlugin runs.
+     *
+     * With the OverloadedConnectionsPlugin one can see what is going on inside a connection with a huge
+     * number of pending packets. It makes use of sampling to give some impression of the content.
+     *
+     * This plugin can be very expensive to use and should only be used as a debugging aid; should not be
+     * used in production due to the fact that packets could be deserialized.
+     *
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERIOD_SECONDS
+            = new HazelcastProperty("hazelcast.performance.monitor.overloaded.connections.period.seconds", 0, SECONDS);
+
+    /**
+     * The minimum number of packets in the connection before it is considered to be overloaded.
+     */
+    public static final HazelcastProperty THRESHOLD
+            = new HazelcastProperty("hazelcast.performance.monitor.overloaded.connections.threshold", 10000);
+
+    /**
+     * The number of samples to take from a single overloaded connection. Increasing the number of packes gives
+     * more accurracy of the content, but it will come at greater price.
+     */
+    public static final HazelcastProperty SAMPLES
+            = new HazelcastProperty("hazelcast.performance.monitor.overloaded.connections.samples", 1000);
+
     private static final Queue<OutboundFrame> EMPTY_QUEUE = new LinkedList<OutboundFrame>();
 
     private final SerializationService serializationService;
@@ -72,9 +100,9 @@ public class OverloadedConnectionsPlugin extends PerformanceMonitorPlugin {
         this.defaultFormat.setMinimumFractionDigits(3);
 
         GroupProperties props = nodeEngine.getGroupProperties();
-        this.periodMillis = props.getMillis(PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_PERIOD_SECONDS);
-        this.threshold = props.getInteger(PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_THRESHOLD);
-        this.samples = props.getInteger(PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_SAMPLES);
+        this.periodMillis = props.getMillis(PERIOD_SECONDS);
+        this.threshold = props.getInteger(THRESHOLD);
+        this.samples = props.getInteger(SAMPLES);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PendingInvocationsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PendingInvocationsPlugin.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.monitors;
 
 import com.hazelcast.internal.properties.GroupProperties;
+import com.hazelcast.internal.properties.HazelcastProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
@@ -25,14 +26,33 @@ import com.hazelcast.spi.impl.operationservice.impl.InvocationRegistry;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.util.ItemCounter;
 
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_PENDING_INVOCATIONS_PERIOD_SECONDS;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_PENDING_INVOCATIONS_THRESHOLD;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * A {@link PerformanceMonitorPlugin} that aggregates the pending invocation so that per type of operation, the occurrence
  * count is displayed.
  */
 public final class PendingInvocationsPlugin extends PerformanceMonitorPlugin {
+
+    /**
+     * The period in seconds the PerformanceMonitor PendingInvocationPlugin runs.
+     *
+     * With the pending invocation plugins an aggregation is made per type of operation how many pending
+     * invocations there are.
+     *
+     * This plugin is very cheap to use.
+     *
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERIOD_SECONDS
+            = new HazelcastProperty("hazelcast.performance.monitor.pending.invocations.period.seconds", 0, SECONDS);
+
+    /**
+     * The minimum number of invocations per type of operation before it start logging this particular operation.
+     */
+    public static final HazelcastProperty THRESHOLD
+            = new HazelcastProperty("hazelcast.performance.monitor.pending.invocations.threshold", 1);
+
 
     private final InvocationRegistry invocationRegistry;
     private final ItemCounter<Class> occurrenceMap = new ItemCounter<Class>();
@@ -45,8 +65,8 @@ public final class PendingInvocationsPlugin extends PerformanceMonitorPlugin {
         this.invocationRegistry = ((OperationServiceImpl) operationService).getInvocationRegistry();
         this.logger = nodeEngine.getLogger(PendingInvocationsPlugin.class);
         GroupProperties props = nodeEngine.getGroupProperties();
-        this.periodMillis = props.getMillis(PERFORMANCE_MONITOR_PENDING_INVOCATIONS_PERIOD_SECONDS);
-        this.threshold = props.getInteger(PERFORMANCE_MONITOR_PENDING_INVOCATIONS_THRESHOLD);
+        this.periodMillis = props.getMillis(PERIOD_SECONDS);
+        this.threshold = props.getInteger(THRESHOLD);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/SlowOperationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/SlowOperationPlugin.java
@@ -16,24 +16,40 @@
 
 package com.hazelcast.internal.monitors;
 
+
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
 import com.hazelcast.internal.management.dto.SlowOperationInvocationDTO;
 import com.hazelcast.internal.properties.GroupProperties;
+import com.hazelcast.internal.properties.GroupProperty;
+import com.hazelcast.internal.properties.HazelcastProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 
 import java.util.List;
 
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_SLOW_OPERATIONS_PERIOD_SECONDS;
-import static com.hazelcast.internal.properties.GroupProperty.SLOW_OPERATION_DETECTOR_ENABLED;
+
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * A {@link PerformanceMonitorPlugin} that displays the slow executing operations. For more information see
  * {@link com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationDetector}.
  */
 public class SlowOperationPlugin extends PerformanceMonitorPlugin {
+
+    /**
+     * The period in seconds the SlowOperationPlugin runs.
+     *
+     * With the slow operation plugin, slow executing operation can be found. This is done by checking
+     * on the caller side which operations take a lot of time executing.
+     *
+     * This plugin is very cheap to use.
+     *
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty(
+            "hazelcast.performance.monitor.slowoperations.period.seconds", 60, SECONDS);
 
     private final InternalOperationService operationService;
     private final long periodMillis;
@@ -47,11 +63,11 @@ public class SlowOperationPlugin extends PerformanceMonitorPlugin {
 
     private long getPeriodMillis(NodeEngineImpl nodeEngine) {
         GroupProperties props = nodeEngine.getGroupProperties();
-        if (!props.getBoolean(SLOW_OPERATION_DETECTOR_ENABLED)) {
+        if (!props.getBoolean(GroupProperty.SLOW_OPERATION_DETECTOR_ENABLED)) {
             return DISABLED;
         }
 
-        return props.getMillis(PERFORMANCE_MONITOR_SLOW_OPERATIONS_PERIOD_SECONDS);
+        return props.getMillis(PERIOD_SECONDS);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/properties/GroupProperty.java
@@ -21,7 +21,6 @@ import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.monitors.HealthMonitorLevel;
-import com.hazelcast.internal.monitors.InvocationPlugin;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.query.QueryResultSizeLimiter;
 import com.hazelcast.query.TruePredicate;
@@ -112,136 +111,6 @@ public final class GroupProperty {
      */
     public static final HazelcastProperty PERFORMANCE_METRICS_LEVEL
             = new HazelcastProperty("hazelcast.performance.metric.level", ProbeLevel.MANDATORY.name());
-
-    /**
-     * Use the performance monitor to see internal performance metrics. Currently this is quite
-     * limited since it will only show read/write events per selector and operations executed per operation-thread. But in
-     * the future, all kinds of new metrics will be added.
-     * <p/>
-     * The performance monitor logs all metrics into the log file.
-     * <p/>
-     * For more detailed information, please check the PERFORMANCE_METRICS_LEVEL.
-     * <p/>
-     * The default is false.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_ENABLED
-            = new HazelcastProperty("hazelcast.performance.monitor.enabled", false);
-
-     /**
-     * The PerformanceMonitor uses a rolling file approach to prevent eating too much disk space.
-     * <p/>
-     * This property sets the maximum size in MB for a single file.
-     * <p/>
-     * Every HazelcastInstance will get its own history of log files.
-     * <p/>
-     * The default is 10.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB
-            = new HazelcastProperty("hazelcast.performance.monitor.max.rolled.file.size.mb", 10);
-
-    /**
-     * The PerformanceMonitor uses a rolling file approach to prevent eating too much disk space.
-     * <p/>
-     * This property sets the maximum number of rolling files to keep on disk.
-     * <p/>
-     * The default is 10.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT
-            = new HazelcastProperty("hazelcast.performance.monitor.max.rolled.file.count", 10);
-
-    /**
-     * If a human friendly, but more difficult to parse, output format should be selected for dumping the metrics.
-     * <p/>
-     * The default is true.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT
-            = new HazelcastProperty("hazelcast.performance.monitor.human.friendly.format", true);
-
-    /**
-     * The period in seconds the PerformanceMonitor SlowOperationPlugin runs.
-     *
-     * With the slow operation plugin, slow executing operation can be found. This is done by checking
-     * on the caller side which operations take a lot of time executing.
-     *
-     * This plugin is very cheap to use.
-     *
-     * If set to 0, the plugin is disabled.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_SLOW_OPERATIONS_PERIOD_SECONDS
-            = new HazelcastProperty("hazelcast.performance.monitor.slowoperations.period.seconds", 60, SECONDS);
-
-    /**
-     * The period in seconds the PerformanceMonitor PendingInvocationPlugin runs.
-     *
-     * With the pending invocation plugins an aggregation is made per type of operation how many pending
-     * invocations there are.
-     *
-     * This plugin is very cheap to use.
-     *
-     * If set to 0, the plugin is disabled.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_PENDING_INVOCATIONS_PERIOD_SECONDS
-            = new HazelcastProperty("hazelcast.performance.monitor.pending.invocations.period.seconds", 0, SECONDS);
-
-    /**
-     * The minimum number of invocations per type of operation before it start logging this particular operation.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_PENDING_INVOCATIONS_THRESHOLD
-            = new HazelcastProperty("hazelcast.performance.monitor.pending.invocations.threshold", 1);
-
-    /**
-     * The sample period in seconds for the {@link InvocationPlugin}.
-     *
-     * If set to 0, the plugin is disabled.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS
-            = new HazelcastProperty("hazelcast.performance.monitor.invocation.sample.period.seconds", 0, SECONDS);
-
-    /**
-     * The threshold in seconds for the {@link InvocationPlugin} to consider an invocation to be slow.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_INVOCATION_SLOW_THRESHOLD_SECONDS
-            = new HazelcastProperty("hazelcast.performance.monitor.invocation.slow.threshold.seconds", 5, SECONDS);
-
-    /**
-     * The period in seconds the PerformanceMonitor OverloadedConnectionPlugin runs.
-     *
-     * With the OverloadedConnectionsPlugin one can see what is going on inside a connection with a huge
-     * number of pending packets. It makes use of sampling to give some impression of the content.
-     *
-     * This plugin can be very expensive to use and should only be used as a debugging aid; should not be
-     * used in production due to the fact that packets could be deserialized.
-     *
-     * If set to 0, the plugin is disabled.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_PERIOD_SECONDS
-            = new HazelcastProperty("hazelcast.performance.monitor.overloaded.connections.period.seconds", 0, SECONDS);
-
-    /**
-     * The minimum number of packets in the connection before it is considered to be overloaded.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_THRESHOLD
-            = new HazelcastProperty("hazelcast.performance.monitor.overloaded.connections.threshold", 10000);
-
-    /**
-     * The number of samples to take from a single overloaded connection. Increasing the number of packes gives
-     * more accurracy of the content, but it will come at greater price.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_SAMPLES
-            = new HazelcastProperty("hazelcast.performance.monitor.overloaded.connections.samples", 1000);
-
-    /**
-     * The period in seconds the PerformanceMonitor MetricsPlugin runs.
-     *
-     * The MetricsPlugin does nothing more than frequently writing the content of the MetricsRegistry
-     * to the logfile. For debugging purposes make sure the {@link #PERFORMANCE_METRICS_LEVEL} is set to debug.
-     *
-     * This plugin is very cheap to use.
-     *
-     * If set to 0, the plugin is disabled.
-     */
-    public static final HazelcastProperty PERFORMANCE_MONITOR_METRICS_PERIOD_SECONDS
-            = new HazelcastProperty("hazelcast.performance.monitor.metrics.period.seconds", 60, SECONDS);
 
     /**
      * The number of threads doing socket input and the number of threads doing socket output.
@@ -526,8 +395,8 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.slow.operation.detector.stacktrace.logging.enabled", false);
 
     /**
-     * Property isn't used anymore, use {@link #PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS}.
-      */
+     * Property isn't used anymore.
+     */
     @Deprecated
     public static final HazelcastProperty SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS
             = new HazelcastProperty("hazelcast.slow.invocation.detector.threshold.millis", -1, MILLISECONDS);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -237,7 +237,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public void clearPartition(boolean onShutdown) {
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
+        LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
         if (lockService != null) {
             final DefaultObjectNamespace namespace
                     = new DefaultObjectNamespace(MapService.SERVICE_NAME, name);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -19,6 +19,8 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
+
+import com.hazelcast.core.Member;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.ClusterService;
@@ -35,9 +37,9 @@ import com.hazelcast.internal.monitors.PerformanceMonitor;
 import com.hazelcast.internal.monitors.InvocationPlugin;
 import com.hazelcast.internal.monitors.SlowOperationPlugin;
 import com.hazelcast.internal.monitors.SystemPropertiesPlugin;
-import com.hazelcast.internal.properties.GroupProperties;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationInfo;
+import com.hazelcast.internal.properties.GroupProperties;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
@@ -72,6 +74,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_METRICS_LEVEL;
+import static java.lang.System.currentTimeMillis;
 
 /**
  * The NodeEngineImpl is the where the construction of the Hazelcast dependencies take place. It can be
@@ -107,8 +110,7 @@ public class NodeEngineImpl implements NodeEngine {
         this.loggingService = node.loggingService;
         this.serializationService = node.getSerializationService();
         this.logger = node.getLogger(NodeEngine.class.getName());
-        ProbeLevel probeLevel = node.getGroupProperties().getEnum(PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
-        this.metricsRegistry = new MetricsRegistryImpl(node.getLogger(MetricsRegistryImpl.class), probeLevel);
+        this.metricsRegistry = newMetricRegistry(node);
         this.proxyService = new ProxyServiceImpl(this);
         this.serviceManager = new ServiceManagerImpl(this);
         this.executionService = new ExecutionServiceImpl(this);
@@ -124,8 +126,22 @@ public class NodeEngineImpl implements NodeEngine {
                 wanReplicationService,
                 new ConnectionManagerPacketHandler());
         this.quorumService = new QuorumServiceImpl(this);
-        this.performanceMonitor = new PerformanceMonitor(
-                node.hazelcastInstance,
+        this.performanceMonitor = newPerformanceMonitor();
+    }
+
+    private MetricsRegistryImpl newMetricRegistry(Node node) {
+        ProbeLevel probeLevel = node.getGroupProperties().getEnum(PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+        return new MetricsRegistryImpl(node.getLogger(MetricsRegistryImpl.class), probeLevel);
+    }
+
+    private PerformanceMonitor newPerformanceMonitor() {
+        Member localMember = node.getLocalMember();
+        Address address = localMember.getAddress();
+        String addressString = address.getHost().replace(":", "_") + "#" + address.getPort();
+        String name = "performance-" + addressString + "-" + currentTimeMillis();
+
+        return new PerformanceMonitor(
+                name,
                 loggingService.getLogger(PerformanceMonitor.class),
                 node.getHazelcastThreadGroup(),
                 node.groupProperties);

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/InvocationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/InvocationPluginTest.java
@@ -15,8 +15,6 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_INVOCATION_SLOW_THRESHOLD_SECONDS;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -29,8 +27,8 @@ public class InvocationPluginTest extends AbstractPerformanceMonitorPluginTest {
     @Before
     public void setup() {
         Config config = new Config();
-        config.setProperty(PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS.getName(), "1");
-        config.setProperty(PERFORMANCE_MONITOR_INVOCATION_SLOW_THRESHOLD_SECONDS.getName(), "5");
+        config.setProperty(InvocationPlugin.SAMPLE_PERIOD_SECONDS.getName(), "1");
+        config.setProperty(InvocationPlugin.SLOW_THRESHOLD_SECONDS.getName(), "5");
 
         hz = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/MetricsPluginTest.java
@@ -16,8 +16,6 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_ENABLED;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_METRICS_PERIOD_SECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 
@@ -31,8 +29,8 @@ public class MetricsPluginTest extends AbstractPerformanceMonitorPluginTest {
     @Before
     public void setup() {
         Config config = new Config();
-        config.setProperty(PERFORMANCE_MONITOR_ENABLED.getName(), "true");
-        config.setProperty(PERFORMANCE_MONITOR_METRICS_PERIOD_SECONDS.getName(), "1");
+        config.setProperty(PerformanceMonitor.ENABLED.getName(), "true");
+        config.setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
         HazelcastInstance hz = createHazelcastInstance(config);
         NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(hz);
         metricsRegistry = nodeEngineImpl.getMetricsRegistry();

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/OverloadedConnectionsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/OverloadedConnectionsPluginTest.java
@@ -18,9 +18,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_PERIOD_SECONDS;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_SAMPLES;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_THRESHOLD;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -42,9 +39,9 @@ public class OverloadedConnectionsPluginTest extends AbstractPerformanceMonitorP
         Hazelcast.shutdownAll();
 
         Config config = new Config();
-        config.setProperty(PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_PERIOD_SECONDS.getName(), "1");
-        config.setProperty(PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_SAMPLES.getName(), "10");
-        config.setProperty(PERFORMANCE_MONITOR_OVERLOADED_CONNECTIONS_THRESHOLD.getName(), "10");
+        config.setProperty(OverloadedConnectionsPlugin.PERIOD_SECONDS.getName(), "1");
+        config.setProperty(OverloadedConnectionsPlugin.SAMPLES.getName(), "10");
+        config.setProperty(OverloadedConnectionsPlugin.THRESHOLD.getName(), "10");
 
         local = Hazelcast.newHazelcastInstance(config);
         serializationService = getSerializationService(local);

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/PendingInvocationsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/PendingInvocationsPluginTest.java
@@ -16,8 +16,6 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.Map;
 
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_PENDING_INVOCATIONS_PERIOD_SECONDS;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_PENDING_INVOCATIONS_THRESHOLD;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -30,8 +28,8 @@ public class PendingInvocationsPluginTest extends AbstractPerformanceMonitorPlug
     @Before
     public void setup() {
         Config config = new Config();
-        config.setProperty(PERFORMANCE_MONITOR_PENDING_INVOCATIONS_PERIOD_SECONDS.getName(), "1");
-        config.setProperty(PERFORMANCE_MONITOR_PENDING_INVOCATIONS_THRESHOLD.getName(), "1");
+        config.setProperty(PendingInvocationsPlugin.PERIOD_SECONDS.getName(), "1");
+        config.setProperty(PendingInvocationsPlugin.THRESHOLD.getName(), "1");
 
         hz = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceLogTest.java
@@ -26,10 +26,6 @@ import java.lang.reflect.Field;
 import java.util.LinkedList;
 import java.util.List;
 
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_ENABLED;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB;
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_METRICS_PERIOD_SECONDS;
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -45,10 +41,10 @@ public class PerformanceLogTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         Config config = new Config();
-        config.setProperty(PERFORMANCE_MONITOR_ENABLED.getName(), "true");
-        config.setProperty(PERFORMANCE_MONITOR_METRICS_PERIOD_SECONDS.getName(), "1");
-        config.setProperty(PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB.getName(), "0.2");
-        config.setProperty(PERFORMANCE_MONITOR_MAX_ROLLED_FILE_COUNT.getName(), "3");
+        config.setProperty(PerformanceMonitor.ENABLED.getName(), "true");
+        config.setProperty(PerformanceMonitor.MAX_ROLLED_FILE_SIZE_MB.getName(), "0.2");
+        config.setProperty(PerformanceMonitor.MAX_ROLLED_FILE_COUNT.getName(), "3");
+        config.setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
 
         HazelcastInstance hz = createHazelcastInstance(config);
 
@@ -76,7 +72,7 @@ public class PerformanceLogTest extends HazelcastTestSupport {
     @Test
     public void testDisabledByDefault() {
         GroupProperties groupProperties = new GroupProperties(new Config());
-        assertFalse(groupProperties.getBoolean(PERFORMANCE_MONITOR_ENABLED));
+        assertFalse(groupProperties.getBoolean(PerformanceMonitor.ENABLED));
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/SlowOperationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/SlowOperationPluginTest.java
@@ -15,10 +15,10 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 
-import static com.hazelcast.internal.properties.GroupProperty.PERFORMANCE_MONITOR_SLOW_OPERATIONS_PERIOD_SECONDS;
 import static com.hazelcast.internal.properties.GroupProperty.SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS;
 import static com.hazelcast.internal.properties.GroupProperty.SLOW_OPERATION_DETECTOR_ENABLED;
 import static com.hazelcast.internal.properties.GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS;
+
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -34,7 +34,8 @@ public class SlowOperationPluginTest extends AbstractPerformanceMonitorPluginTes
         config.setProperty(SLOW_OPERATION_DETECTOR_ENABLED.getName(), "true");
         config.setProperty(SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS.getName(), "1000");
         config.setProperty(SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS.getName(), "1000");
-        config.setProperty(PERFORMANCE_MONITOR_SLOW_OPERATIONS_PERIOD_SECONDS.getName(), "1");
+        config.setProperty(SlowOperationPlugin.PERIOD_SECONDS.getName(), "1");
+
 
         hz = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/properties/HazelcastPropertiesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/properties/HazelcastPropertiesTest.java
@@ -135,7 +135,9 @@ public class HazelcastPropertiesTest {
 
     @Test
     public void getBoolean() {
-        boolean isHumanReadable = defaultGroupProperties.getBoolean(GroupProperty.PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT);
+        HazelcastProperty property = new HazelcastProperty("foo","true");
+
+        boolean isHumanReadable = defaultGroupProperties.getBoolean(property);
 
         assertTrue(isHumanReadable);
     }
@@ -156,7 +158,9 @@ public class HazelcastPropertiesTest {
 
     @Test
     public void getFloat() {
-        float maxFileSize = defaultGroupProperties.getFloat(GroupProperty.PERFORMANCE_MONITOR_MAX_ROLLED_FILE_SIZE_MB);
+        HazelcastProperty property = new HazelcastProperty("foo","10");
+
+        float maxFileSize = defaultGroupProperties.getFloat(property);
 
         assertEquals(10, maxFileSize, 0.0001);
     }


### PR DESCRIPTION
It is disabled by default.

The Hazelcast Java client can now benefit from the same metrics (and additional performance plugins)
as the Hazelcast Member. This will help to speed up debugging since we can see better what is happening
inside of the Java client.