### PR TITLE
Introducing `MemoryAccessor` for abstraction on memory access operations

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -99,6 +99,12 @@
     <suppress checks="MethodCount" files="com/hazelcast/concurrent/lock/LockStoreImpl"/>
     <suppress checks="Todo" files="com/hazelcast/concurrent/lock/ConditionImpl"/>
 
+    <!-- Memory -->
+    <suppress checks="MagicNumber|IllegalImport" files="com.hazelcast.internal.memory.impl.UnsafeUtil"/>
+    <suppress checks="MethodCount|IllegalImport" files="com.hazelcast.internal.memory.*MemoryAccessor"/>
+    <suppress checks="MagicNumber" files="com.hazelcast.internal.memory.impl.AlignmentAwareMemoryAccessor"/>
+    <suppress checks="MethodCount|MagicNumber|IllegalImport" files="com.hazelcast.internal.memory.impl.DirectMemoryBits"/>
+
     <!-- OSGI -->
     <suppress checks="MethodCount" files="com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl"/>
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
@@ -1,0 +1,763 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory;
+
+import java.lang.reflect.Field;
+
+/**
+ * <p>
+ * Contract point for memory access operations.
+ * </p>
+ *
+ * <p>
+ * A few notes on this contract point:
+ * <ul>
+ *      <li>
+ *        Addresses are not required to be a native memory addresses.
+ *        It depends on the actual {@link MemoryAccessor} implementation.
+ *      </li>
+ *      <li>
+ *        {@link MemoryAccessor} implementations can be retrieved
+ *        via {@link MemoryAccessorProvider} by specifying {@link MemoryAccessorType}.
+ *      </li>
+ *      <li>
+ *        The default {@link MemoryAccessor} implementation
+ *        can be accessed via #DEFAULT field of this interface
+ *        and its availability state can be checked via #AVAILABLE field.
+ *      </li>
+ * </ul>
+ * </p>
+ *
+ * @see MemoryAccessorType
+ * @see MemoryAccessorProvider
+ */
+public interface MemoryAccessor {
+
+    /**
+     * The default {@link MemoryAccessor} instance.
+     */
+    MemoryAccessor DEFAULT = MemoryAccessorProvider.getDefaultMemoryAccessor();
+
+    /**
+     * State about {@link #DEFAULT} {@link MemoryAccessor} is available to be used.
+     */
+    boolean AVAILABLE = DEFAULT != null;
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Base offset of boolean[]
+     */
+    int ARRAY_BOOLEAN_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(boolean[].class) : -1;
+
+    /**
+     * Base offset of byte[]
+     */
+    int ARRAY_BYTE_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(byte[].class) : -1;
+
+    /**
+     * Base offset of short[]
+     */
+    int ARRAY_SHORT_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(short[].class) : -1;
+
+    /**
+     * Base offset of char[]
+     */
+    int ARRAY_CHAR_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(char[].class) : -1;
+
+    /**
+     * Base offset of int[]
+     */
+    int ARRAY_INT_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(int[].class) : -1;
+
+    /**
+     * Base offset of float[]
+     */
+    int ARRAY_FLOAT_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(float[].class) : -1;
+
+    /**
+     * Base offset of long[]
+     */
+    int ARRAY_LONG_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(long[].class) : -1;
+
+    /**
+     * Base offset of double[]
+     */
+    int ARRAY_DOUBLE_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(double[].class) : -1;
+
+    /**
+     * Base offset of any type of Object[]
+     */
+    int ARRAY_OBJECT_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(Object[].class) : -1;
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Index scale of boolean[]
+     */
+    int ARRAY_BOOLEAN_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(boolean[].class) : -1;
+
+    /**
+     * Index scale of byte[]
+     */
+    int ARRAY_BYTE_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(byte[].class) : -1;
+
+    /**
+     * Index scale of short[]
+     */
+    int ARRAY_SHORT_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(short[].class) : -1;
+
+    /**
+     * Index scale of char[]
+     */
+    int ARRAY_CHAR_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(char[].class) : -1;
+
+    /**
+     * Index scale of int[]
+     */
+    int ARRAY_INT_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(int[].class) : -1;
+
+    /**
+     * Index scale of float[]
+     */
+    int ARRAY_FLOAT_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(float[].class) : -1;
+
+    /**
+     * Index scale of long[]
+     */
+    int ARRAY_LONG_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(long[].class) : -1;
+
+    /**
+     * Index scale of double[]
+     */
+    int ARRAY_DOUBLE_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(double[].class) : -1;
+
+    /**
+     * Index scale of any type of Object[]
+     */
+    int ARRAY_OBJECT_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(Object[].class) : -1;
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Gets the offset of given field.
+     *
+     * @param field the field whose offset is requested
+     * @return the offset of given field
+     */
+    long getObjectFieldOffset(Field field);
+
+    /**
+     * Gets the base offset of the array typed with given class.
+     *
+     * @param arrayClass the type of the array whose base offset is requested
+     * @return the base offset of the array typed with given class
+     */
+    int getArrayBaseOffset(Class<?> arrayClass);
+
+    /**
+     * Gets the index scale of the array typed with given class.
+     *
+     * @param arrayClass the type of the array whose index scale is requested
+     * @return the index scale of the array typed with given class
+     */
+    int getArrayIndexScale(Class<?> arrayClass);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Copies memory from given source address to given destination address
+     * as given size.
+     *
+     * @param srcAddress    the source address to be copied from
+     * @param destAddress   the destination address to be copied to
+     * @param bytes         the number of bytes to be copied
+     */
+    void copyMemory(long srcAddress, long destAddress, long bytes);
+
+    /**
+     * Sets memory with given value from specified address as given size.
+     *
+     * @param address   the start address of the memory region
+     *                  which will be set with given value
+     * @param bytes     the number of bytes to be set
+     * @param value     the value to be set
+     */
+    void setMemory(long address, long bytes, byte value);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Reads the boolean value from given address.
+     *
+     * @param address the address where boolean value will be read from
+     * @return the read value
+     */
+    boolean getBoolean(long address);
+
+    /**
+     * Reads the boolean value from given object by its offset.
+     *
+     * @param o         the object where boolean value will be read from
+     * @param offset    the offset of boolean field relative to object itself
+     * @return the read value
+     */
+    boolean getBoolean(Object o, long offset);
+
+    /**
+     * Reads the boolean value as volatile from given object by its offset.
+     *
+     * @param o         the object where boolean value will be read from
+     * @param offset    the offset of boolean field relative to object itself
+     * @return the read value
+     */
+    boolean getBooleanVolatile(Object o, long offset);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Writes the given boolean value to given address.
+     *
+     * @param address   the address where boolean value will be written to
+     * @param x         the boolean value to be written
+     */
+    void putBoolean(long address, boolean x);
+
+    /**
+     * Writes the boolean value to given object by its offset.
+     *
+     * @param o         the object where boolean value will be written to
+     * @param offset    the offset of boolean field relative to object itself
+     * @param x         the boolean value to be written
+     */
+    void putBoolean(Object o, long offset, boolean x);
+
+    /**
+     * Writes the boolean value as volatile to given object by its offset.
+     *
+     * @param o         the object where boolean value will be written to
+     * @param offset    the offset of boolean field relative to object itself
+     * @param x         the boolean value to be written
+     */
+    void putBooleanVolatile(Object o, long offset, boolean x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Reads the byte value from given address.
+     *
+     * @param address the address where byte value will be read from
+     * @return the read value
+     */
+    byte getByte(long address);
+
+    /**
+     * Reads the byte value from given object by its offset.
+     *
+     * @param o         the object where byte value will be read from
+     * @param offset    the offset of byte field relative to object itself
+     * @return the read value
+     */
+    byte getByte(Object o, long offset);
+
+    /**
+     * Reads the byte value as volatile from given object by its offset.
+     *
+     * @param o         the object where byte value will be read from
+     * @param offset    the offset of byte field relative to object itself
+     * @return the read value
+     */
+    byte getByteVolatile(Object o, long offset);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Writes the given byte value to given address.
+     *
+     * @param address   the address where byte value will be written to
+     * @param x         the byte value to be written
+     */
+    void putByte(long address, byte x);
+
+    /**
+     * Writes the byte value to given object by its offset.
+     *
+     * @param o         the object where byte value will be written to
+     * @param offset    the offset of byte field relative to object itself
+     * @param x         the byte value to be written
+     */
+    void putByte(Object o, long offset, byte x);
+
+    /**
+     * Writes the byte value as volatile to given object by its offset.
+     *
+     * @param o         the object where byte value will be written to
+     * @param offset    the offset of byte field relative to object itself
+     * @param x         the byte value to be written
+     */
+    void putByteVolatile(Object o, long offset, byte x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Reads the char value from given address.
+     *
+     * @param address the address where char value will be read from
+     * @return the read value
+     */
+    char getChar(long address);
+
+    /**
+     * Reads the char value from given object by its offset.
+     *
+     * @param o         the object where char value will be read from
+     * @param offset    the offset of char field relative to object itself
+     * @return the read value
+     */
+    char getChar(Object o, long offset);
+
+    /**
+     * Reads the char value as volatile from given object by its offset.
+     *
+     * @param o         the object where char value will be read from
+     * @param offset    the offset of char field relative to object itself
+     * @return the read value
+     */
+    char getCharVolatile(Object o, long offset);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Writes the given char value to given address.
+     *
+     * @param address   the address where char value will be written to
+     * @param x         the char value to be written
+     */
+    void putChar(long address, char x);
+
+    /**
+     * Writes the char value to given object by its offset.
+     *
+     * @param o         the object where char value will be written to
+     * @param offset    the offset of char field relative to object itself
+     * @param x         the char value to be written
+     */
+    void putChar(Object o, long offset, char x);
+
+    /**
+     * Writes the char value as volatile to given object by its offset.
+     *
+     * @param o         the object where char value will be written to
+     * @param offset    the offset of char field relative to object itself
+     * @param x         the char value to be written
+     */
+    void putCharVolatile(Object o, long offset, char x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Reads the short value from given address.
+     *
+     * @param address the address where short value will be read from
+     * @return the read value
+     */
+    short getShort(long address);
+
+    /**
+     * Reads the short value from given object by its offset.
+     *
+     * @param o         the object where short value will be read from
+     * @param offset    the offset of short field relative to object itself
+     * @return the read value
+     */
+    short getShort(Object o, long offset);
+
+    /**
+     * Reads the short value as volatile from given object by its offset.
+     *
+     * @param o         the object where short value will be read from
+     * @param offset    the offset of short field relative to object itself
+     * @return the read value
+     */
+    short getShortVolatile(Object o, long offset);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Writes the given short value to given address.
+     *
+     * @param address   the address where short value will be written to
+     * @param x         the short value to be written
+     */
+    void putShort(long address, short x);
+
+    /**
+     * Writes the short value to given object by its offset.
+     *
+     * @param o         the object where short value will be written to
+     * @param offset    the offset of short field relative to object itself
+     * @param x         the short value to be written
+     */
+    void putShort(Object o, long offset, short x);
+
+    /**
+     * Writes the short value as volatile to given object by its offset.
+     *
+     * @param o         the object where short value will be written to
+     * @param offset    the offset of short field relative to object itself
+     * @param x         the short value to be written
+     */
+    void putShortVolatile(Object o, long offset, short x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Reads the int value from given address.
+     *
+     * @param address the address where int value will be read from
+     * @return the read value
+     */
+    int getInt(long address);
+
+    /**
+     * Reads the int value from given object by its offset.
+     *
+     * @param o         the object where int value will be read from
+     * @param offset    the offset of int field relative to object itself
+     * @return the read value
+     */
+    int getInt(Object o, long offset);
+
+    /**
+     * Reads the int value as volatile from given object by its offset.
+     *
+     * @param o         the object where int value will be read from
+     * @param offset    the offset of int field relative to object itself
+     * @return the read value
+     */
+    int getIntVolatile(Object o, long offset);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Writes the given int value to given address.
+     *
+     * @param address   the address where int value will be written to
+     * @param x         the int value to be written
+     */
+    void putInt(long address, int x);
+
+    /**
+     * Writes the int value to given object by its offset.
+     *
+     * @param o         the object where int value will be written to
+     * @param offset    the offset of int field relative to object itself
+     * @param x         the int value to be written
+     */
+    void putInt(Object o, long offset, int x);
+
+    /**
+     * Writes the int value as volatile to given object by its offset.
+     *
+     * @param o         the object where int value will be written to
+     * @param offset    the offset of int field relative to object itself
+     * @param x         the int value to be written
+     */
+    void putIntVolatile(Object o, long offset, int x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Reads the float value from given address.
+     *
+     * @param address the address where float value will be read from
+     * @return the read value
+     */
+    float getFloat(long address);
+
+    /**
+     * Reads the float value from given object by its offset.
+     *
+     * @param o         the object where float value will be read from
+     * @param offset    the offset of float field relative to object itself
+     * @return the read value
+     */
+    float getFloat(Object o, long offset);
+
+    /**
+     * Reads the float value as volatile from given object by its offset.
+     *
+     * @param o         the object where float value will be read from
+     * @param offset    the offset of float field relative to object itself
+     * @return the read value
+     */
+    float getFloatVolatile(Object o, long offset);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Writes the given float value to given address.
+     *
+     * @param address   the address where float value will be written to
+     * @param x         the float value to be written
+     */
+    void putFloat(long address, float x);
+
+    /**
+     * Writes the float value to given object by its offset.
+     *
+     * @param o         the object where float value will be written to
+     * @param offset    the offset of float field relative to object itself
+     * @param x         the float value to be written
+     */
+    void putFloat(Object o, long offset, float x);
+
+    /**
+     * Writes the float value as volatile to given object by its offset.
+     *
+     * @param o         the object where float value will be written to
+     * @param offset    the offset of float field relative to object itself
+     * @param x         the float value to be written
+     */
+    void putFloatVolatile(Object o, long offset, float x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Reads the long value from given address.
+     *
+     * @param address the address where long value will be read from
+     * @return the read value
+     */
+    long getLong(long address);
+
+    /**
+     * Reads the long value from given object by its offset.
+     *
+     * @param o         the object where long value will be read from
+     * @param offset    the offset of long field relative to object itself
+     * @return the read value
+     */
+    long getLong(Object o, long offset);
+
+    /**
+     * Reads the long value as volatile from given object by its offset.
+     *
+     * @param o         the object where long value will be read from
+     * @param offset    the offset of long field relative to object itself
+     * @return the read value
+     */
+    long getLongVolatile(Object o, long offset);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Writes the given long value to given address.
+     *
+     * @param address   the address where long value will be written to
+     * @param x         the long value to be written
+     */
+    void putLong(long address, long x);
+
+    /**
+     * Writes the long value to given object by its offset.
+     *
+     * @param o         the object where long value will be written to
+     * @param offset    the offset of long field relative to object itself
+     * @param x         the long value to be written
+     */
+    void putLong(Object o, long offset, long x);
+
+    /**
+     * Writes the long value as volatile to given object by its offset.
+     *
+     * @param o         the object where long value will be written to
+     * @param offset    the offset of long field relative to object itself
+     * @param x         the long value to be written
+     */
+    void putLongVolatile(Object o, long offset, long x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Reads the double value from given address.
+     *
+     * @param address the address where double value will be read from
+     * @return the read value
+     */
+    double getDouble(long address);
+
+    /**
+     * Reads the double value from given object by its offset.
+     *
+     * @param o         the object where double value will be read from
+     * @param offset    the offset of double field relative to object itself
+     * @return the read value
+     */
+    double getDouble(Object o, long offset);
+
+    /**
+     * Reads the double value as volatile from given object by its offset.
+     *
+     * @param o         the object where double value will be read from
+     * @param offset    the offset of double field relative to object itself
+     * @return the read value
+     */
+    double getDoubleVolatile(Object o, long offset);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Writes the given double value to given address.
+     *
+     * @param address   the address where double value will be written to
+     * @param x         the double value to be written
+     */
+    void putDouble(long address, double x);
+
+    /**
+     * Writes the double value to given object by its offset.
+     *
+     * @param o         the object where double value will be written to
+     * @param offset    the offset of double field relative to object itself
+     * @param x         the double value to be written
+     */
+    void putDouble(Object o, long offset, double x);
+
+    /**
+     * Writes the double value as volatile to given object by its offset.
+     *
+     * @param o         the object where double value will be written to
+     * @param offset    the offset of double field relative to object itself
+     * @param x         the double value to be written
+     */
+    void putDoubleVolatile(Object o, long offset, double x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Gets the referenced object from given owner object by its offset.
+     *
+     * @param o         the owner object where the referenced object will be read from
+     * @param offset    the offset of the referenced object field relative to owner object itself
+     * @return the retrieved referenced object
+     */
+    Object getObject(Object o, long offset);
+
+    /**
+     * Gets the referenced object from given owner object as volatile by its offset.
+     *
+     * @param o         the owner object where the referenced object will be read from
+     * @param offset    the offset of the referenced object field relative to owner object itself
+     * @return the retrieved referenced object
+     */
+    Object getObjectVolatile(Object o, long offset);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Puts the referenced object to given owner object by its offset.
+     *
+     * @param o         the owner object where the referenced object will be written to
+     * @param offset    the offset of the referenced object field relative to owner object itself
+     * @param x         the referenced object to be written
+     */
+    void putObject(Object o, long offset, Object x);
+
+    /**
+     * Puts the referenced object to given owner object as volatile by its offset.
+     *
+     * @param o         the owner object where the referenced object will be written to
+     * @param offset    the offset of the referenced object field relative to owner object itself
+     * @param x         the referenced object to be written
+     */
+    void putObjectVolatile(Object o, long offset, Object x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Compares and swaps int value to specified value atomically
+     * based by given object with given offset
+     * if and only if its current value equals to specified expected value.
+     *
+     * @param o         the object where int value will be written to
+     * @param offset    the offset of int field relative to object itself
+     * @param expected  the expected current int value to be set new int value
+     * @param x         the int value to be written
+     * @return
+     */
+    boolean compareAndSwapInt(Object o, long offset, int expected, int x);
+
+    /**
+     * Compares and swaps long value to specified value atomically
+     * based by given object with given offset
+     * if and only if its current value equals to specified expected value.
+     *
+     * @param o         the object where long value will be written to
+     * @param offset    the offset of long field relative to object itself
+     * @param expected  the expected current long value to be set new long value
+     * @param x         the long value to be written
+     * @return <tt>true</tt> if CAS is successful, <tt>false</tt> otherwise
+     */
+    boolean compareAndSwapLong(Object o, long offset, long expected, long x);
+
+    /**
+     * Compares and swaps referenced object to specified object atomically
+     * based by given owner object at given offset
+     * if and only if its current object is the specified object.
+     *
+     * @param o         the owner object where the referenced object will be written to
+     * @param offset    the offset of the referenced object field relative to owner object itself
+     * @param expected  the expected current referenced object to be set new referenced object
+     * @param x         the referenced object to be written
+     * @return <tt>true</tt> if CAS is successful, <tt>false</tt> otherwise
+     */
+    boolean compareAndSwapObject(Object o, long offset, Object expected, Object x);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Puts given int value as ordered to CPU write buffer
+     * based by given object at given offset.
+     *
+     * @param o         the object where int value will be written to
+     * @param offset    the offset of int field relative to object itself
+     * @param x         the int value to be written
+     */
+    void putOrderedInt(Object o, long offset, int x);
+
+    /**
+     * Puts given long value as ordered to CPU write buffer
+     * based by given object at given offset.
+     *
+     * @param o         the object where long value will be written to
+     * @param offset    the offset of long field relative to object itself
+     * @param x         the long value to be written
+     */
+    void putOrderedLong(Object o, long offset, long x);
+
+    /**
+     * Puts given referenced object as ordered to CPU write buffer
+     * based by given owner object at given offset.
+     *
+     * @param o         the owner object where the referenced object will be written to
+     * @param offset    the offset of the referenced object field relative to owner object itself
+     * @param x         the referenced object to be written
+     */
+    void putOrderedObject(Object o, long offset, Object x);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory;
+
+import com.hazelcast.internal.memory.impl.AlignmentAwareMemoryAccessor;
+import com.hazelcast.internal.memory.impl.StandardMemoryAccessor;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Provides {@link MemoryAccessor} implementations as their {@link MemoryAccessorType}.
+ */
+public final class MemoryAccessorProvider {
+
+    private static final Map<MemoryAccessorType, MemoryAccessor> MEMORY_ACCESSOR_MAP
+            = new EnumMap<MemoryAccessorType, MemoryAccessor>(MemoryAccessorType.class);
+
+    static {
+        final boolean unalignedAccessAllowed = isUnalignedAccessAllowed();
+
+        if (StandardMemoryAccessor.isAvailable()) {
+            StandardMemoryAccessor standardMemoryAccessor = new StandardMemoryAccessor();
+            MEMORY_ACCESSOR_MAP.put(MemoryAccessorType.STANDARD, standardMemoryAccessor);
+            if (unalignedAccessAllowed) {
+                MEMORY_ACCESSOR_MAP.put(MemoryAccessorType.PLATFORM_AWARE, standardMemoryAccessor);
+            }
+        }
+
+        if (AlignmentAwareMemoryAccessor.isAvailable()) {
+            AlignmentAwareMemoryAccessor alignmentAwareMemoryAccessor = new AlignmentAwareMemoryAccessor();
+            MEMORY_ACCESSOR_MAP.put(MemoryAccessorType.ALIGNMENT_AWARE, alignmentAwareMemoryAccessor);
+            if (!unalignedAccessAllowed) {
+                MEMORY_ACCESSOR_MAP.put(MemoryAccessorType.PLATFORM_AWARE, alignmentAwareMemoryAccessor);
+            }
+        }
+    }
+
+    private MemoryAccessorProvider() {
+    }
+
+    static boolean isUnalignedAccessAllowed() {
+        // we can't use Unsafe to access memory on platforms where unaligned access is not allowed
+        // see https://github.com/hazelcast/hazelcast/issues/5518 for details.
+        String arch = System.getProperty("os.arch");
+        // list of architectures copied from OpenJDK - java.nio.Bits::unaligned
+        return arch.equals("i386") || arch.equals("x86") || arch.equals("amd64") || arch.equals("x86_64");
+    }
+
+    /**
+     * Gets the {@link MemoryAccessor} instance related with given {@link MemoryAccessorType}.
+     *
+     * @param memoryAccessorType the type of the requested {@link MemoryAccessor}
+     * @return the {@link MemoryAccessor} instance related with given {@link MemoryAccessorType}
+     */
+    public static MemoryAccessor getMemoryAccessor(MemoryAccessorType memoryAccessorType) {
+        return MEMORY_ACCESSOR_MAP.get(memoryAccessorType);
+    }
+
+    /**
+     * Gets the default {@link MemoryAccessor} instance.
+     *
+     * @return the default {@link MemoryAccessor} instance
+     */
+    public static MemoryAccessor getDefaultMemoryAccessor() {
+        return MEMORY_ACCESSOR_MAP.get(MemoryAccessorType.PLATFORM_AWARE);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory;
+
+/**
+ * Types of the {@link MemoryAccessor} implementations.
+ */
+public enum MemoryAccessorType {
+
+    /**
+     * Represents standard {@link MemoryAccessor} directly uses {@link sun.misc.Unsafe} for accessing to memory.
+     *
+     * @see com.hazelcast.internal.memory.impl.StandardMemoryAccessor
+     */
+    STANDARD,
+
+    /**
+     * Represents aligned {@link MemoryAccessor} checks and handles unaligned memory accesses if possible
+     * by using {@link sun.misc.Unsafe} for accessing to memory.
+     *
+     * @see com.hazelcast.internal.memory.impl.AlignmentAwareMemoryAccessor
+     */
+    ALIGNMENT_AWARE,
+
+    /**
+     * Represents {@link MemoryAccessor} that checks underlying platform and behaves regarding to its architecture
+     * as aligned or standard.
+     *
+     * If the underlying platform supports unaligned memory accesses,
+     * it behaves as standard {@link MemoryAccessor} because no need to additional checks.
+     * Otherwise, it behaves as alignment-aware {@link MemoryAccessor}.
+     *
+     * @see com.hazelcast.internal.memory.impl.PlatformAwareMemoryAccessor
+     */
+    PLATFORM_AWARE;
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/AlignmentAwareMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/AlignmentAwareMemoryAccessor.java
@@ -1,0 +1,540 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory.impl;
+
+import java.nio.ByteOrder;
+
+/**
+ * <p>
+ * Aligned {@link com.hazelcast.internal.memory.MemoryAccessor} implementation
+ * that checks and handles unaligned memory accesses if possible
+ * by using {@link sun.misc.Unsafe} for accessing to memory.
+ * </p>
+ *
+ * <p>
+ * A few notes on this implementation:
+ * <ul>
+ *      <li>
+ *        There is no atomicity guarantee for unaligned memory accesses.
+ *        In fact, even on platforms which support unaligned memory accesses,
+ *        there is no guarantee for atomicity when there is unaligned memory accesses.
+ *        On the other hand, on later Intel processor unaligned access
+ *        within the cache line is atomic, but access across the line is not.
+ *        See http://psy-lob-saw.blogspot.com.tr/2013/07/atomicity-of-unaligned-memory-access-in.html
+ *        for more details
+ *      </li>
+ *      <li>
+ *        Unaligned memory accesses are not supported for CAS operations.
+ *      </li>
+ *      <li>
+ *        Unaligned memory accesses are not supported for ordered writes.
+ *      </li>
+ * </ul>
+ * </p>
+ */
+public class AlignmentAwareMemoryAccessor extends StandardMemoryAccessor {
+
+    private static final int OBJECT_REFERENCE_ALIGN = UNSAFE.arrayIndexScale(Object[].class);
+    private static final int OBJECT_REFERENCE_MASK = OBJECT_REFERENCE_ALIGN - 1;
+    private static final boolean BIG_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+
+    public AlignmentAwareMemoryAccessor() {
+        if (!AVAILABLE) {
+            throw new IllegalStateException(getClass().getName() + " can only be used only when Unsafe is available!");
+        }
+    }
+
+    private boolean is2BytesAligned(long value) {
+        return (value & 0x01) == 0;
+    }
+
+    private boolean is4BytesAligned(long value) {
+        return (value & 0x03) == 0;
+    }
+
+    private boolean is8BytesAligned(long value) {
+        return (value & 0x07) == 0;
+    }
+
+    private boolean isReferenceAligned(long offset) {
+        return (offset & OBJECT_REFERENCE_MASK) == 0;
+    }
+
+    private void checkReferenceAligned(long offset) {
+        if (!isReferenceAligned(offset)) {
+            throw new IllegalArgumentException("Memory accesses to references must be "
+                    + OBJECT_REFERENCE_ALIGN + "-bytes aligned, but it is " + offset);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void copyMemory(long srcAddress, long destAddress, long bytes) {
+        // TODO Should we check and handle alignment???
+        super.copyMemory(srcAddress, destAddress, bytes);
+    }
+
+    @Override
+    public void setMemory(long address, long bytes, byte value) {
+        // TODO Should we check and handle alignment???
+        super.setMemory(address, bytes, value);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public char getChar(long address) {
+        if (is2BytesAligned(address)) {
+            return super.getChar(address);
+        } else {
+            return DirectMemoryBits.readChar(address, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public char getChar(Object o, long offset) {
+        if (is2BytesAligned(offset)) {
+            return super.getChar(o, offset);
+        } else {
+            return DirectMemoryBits.readChar(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public char getCharVolatile(Object o, long offset) {
+        if (is2BytesAligned(offset)) {
+            return super.getCharVolatile(o, offset);
+        } else {
+            return DirectMemoryBits.readCharVolatile(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putChar(long address, char x) {
+        if (is2BytesAligned(address)) {
+            super.putChar(address, x);
+        } else {
+            DirectMemoryBits.writeChar(address, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putChar(Object o, long offset, char x) {
+        if (is2BytesAligned(offset)) {
+            super.putChar(o, offset, x);
+        } else {
+            DirectMemoryBits.writeChar(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putCharVolatile(Object o, long offset, char x) {
+        if (is2BytesAligned(offset)) {
+            super.putChar(o, offset, x);
+        } else {
+            DirectMemoryBits.writeCharVolatile(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public short getShort(long address) {
+        if (is2BytesAligned(address)) {
+            return super.getShort(address);
+        } else {
+            return DirectMemoryBits.readShort(address, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public short getShort(Object o, long offset) {
+        if (is2BytesAligned(offset)) {
+            return super.getShort(o, offset);
+        } else {
+            return DirectMemoryBits.readShort(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public short getShortVolatile(Object o, long offset) {
+        if (is2BytesAligned(offset)) {
+            return super.getShortVolatile(o, offset);
+        } else {
+            return DirectMemoryBits.readShortVolatile(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putShort(long address, short x) {
+        if (is2BytesAligned(address)) {
+            super.putShort(address, x);
+        } else {
+            DirectMemoryBits.writeShort(address, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putShort(Object o, long offset, short x) {
+        if (is2BytesAligned(offset)) {
+            super.putShort(o, offset, x);
+        } else {
+            DirectMemoryBits.writeShort(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putShortVolatile(Object o, long offset, short x) {
+        if (is2BytesAligned(offset)) {
+            super.putShortVolatile(o, offset, x);
+        } else {
+            DirectMemoryBits.writeShortVolatile(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public int getInt(long address) {
+        if (is4BytesAligned(address)) {
+            return super.getInt(address);
+        } else {
+            return DirectMemoryBits.readInt(address, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public int getInt(Object o, long offset) {
+        if (is4BytesAligned(offset)) {
+            return super.getInt(o, offset);
+        } else {
+            return DirectMemoryBits.readInt(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public int getIntVolatile(Object o, long offset) {
+        if (is4BytesAligned(offset)) {
+            return super.getIntVolatile(o, offset);
+        } else {
+            return DirectMemoryBits.readIntVolatile(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putInt(long address, int x) {
+        if (is4BytesAligned(address)) {
+            super.putInt(address, x);
+        } else {
+            DirectMemoryBits.writeInt(address, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putInt(Object o, long offset, int x) {
+        if (is4BytesAligned(offset)) {
+            super.putInt(o, offset, x);
+        } else {
+            DirectMemoryBits.writeInt(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putIntVolatile(Object o, long offset, int x) {
+        if (is4BytesAligned(offset)) {
+            super.putIntVolatile(o, offset, x);
+        } else {
+            DirectMemoryBits.writeIntVolatile(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public float getFloat(long address) {
+        if (is4BytesAligned(address)) {
+            return super.getFloat(address);
+        } else {
+            return DirectMemoryBits.readFloat(address, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public float getFloat(Object o, long offset) {
+        if (is4BytesAligned(offset)) {
+            return super.getFloat(o, offset);
+        } else {
+            return DirectMemoryBits.readFloat(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public float getFloatVolatile(Object o, long offset) {
+        if (is4BytesAligned(offset)) {
+            return super.getFloatVolatile(o, offset);
+        } else {
+            return DirectMemoryBits.readFloatVolatile(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putFloat(long address, float x) {
+        if (is4BytesAligned(address)) {
+            super.putFloat(address, x);
+        } else {
+            DirectMemoryBits.writeFloat(address, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putFloat(Object o, long offset, float x) {
+        if (is4BytesAligned(offset)) {
+            super.putFloat(o, offset, x);
+        } else {
+            DirectMemoryBits.writeFloat(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putFloatVolatile(Object o, long offset, float x) {
+        if (is4BytesAligned(offset)) {
+            super.putFloatVolatile(o, offset, x);
+        } else {
+            DirectMemoryBits.writeFloatVolatile(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public long getLong(long address) {
+        if (is8BytesAligned(address)) {
+            return super.getLong(address);
+        } else {
+            return DirectMemoryBits.readLong(address, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public long getLong(Object o, long offset) {
+        if (is8BytesAligned(offset)) {
+            return super.getLong(o, offset);
+        } else {
+            return DirectMemoryBits.readLong(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public long getLongVolatile(Object o, long offset) {
+        if (is8BytesAligned(offset)) {
+            return super.getLongVolatile(o, offset);
+        } else {
+            return DirectMemoryBits.readLongVolatile(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putLong(long address, long x) {
+        if (is8BytesAligned(address)) {
+            super.putLong(address, x);
+        } else {
+            DirectMemoryBits.writeLong(address, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putLong(Object o, long offset, long x) {
+        if (is8BytesAligned(offset)) {
+            super.putLong(o, offset, x);
+        } else {
+            DirectMemoryBits.writeLong(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putLongVolatile(Object o, long offset, long x) {
+        if (is8BytesAligned(offset)) {
+            super.putLongVolatile(o, offset, x);
+        } else {
+            DirectMemoryBits.writeLongVolatile(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public double getDouble(long address) {
+        if (is8BytesAligned(address)) {
+            return super.getDouble(address);
+        } else {
+            return DirectMemoryBits.readDouble(address, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public double getDouble(Object o, long offset) {
+        if (is8BytesAligned(offset)) {
+            return super.getDouble(o, offset);
+        } else {
+            return DirectMemoryBits.readDouble(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public double getDoubleVolatile(Object o, long offset) {
+        if (is8BytesAligned(offset)) {
+            return super.getDoubleVolatile(o, offset);
+        } else {
+            return DirectMemoryBits.readDoubleVolatile(o, offset, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putDouble(long address, double x) {
+        if (is8BytesAligned(address)) {
+            super.putDouble(address, x);
+        } else {
+            DirectMemoryBits.writeDouble(address, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putDouble(Object o, long offset, double x) {
+        if (is8BytesAligned(offset)) {
+            super.putDouble(o, offset, x);
+        } else {
+            DirectMemoryBits.writeDouble(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    @Override
+    public void putDoubleVolatile(Object o, long offset, double x) {
+        if (is8BytesAligned(offset)) {
+            super.putDoubleVolatile(o, offset, x);
+        } else {
+            DirectMemoryBits.writeDoubleVolatile(o, offset, x, BIG_ENDIAN);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public Object getObject(Object o, long offset) {
+        checkReferenceAligned(offset);
+        return super.getObject(o, offset);
+    }
+
+    @Override
+    public Object getObjectVolatile(Object o, long offset) {
+        checkReferenceAligned(offset);
+        return super.getObjectVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putObject(Object o, long offset, Object x) {
+        checkReferenceAligned(offset);
+        super.putObject(o, offset, x);
+    }
+
+    @Override
+    public void putObjectVolatile(Object o, long offset, Object x) {
+        checkReferenceAligned(offset);
+        super.putObjectVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public boolean compareAndSwapInt(Object o, long offset, int expected, int x) {
+        if (is4BytesAligned(offset)) {
+            return super.compareAndSwapInt(o, offset, expected, x);
+        } else {
+            throw new IllegalArgumentException("Unaligned memory accesses are not supported for CAS operations. "
+                    + "Offset must be 4-bytes aligned for integer typed CAS, but it is " + offset);
+        }
+    }
+
+    @Override
+    public boolean compareAndSwapLong(Object o, long offset, long expected, long x) {
+        if (is4BytesAligned(offset)) {
+            return super.compareAndSwapLong(o, offset, expected, x);
+        } else {
+            throw new IllegalArgumentException("Unaligned memory accesses are not supported for CAS operations. "
+                    + "Offset must be 8-bytes aligned for long typed CAS, but it is " + offset);
+        }
+    }
+
+    @Override
+    public boolean compareAndSwapObject(Object o, long offset, Object expected, Object x) {
+        if (isReferenceAligned(offset)) {
+            return super.compareAndSwapObject(o, offset, expected, x);
+        } else {
+            throw new IllegalArgumentException("Unaligned memory accesses are not supported for CAS operations. "
+                    + "Offset must be " + OBJECT_REFERENCE_ALIGN + "-bytes "
+                    + "aligned for object reference typed CAS, but it is " + offset);
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putOrderedInt(Object o, long offset, int x) {
+        if (is4BytesAligned(offset)) {
+            super.putOrderedInt(o, offset, x);
+        } else {
+            throw new IllegalArgumentException("Unaligned memory accesses are not supported for ordered writes. "
+                    + "Offset must be 4-bytes aligned for integer typed ordered write, but it is " + offset);
+        }
+    }
+
+    @Override
+    public void putOrderedLong(Object o, long offset, long x) {
+        if (is8BytesAligned(offset)) {
+            super.putOrderedLong(o, offset, x);
+        } else {
+            throw new IllegalArgumentException("Unaligned memory accesses are not supported for ordered writes. "
+                    + "Offset must be 8-bytes aligned for long typed ordered write, but it is " + offset);
+        }
+    }
+
+    @Override
+    public void putOrderedObject(Object o, long offset, Object x) {
+        if (isReferenceAligned(offset)) {
+            super.putOrderedObject(o, offset, x);
+        } else {
+            throw new IllegalArgumentException("Unaligned memory accesses are not supported for CAS operations. "
+                    + "Offset must be " + OBJECT_REFERENCE_ALIGN + "-bytes "
+                    + "aligned for object reference typed ordered writes, but it is " + offset);
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/DirectMemoryBits.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/DirectMemoryBits.java
@@ -1,0 +1,745 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory.impl;
+
+import sun.misc.Unsafe;
+
+/**
+ * Utility class to read/write bits to given location (by base object/offset or native memory address)
+ * by specified byte order (little/big endian).
+ */
+public final class DirectMemoryBits {
+
+    private static final Unsafe UNSAFE = UnsafeUtil.UNSAFE;
+    private static final int BYTE_ARRAY_BASE_OFFSET = UNSAFE != null ? UNSAFE.arrayBaseOffset(byte[].class) : -1;
+
+    private DirectMemoryBits() {
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static char readChar(long address, boolean bigEndian) {
+        return readChar(null, address, bigEndian);
+    }
+
+    public static char readChar(byte[] buffer, int pos, boolean bigEndian) {
+        return readChar(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static char readChar(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readCharB(base, offset);
+        } else {
+            return readCharL(base, offset);
+        }
+    }
+
+    public static char readCharB(Object base, long offset) {
+        int byte1 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte0 = UNSAFE.getByte(base, offset + 1) & 0xFF;
+        return (char) ((byte1 << 8) + byte0);
+    }
+
+    public static char readCharL(Object base, long offset) {
+        int byte1 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte0 = UNSAFE.getByte(base, offset + 1) & 0xFF;
+        return (char) ((byte0 << 8) + byte1);
+    }
+
+    public static void writeChar(long address, char v, boolean bigEndian) {
+        writeChar(null, address, v, bigEndian);
+    }
+
+    public static void writeChar(byte[] buffer, int pos, char v, boolean bigEndian) {
+        writeChar(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeChar(Object base, long offset, char v, boolean bigEndian) {
+        if (bigEndian) {
+            writeCharB(base, offset, v);
+        } else {
+            writeCharL(base, offset, v);
+        }
+    }
+
+    public static void writeCharB(Object base, long offset, char v) {
+        UNSAFE.putByte(base, offset, (byte) ((v >>> 8) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v) & 0xFF));
+    }
+
+    public static void writeCharL(Object base, long offset, char v) {
+        UNSAFE.putByte(base, offset, (byte) ((v) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v >>> 8) & 0xFF));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static short readShort(long address, boolean bigEndian) {
+        return readShort(null, address, bigEndian);
+    }
+
+    public static short readShort(byte[] buffer, int pos, boolean bigEndian) {
+        return readShort(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static short readShort(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readShortB(base, offset);
+        } else {
+            return readShortL(base, offset);
+        }
+    }
+
+    public static short readShortB(Object base, long offset) {
+        int byte1 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte0 = UNSAFE.getByte(base, offset + 1) & 0xFF;
+        return (short) ((byte1 << 8) + byte0);
+    }
+
+    public static short readShortL(Object base, long offset) {
+        int byte1 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte0 = UNSAFE.getByte(base, offset + 1) & 0xFF;
+        return (short) ((byte0 << 8) + byte1);
+    }
+
+    public static void writeShort(long address, short v, boolean bigEndian) {
+        writeShort(null, address, v, bigEndian);
+    }
+
+    public static void writeShort(byte[] buffer, int pos, short v, boolean bigEndian) {
+        writeShort(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeShort(Object base, long offset, short v, boolean bigEndian) {
+        if (bigEndian) {
+            writeShortB(base, offset, v);
+        } else {
+            writeShortL(base, offset, v);
+        }
+    }
+
+    public static void writeShortB(Object base, long offset, short v) {
+        UNSAFE.putByte(base, offset, (byte) ((v >>> 8) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v) & 0xFF));
+    }
+
+    public static void writeShortL(Object base, long offset, short v) {
+        UNSAFE.putByte(base, offset, (byte) ((v) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v >>> 8) & 0xFF));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static int readInt(long address, boolean bigEndian) {
+        return readInt(null, address, bigEndian);
+    }
+
+    public static int readInt(byte[] buffer, int pos, boolean bigEndian) {
+        return readInt(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static int readInt(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readIntB(base, offset);
+        } else {
+            return readIntL(base, offset);
+        }
+    }
+
+    public static int readIntB(Object base, long offset) {
+        int byte3 = (UNSAFE.getByte(base, offset) & 0xFF) << 24;
+        int byte2 = (UNSAFE.getByte(base, offset + 1) & 0xFF) << 16;
+        int byte1 = (UNSAFE.getByte(base, offset + 2) & 0xFF) << 8;
+        int byte0 = UNSAFE.getByte(base, offset + 3) & 0xFF;
+        return byte3 + byte2 + byte1 + byte0;
+    }
+
+    public static int readIntL(Object base, long offset) {
+        int byte3 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte2 = (UNSAFE.getByte(base, offset + 1) & 0xFF) << 8;
+        int byte1 = (UNSAFE.getByte(base, offset + 2) & 0xFF) << 16;
+        int byte0 = (UNSAFE.getByte(base, offset + 3) & 0xFF) << 24;
+        return byte3 + byte2 + byte1 + byte0;
+    }
+
+    public static void writeInt(long address, int v, boolean bigEndian) {
+        writeInt(null, address, v, bigEndian);
+    }
+
+    public static void writeInt(byte[] buffer, int pos, int v, boolean bigEndian) {
+        writeInt(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeInt(Object base, long offset, int v, boolean bigEndian) {
+        if (bigEndian) {
+            writeIntB(base, offset, v);
+        } else {
+            writeIntL(base, offset, v);
+        }
+    }
+
+    public static void writeIntB(Object base, long offset, int v) {
+        UNSAFE.putByte(base, offset, (byte) ((v >>> 24) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v >>> 16) & 0xFF));
+        UNSAFE.putByte(base, offset + 2, (byte) ((v >>> 8) & 0xFF));
+        UNSAFE.putByte(base, offset + 3, (byte) ((v) & 0xFF));
+    }
+
+    public static void writeIntL(Object base, long offset, int v) {
+        UNSAFE.putByte(base, offset, (byte) ((v) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v >>> 8) & 0xFF));
+        UNSAFE.putByte(base, offset + 2, (byte) ((v >>> 16) & 0xFF));
+        UNSAFE.putByte(base, offset + 3, (byte) ((v >>> 24) & 0xFF));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static float readFloat(long address, boolean bigEndian) {
+        return readFloat(null, address, bigEndian);
+    }
+
+    public static float readFloat(byte[] buffer, int pos, boolean bigEndian) {
+        return readFloat(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static float readFloat(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readFloatB(base, offset);
+        } else {
+            return readFloatL(base, offset);
+        }
+    }
+
+    public static float readFloatB(Object base, long offset) {
+        return Float.intBitsToFloat(readIntB(base, offset));
+    }
+
+    public static float readFloatL(Object base, long offset) {
+        return Float.intBitsToFloat(readIntL(base, offset));
+    }
+
+    public static void writeFloat(long address, float v, boolean bigEndian) {
+        writeFloat(null, address, v, bigEndian);
+    }
+
+    public static void writeFloat(byte[] buffer, int pos, float v, boolean bigEndian) {
+        writeFloat(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeFloat(Object base, long offset, float v, boolean bigEndian) {
+        if (bigEndian) {
+            writeFloatB(base, offset, v);
+        } else {
+            writeFloatL(base, offset, v);
+        }
+    }
+
+    public static void writeFloatB(Object base, long offset, float v) {
+        writeIntB(base, offset, Float.floatToRawIntBits(v));
+    }
+
+    public static void writeFloatL(Object base, long offset, float v) {
+        writeIntL(base, offset, Float.floatToRawIntBits(v));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static long readLong(long address, boolean bigEndian) {
+        return readLong(null, address, bigEndian);
+    }
+
+    public static long readLong(byte[] buffer, int pos, boolean bigEndian) {
+        return readLong(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static long readLong(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readLongB(base, offset);
+        } else {
+            return readLongL(base, offset);
+        }
+    }
+
+    public static long readLongB(Object base, long offset) {
+        long byte7 = (long) UNSAFE.getByte(base, offset) << 56;
+        long byte6 = (long) (UNSAFE.getByte(base, offset + 1) & 0xFF) << 48;
+        long byte5 = (long) (UNSAFE.getByte(base, offset + 2) & 0xFF) << 40;
+        long byte4 = (long) (UNSAFE.getByte(base, offset + 3) & 0xFF) << 32;
+        long byte3 = (long) (UNSAFE.getByte(base, offset + 4) & 0xFF) << 24;
+        long byte2 = (long) (UNSAFE.getByte(base, offset + 5) & 0xFF) << 16;
+        long byte1 = (long) (UNSAFE.getByte(base, offset + 6) & 0xFF) << 8;
+        long byte0 = (long) (UNSAFE.getByte(base, offset + 7) & 0xFF);
+        return byte7 + byte6 + byte5 + byte4 + byte3 + byte2 + byte1 + byte0;
+    }
+
+    public static long readLongL(Object base, long offset) {
+        long byte7 = (long) (UNSAFE.getByte(base, offset) & 0xFF);
+        long byte6 = (long) (UNSAFE.getByte(base, offset + 1) & 0xFF) << 8;
+        long byte5 = (long) (UNSAFE.getByte(base, offset + 2) & 0xFF) << 16;
+        long byte4 = (long) (UNSAFE.getByte(base, offset + 3) & 0xFF) << 24;
+        long byte3 = (long) (UNSAFE.getByte(base, offset + 4) & 0xFF) << 32;
+        long byte2 = (long) (UNSAFE.getByte(base, offset + 5) & 0xFF) << 40;
+        long byte1 = (long) (UNSAFE.getByte(base, offset + 6) & 0xFF) << 48;
+        long byte0 = (long) (UNSAFE.getByte(base, offset + 7) & 0xFF) << 56;
+        return byte7 + byte6 + byte5 + byte4 + byte3 + byte2 + byte1 + byte0;
+    }
+
+    public static void writeLong(long address, long v, boolean bigEndian) {
+        writeLong(null, address, v, bigEndian);
+    }
+
+    public static void writeLong(byte[] buffer, int pos, long v, boolean bigEndian) {
+        writeLong(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeLong(Object base, long offset, long v, boolean bigEndian) {
+        if (bigEndian) {
+            writeLongB(base, offset, v);
+        } else {
+            writeLongL(base, offset, v);
+        }
+    }
+
+    public static void writeLongB(Object base, long offset, long v) {
+        UNSAFE.putByte(base, offset, (byte) (v >>> 56));
+        UNSAFE.putByte(base, offset + 1, (byte) (v >>> 48));
+        UNSAFE.putByte(base, offset + 2, (byte) (v >>> 40));
+        UNSAFE.putByte(base, offset + 3, (byte) (v >>> 32));
+        UNSAFE.putByte(base, offset + 4, (byte) (v >>> 24));
+        UNSAFE.putByte(base, offset + 5, (byte) (v >>> 16));
+        UNSAFE.putByte(base, offset + 6, (byte) (v >>> 8));
+        UNSAFE.putByte(base, offset + 7, (byte) (v));
+    }
+
+    public static void writeLongL(Object base, long offset, long v) {
+        UNSAFE.putByte(base, offset, (byte) (v));
+        UNSAFE.putByte(base, offset + 1, (byte) (v >>> 8));
+        UNSAFE.putByte(base, offset + 2, (byte) (v >>> 16));
+        UNSAFE.putByte(base, offset + 3, (byte) (v >>> 24));
+        UNSAFE.putByte(base, offset + 4, (byte) (v >>> 32));
+        UNSAFE.putByte(base, offset + 5, (byte) (v >>> 40));
+        UNSAFE.putByte(base, offset + 6, (byte) (v >>> 48));
+        UNSAFE.putByte(base, offset + 7, (byte) (v >>> 56));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static double readDouble(long address, boolean bigEndian) {
+        return readDouble(null, address, bigEndian);
+    }
+
+    public static double readDouble(byte[] buffer, int pos, boolean bigEndian) {
+        return readDouble(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static double readDouble(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readDoubleB(base, offset);
+        } else {
+            return readDoubleL(base, offset);
+        }
+    }
+
+    public static double readDoubleB(Object base, long offset) {
+        return Double.longBitsToDouble(readLongB(base, offset));
+    }
+
+    public static double readDoubleL(Object base, long offset) {
+        return Double.longBitsToDouble(readLongL(base, offset));
+    }
+
+    public static void writeDouble(long address, double v, boolean bigEndian) {
+        writeDouble(null, address, v, bigEndian);
+    }
+
+    public static void writeDouble(byte[] buffer, int pos, double v, boolean bigEndian) {
+        writeDouble(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeDouble(Object base, long offset, double v, boolean bigEndian) {
+        if (bigEndian) {
+            writeDoubleB(base, offset, v);
+        } else {
+            writeDoubleL(base, offset, v);
+        }
+    }
+
+    public static void writeDoubleB(Object base, long offset, double v) {
+        writeLongB(base, offset, Double.doubleToRawLongBits(v));
+    }
+
+    public static void writeDoubleL(Object base, long offset, double v) {
+        writeLongL(base, offset, Double.doubleToRawLongBits(v));
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public static char readCharVolatile(long address, boolean bigEndian) {
+        return readCharVolatile(null, address, bigEndian);
+    }
+
+    public static char readCharVolatile(byte[] buffer, int pos, boolean bigEndian) {
+        return readCharVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static char readCharVolatile(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readCharVolatileB(base, offset);
+        } else {
+            return readCharVolatileL(base, offset);
+        }
+    }
+
+    public static char readCharVolatileB(Object base, long offset) {
+        int byte1 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte0 = UNSAFE.getByte(base, offset + 1) & 0xFF;
+        return (char) ((byte1 << 8) + byte0);
+    }
+
+    public static char readCharVolatileL(Object base, long offset) {
+        int byte1 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte0 = UNSAFE.getByte(base, offset + 1) & 0xFF;
+        return (char) ((byte0 << 8) + byte1);
+    }
+
+    public static void writeCharVolatile(long address, char v, boolean bigEndian) {
+        writeCharVolatile(null, address, v, bigEndian);
+    }
+
+    public static void writeCharVolatile(byte[] buffer, int pos, char v, boolean bigEndian) {
+        writeCharVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeCharVolatile(Object base, long offset, char v, boolean bigEndian) {
+        if (bigEndian) {
+            writeCharVolatileB(base, offset, v);
+        } else {
+            writeCharVolatileL(base, offset, v);
+        }
+    }
+
+    public static void writeCharVolatileB(Object base, long offset, char v) {
+        UNSAFE.putByte(base, offset, (byte) ((v >>> 8) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v) & 0xFF));
+    }
+
+    public static void writeCharVolatileL(Object base, long offset, char v) {
+        UNSAFE.putByte(base, offset, (byte) ((v) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v >>> 8) & 0xFF));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static short readShortVolatile(long address, boolean bigEndian) {
+        return readShortVolatile(null, address, bigEndian);
+    }
+
+    public static short readShortVolatile(byte[] buffer, int pos, boolean bigEndian) {
+        return readShortVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static short readShortVolatile(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readShortVolatileB(base, offset);
+        } else {
+            return readShortVolatileL(base, offset);
+        }
+    }
+
+    public static short readShortVolatileB(Object base, long offset) {
+        int byte1 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte0 = UNSAFE.getByte(base, offset + 1) & 0xFF;
+        return (short) ((byte1 << 8) + byte0);
+    }
+
+    public static short readShortVolatileL(Object base, long offset) {
+        int byte1 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte0 = UNSAFE.getByte(base, offset + 1) & 0xFF;
+        return (short) ((byte0 << 8) + byte1);
+    }
+
+    public static void writeShortVolatile(long address, short v, boolean bigEndian) {
+        writeShortVolatile(null, address, v, bigEndian);
+    }
+
+    public static void writeShortVolatile(byte[] buffer, int pos, short v, boolean bigEndian) {
+        writeShortVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeShortVolatile(Object base, long offset, short v, boolean bigEndian) {
+        if (bigEndian) {
+            writeShortVolatileB(base, offset, v);
+        } else {
+            writeShortVolatileL(base, offset, v);
+        }
+    }
+
+    public static void writeShortVolatileB(Object base, long offset, short v) {
+        UNSAFE.putByte(base, offset, (byte) ((v >>> 8) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v) & 0xFF));
+    }
+
+    public static void writeShortVolatileL(Object base, long offset, short v) {
+        UNSAFE.putByte(base, offset, (byte) ((v) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v >>> 8) & 0xFF));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static int readIntVolatile(long address, boolean bigEndian) {
+        return readIntVolatile(null, address, bigEndian);
+    }
+
+    public static int readIntVolatile(byte[] buffer, int pos, boolean bigEndian) {
+        return readIntVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static int readIntVolatile(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readIntVolatileB(base, offset);
+        } else {
+            return readIntVolatileL(base, offset);
+        }
+    }
+
+    public static int readIntVolatileB(Object base, long offset) {
+        int byte3 = (UNSAFE.getByte(base, offset) & 0xFF) << 24;
+        int byte2 = (UNSAFE.getByte(base, offset + 1) & 0xFF) << 16;
+        int byte1 = (UNSAFE.getByte(base, offset + 2) & 0xFF) << 8;
+        int byte0 = UNSAFE.getByte(base, offset + 3) & 0xFF;
+        return byte3 + byte2 + byte1 + byte0;
+    }
+
+    public static int readIntVolatileL(Object base, long offset) {
+        int byte3 = UNSAFE.getByte(base, offset) & 0xFF;
+        int byte2 = (UNSAFE.getByte(base, offset + 1) & 0xFF) << 8;
+        int byte1 = (UNSAFE.getByte(base, offset + 2) & 0xFF) << 16;
+        int byte0 = (UNSAFE.getByte(base, offset + 3) & 0xFF) << 24;
+        return byte3 + byte2 + byte1 + byte0;
+    }
+
+    public static void writeIntVolatile(long address, int v, boolean bigEndian) {
+        writeIntVolatile(null, address, v, bigEndian);
+    }
+
+    public static void writeIntVolatile(byte[] buffer, int pos, int v, boolean bigEndian) {
+        writeIntVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeIntVolatile(Object base, long offset, int v, boolean bigEndian) {
+        if (bigEndian) {
+            writeIntVolatileB(base, offset, v);
+        } else {
+            writeIntVolatileL(base, offset, v);
+        }
+    }
+
+    public static void writeIntVolatileB(Object base, long offset, int v) {
+        UNSAFE.putByte(base, offset, (byte) ((v >>> 24) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v >>> 16) & 0xFF));
+        UNSAFE.putByte(base, offset + 2, (byte) ((v >>> 8) & 0xFF));
+        UNSAFE.putByte(base, offset + 3, (byte) ((v) & 0xFF));
+    }
+
+    public static void writeIntVolatileL(Object base, long offset, int v) {
+        UNSAFE.putByte(base, offset, (byte) ((v) & 0xFF));
+        UNSAFE.putByte(base, offset + 1, (byte) ((v >>> 8) & 0xFF));
+        UNSAFE.putByte(base, offset + 2, (byte) ((v >>> 16) & 0xFF));
+        UNSAFE.putByte(base, offset + 3, (byte) ((v >>> 24) & 0xFF));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static float readFloatVolatile(long address, boolean bigEndian) {
+        return readFloatVolatile(null, address, bigEndian);
+    }
+
+    public static float readFloatVolatile(byte[] buffer, int pos, boolean bigEndian) {
+        return readFloatVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static float readFloatVolatile(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readFloatVolatileB(base, offset);
+        } else {
+            return readFloatVolatileL(base, offset);
+        }
+    }
+
+    public static float readFloatVolatileB(Object base, long offset) {
+        return Float.intBitsToFloat(readIntVolatileB(base, offset));
+    }
+
+    public static float readFloatVolatileL(Object base, long offset) {
+        return Float.intBitsToFloat(readIntVolatileL(base, offset));
+    }
+
+    public static void writeFloatVolatile(long address, float v, boolean bigEndian) {
+        writeFloatVolatile(null, address, v, bigEndian);
+    }
+
+    public static void writeFloatVolatile(byte[] buffer, int pos, float v, boolean bigEndian) {
+        writeFloatVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeFloatVolatile(Object base, long offset, float v, boolean bigEndian) {
+        if (bigEndian) {
+            writeFloatVolatileB(base, offset, v);
+        } else {
+            writeFloatVolatileL(base, offset, v);
+        }
+    }
+
+    public static void writeFloatVolatileB(Object base, long offset, float v) {
+        writeIntVolatileB(base, offset, Float.floatToRawIntBits(v));
+    }
+
+    public static void writeFloatVolatileL(Object base, long offset, float v) {
+        writeIntVolatileL(base, offset, Float.floatToRawIntBits(v));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static long readLongVolatile(long address, boolean bigEndian) {
+        return readLongVolatile(null, address, bigEndian);
+    }
+
+    public static long readLongVolatile(byte[] buffer, int pos, boolean bigEndian) {
+        return readLongVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static long readLongVolatile(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readLongVolatileB(base, offset);
+        } else {
+            return readLongVolatileL(base, offset);
+        }
+    }
+
+    public static long readLongVolatileB(Object base, long offset) {
+        long byte7 = (long) UNSAFE.getByte(base, offset) << 56;
+        long byte6 = (long) (UNSAFE.getByte(base, offset + 1) & 0xFF) << 48;
+        long byte5 = (long) (UNSAFE.getByte(base, offset + 2) & 0xFF) << 40;
+        long byte4 = (long) (UNSAFE.getByte(base, offset + 3) & 0xFF) << 32;
+        long byte3 = (long) (UNSAFE.getByte(base, offset + 4) & 0xFF) << 24;
+        long byte2 = (long) (UNSAFE.getByte(base, offset + 5) & 0xFF) << 16;
+        long byte1 = (long) (UNSAFE.getByte(base, offset + 6) & 0xFF) << 8;
+        long byte0 = (long) (UNSAFE.getByte(base, offset + 7) & 0xFF);
+        return byte7 + byte6 + byte5 + byte4 + byte3 + byte2 + byte1 + byte0;
+    }
+
+    public static long readLongVolatileL(Object base, long offset) {
+        long byte7 = (long) (UNSAFE.getByte(base, offset) & 0xFF);
+        long byte6 = (long) (UNSAFE.getByte(base, offset + 1) & 0xFF) << 8;
+        long byte5 = (long) (UNSAFE.getByte(base, offset + 2) & 0xFF) << 16;
+        long byte4 = (long) (UNSAFE.getByte(base, offset + 3) & 0xFF) << 24;
+        long byte3 = (long) (UNSAFE.getByte(base, offset + 4) & 0xFF) << 32;
+        long byte2 = (long) (UNSAFE.getByte(base, offset + 5) & 0xFF) << 40;
+        long byte1 = (long) (UNSAFE.getByte(base, offset + 6) & 0xFF) << 48;
+        long byte0 = (long) (UNSAFE.getByte(base, offset + 7) & 0xFF) << 56;
+        return byte7 + byte6 + byte5 + byte4 + byte3 + byte2 + byte1 + byte0;
+    }
+
+    public static void writeLongVolatile(long address, long v, boolean bigEndian) {
+        writeLongVolatile(null, address, v, bigEndian);
+    }
+
+    public static void writeLongVolatile(byte[] buffer, int pos, long v, boolean bigEndian) {
+        writeLongVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeLongVolatile(Object base, long offset, long v, boolean bigEndian) {
+        if (bigEndian) {
+            writeLongVolatileB(base, offset, v);
+        } else {
+            writeLongVolatileL(base, offset, v);
+        }
+    }
+
+    public static void writeLongVolatileB(Object base, long offset, long v) {
+        UNSAFE.putByte(base, offset, (byte) (v >>> 56));
+        UNSAFE.putByte(base, offset + 1, (byte) (v >>> 48));
+        UNSAFE.putByte(base, offset + 2, (byte) (v >>> 40));
+        UNSAFE.putByte(base, offset + 3, (byte) (v >>> 32));
+        UNSAFE.putByte(base, offset + 4, (byte) (v >>> 24));
+        UNSAFE.putByte(base, offset + 5, (byte) (v >>> 16));
+        UNSAFE.putByte(base, offset + 6, (byte) (v >>> 8));
+        UNSAFE.putByte(base, offset + 7, (byte) (v));
+    }
+
+    public static void writeLongVolatileL(Object base, long offset, long v) {
+        UNSAFE.putByte(base, offset, (byte) (v));
+        UNSAFE.putByte(base, offset + 1, (byte) (v >>> 8));
+        UNSAFE.putByte(base, offset + 2, (byte) (v >>> 16));
+        UNSAFE.putByte(base, offset + 3, (byte) (v >>> 24));
+        UNSAFE.putByte(base, offset + 4, (byte) (v >>> 32));
+        UNSAFE.putByte(base, offset + 5, (byte) (v >>> 40));
+        UNSAFE.putByte(base, offset + 6, (byte) (v >>> 48));
+        UNSAFE.putByte(base, offset + 7, (byte) (v >>> 56));
+    }
+
+    //////////////////////////////////////////////////////////////////
+
+    public static double readDoubleVolatile(long address, boolean bigEndian) {
+        return readDoubleVolatile(null, address, bigEndian);
+    }
+
+    public static double readDoubleVolatile(byte[] buffer, int pos, boolean bigEndian) {
+        return readDoubleVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), bigEndian);
+    }
+
+    public static double readDoubleVolatile(Object base, long offset, boolean bigEndian) {
+        if (bigEndian) {
+            return readDoubleVolatileB(base, offset);
+        } else {
+            return readDoubleVolatileL(base, offset);
+        }
+    }
+
+    public static double readDoubleVolatileB(Object base, long offset) {
+        return Double.longBitsToDouble(readLongVolatileB(base, offset));
+    }
+
+    public static double readDoubleVolatileL(Object base, long offset) {
+        return Double.longBitsToDouble(readLongVolatileL(base, offset));
+    }
+
+    public static void writeDoubleVolatile(long address, double v, boolean bigEndian) {
+        writeDoubleVolatile(null, address, v, bigEndian);
+    }
+
+    public static void writeDoubleVolatile(byte[] buffer, int pos, double v, boolean bigEndian) {
+        writeDoubleVolatile(buffer, (long) (BYTE_ARRAY_BASE_OFFSET + pos), v, bigEndian);
+    }
+
+    public static void writeDoubleVolatile(Object base, long offset, double v, boolean bigEndian) {
+        if (bigEndian) {
+            writeDoubleVolatileB(base, offset, v);
+        } else {
+            writeDoubleVolatileL(base, offset, v);
+        }
+    }
+
+    public static void writeDoubleVolatileB(Object base, long offset, double v) {
+        writeLongVolatileB(base, offset, Double.doubleToRawLongBits(v));
+    }
+
+    public static void writeDoubleVolatileL(Object base, long offset, double v) {
+        writeLongVolatileL(base, offset, Double.doubleToRawLongBits(v));
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory.impl;
+
+import java.lang.reflect.Field;
+
+/**
+ * Standard {@link com.hazelcast.internal.memory.MemoryAccessor} implementations
+ * that directly uses {@link sun.misc.Unsafe} for accessing to memory.
+ */
+public class StandardMemoryAccessor extends UnsafeBasedMemoryAccessor {
+
+    public StandardMemoryAccessor() {
+        if (!AVAILABLE) {
+            throw new IllegalStateException(getClass().getName() + " can only be used only when Unsafe is available!");
+        }
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public long getObjectFieldOffset(Field field) {
+        return UNSAFE.objectFieldOffset(field);
+    }
+
+    @Override
+    public int getArrayBaseOffset(Class<?> arrayClass) {
+        return UNSAFE.arrayBaseOffset(arrayClass);
+    }
+
+    @Override
+    public int getArrayIndexScale(Class<?> arrayClass) {
+        return UNSAFE.arrayIndexScale(arrayClass);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void copyMemory(long srcAddress, long destAddress, long bytes) {
+        UNSAFE.copyMemory(srcAddress, destAddress, bytes);
+    }
+
+    @Override
+    public void setMemory(long address, long bytes, byte value) {
+        UNSAFE.setMemory(address, bytes, value);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public boolean getBoolean(long address) {
+        return UNSAFE.getBoolean(null, address);
+    }
+
+    @Override
+    public boolean getBoolean(Object o, long offset) {
+        return UNSAFE.getBoolean(o, offset);
+    }
+
+    @Override
+    public boolean getBooleanVolatile(Object o, long offset) {
+        return UNSAFE.getBooleanVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putBoolean(long address, boolean x) {
+        UNSAFE.putBoolean(null, address, x);
+    }
+
+    @Override
+    public void putBoolean(Object o, long offset, boolean x) {
+        UNSAFE.putBoolean(o, offset, x);
+    }
+
+    @Override
+    public void putBooleanVolatile(Object o, long offset, boolean x) {
+        UNSAFE.putBooleanVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public byte getByte(long address) {
+        return UNSAFE.getByte(address);
+    }
+
+    @Override
+    public byte getByte(Object o, long offset) {
+        return UNSAFE.getByte(o, offset);
+    }
+
+    @Override
+    public byte getByteVolatile(Object o, long offset) {
+        return UNSAFE.getByteVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putByte(long address, byte x) {
+        UNSAFE.putByte(address, x);
+    }
+
+    @Override
+    public void putByte(Object o, long offset, byte x) {
+        UNSAFE.putByte(o, offset, x);
+    }
+
+    @Override
+    public void putByteVolatile(Object o, long offset, byte x) {
+        UNSAFE.putByteVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public char getChar(long address) {
+        return UNSAFE.getChar(address);
+    }
+
+    @Override
+    public char getChar(Object o, long offset) {
+        return UNSAFE.getChar(o, offset);
+    }
+
+    @Override
+    public char getCharVolatile(Object o, long offset) {
+        return UNSAFE.getCharVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putChar(long address, char x) {
+        UNSAFE.putChar(address, x);
+    }
+
+    @Override
+    public void putChar(Object o, long offset, char x) {
+        UNSAFE.putChar(o, offset, x);
+    }
+
+    @Override
+    public void putCharVolatile(Object o, long offset, char x) {
+        UNSAFE.putCharVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public short getShort(long address) {
+        return UNSAFE.getShort(address);
+    }
+
+    @Override
+    public short getShort(Object o, long offset) {
+        return UNSAFE.getShort(o, offset);
+    }
+
+    @Override
+    public short getShortVolatile(Object o, long offset) {
+        return UNSAFE.getShortVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putShort(long address, short x) {
+        UNSAFE.putShort(address, x);
+    }
+
+    @Override
+    public void putShort(Object o, long offset, short x) {
+        UNSAFE.putShort(o, offset, x);
+    }
+
+    @Override
+    public void putShortVolatile(Object o, long offset, short x) {
+        UNSAFE.putShortVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public int getInt(long address) {
+        return UNSAFE.getInt(address);
+    }
+
+    @Override
+    public int getInt(Object o, long offset) {
+        return UNSAFE.getInt(o, offset);
+    }
+
+    @Override
+    public int getIntVolatile(Object o, long offset) {
+        return UNSAFE.getIntVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putInt(long address, int x) {
+        UNSAFE.putInt(address, x);
+    }
+
+    @Override
+    public void putInt(Object o, long offset, int x) {
+        UNSAFE.putInt(o, offset, x);
+    }
+
+    @Override
+    public void putIntVolatile(Object o, long offset, int x) {
+        UNSAFE.putIntVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public float getFloat(long address) {
+        return UNSAFE.getFloat(address);
+    }
+
+    @Override
+    public float getFloat(Object o, long offset) {
+        return UNSAFE.getFloat(o, offset);
+    }
+
+    @Override
+    public float getFloatVolatile(Object o, long offset) {
+        return UNSAFE.getFloatVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putFloat(long address, float x) {
+        UNSAFE.putFloat(address, x);
+    }
+
+    @Override
+    public void putFloat(Object o, long offset, float x) {
+        UNSAFE.putFloat(o, offset, x);
+    }
+
+    @Override
+    public void putFloatVolatile(Object o, long offset, float x) {
+        UNSAFE.putFloatVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public long getLong(long address) {
+        return UNSAFE.getLong(address);
+    }
+
+    @Override
+    public long getLong(Object o, long offset) {
+        return UNSAFE.getLong(o, offset);
+    }
+
+    @Override
+    public long getLongVolatile(Object o, long offset) {
+        return UNSAFE.getLongVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putLong(long address, long x) {
+        UNSAFE.putLong(address, x);
+    }
+
+    @Override
+    public void putLong(Object o, long offset, long x) {
+        UNSAFE.putLong(o, offset, x);
+    }
+
+    @Override
+    public void putLongVolatile(Object o, long offset, long x) {
+        UNSAFE.putLongVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public double getDouble(long address) {
+        return UNSAFE.getDouble(address);
+    }
+
+    @Override
+    public double getDouble(Object o, long offset) {
+        return UNSAFE.getDouble(o, offset);
+    }
+
+    @Override
+    public double getDoubleVolatile(Object o, long offset) {
+        return UNSAFE.getDoubleVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putDouble(long address, double x) {
+        UNSAFE.putDouble(address, x);
+    }
+
+    @Override
+    public void putDouble(Object o, long offset, double x) {
+        UNSAFE.putDouble(o, offset, x);
+    }
+
+    @Override
+    public void putDoubleVolatile(Object o, long offset, double x) {
+        UNSAFE.putDoubleVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public Object getObject(Object o, long offset) {
+        return UNSAFE.getObject(o, offset);
+    }
+
+    @Override
+    public Object getObjectVolatile(Object o, long offset) {
+        return UNSAFE.getObjectVolatile(o, offset);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putObject(Object o, long offset, Object x) {
+        UNSAFE.putObject(o, offset, x);
+    }
+
+    @Override
+    public void putObjectVolatile(Object o, long offset, Object x) {
+        UNSAFE.putObjectVolatile(o, offset, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public boolean compareAndSwapInt(Object o, long offset, int expected, int x) {
+        return UNSAFE.compareAndSwapInt(o, offset, expected, x);
+    }
+
+    @Override
+    public boolean compareAndSwapLong(Object o, long offset, long expected, long x) {
+        return UNSAFE.compareAndSwapLong(o, offset, expected, x);
+    }
+
+    @Override
+    public boolean compareAndSwapObject(Object o, long offset, Object expected, Object x) {
+        return UNSAFE.compareAndSwapObject(o, offset, expected, x);
+    }
+
+    /////////////////////////////////////////////////////////////////////////
+
+    @Override
+    public void putOrderedInt(Object o, long offset, int x) {
+        UNSAFE.putOrderedInt(o, offset, x);
+    }
+
+    @Override
+    public void putOrderedLong(Object o, long offset, long x) {
+        UNSAFE.putOrderedLong(o, offset, x);
+    }
+
+    @Override
+    public void putOrderedObject(Object o, long offset, Object x) {
+        UNSAFE.putOrderedObject(o, offset, x);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeBasedMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeBasedMemoryAccessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import sun.misc.Unsafe;
+
+/**
+ * Base class for {@link sun.misc.Unsafe} backed {@link MemoryAccessor} implementations.
+ */
+abstract class UnsafeBasedMemoryAccessor implements MemoryAccessor {
+
+    /**
+     * The {@link sun.misc.Unsafe} instance which is available and ready to use.
+     */
+    protected static final Unsafe UNSAFE = UnsafeUtil.UNSAFE;
+
+    /**
+     * State about {@link sun.misc.Unsafe} is available to be used.
+     */
+    protected static final boolean AVAILABLE = UNSAFE != null;
+
+    /**
+     * Returns the state about this kind of {@link UnsafeBasedMemoryAccessor} instances are available or not.
+     *
+     * @return <tt>true</tt> if this kind of {@link UnsafeBasedMemoryAccessor} instances are available,
+     *         otherwise <tt>false</tt>
+     */
+    public static boolean isAvailable() {
+        return AVAILABLE;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.Bits;
+import com.hazelcast.util.ExceptionUtil;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import static com.hazelcast.util.QuickMath.normalize;
+
+/**
+ * Utility class on {@link sun.misc.Unsafe}.
+ */
+final class UnsafeUtil {
+
+    /**
+     * The {@link sun.misc.Unsafe} instance which is available and ready to use.
+     */
+    static final Unsafe UNSAFE;
+
+    /**
+     * State about {@link sun.misc.Unsafe} is available to be used.
+     */
+    static final boolean UNSAFE_AVAILABLE;
+
+    private static final ILogger LOGGER = Logger.getLogger(UnsafeUtil.class);
+
+    static {
+        Unsafe unsafe;
+        try {
+            unsafe = findUnsafe();
+            // Test if unsafe has required methods...
+            if (unsafe != null) {
+                long arrayBaseOffset = unsafe.arrayBaseOffset(byte[].class);
+                byte[] buffer = new byte[(int) arrayBaseOffset + (2 * Bits.LONG_SIZE_IN_BYTES)];
+                unsafe.putByte(buffer, arrayBaseOffset, (byte) 0x00);
+                unsafe.putBoolean(buffer, arrayBaseOffset, false);
+                unsafe.putChar(buffer, normalize(arrayBaseOffset, Bits.CHAR_SIZE_IN_BYTES), '0');
+                unsafe.putShort(buffer, normalize(arrayBaseOffset, Bits.SHORT_SIZE_IN_BYTES), (short) 1);
+                unsafe.putInt(buffer, normalize(arrayBaseOffset, Bits.INT_SIZE_IN_BYTES), 2);
+                unsafe.putFloat(buffer, normalize(arrayBaseOffset, Bits.FLOAT_SIZE_IN_BYTES),  3f);
+                unsafe.putLong(buffer, normalize(arrayBaseOffset, Bits.LONG_SIZE_IN_BYTES), 4L);
+                unsafe.putDouble(buffer, normalize(arrayBaseOffset, Bits.DOUBLE_SIZE_IN_BYTES), 5d);
+                unsafe.copyMemory(new byte[buffer.length], arrayBaseOffset,
+                                  buffer, arrayBaseOffset,
+                                  buffer.length);
+            }
+        } catch (Throwable t) {
+            unsafe = null;
+            LOGGER.warning("Unable to get Unsafe. So skipping Unsafe support...", t);
+        }
+        UNSAFE = unsafe;
+        UNSAFE_AVAILABLE = UNSAFE != null;
+    }
+
+    private UnsafeUtil() {
+    }
+
+    private static Unsafe findUnsafe() {
+        try {
+            return Unsafe.getUnsafe();
+        } catch (SecurityException se) {
+            return AccessController.doPrivileged(new PrivilegedAction<Unsafe>() {
+                @Override
+                public Unsafe run() {
+                    try {
+                        Class<Unsafe> type = Unsafe.class;
+                        try {
+                            Field field = type.getDeclaredField("theUnsafe");
+                            field.setAccessible(true);
+                            return type.cast(field.get(type));
+                        } catch (Exception e) {
+                            for (Field field : type.getDeclaredFields()) {
+                                if (type.isAssignableFrom(field.getType())) {
+                                    field.setAccessible(true);
+                                    return type.cast(field.get(type));
+                                }
+                            }
+                        }
+                    } catch (Throwable t) {
+                        throw ExceptionUtil.rethrow(t);
+                    }
+                    throw new RuntimeException("Unsafe unavailable");
+                }
+            });
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>
+ *     Internal memory management API implementations
+ * </p>
+ */
+package com.hazelcast.internal.memory.impl;

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <p>
+ *     Internal memory management API
+ * </p>
+ */
+package com.hazelcast.internal.memory;

--- a/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
@@ -30,12 +30,37 @@ import java.security.PrivilegedAction;
  * a later JVM implementation can change this behaviour to allow varying index-scales and base-offsets
  * over time or per array instances (e.g. compressed primitive arrays or backwards growing arrays...)
  * <p/>
+ * <p>
  * See Gil Tene's comment related to Unsafe usage;
  * https://groups.google.com/d/msg/mechanical-sympathy/X-GtLuG0ETo/LMV1d_2IybQJ
+ * </p>
+ * @deprecated Use {@link com.hazelcast.internal.memory.MemoryAccessor} instead due to following reasons:
+ * <p>
+ * Deprecated to {@link com.hazelcast.internal.memory.MemoryAccessor} due to following reasons:
+ * <ul>
+ *     <li>
+ *          Preventing hard-dependency to {@link sun.misc.Unsafe}/
+ *     </li>
+ *     <li>
+ *          Some platforms (such as SPARC) don't support unaligned memory access.
+ *          So on these platforms memory access alignments must be checked and handled if possible.
+ *     </li>
+ * </ul>
+ * </p>
  */
+@Deprecated
 public final class UnsafeHelper {
 
+    /**
+     * @deprecated {@link com.hazelcast.internal.memory.MemoryAccessor#DEFAULT} instead
+     */
+    @Deprecated
     public static final Unsafe UNSAFE;
+
+    /**
+     * @deprecated {@link com.hazelcast.internal.memory.MemoryAccessor#AVAILABLE} instead
+     */
+    @Deprecated
     public static final boolean UNSAFE_AVAILABLE;
 
     public static final long BYTE_ARRAY_BASE_OFFSET;

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/MemoryAccessorProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/MemoryAccessorProviderTest.java
@@ -1,0 +1,59 @@
+package com.hazelcast.internal.memory;
+
+import com.hazelcast.internal.memory.impl.AlignmentAwareMemoryAccessor;
+import com.hazelcast.internal.memory.impl.StandardMemoryAccessor;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class MemoryAccessorProviderTest extends UnsafeDependentMemoryAccessorTest {
+
+    @Test
+    public void test_getMemoryAccessor_default() {
+        assertNotNull(MemoryAccessorProvider.getDefaultMemoryAccessor());
+    }
+
+    private void checkStandardMemoryAccessorAvailable() {
+        MemoryAccessor memoryAccessor = MemoryAccessorProvider.getMemoryAccessor(MemoryAccessorType.STANDARD);
+        if (StandardMemoryAccessor.isAvailable()) {
+            assertNotNull(memoryAccessor);
+            assertTrue(memoryAccessor instanceof StandardMemoryAccessor);
+        }
+    }
+
+    private void checkAlignmentAwareMemoryAccessorAvailable() {
+        MemoryAccessor memoryAccessor = MemoryAccessorProvider.getMemoryAccessor(MemoryAccessorType.ALIGNMENT_AWARE);
+        if (AlignmentAwareMemoryAccessor.isAvailable()) {
+            assertNotNull(memoryAccessor);
+            assertTrue(memoryAccessor instanceof AlignmentAwareMemoryAccessor);
+        }
+    }
+
+    @Test
+    public void test_getMemoryAccessor_standard() {
+        checkStandardMemoryAccessorAvailable();
+    }
+
+    @Test
+    public void test_getMemoryAccessor_alignmentAware() {
+        checkAlignmentAwareMemoryAccessorAvailable();
+    }
+
+    @Test
+    public void test_getMemoryAccessor_platformAware() {
+        if (MemoryAccessorProvider.isUnalignedAccessAllowed()) {
+            checkStandardMemoryAccessorAvailable();
+        } else {
+            checkAlignmentAwareMemoryAccessorAvailable();
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/UnsafeDependentMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/UnsafeDependentMemoryAccessorTest.java
@@ -1,0 +1,12 @@
+package com.hazelcast.internal.memory;
+
+import com.hazelcast.internal.memory.impl.TestIgnoreRuleAccordingToUnsafeAvailability;
+import org.junit.ClassRule;
+
+public abstract class UnsafeDependentMemoryAccessorTest {
+
+    @ClassRule
+    public static final TestIgnoreRuleAccordingToUnsafeAvailability UNSAFE_AVAILABILITY_RULE
+            = new TestIgnoreRuleAccordingToUnsafeAvailability();
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/AlignmentAwareMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/AlignmentAwareMemoryAccessorTest.java
@@ -1,0 +1,55 @@
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class AlignmentAwareMemoryAccessorTest extends BaseMemoryAccessorTest {
+
+    @Override
+    protected MemoryAccessor createMemoryAccessor() {
+        return new AlignmentAwareMemoryAccessor();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_putGetObject_whenUnaligned() {
+        do_test_putGetObject(false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_compareAndSwapInt_whenUnaligned() {
+        super.test_compareAndSwapInt_whenUnaligned();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_compareAndSwapLong_whenUnaligned() {
+        super.test_compareAndSwapLong_whenUnaligned();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_compareAndSwapObject_whenUnaligned() {
+        do_test_compareAndSwapObject(false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_putOrderedInt_whenUnaligned() {
+        super.test_putOrderedInt_whenUnaligned();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_putOrderedLong_whenUnaligned() {
+        super.test_putOrderedLong_whenUnaligned();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_putOrderedObject_whenUnaligned() {
+        do_test_putOrderedObject(false);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
@@ -1,0 +1,760 @@
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.internal.memory.UnsafeDependentMemoryAccessorTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.ExceptionUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import sun.misc.Unsafe;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccessorTest {
+
+    protected final Unsafe UNSAFE = UnsafeUtil.UNSAFE;
+
+    private MemoryAccessor memoryAccessor;
+
+    abstract protected MemoryAccessor createMemoryAccessor();
+
+    @Before
+    public void setup() {
+        memoryAccessor = createMemoryAccessor();
+    }
+
+    protected long allocateMemory(long size) {
+        return UNSAFE.allocateMemory(size);
+    }
+
+    protected void freeMemory(long address) {
+        UNSAFE.freeMemory(address);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_getObjectFieldOffset() throws NoSuchFieldException {
+        assertEquals(SampleObject.BOOLEAN_VALUE_OFFSET,
+                     memoryAccessor.getObjectFieldOffset(
+                        SampleObject.class.getDeclaredField("booleanValue")));
+        assertEquals(SampleObject.BYTE_VALUE_OFFSET,
+                     memoryAccessor.getObjectFieldOffset(
+                        SampleObject.class.getDeclaredField("byteValue")));
+        assertEquals(SampleObject.CHAR_VALUE_OFFSET,
+                     memoryAccessor.getObjectFieldOffset(
+                        SampleObject.class.getDeclaredField("charValue")));
+        assertEquals(SampleObject.SHORT_VALUE_OFFSET,
+                     memoryAccessor.getObjectFieldOffset(
+                        SampleObject.class.getDeclaredField("shortValue")));
+        assertEquals(SampleObject.INT_VALUE_OFFSET,
+                     memoryAccessor.getObjectFieldOffset(
+                        SampleObject.class.getDeclaredField("intValue")));
+        assertEquals(SampleObject.FLOAT_VALUE_OFFSET,
+                     memoryAccessor.getObjectFieldOffset(
+                        SampleObject.class.getDeclaredField("floatValue")));
+        assertEquals(SampleObject.LONG_VALUE_OFFSET,
+                     memoryAccessor.getObjectFieldOffset(
+                        SampleObject.class.getDeclaredField("longValue")));
+        assertEquals(SampleObject.DOUBLE_VALUE_OFFSET,
+                     memoryAccessor.getObjectFieldOffset(
+                        SampleObject.class.getDeclaredField("doubleValue")));
+        assertEquals(SampleObject.OBJECT_VALUE_OFFSET,
+                     memoryAccessor.getObjectFieldOffset(
+                        SampleObject.class.getDeclaredField("objectValue")));
+    }
+
+    @Test
+    public void test_getArrayBaseOffset() {
+        assertEquals(UNSAFE.arrayBaseOffset(boolean[].class),
+                     memoryAccessor.getArrayBaseOffset(boolean[].class));
+        assertEquals(UNSAFE.arrayBaseOffset(byte[].class),
+                     memoryAccessor.getArrayBaseOffset(byte[].class));
+        assertEquals(UNSAFE.arrayBaseOffset(char[].class),
+                     memoryAccessor.getArrayBaseOffset(char[].class));
+        assertEquals(UNSAFE.arrayBaseOffset(short[].class),
+                     memoryAccessor.getArrayBaseOffset(short[].class));
+        assertEquals(UNSAFE.arrayBaseOffset(int[].class),
+                     memoryAccessor.getArrayBaseOffset(int[].class));
+        assertEquals(UNSAFE.arrayBaseOffset(float[].class),
+                     memoryAccessor.getArrayBaseOffset(float[].class));
+        assertEquals(UNSAFE.arrayBaseOffset(long[].class),
+                     memoryAccessor.getArrayBaseOffset(long[].class));
+        assertEquals(UNSAFE.arrayBaseOffset(double[].class),
+                     memoryAccessor.getArrayBaseOffset(double[].class));
+        assertEquals(UNSAFE.arrayBaseOffset(Object[].class),
+                     memoryAccessor.getArrayBaseOffset(Object[].class));
+    }
+
+    @Test
+    public void test_getArrayIndexScale() {
+        assertEquals(UNSAFE.arrayIndexScale(boolean[].class),
+                     memoryAccessor.getArrayIndexScale(boolean[].class));
+        assertEquals(UNSAFE.arrayIndexScale(byte[].class),
+                     memoryAccessor.getArrayIndexScale(byte[].class));
+        assertEquals(UNSAFE.arrayIndexScale(char[].class),
+                     memoryAccessor.getArrayIndexScale(char[].class));
+        assertEquals(UNSAFE.arrayIndexScale(short[].class),
+                     memoryAccessor.getArrayIndexScale(short[].class));
+        assertEquals(UNSAFE.arrayIndexScale(int[].class),
+                     memoryAccessor.getArrayIndexScale(int[].class));
+        assertEquals(UNSAFE.arrayIndexScale(float[].class),
+                     memoryAccessor.getArrayIndexScale(float[].class));
+        assertEquals(UNSAFE.arrayIndexScale(long[].class),
+                     memoryAccessor.getArrayIndexScale(long[].class));
+        assertEquals(UNSAFE.arrayIndexScale(double[].class),
+                     memoryAccessor.getArrayIndexScale(double[].class));
+        assertEquals(UNSAFE.arrayIndexScale(Object[].class),
+                     memoryAccessor.getArrayIndexScale(Object[].class));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_copyMemory_whenAligned() {
+        do_test_copyMemory(true);
+    }
+
+    @Test
+    public void test_copyMemory_whenUnaligned() {
+        do_test_copyMemory(false);
+    }
+
+    private void do_test_copyMemory(boolean aligned) {
+        final int COPY_LENGTH = 8;
+
+        long sourceAddress = 0;
+        long destinationAddress = 0;
+        try {
+            sourceAddress = allocateMemory(2 * COPY_LENGTH);
+            destinationAddress = allocateMemory(2 * COPY_LENGTH);
+
+            long accessSourceAddress = aligned ? sourceAddress : sourceAddress + 1;
+            long accessDestinationAddress = aligned ? destinationAddress : destinationAddress + 1;
+
+            for (int i = 0; i < COPY_LENGTH; i++) {
+                memoryAccessor.putByte(accessSourceAddress + i, (byte) (i * i));
+            }
+
+            memoryAccessor.copyMemory(accessSourceAddress, accessDestinationAddress, COPY_LENGTH);
+
+            for (int i = 0; i < COPY_LENGTH; i++) {
+                assertEquals((byte) (i * i), memoryAccessor.getByte(accessDestinationAddress + i));
+            }
+        } finally {
+            if (sourceAddress != 0) {
+                freeMemory(sourceAddress);
+            }
+            if (destinationAddress != 0) {
+                freeMemory(destinationAddress);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_setMemory_whenAligned() {
+        do_test_setMemory(true);
+    }
+
+    @Test
+    public void test_setMemory_whenUnaligned() {
+        do_test_setMemory(false);
+    }
+
+    private void do_test_setMemory(boolean aligned) {
+        final int SET_LENGTH = 8;
+
+        long address = 0;
+        try {
+            address = allocateMemory(2 * SET_LENGTH);
+            long accessAddress = aligned ? address : address + 1;
+
+            memoryAccessor.setMemory(accessAddress, SET_LENGTH, (byte) 0x01);
+
+            for (int i = 0; i < SET_LENGTH; i++) {
+                assertEquals((byte) 0x01, memoryAccessor.getByte(accessAddress + i));
+            }
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putGetBoolean() {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+
+            memoryAccessor.putBoolean(address, true);
+            assertEquals(true, memoryAccessor.getBoolean(address));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putBooleanVolatile(null, address, false);
+            assertEquals(false, memoryAccessor.getBooleanVolatile(null, address));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putBoolean(obj, SampleObject.BOOLEAN_VALUE_OFFSET, true);
+            assertEquals(true, memoryAccessor.getBoolean(obj, SampleObject.BOOLEAN_VALUE_OFFSET));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putBooleanVolatile(obj, SampleObject.BOOLEAN_VALUE_OFFSET, false);
+            assertEquals(false, memoryAccessor.getBooleanVolatile(obj, SampleObject.BOOLEAN_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putGetByte() {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+
+            memoryAccessor.putByte(address, (byte) 1);
+            assertEquals(1, memoryAccessor.getByte(address));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putByteVolatile(null, address, (byte) 2);
+            assertEquals(2, memoryAccessor.getByteVolatile(null, address));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putByte(obj, SampleObject.BYTE_VALUE_OFFSET, (byte) 3);
+            assertEquals(3, memoryAccessor.getByte(obj, SampleObject.BYTE_VALUE_OFFSET));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putByteVolatile(obj, SampleObject.BYTE_VALUE_OFFSET, (byte) 4);
+            assertEquals(4, memoryAccessor.getByteVolatile(obj, SampleObject.BYTE_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putGetChar_whenAligned() {
+        do_test_putGetChar(true);
+    }
+
+    @Test
+    public void test_putGetChar_whenUnaligned() {
+        do_test_putGetChar(false);
+    }
+
+    private void do_test_putGetChar(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            memoryAccessor.putChar(accessAddress, 'A');
+            assertEquals('A', memoryAccessor.getChar(accessAddress));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putCharVolatile(null, accessAddress, 'B');
+            assertEquals('B', memoryAccessor.getCharVolatile(null, accessAddress));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putChar(obj, SampleObject.CHAR_VALUE_OFFSET, 'C');
+            assertEquals('C', memoryAccessor.getChar(obj, SampleObject.CHAR_VALUE_OFFSET));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putCharVolatile(obj, SampleObject.CHAR_VALUE_OFFSET, 'D');
+            assertEquals('D', memoryAccessor.getCharVolatile(obj, SampleObject.CHAR_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putGetShort_whenAligned() {
+        do_test_putGetShort(true);
+    }
+
+    @Test
+    public void test_putGetShort_whenUnaligned() {
+        do_test_putGetShort(false);
+    }
+
+    private void do_test_putGetShort(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            memoryAccessor.putShort(accessAddress, (short) 1);
+            assertEquals((short) 1, memoryAccessor.getShort(accessAddress));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putShortVolatile(null, accessAddress, (short) 2);
+            assertEquals((short) 2, memoryAccessor.getShortVolatile(null, accessAddress));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putShort(obj, SampleObject.SHORT_VALUE_OFFSET, (short) 3);
+            assertEquals((short) 3, memoryAccessor.getShort(obj, SampleObject.SHORT_VALUE_OFFSET));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putShortVolatile(obj, SampleObject.SHORT_VALUE_OFFSET, (short) 4);
+            assertEquals((short) 4, memoryAccessor.getShortVolatile(obj, SampleObject.SHORT_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putGetInt_whenAligned() {
+        do_test_putGetInt(true);
+    }
+
+    @Test
+    public void test_putGetInt_whenUnaligned() {
+        do_test_putGetInt(false);
+    }
+
+    private void do_test_putGetInt(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            memoryAccessor.putInt(accessAddress, 1);
+            assertEquals(1, memoryAccessor.getInt(accessAddress));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putIntVolatile(null, accessAddress, 2);
+            assertEquals(2, memoryAccessor.getIntVolatile(null, accessAddress));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putInt(obj, SampleObject.INT_VALUE_OFFSET, 3);
+            assertEquals(3, memoryAccessor.getInt(obj, SampleObject.INT_VALUE_OFFSET));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putIntVolatile(obj, SampleObject.INT_VALUE_OFFSET, 4);
+            assertEquals(4, memoryAccessor.getIntVolatile(obj, SampleObject.INT_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putGetFloat_whenAligned() {
+        do_test_putGetFloat(true);
+    }
+
+    @Test
+    public void test_putGetFloat_whenUnaligned() {
+        do_test_putGetFloat(false);
+    }
+
+    private void do_test_putGetFloat(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            memoryAccessor.putFloat(accessAddress, 11.2F);
+            assertEquals(11.2F, memoryAccessor.getFloat(accessAddress), 0.0F);
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putFloatVolatile(null, accessAddress, 33.4F);
+            assertEquals(33.4F, memoryAccessor.getFloatVolatile(null, accessAddress), 0.0F);
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putFloat(obj, SampleObject.FLOAT_VALUE_OFFSET, 55.6F);
+            assertEquals(55.6F, memoryAccessor.getFloat(obj, SampleObject.FLOAT_VALUE_OFFSET), 0.0F);
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putFloatVolatile(obj, SampleObject.FLOAT_VALUE_OFFSET, 77.8F);
+            assertEquals(77.8F, memoryAccessor.getFloatVolatile(obj, SampleObject.FLOAT_VALUE_OFFSET), 0.0F);
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putGetLong_whenAligned() {
+        do_test_putGetLong(true);
+    }
+
+    @Test
+    public void test_putGetLong_whenUnaligned() {
+        do_test_putGetLong(false);
+    }
+
+    private void do_test_putGetLong(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            memoryAccessor.putLong(accessAddress, 1L);
+            assertEquals(1L, memoryAccessor.getLong(accessAddress));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putLongVolatile(null, accessAddress, 2L);
+            assertEquals(2L, memoryAccessor.getLongVolatile(null, accessAddress));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putLong(obj, SampleObject.LONG_VALUE_OFFSET, 3L);
+            assertEquals(3L, memoryAccessor.getLong(obj, SampleObject.LONG_VALUE_OFFSET));
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putLongVolatile(obj, SampleObject.LONG_VALUE_OFFSET, 4L);
+            assertEquals(4L, memoryAccessor.getLongVolatile(obj, SampleObject.LONG_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putGetDouble_whenAligned() {
+        do_test_putGetDouble(true);
+    }
+
+    @Test
+    public void test_putGetDouble_whenUnaligned() {
+        do_test_putGetDouble(false);
+    }
+
+    private void do_test_putGetDouble(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            memoryAccessor.putDouble(accessAddress, 11.2);
+            assertEquals(11.2, memoryAccessor.getDouble(accessAddress), 0.0);
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putDoubleVolatile(null, accessAddress, 33.4);
+            assertEquals(33.4, memoryAccessor.getDoubleVolatile(null, accessAddress), 0.0);
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putDouble(obj, SampleObject.DOUBLE_VALUE_OFFSET, 55.6);
+            assertEquals(55.6, memoryAccessor.getDouble(obj, SampleObject.DOUBLE_VALUE_OFFSET), 0.0);
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really accesses memory as volatile. Does it worth???
+            memoryAccessor.putDoubleVolatile(obj, SampleObject.DOUBLE_VALUE_OFFSET, 77.8);
+            assertEquals(77.8, memoryAccessor.getDoubleVolatile(obj, SampleObject.DOUBLE_VALUE_OFFSET), 0.0);
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putGetObject_whenAligned() {
+        do_test_putGetObject(true);
+    }
+
+    protected void do_test_putGetObject(boolean aligned) {
+        long offset = SampleObject.OBJECT_VALUE_OFFSET;
+        SampleObject obj = new SampleObject();
+        long accessOffset = aligned ? offset : offset + 1;
+
+        String str1 = "String Object 1";
+        memoryAccessor.putObject(obj, accessOffset, str1);
+        assertEquals(str1, memoryAccessor.getObject(obj, accessOffset));
+
+        // TODO Do we really need to concurrency test to verify that
+        // memory accessor really accesses memory as volatile. Does it worth???
+        String str2 = "String Object 2";
+        memoryAccessor.putObjectVolatile(obj, accessOffset, str2);
+        assertEquals(str2, memoryAccessor.getObjectVolatile(obj, accessOffset));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_compareAndSwapInt_whenAligned() {
+        do_test_compareAndSwapInt(true);
+    }
+
+    @Test
+    public void test_compareAndSwapInt_whenUnaligned() {
+        do_test_compareAndSwapInt(false);
+    }
+
+    private void do_test_compareAndSwapInt(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            memoryAccessor.putInt(accessAddress, 1);
+            assertEquals(1, memoryAccessor.getInt(accessAddress));
+
+            assertFalse(memoryAccessor.compareAndSwapInt(null, accessAddress, 0, 2));
+            assertTrue(memoryAccessor.compareAndSwapInt(null, accessAddress, 1, 2));
+
+            assertEquals(2, memoryAccessor.getInt(accessAddress));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putInt(obj, SampleObject.INT_VALUE_OFFSET, 1);
+            assertEquals(1, memoryAccessor.getInt(obj, SampleObject.INT_VALUE_OFFSET));
+
+            assertFalse(memoryAccessor.compareAndSwapInt(obj, SampleObject.INT_VALUE_OFFSET, 0, 2));
+            assertTrue(memoryAccessor.compareAndSwapInt(obj, SampleObject.INT_VALUE_OFFSET, 1, 2));
+
+            assertEquals(2, memoryAccessor.getInt(obj, SampleObject.INT_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_compareAndSwapLong_whenAligned() {
+        do_test_compareAndSwapLong(true);
+    }
+
+    @Test
+    public void test_compareAndSwapLong_whenUnaligned() {
+        do_test_compareAndSwapLong(false);
+    }
+
+    private void do_test_compareAndSwapLong(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            memoryAccessor.putLong(accessAddress, 1L);
+            assertEquals(1L, memoryAccessor.getLong(accessAddress));
+
+            assertFalse(memoryAccessor.compareAndSwapLong(null, accessAddress, 0L, 2L));
+            assertTrue(memoryAccessor.compareAndSwapLong(null, accessAddress, 1L, 2L));
+
+            assertEquals(2L, memoryAccessor.getLong(accessAddress));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putLong(obj, SampleObject.LONG_VALUE_OFFSET, 1L);
+            assertEquals(1L, memoryAccessor.getLong(obj, SampleObject.LONG_VALUE_OFFSET));
+
+            assertFalse(memoryAccessor.compareAndSwapLong(obj, SampleObject.LONG_VALUE_OFFSET, 0L, 2L));
+            assertTrue(memoryAccessor.compareAndSwapLong(obj, SampleObject.LONG_VALUE_OFFSET, 1L, 2L));
+
+            assertEquals(2L, memoryAccessor.getLong(obj, SampleObject.LONG_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_compareAndSwapObject_whenAligned() {
+        do_test_compareAndSwapObject(true);
+    }
+
+    protected void do_test_compareAndSwapObject(boolean aligned) {
+        long offset = SampleObject.OBJECT_VALUE_OFFSET;
+        SampleObject obj = new SampleObject();
+        long accessOffset = aligned ? offset : offset + 1;
+
+        String str1 = "String Object 1";
+        memoryAccessor.putObject(obj, accessOffset, str1);
+        assertEquals(str1, memoryAccessor.getObject(obj, accessOffset));
+
+        String str2 = "String Object 2";
+        assertFalse(memoryAccessor.compareAndSwapObject(obj, accessOffset, null, str2));
+        assertTrue(memoryAccessor.compareAndSwapObject(obj, accessOffset, str1, str2));
+
+        assertEquals(str2, memoryAccessor.getObject(obj, accessOffset));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putOrderedInt_whenAligned() {
+        do_test_putOrderedInt(true);
+    }
+
+    @Test
+    public void test_putOrderedInt_whenUnaligned() {
+        do_test_putOrderedInt(false);
+    }
+
+    private void do_test_putOrderedInt(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really applies writes as ordered. Does it worth???
+            memoryAccessor.putOrderedInt(null, accessAddress, 1);
+            assertEquals(1, memoryAccessor.getInt(accessAddress));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putOrderedInt(obj, SampleObject.INT_VALUE_OFFSET, 1);
+            assertEquals(1, memoryAccessor.getInt(obj, SampleObject.INT_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putOrderedLong_whenAligned() {
+        do_test_putOrderedLong(true);
+    }
+
+    @Test
+    public void test_putOrderedLong_whenUnaligned() {
+        do_test_putOrderedLong(false);
+    }
+
+    private void do_test_putOrderedLong(boolean aligned) {
+        long address = 0;
+        try {
+            address = allocateMemory(16);
+            long accessAddress = aligned ? address : address + 1;
+
+            // TODO Do we really need to concurrency test to verify that
+            // memory accessor really applies writes as ordered. Does it worth???
+            memoryAccessor.putOrderedLong(null, accessAddress, 1L);
+            assertEquals(1L, memoryAccessor.getLong(accessAddress));
+
+            SampleObject obj = new SampleObject();
+
+            memoryAccessor.putOrderedLong(obj, SampleObject.LONG_VALUE_OFFSET, 1L);
+            assertEquals(1L, memoryAccessor.getLong(obj, SampleObject.LONG_VALUE_OFFSET));
+        } finally {
+            if (address != 0) {
+                freeMemory(address);
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    public void test_putOrderedObject_whenAligned() {
+        do_test_putOrderedObject(true);
+    }
+
+    protected void do_test_putOrderedObject(boolean aligned) {
+        long offset = SampleObject.OBJECT_VALUE_OFFSET;
+        SampleObject obj = new SampleObject();
+        long accessOffset = aligned ? offset : offset + 1;
+
+        // TODO Do we really need to concurrency test to verify that
+        // memory accessor really applies writes as ordered. Does it worth???
+        String str = "String Object";
+        memoryAccessor.putOrderedObject(obj, accessOffset, str);
+        assertEquals(str, memoryAccessor.getObject(obj, accessOffset));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////
+
+    private static long getSampleObjectFieldOffset(String fieldName) {
+        try {
+            return UnsafeUtil.UNSAFE.objectFieldOffset(SampleObject.class.getDeclaredField(fieldName));
+        } catch (NoSuchFieldException e) {
+            throw ExceptionUtil.rethrow(e);
+        }
+    }
+
+    private static class SampleObject {
+
+        private static final long BYTE_VALUE_OFFSET = getSampleObjectFieldOffset("byteValue");
+        private static final long BOOLEAN_VALUE_OFFSET = getSampleObjectFieldOffset("booleanValue");
+        private static final long CHAR_VALUE_OFFSET = getSampleObjectFieldOffset("charValue");
+        private static final long SHORT_VALUE_OFFSET = getSampleObjectFieldOffset("shortValue");
+        private static final long INT_VALUE_OFFSET = getSampleObjectFieldOffset("intValue");
+        private static final long FLOAT_VALUE_OFFSET = getSampleObjectFieldOffset("floatValue");
+        private static final long LONG_VALUE_OFFSET = getSampleObjectFieldOffset("longValue");
+        private static final long DOUBLE_VALUE_OFFSET = getSampleObjectFieldOffset("doubleValue");
+        private static final long OBJECT_VALUE_OFFSET = getSampleObjectFieldOffset("objectValue");
+
+        private byte byteValue;
+        private boolean booleanValue;
+        private char charValue;
+        private short shortValue;
+        private int intValue;
+        private float floatValue;
+        private long longValue;
+        private double doubleValue;
+        private Object objectValue;
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessorTest.java
@@ -1,0 +1,19 @@
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class StandardMemoryAccessorTest extends BaseMemoryAccessorTest {
+
+    @Override
+    protected MemoryAccessor createMemoryAccessor() {
+        return new StandardMemoryAccessor();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnsafeAvailability.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnsafeAvailability.java
@@ -1,0 +1,37 @@
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class TestIgnoreRuleAccordingToUnsafeAvailability implements TestRule {
+
+    private static final ILogger LOGGER = Logger.getLogger(TestIgnoreRuleAccordingToUnsafeAvailability.class);
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        if(UnsafeUtil.UNSAFE_AVAILABLE) {
+            return base;
+        } else {
+            return new IgnoreStatement(description);
+        }
+    }
+
+    private static class IgnoreStatement extends Statement {
+
+        private final Description description;
+
+        IgnoreStatement(Description description) {
+            this.description = description;
+        }
+
+        @Override
+        public void evaluate() {
+            LOGGER.finest("Ignoring `" + description.getClassName() + "` because Unsafe is not available");
+        }
+
+    }
+
+}


### PR DESCRIPTION
* `MemoryAccessor` is a new contact point for accessing memory.
* The current `MemoryAccessor` implementations are `Unsafe` based and interprets given addresses as native memory addresses. So these implementations can be thought as direct memory accessors.
* Note that address in this contract is not needed to be a native memory address. It might be interpreted differently by the implementation itself.
* Also `UnsafeHelper` is deprecated and offered `MemoryAccessor` instead.

The follow-up task of this PR should be cleaning `Unsafe` usages in our code base.