### PR TITLE
Client logging structure is improved.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
@@ -29,7 +29,6 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -73,14 +72,12 @@ abstract class AbstractClientCacheProxyBase<K, V> implements ICacheInternal<K, V
         }
     };
 
-    protected final ILogger logger = Logger.getLogger(getClass());
-
     protected final ClientContext clientContext;
     protected final CacheConfig<K, V> cacheConfig;
     //this will represent the name from the user perspective
     protected final String name;
     protected final String nameWithPrefix;
-
+    protected final ILogger logger;
     private final ConcurrentMap<Future, CompletionListener> loadAllCalls
             = new ConcurrentHashMap<Future, CompletionListener>();
 
@@ -90,6 +87,7 @@ abstract class AbstractClientCacheProxyBase<K, V> implements ICacheInternal<K, V
     private final AtomicInteger completionIdCounter = new AtomicInteger();
 
     protected AbstractClientCacheProxyBase(CacheConfig cacheConfig, ClientContext clientContext) {
+        this.logger = clientContext.getLoggingService().getLogger(getClass());
         this.name = cacheConfig.getName();
         this.nameWithPrefix = cacheConfig.getNameWithPrefix();
         this.cacheConfig = cacheConfig;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
@@ -18,10 +18,10 @@ package com.hazelcast.client.connection.nio;
 
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.nio.tcp.SocketChannelWrapper;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.nio.tcp.nonblocking.SelectionHandler;
-import com.hazelcast.nio.tcp.SocketChannelWrapper;
 
 import java.nio.channels.SelectionKey;
 
@@ -34,12 +34,13 @@ public abstract class AbstractClientSelectionHandler implements SelectionHandler
     private final NonBlockingIOThread ioThread;
     private SelectionKey sk;
 
-    public AbstractClientSelectionHandler(final ClientConnection connection, NonBlockingIOThread ioThread) {
+    public AbstractClientSelectionHandler(final ClientConnection connection, NonBlockingIOThread ioThread,
+                                          LoggingService loggingService) {
         this.connection = connection;
         this.ioThread = ioThread;
         this.socketChannel = connection.getSocketChannelWrapper();
         this.connectionManager = connection.getConnectionManager();
-        this.logger = Logger.getLogger(getClass().getName());
+        this.logger = loggingService.getLogger(getClass().getName());
     }
 
     protected void shutdown() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -19,14 +19,14 @@ package com.hazelcast.client.connection.nio;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.core.LifecycleService;
+import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionType;
-import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.OutboundFrame;
-import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.tcp.SocketChannelWrapper;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -45,7 +45,7 @@ public class ClientConnection implements Connection {
 
     protected final int connectionId;
     private final AtomicBoolean live = new AtomicBoolean(true);
-    private final ILogger logger = Logger.getLogger(ClientConnection.class);
+    private final ILogger logger;
 
     private final AtomicInteger pendingPacketCount = new AtomicInteger(0);
     private final ClientWriteHandler writeHandler;
@@ -67,8 +67,10 @@ public class ClientConnection implements Connection {
         this.lifecycleService = client.getLifecycleService();
         this.socketChannelWrapper = socketChannelWrapper;
         this.connectionId = connectionId;
-        this.readHandler = new ClientReadHandler(this, in, socket.getReceiveBufferSize());
-        this.writeHandler = new ClientWriteHandler(this, out, socket.getSendBufferSize());
+        LoggingService clientLoggingService = client.getLoggingService();
+        this.logger = clientLoggingService.getLogger(ClientConnection.class);
+        this.readHandler = new ClientReadHandler(this, in, socket.getReceiveBufferSize(), clientLoggingService);
+        this.writeHandler = new ClientWriteHandler(this, out, socket.getSendBufferSize(), clientLoggingService);
     }
 
     public ClientConnection(HazelcastClientInstanceImpl client,
@@ -80,6 +82,7 @@ public class ClientConnection implements Connection {
         writeHandler = null;
         readHandler = null;
         socketChannelWrapper = null;
+        logger = client.getLoggingService().getLogger(ClientConnection.class);
     }
 
     public void incrementPendingPacketCount() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.connection.nio;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.util.ClientMessageBuilder;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.util.Clock;
 
@@ -33,8 +34,9 @@ public class ClientReadHandler
 
     private volatile long lastHandle;
 
-    public ClientReadHandler(final ClientConnection connection, NonBlockingIOThread ioThread, int bufferSize) {
-        super(connection, ioThread);
+    public ClientReadHandler(final ClientConnection connection, NonBlockingIOThread ioThread, int bufferSize,
+                             LoggingService loggingService) {
+        super(connection, ioThread, loggingService);
         buffer = ByteBuffer.allocate(bufferSize);
         lastHandle = Clock.currentTimeMillis();
         builder = new ClientMessageBuilder(new ClientMessageBuilder.MessageHandler() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientWriteHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientWriteHandler.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.connection.nio;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.OutboundFrame;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.util.Clock;
@@ -42,8 +43,9 @@ public class ClientWriteHandler extends AbstractClientSelectionHandler implement
 
     private volatile long lastHandle;
 
-    public ClientWriteHandler(ClientConnection connection, NonBlockingIOThread ioThread, int bufferSize) {
-        super(connection, ioThread);
+    public ClientWriteHandler(ClientConnection connection, NonBlockingIOThread ioThread, int bufferSize,
+                              LoggingService loggingService) {
+        super(connection, ioThread, loggingService);
         buffer = ByteBuffer.allocate(bufferSize);
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientLoggingService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientLoggingService.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl;
+
+import com.hazelcast.instance.BuildInfo;
+import com.hazelcast.logging.AbstractLogger;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LogEvent;
+import com.hazelcast.logging.LogListener;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.LoggerFactory;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.util.ConstructorFunction;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
+
+public class ClientLoggingService implements LoggingService {
+
+    private final String groupName;
+
+    private final ConcurrentMap<String, ILogger> mapLoggers = new ConcurrentHashMap<String, ILogger>(100);
+
+    private final ConstructorFunction<String, ILogger> loggerConstructor
+            = new ConstructorFunction<String, ILogger>() {
+
+        @Override
+        public ILogger createNew(String key) {
+            return new DefaultLogger(key);
+        }
+    };
+
+    private final LoggerFactory loggerFactory;
+    private final BuildInfo buildInfo;
+    private final String clientName;
+
+    public ClientLoggingService(String groupName, String loggingType, BuildInfo buildInfo,
+                                String clientName) {
+        this.groupName = groupName;
+        this.clientName = clientName;
+        this.loggerFactory = Logger.newLoggerFactory(loggingType);
+        this.buildInfo = buildInfo;
+    }
+
+    @Override
+    public void addLogListener(Level level, LogListener logListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeLogListener(LogListener logListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    public ILogger getLogger(String name) {
+        return getOrPutIfAbsent(mapLoggers, name, loggerConstructor);
+    }
+
+    public ILogger getLogger(Class clazz) {
+        return getOrPutIfAbsent(mapLoggers, clazz.getName(), loggerConstructor);
+    }
+
+    private class DefaultLogger extends AbstractLogger {
+        final String name;
+        final ILogger logger;
+
+        DefaultLogger(String name) {
+            this.name = name;
+            this.logger = loggerFactory.getLogger(name);
+        }
+
+        @Override
+        public void log(Level level, String message) {
+            log(level, message, null);
+        }
+
+        @Override
+        public void log(Level level, String message, Throwable thrown) {
+            boolean loggable = logger.isLoggable(level);
+            if (loggable) {
+                String logMessage = clientName
+                        + " [" + groupName + "] [" + buildInfo.getVersion() + "] " + message;
+                logger.log(level, logMessage, thrown);
+            }
+        }
+
+        public void log(LogEvent logEvent) {
+            //unsued
+        }
+
+        @Override
+        public Level getLevel() {
+            return logger.getLevel();
+        }
+
+        @Override
+        public boolean isLoggable(Level level) {
+            return logger.isLoggable(level);
+        }
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
@@ -26,14 +26,12 @@ import com.hazelcast.client.spi.impl.AwsAddressTranslator;
 import com.hazelcast.client.spi.impl.DefaultAddressTranslator;
 import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressTranslator;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 import java.util.logging.Level;
 
 public class DefaultClientConnectionManagerFactory implements ClientConnectionManagerFactory {
-
-    private static final ILogger LOGGER = Logger.getLogger(HazelcastClient.class);
 
     public DefaultClientConnectionManagerFactory() {
     }
@@ -42,13 +40,15 @@ public class DefaultClientConnectionManagerFactory implements ClientConnectionMa
     public ClientConnectionManager createConnectionManager(ClientConfig config, HazelcastClientInstanceImpl client,
                                                            DiscoveryService discoveryService) {
 
-        final ClientAwsConfig awsConfig = config.getNetworkConfig().getAwsConfig();
+        LoggingService loggingService = client.getLoggingService();
+        ILogger logger = loggingService.getLogger(HazelcastClient.class);
+        ClientAwsConfig awsConfig = config.getNetworkConfig().getAwsConfig();
         AddressTranslator addressTranslator;
         if (awsConfig != null && awsConfig.isEnabled()) {
             try {
-                addressTranslator = new AwsAddressTranslator(awsConfig);
+                addressTranslator = new AwsAddressTranslator(awsConfig, loggingService);
             } catch (NoClassDefFoundError e) {
-                LOGGER.log(Level.WARNING, "hazelcast-cloud.jar might be missing!");
+                logger.log(Level.WARNING, "hazelcast-cloud.jar might be missing!");
                 throw e;
             }
         } else if (discoveryService != null) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
@@ -24,7 +24,6 @@ import com.hazelcast.core.LifecycleService;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.util.UuidUtil;
 
 import java.util.List;
@@ -63,7 +62,7 @@ public final class LifecycleServiceImpl implements LifecycleService {
     }
 
     private ILogger getLogger() {
-        return Logger.getLogger(LifecycleService.class);
+        return client.getLoggingService().getLogger(LifecycleService.class);
     }
 
     @Override
@@ -79,9 +78,12 @@ public final class LifecycleServiceImpl implements LifecycleService {
     }
 
     public void fireLifecycleEvent(LifecycleEvent.LifecycleState lifecycleState) {
-        final LifecycleEvent lifecycleEvent = new LifecycleEvent(lifecycleState);
-        getLogger().info("HazelcastClient[" + client.getName() + "]" + "["
-                + buildInfo.getVersion() + "] is " + lifecycleEvent.getState());
+        LifecycleEvent lifecycleEvent = new LifecycleEvent(lifecycleState);
+        String revision = buildInfo.getRevision();
+        revision = revision == null || revision.isEmpty() ? "" : " - " + revision;
+        getLogger().info("HazelcastClient " + buildInfo.getVersion() + " ("
+                + buildInfo.getBuild() + revision + ") is "
+                + lifecycleEvent.getState());
         for (LifecycleListener lifecycleListener : lifecycleListeners.values()) {
             lifecycleListener.stateChanged(lifecycleEvent);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -31,7 +31,6 @@ import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.mapreduce.Collator;
 import com.hazelcast.mapreduce.CombinerFactory;
 import com.hazelcast.mapreduce.Job;
@@ -237,7 +236,8 @@ public class ClientMapReduceProxy
         private final String jobId;
 
         protected ClientCompletableFuture(String jobId) {
-            super(getContext().getExecutionService().getAsyncExecutor(), Logger.getLogger(ClientCompletableFuture.class));
+            super(getContext().getExecutionService().getAsyncExecutor(),
+                    getContext().getLoggingService().getLogger(ClientCompletableFuture.class));
             this.jobId = jobId;
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -29,7 +29,6 @@ import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.ringbuffer.OverflowPolicy;
@@ -58,7 +57,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
     private static final int MAX_BACKOFF = 2000;
     private static final int INITIAL_BACKOFF_MS = 100;
 
-    private final ILogger logger = Logger.getLogger(getClass());
+    private final ILogger logger;
     private final ConcurrentMap<String, MessageRunner> runnersMap = new ConcurrentHashMap<String, MessageRunner>();
     private final Ringbuffer ringbuffer;
     private final SerializationService serializationService;
@@ -70,10 +69,10 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
         super(SERVICE_NAME, objectId);
         this.ringbuffer = client.getRingbuffer(TOPIC_RB_PREFIX + objectId);
         this.serializationService = client.getSerializationService();
-
         this.config = client.getClientConfig().getReliableTopicConfig(objectId);
         this.executor = getExecutor(config, client);
         this.overloadPolicy = config.getTopicOverloadPolicy();
+        logger = client.getLoggingService().getLogger(getClass());
     }
 
     private Executor getExecutor(ClientReliableTopicConfig config, HazelcastClientInstanceImpl client) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -47,7 +47,7 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.ReplicatedMap;
-import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.monitor.LocalReplicatedMapStats;
 import com.hazelcast.nio.serialization.Data;
@@ -55,6 +55,7 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.replicatedmap.impl.record.ResultSet;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.util.IterationType;
+
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -424,8 +425,8 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
             EventHandler handler = new ReplicatedMapAddNearCacheEventHandler();
             invalidationListenerId = registerListener(createNearCacheInvalidationListenerCodec(), handler);
         } catch (Exception e) {
-            Logger.getLogger(ClientHeapNearCache.class).severe(
-                    "-----------------\n Near Cache is not initialized!!! \n-----------------", e);
+            ILogger logger = getContext().getLoggingService().getLogger(ClientHeapNearCache.class);
+            logger.severe("-----------------\n Near Cache is not initialized!!! \n-----------------", e);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -29,7 +29,7 @@ import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.NearCacheStats;
@@ -371,8 +371,8 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
             invalidationListenerId = registerListener(createNearCacheEntryListenerCodec(), handler);
 
         } catch (Exception e) {
-            Logger.getLogger(ClientHeapNearCache.class).severe(
-                    "-----------------\n Near Cache is not initialized!!! \n-----------------", e);
+            ILogger logger = getContext().getLoggingService().getLogger(ClientHeapNearCache.class);
+            logger.severe("-----------------\n Near Cache is not initialized!!! \n-----------------", e);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
@@ -23,10 +23,9 @@ import com.hazelcast.client.impl.protocol.codec.XATransactionFinalizeCodec;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.ClientTransactionManagerService;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionOptions;
@@ -51,7 +50,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class XAResourceProxy extends ClientProxy implements HazelcastXAResource {
 
     private static final int DEFAULT_TIMEOUT_SECONDS = (int) MILLISECONDS.toSeconds(TransactionOptions.DEFAULT_TIMEOUT_MILLIS);
-    private static final ILogger LOGGER = Logger.getLogger(XAResourceProxy.class);
 
     private final ConcurrentMap<Long, TransactionContext> threadContextMap = new ConcurrentHashMap<Long, TransactionContext>();
     private final ConcurrentMap<Xid, List<TransactionContext>> xidContextMap
@@ -106,12 +104,13 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
     public void end(Xid xid, int flags) throws XAException {
         long threadId = currentThreadId();
         TransactionContext threadContext = threadContextMap.remove(threadId);
-        if (threadContext == null && LOGGER.isFinestEnabled()) {
-            LOGGER.finest("There is no TransactionContext for the current thread: " + threadId);
+        ILogger logger = getContext().getLoggingService().getLogger(this.getClass());
+        if (threadContext == null && logger.isFinestEnabled()) {
+            logger.finest("There is no TransactionContext for the current thread: " + threadId);
         }
         List<TransactionContext> contexts = xidContextMap.get(xid);
-        if (contexts == null && LOGGER.isFinestEnabled()) {
-            LOGGER.finest("There is no TransactionContexts for the given xid: " + xid);
+        if (contexts == null && logger.isFinestEnabled()) {
+            logger.finest("There is no TransactionContexts for the given xid: " + xid);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.logging.LoggingService;
 
 public final class ClientContext {
 
@@ -34,6 +35,7 @@ public final class ClientContext {
     private final ClientTransactionManagerService transactionManager;
     private final ProxyManager proxyManager;
     private final ClientConfig clientConfig;
+    private final LoggingService loggingService;
 
     ClientContext(HazelcastClientInstanceImpl client, ProxyManager proxyManager) {
         this.serializationService = client.getSerializationService();
@@ -46,6 +48,7 @@ public final class ClientContext {
         this.proxyManager = proxyManager;
         this.clientConfig = client.getClientConfig();
         this.transactionManager = client.getTransactionManager();
+        this.loggingService = client.getLoggingService();
     }
 
     public HazelcastInstance getHazelcastInstance() {
@@ -82,6 +85,10 @@ public final class ClientContext {
 
     public NearCacheManager getNearCacheManager() {
         return nearCacheManager;
+    }
+
+    public LoggingService getLoggingService() {
+        return loggingService;
     }
 
     public void removeProxy(ClientProxy proxy) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
@@ -21,7 +21,7 @@ import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.util.AddressHelper;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.LoggingService;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -35,12 +35,13 @@ import java.util.logging.Level;
  */
 public class AwsAddressProvider implements AddressProvider {
 
-    private static final ILogger LOGGER = Logger.getLogger(AwsAddressProvider.class);
+    private final ILogger logger;
     private final AWSClient awsClient;
     private volatile Map<String, String> privateToPublic;
 
-    public AwsAddressProvider(ClientAwsConfig awsConfig) {
+    public AwsAddressProvider(ClientAwsConfig awsConfig, LoggingService loggingService) {
         awsClient = new AWSClient(awsConfig);
+        logger = loggingService.getLogger(AwsAddressProvider.class);
     }
 
     @Override
@@ -65,7 +66,7 @@ public class AwsAddressProvider implements AddressProvider {
         try {
             privateToPublic = awsClient.getAddresses();
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Aws addresses are failed to load : " + e.getMessage());
+            logger.log(Level.WARNING, "Aws addresses are failed to load : " + e.getMessage());
         }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressTranslator.java
@@ -20,7 +20,7 @@ import com.hazelcast.aws.AWSClient;
 import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 
 import java.net.UnknownHostException;
@@ -34,14 +34,15 @@ import java.util.logging.Level;
  */
 public class AwsAddressTranslator implements AddressTranslator {
 
-    private static final ILogger LOGGER = Logger.getLogger(AwsAddressTranslator.class);
+    private final ILogger logger;
     private volatile Map<String, String> privateToPublic;
     private final AWSClient awsClient;
     private final boolean isInsideAws;
 
-    public AwsAddressTranslator(ClientAwsConfig awsConfig) {
+    public AwsAddressTranslator(ClientAwsConfig awsConfig, LoggingService loggingService) {
         awsClient = new AWSClient(awsConfig);
         isInsideAws = awsConfig.isInsideAws();
+        logger = loggingService.getLogger(AwsAddressTranslator.class);
     }
 
     /**
@@ -88,7 +89,7 @@ public class AwsAddressTranslator implements AddressTranslator {
         try {
             privateToPublic = awsClient.getAddresses();
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Aws addresses are failed to load : " + e.getMessage());
+            logger.log(Level.WARNING, "Aws addresses are failed to load : " + e.getMessage());
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -36,7 +36,6 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.util.Clock;
@@ -59,15 +58,16 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ClientClusterServiceImpl extends ClusterListenerSupport {
 
-    private static final ILogger LOGGER = Logger.getLogger(ClientClusterService.class);
+    private final ILogger logger;
     private final AtomicReference<Map<Address, Member>> members = new AtomicReference<Map<Address, Member>>();
     private final ConcurrentMap<String, MembershipListener> listeners = new ConcurrentHashMap<String, MembershipListener>();
     private final Object initialMembershipListenerMutex = new Object();
 
     public ClientClusterServiceImpl(HazelcastClientInstanceImpl client, Collection<AddressProvider> addressProviders) {
         super(client, addressProviders);
-        final ClientConfig clientConfig = getClientConfig();
-        final List<ListenerConfig> listenerConfigs = client.getClientConfig().getListenerConfigs();
+        logger = client.getLoggingService().getLogger(ClientClusterService.class);
+        ClientConfig clientConfig = getClientConfig();
+        List<ListenerConfig> listenerConfigs = client.getClientConfig().getListenerConfigs();
         for (ListenerConfig listenerConfig : listenerConfigs) {
             EventListener listener = listenerConfig.getImplementation();
             if (listener == null) {
@@ -75,7 +75,7 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
                     listener = ClassLoaderUtil.newInstance(clientConfig.getClassLoader(),
                             listenerConfig.getClassName());
                 } catch (Exception e) {
-                    LOGGER.severe(e);
+                    logger.severe(e);
                 }
             }
             if (listener instanceof MembershipListener) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -30,7 +30,6 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.HazelcastOverloadException;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
@@ -53,9 +52,9 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
 
     public static final long RETRY_WAIT_TIME_IN_SECONDS = 1;
     protected static final int UNASSIGNED_PARTITION = -1;
-    private static final ILogger LOGGER = Logger.getLogger(ClientInvocation.class);
 
-    protected ClientInvocationFuture clientInvocationFuture;
+    protected final ClientInvocationFuture clientInvocationFuture;
+    private final ILogger logger;
     private final LifecycleService lifecycleService;
     private final ClientInvocationService invocationService;
     private final ClientExecutionService executionService;
@@ -88,8 +87,8 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
         long waitTimeResolved = waitTime > 0 ? waitTime : Integer.parseInt(INVOCATION_TIMEOUT_SECONDS.getDefaultValue());
         retryTimeoutPointInMillis = System.currentTimeMillis() + waitTimeResolved;
 
-        clientInvocationFuture = new ClientInvocationFuture(this, client, clientMessage);
-
+        logger = ((ClientInvocationServiceSupport) invocationService).invocationLogger;
+        clientInvocationFuture = new ClientInvocationFuture(this, client, clientMessage, logger);
 
         int interval = clientProperties.getInteger(HEARTBEAT_INTERVAL);
         this.heartBeatInterval = interval > 0 ? interval : Integer.parseInt(HEARTBEAT_INTERVAL.getDefaultValue());
@@ -208,8 +207,8 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
         try {
             rescheduleInvocation();
         } catch (RejectedExecutionException e) {
-            if (LOGGER.isFinestEnabled()) {
-                LOGGER.finest("Retry could not be scheduled ", e);
+            if (logger.isFinestEnabled()) {
+                logger.finest("Retry could not be scheduled ", e);
             }
             notifyException(e);
         }
@@ -292,8 +291,8 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
 
     @Override
     public void onFailure(Throwable t) {
-        if (LOGGER.isFinestEnabled()) {
-            LOGGER.finest("Failure during retry ", t);
+        if (logger.isFinestEnabled()) {
+            logger.finest("Failure during retry ", t);
         }
         clientInvocationFuture.setResponse(t);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -22,7 +22,6 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -36,7 +35,7 @@ import java.util.concurrent.TimeoutException;
 
 public class ClientInvocationFuture implements ICompletableFuture<ClientMessage> {
 
-    protected static final ILogger LOGGER = Logger.getLogger(ClientInvocationFuture.class);
+    protected final ILogger logger;
 
     protected final ClientMessage clientMessage;
     protected volatile Object response;
@@ -46,11 +45,12 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
     private final ClientInvocation invocation;
 
     public ClientInvocationFuture(ClientInvocation invocation, HazelcastClientInstanceImpl client,
-                                  ClientMessage clientMessage) {
+                                  ClientMessage clientMessage, ILogger logger) {
 
         this.executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
         this.clientMessage = clientMessage;
         this.invocation = invocation;
+        this.logger = logger;
     }
 
     @Override
@@ -101,7 +101,7 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
      */
     boolean shouldSetResponse(Object response) {
         if (this.response != null) {
-            LOGGER.warning("The Future.set() method can only be called once. Request: " + clientMessage
+            logger.warning("The Future.set() method can only be called once. Request: " + clientMessage
                     + ", current response: " + this.response + ", new response: " + response);
             return false;
         }
@@ -177,13 +177,13 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
                         }
                         callback.onResponse(resp);
                     } catch (Throwable t) {
-                        LOGGER.severe("Failed to execute callback: " + callback
+                        logger.severe("Failed to execute callback: " + callback
                                 + "! Request: " + clientMessage + ", response: " + response, t);
                     }
                 }
             });
         } catch (RejectedExecutionException e) {
-            LOGGER.warning("Execution of callback: " + callback + " is rejected!", e);
+            logger.warning("Execution of callback: " + callback + " is rejected!", e);
             callback.onFailure(new HazelcastClientNotActiveException(e.getMessage()));
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -18,7 +18,7 @@ package com.hazelcast.client.spi.impl.discovery;
 
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
@@ -31,12 +31,12 @@ import java.util.Collection;
 public class DiscoveryAddressProvider
         implements AddressProvider {
 
-    private static final ILogger LOGGER = Logger.getLogger(DiscoveryAddressProvider.class);
-
+    private final ILogger logger;
     private final DiscoveryService discoveryService;
 
-    public DiscoveryAddressProvider(DiscoveryService discoveryService) {
+    public DiscoveryAddressProvider(DiscoveryService discoveryService, LoggingService loggingService) {
         this.discoveryService = discoveryService;
+        logger = loggingService.getLogger(DiscoveryAddressProvider.class);
     }
 
     @Override
@@ -49,7 +49,7 @@ public class DiscoveryAddressProvider
             try {
                 possibleMembers.add(discoveredAddress.getInetSocketAddress());
             } catch (UnknownHostException e) {
-                LOGGER.warning("Unresolvable host exception", e);
+                logger.warning("Unresolvable host exception", e);
             }
         }
         return possibleMembers;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -25,7 +25,6 @@ import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ClientExecutionServiceImpl;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.util.executor.StripedExecutor;
 import com.hazelcast.util.executor.StripedRunnable;
@@ -42,7 +41,7 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
     protected final ClientExecutionServiceImpl executionService;
     protected final SerializationService serializationService;
     protected final ClientInvocationService invocationService;
-    protected final ILogger logger = Logger.getLogger(ClientListenerService.class);
+    protected final ILogger logger;
     private final ConcurrentMap<Long, EventHandler> eventHandlerMap
             = new ConcurrentHashMap<Long, EventHandler>();
 
@@ -50,10 +49,11 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
 
     public ClientListenerServiceImpl(HazelcastClientInstanceImpl client, int eventThreadCount, int eventQueueCapacity) {
         this.client = client;
-        this.executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
-        this.invocationService = client.getInvocationService();
-        this.serializationService = client.getSerializationService();
-        this.eventExecutor = new StripedExecutor(logger, client.getName() + ".event",
+        executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
+        invocationService = client.getInvocationService();
+        serializationService = client.getSerializationService();
+        logger = client.getLoggingService().getLogger(ClientListenerService.class);
+        eventExecutor = new StripedExecutor(logger, client.getName() + ".event",
                 client.getThreadGroup(), eventThreadCount, eventQueueCapacity);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -85,7 +85,7 @@ public class TestClientRegistry {
             AddressTranslator addressTranslator;
             if (awsConfig != null && awsConfig.isEnabled()) {
                 try {
-                    addressTranslator = new AwsAddressTranslator(awsConfig);
+                    addressTranslator = new AwsAddressTranslator(awsConfig, client.getLoggingService());
                 } catch (NoClassDefFoundError e) {
                     LOGGER.log(Level.WARNING, "hazelcast-cloud.jar might be missing!");
                     throw e;


### PR DESCRIPTION
Static Logger.getLogger usage is removed.
ClientLoggingService.getLogger is used instead.
This logger has following format
ClientInstanceName [Cluster Name] [Version]

When client started it prints buildNumber and github commit id
as server.A sample line is as follows
hz.client_0 [dev] [3.7-SNAPSHOT] HazelcastClient 3.7-SNAPSHOT (20160201 - bc4f0b5) is CLIENT_CONNECTED