### PR TITLE
Packet read/write simplification

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -20,11 +20,12 @@ import com.hazelcast.internal.serialization.impl.HeapData;
 
 import java.nio.ByteBuffer;
 
+import static com.hazelcast.nio.Bits.BYTE_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
+import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
 
 /**
- * A Packet is a piece of data send over the line. The Packet is used for member to member communication and old-client to
- * member communication.
+ * A Packet is a piece of data send over the line. The Packet is used for member to member communication.
  *
  * The Packet extends HeapData instead of wrapping it. From a design point of view this is often not the preferred solution (
  * prefer composition over inheritance), but in this case that would mean more object litter.
@@ -42,14 +43,7 @@ public final class Packet extends HeapData implements OutboundFrame {
     public static final int HEADER_URGENT = 4;
     public static final int HEADER_BIND = 5;
 
-    // The value of these constants is important. The order needs to match the order in the read/write process
-    private static final short PERSIST_VERSION = 1;
-    private static final short PERSIST_HEADER = 2;
-    private static final short PERSIST_PARTITION = 3;
-    private static final short PERSIST_SIZE = 4;
-    private static final short PERSIST_VALUE = 5;
-
-    private static final short PERSIST_COMPLETED = Short.MAX_VALUE;
+    private static final int HEAD_SIZE = BYTE_SIZE_IN_BYTES + SHORT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES;
 
     private short header;
     private int partitionId;
@@ -59,7 +53,7 @@ public final class Packet extends HeapData implements OutboundFrame {
     private int valueOffset;
     private int size;
     // Stores the current 'phase' of read/write. This is needed so that repeated calls can be made to read/write.
-    private short persistStatus;
+    private boolean headComplete;
 
     public Packet() {
     }
@@ -121,230 +115,114 @@ public final class Packet extends HeapData implements OutboundFrame {
         return partitionId;
     }
 
+    public void reset() {
+        headComplete = false;
+    }
+
     @Override
     public boolean isUrgent() {
         return isHeaderSet(HEADER_URGENT);
     }
 
     public boolean writeTo(ByteBuffer dst) {
-        if (!writeVersion(dst)) {
-            return false;
+        if (!headComplete) {
+            if (dst.remaining() < HEAD_SIZE) {
+                return false;
+            }
+
+            dst.put(VERSION);
+            dst.putShort(header);
+            dst.putInt(partitionId);
+            size = totalSize();
+            dst.putInt(size);
+            headComplete = true;
         }
 
-        if (!writeHeader(dst)) {
-            return false;
-        }
-
-        if (!writePartition(dst)) {
-            return false;
-        }
-
-        if (!writeSize(dst)) {
-            return false;
-        }
-
-        if (!writeValue(dst)) {
-            return false;
-        }
-
-        setPersistStatus(PERSIST_COMPLETED);
-        return true;
+        return writeValue(dst);
     }
 
     public boolean readFrom(ByteBuffer src) {
-        if (!readVersion(src)) {
-            return false;
-        }
-
-        if (!readHeader(src)) {
-            return false;
-        }
-
-        if (!readPartition(src)) {
-            return false;
-        }
-
-        if (!readSize(src)) {
-            return false;
-        }
-
-        if (!readValue(src)) {
-            return false;
-        }
-
-        setPersistStatus(PERSIST_COMPLETED);
-        return true;
-    }
-
-    // ========================= version =================================================
-
-    private boolean readVersion(ByteBuffer src) {
-        if (!isPersistStatusSet(PERSIST_VERSION)) {
-            if (!src.hasRemaining()) {
+        if (!headComplete) {
+            if (src.remaining() < HEAD_SIZE) {
                 return false;
             }
+
             byte version = src.get();
-            setPersistStatus(PERSIST_VERSION);
             if (VERSION != version) {
                 throw new IllegalArgumentException("Packet versions are not matching! Expected -> "
                         + VERSION + ", Incoming -> " + version);
             }
-        }
-        return true;
-    }
 
-    private boolean writeVersion(ByteBuffer dst) {
-        if (!isPersistStatusSet(PERSIST_VERSION)) {
-            if (!dst.hasRemaining()) {
-                return false;
-            }
-            dst.put(VERSION);
-            setPersistStatus(PERSIST_VERSION);
-        }
-        return true;
-    }
-
-    // ========================= header =================================================
-
-    private boolean readHeader(ByteBuffer src) {
-        if (!isPersistStatusSet(PERSIST_HEADER)) {
-            if (src.remaining() < 2) {
-                return false;
-            }
             header = src.getShort();
-            setPersistStatus(PERSIST_HEADER);
-        }
-        return true;
-    }
-
-    private boolean writeHeader(ByteBuffer dst) {
-        if (!isPersistStatusSet(PERSIST_HEADER)) {
-            if (dst.remaining() < Bits.SHORT_SIZE_IN_BYTES) {
-                return false;
-            }
-            dst.putShort(header);
-            setPersistStatus(PERSIST_HEADER);
-        }
-        return true;
-    }
-
-    // ========================= partition =================================================
-
-    private boolean readPartition(ByteBuffer src) {
-        if (!isPersistStatusSet(PERSIST_PARTITION)) {
-            if (src.remaining() < 4) {
-                return false;
-            }
             partitionId = src.getInt();
-            setPersistStatus(PERSIST_PARTITION);
-        }
-        return true;
-    }
-
-
-    private boolean writePartition(ByteBuffer dst) {
-        if (!isPersistStatusSet(PERSIST_PARTITION)) {
-            if (dst.remaining() < Bits.INT_SIZE_IN_BYTES) {
-                return false;
-            }
-            dst.putInt(partitionId);
-            setPersistStatus(PERSIST_PARTITION);
-        }
-        return true;
-    }
-
-    // ========================= size =================================================
-
-    private boolean readSize(ByteBuffer src) {
-        if (!isPersistStatusSet(PERSIST_SIZE)) {
-            if (src.remaining() < INT_SIZE_IN_BYTES) {
-                return false;
-            }
             size = src.getInt();
-            setPersistStatus(PERSIST_SIZE);
+            headComplete = true;
         }
-        return true;
-    }
 
-    private boolean writeSize(ByteBuffer dst) {
-        if (!isPersistStatusSet(PERSIST_SIZE)) {
-            if (dst.remaining() < INT_SIZE_IN_BYTES) {
-                return false;
-            }
-            size = totalSize();
-            dst.putInt(size);
-            setPersistStatus(PERSIST_SIZE);
-        }
-        return true;
+        return readValue(src);
     }
 
     // ========================= value =================================================
 
     private boolean readValue(ByteBuffer src) {
-        if (!isPersistStatusSet(PERSIST_VALUE)) {
-            if (payload == null) {
-                payload = new byte[size];
-            }
-
-            if (size > 0) {
-                int bytesReadable = src.remaining();
-
-                int bytesNeeded = size - valueOffset;
-
-                boolean done;
-                int bytesRead;
-                if (bytesReadable >= bytesNeeded) {
-                    bytesRead = bytesNeeded;
-                    done = true;
-                } else {
-                    bytesRead = bytesReadable;
-                    done = false;
-                }
-
-                // read the data from the byte-buffer into the bytes-array.
-                src.get(payload, valueOffset, bytesRead);
-                valueOffset += bytesRead;
-
-                if (!done) {
-                    return false;
-                }
-            }
-
-            setPersistStatus(PERSIST_VALUE);
+        if (payload == null) {
+            payload = new byte[size];
         }
+
+        if (size > 0) {
+            int bytesReadable = src.remaining();
+
+            int bytesNeeded = size - valueOffset;
+
+            boolean done;
+            int bytesRead;
+            if (bytesReadable >= bytesNeeded) {
+                bytesRead = bytesNeeded;
+                done = true;
+            } else {
+                bytesRead = bytesReadable;
+                done = false;
+            }
+
+            // read the data from the byte-buffer into the bytes-array.
+            src.get(payload, valueOffset, bytesRead);
+            valueOffset += bytesRead;
+
+            if (!done) {
+                return false;
+            }
+        }
+
         return true;
     }
 
     private boolean writeValue(ByteBuffer dst) {
-        if (!isPersistStatusSet(PERSIST_VALUE)) {
-            if (size > 0) {
-                // the number of bytes that can be written to the bb.
-                int bytesWritable = dst.remaining();
+        if (size > 0) {
+            // the number of bytes that can be written to the bb.
+            int bytesWritable = dst.remaining();
 
-                // the number of bytes that need to be written.
-                int bytesNeeded = size - valueOffset;
+            // the number of bytes that need to be written.
+            int bytesNeeded = size - valueOffset;
 
-                int bytesWrite;
-                boolean done;
-                if (bytesWritable >= bytesNeeded) {
-                    // All bytes for the value are available.
-                    bytesWrite = bytesNeeded;
-                    done = true;
-                } else {
-                    // Not all bytes for the value are available. So lets write as much as is available.
-                    bytesWrite = bytesWritable;
-                    done = false;
-                }
-
-                byte[] byteArray = toByteArray();
-                dst.put(byteArray, valueOffset, bytesWrite);
-                valueOffset += bytesWrite;
-
-                if (!done) {
-                    return false;
-                }
+            int bytesWrite;
+            boolean done;
+            if (bytesWritable >= bytesNeeded) {
+                // All bytes for the value are available.
+                bytesWrite = bytesNeeded;
+                done = true;
+            } else {
+                // Not all bytes for the value are available. So lets write as much as is available.
+                bytesWrite = bytesWritable;
+                done = false;
             }
-            setPersistStatus(PERSIST_VALUE);
+
+            byte[] byteArray = toByteArray();
+            dst.put(byteArray, valueOffset, bytesWrite);
+            valueOffset += bytesWrite;
+
+            if (!done) {
+                return false;
+            }
         }
         return true;
     }
@@ -356,24 +234,7 @@ public final class Packet extends HeapData implements OutboundFrame {
      */
     public int packetSize() {
         // 11 = byte(version) + short(header) + int(partitionId) + int(data size)
-        return (payload != null ? totalSize() : 0) + 11;
-    }
-
-    public boolean done() {
-        return isPersistStatusSet(PERSIST_COMPLETED);
-    }
-
-    public void reset() {
-        payload = null;
-        persistStatus = 0;
-    }
-
-    private void setPersistStatus(short persistStatus) {
-        this.persistStatus = persistStatus;
-    }
-
-    private boolean isPersistStatusSet(short status) {
-        return this.persistStatus >= status;
+        return (payload != null ? totalSize() : 0) + HEAD_SIZE;
     }
 
     @Override


### PR DESCRIPTION
Instead of dealing with each parameter from the head individually, they are done in 1 go.

So we check if there is space to read them all, or write them all. If not, we don't read any,
and if there is, we read them all. This reduces the amount and complexity of the code considerably.

Doesn't have a negative impact on performance:

```
Benchmark            Mode  Cnt   Score   Error  Units
PacketBenchmark.run  avgt   20  50.052 ± 1.840  ns/op

new:

Benchmark            Mode  Cnt   Score   Error  Units
PacketBenchmark.run  avgt   20  48.389 ± 0.578  ns/op
```

Using the following benchmark:

```
package hazelcast;

import com.hazelcast.nio.Packet;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Warmup;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;

import java.nio.ByteBuffer;
import java.util.concurrent.TimeUnit;

@BenchmarkMode(Mode.AverageTime)
@Warmup(iterations = 1)
@Measurement(iterations = 2)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Thread)
public class PacketBenchmark {

    private Packet sourceBuffer;
    private Packet dstBuffer;
    private ByteBuffer buffer;

    @Setup
    public void init() {
        sourceBuffer = new Packet(new byte[10]);
        dstBuffer = new Packet();
        buffer = ByteBuffer.allocate(100);
    }

    @Benchmark
    public void run() {
        buffer.clear();

        sourceBuffer.writeTo(buffer);
        sourceBuffer.reset();

        buffer.flip();

        dstBuffer.readFrom(buffer);
        dstBuffer.reset();
    }

    public static void main(String[] args) throws RunnerException {
        Options opt = new OptionsBuilder()
                .include( ".*" + PacketBenchmark.class.getSimpleName() + ".*" )
                .build();
        new Runner( opt ).run();
    }
}
```

