### PR TITLE
Stricter type check for ClientAuthenticationCustomCodec in ClusterAuthenticator

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
@@ -59,7 +59,7 @@ public class ClusterAuthenticator implements Authenticator {
         String ownerUuid = principal.getOwnerUuid();
 
         ClientMessage clientMessage;
-        if (credentials instanceof UsernamePasswordCredentials) {
+        if (credentials.getClass().equals(UsernamePasswordCredentials.class)) {
             UsernamePasswordCredentials cr = (UsernamePasswordCredentials) credentials;
             clientMessage = ClientAuthenticationCodec.encodeRequest(cr.getUsername(), cr.getPassword(), uuid, ownerUuid, false,
                     ClientTypes.JAVA, client.getSerializationService().getVersion());


### PR DESCRIPTION
The type checking should be done same as it is in ManagerAuthenticator.

Fixes #7524