### PR TITLE
Rename MemoryAccessor.DEFAULT to MEM

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
@@ -20,7 +20,7 @@ import java.lang.reflect.Field;
 
 /**
  * <p>
- * Contract point for memory access operations.
+ * Contract point for direct memory access operations.
  * </p>
  *
  * <p>
@@ -36,8 +36,8 @@ import java.lang.reflect.Field;
  *      </li>
  *      <li>
  *        The default {@link MemoryAccessor} implementation
- *        can be accessed via #DEFAULT field of this interface
- *        and its availability state can be checked via #AVAILABLE field.
+ *        can be accessed via {@link #MEM} field of this interface
+ *        and its availability state can be checked via {@link #AVAILABLE} field.
  *      </li>
  * </ul>
  * </p>
@@ -50,111 +50,113 @@ public interface MemoryAccessor {
     /**
      * The default {@link MemoryAccessor} instance.
      */
-    MemoryAccessor DEFAULT = MemoryAccessorProvider.getDefaultMemoryAccessor();
+    MemoryAccessor MEM = MemoryAccessorProvider.getDefaultMemoryAccessor();
 
     /**
-     * State about {@link #DEFAULT} {@link MemoryAccessor} is available to be used.
+     * If this constant is {@code true}, then {@link MEM} refers to a usable {@code MemoryAccessor}
+     * instance.
      */
-    boolean AVAILABLE = DEFAULT != null;
+    boolean AVAILABLE = MEM != null;
 
     /////////////////////////////////////////////////////////////////////////
 
     /**
-     * Memory copy threshold in bytes.
+     * Maximum size of a block of memory to copy in a single low-level memory-copying
+     * operation. The goal is to prevent large periods without a GC safepoint.
      */
     int MEM_COPY_THRESHOLD = 1024 * 1024;
 
     /**
      * Base offset of boolean[]
      */
-    int ARRAY_BOOLEAN_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(boolean[].class) : -1;
+    int ARRAY_BOOLEAN_BASE_OFFSET = MEM != null ? MEM.arrayBaseOffset(boolean[].class) : -1;
 
     /**
      * Base offset of byte[]
      */
-    int ARRAY_BYTE_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(byte[].class) : -1;
+    int ARRAY_BYTE_BASE_OFFSET = MEM != null ? MEM.arrayBaseOffset(byte[].class) : -1;
 
     /**
      * Base offset of short[]
      */
-    int ARRAY_SHORT_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(short[].class) : -1;
+    int ARRAY_SHORT_BASE_OFFSET = MEM != null ? MEM.arrayBaseOffset(short[].class) : -1;
 
     /**
      * Base offset of char[]
      */
-    int ARRAY_CHAR_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(char[].class) : -1;
+    int ARRAY_CHAR_BASE_OFFSET = MEM != null ? MEM.arrayBaseOffset(char[].class) : -1;
 
     /**
      * Base offset of int[]
      */
-    int ARRAY_INT_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(int[].class) : -1;
+    int ARRAY_INT_BASE_OFFSET = MEM != null ? MEM.arrayBaseOffset(int[].class) : -1;
 
     /**
      * Base offset of float[]
      */
-    int ARRAY_FLOAT_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(float[].class) : -1;
+    int ARRAY_FLOAT_BASE_OFFSET = MEM != null ? MEM.arrayBaseOffset(float[].class) : -1;
 
     /**
      * Base offset of long[]
      */
-    int ARRAY_LONG_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(long[].class) : -1;
+    int ARRAY_LONG_BASE_OFFSET = MEM != null ? MEM.arrayBaseOffset(long[].class) : -1;
 
     /**
      * Base offset of double[]
      */
-    int ARRAY_DOUBLE_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(double[].class) : -1;
+    int ARRAY_DOUBLE_BASE_OFFSET = MEM != null ? MEM.arrayBaseOffset(double[].class) : -1;
 
     /**
      * Base offset of any type of Object[]
      */
-    int ARRAY_OBJECT_BASE_OFFSET = DEFAULT != null ? DEFAULT.getArrayBaseOffset(Object[].class) : -1;
+    int ARRAY_OBJECT_BASE_OFFSET = MEM != null ? MEM.arrayBaseOffset(Object[].class) : -1;
 
     /////////////////////////////////////////////////////////////////////////
 
     /**
      * Index scale of boolean[]
      */
-    int ARRAY_BOOLEAN_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(boolean[].class) : -1;
+    int ARRAY_BOOLEAN_INDEX_SCALE = MEM != null ? MEM.arrayIndexScale(boolean[].class) : -1;
 
     /**
      * Index scale of byte[]
      */
-    int ARRAY_BYTE_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(byte[].class) : -1;
+    int ARRAY_BYTE_INDEX_SCALE = MEM != null ? MEM.arrayIndexScale(byte[].class) : -1;
 
     /**
      * Index scale of short[]
      */
-    int ARRAY_SHORT_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(short[].class) : -1;
+    int ARRAY_SHORT_INDEX_SCALE = MEM != null ? MEM.arrayIndexScale(short[].class) : -1;
 
     /**
      * Index scale of char[]
      */
-    int ARRAY_CHAR_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(char[].class) : -1;
+    int ARRAY_CHAR_INDEX_SCALE = MEM != null ? MEM.arrayIndexScale(char[].class) : -1;
 
     /**
      * Index scale of int[]
      */
-    int ARRAY_INT_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(int[].class) : -1;
+    int ARRAY_INT_INDEX_SCALE = MEM != null ? MEM.arrayIndexScale(int[].class) : -1;
 
     /**
      * Index scale of float[]
      */
-    int ARRAY_FLOAT_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(float[].class) : -1;
+    int ARRAY_FLOAT_INDEX_SCALE = MEM != null ? MEM.arrayIndexScale(float[].class) : -1;
 
     /**
      * Index scale of long[]
      */
-    int ARRAY_LONG_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(long[].class) : -1;
+    int ARRAY_LONG_INDEX_SCALE = MEM != null ? MEM.arrayIndexScale(long[].class) : -1;
 
     /**
      * Index scale of double[]
      */
-    int ARRAY_DOUBLE_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(double[].class) : -1;
+    int ARRAY_DOUBLE_INDEX_SCALE = MEM != null ? MEM.arrayIndexScale(double[].class) : -1;
 
     /**
      * Index scale of any type of Object[]
      */
-    int ARRAY_OBJECT_INDEX_SCALE = DEFAULT != null ? DEFAULT.getArrayIndexScale(Object[].class) : -1;
+    int ARRAY_OBJECT_INDEX_SCALE = MEM != null ? MEM.arrayIndexScale(Object[].class) : -1;
 
     /////////////////////////////////////////////////////////////////////////
 
@@ -164,7 +166,7 @@ public interface MemoryAccessor {
      * @param field the field whose offset is requested
      * @return the offset of given field
      */
-    long getObjectFieldOffset(Field field);
+    long objectFieldOffset(Field field);
 
     /**
      * Gets the base offset of the array typed with given class.
@@ -172,7 +174,7 @@ public interface MemoryAccessor {
      * @param arrayClass the type of the array whose base offset is requested
      * @return the base offset of the array typed with given class
      */
-    int getArrayBaseOffset(Class<?> arrayClass);
+    int arrayBaseOffset(Class<?> arrayClass);
 
     /**
      * Gets the index scale of the array typed with given class.
@@ -180,7 +182,7 @@ public interface MemoryAccessor {
      * @param arrayClass the type of the array whose index scale is requested
      * @return the index scale of the array typed with given class
      */
-    int getArrayIndexScale(Class<?> arrayClass);
+    int arrayIndexScale(Class<?> arrayClass);
 
     /////////////////////////////////////////////////////////////////////////
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
@@ -18,6 +18,8 @@ package com.hazelcast.internal.memory;
 
 import java.lang.reflect.Field;
 
+import static com.hazelcast.internal.memory.MemoryAccessorType.STANDARD;
+
 /**
  * <p>
  * Contract point for direct memory access operations.
@@ -37,7 +39,7 @@ import java.lang.reflect.Field;
  *      <li>
  *        The default {@link MemoryAccessor} implementation
  *        can be accessed via {@link #MEM} field of this interface
- *        and its availability state can be checked via {@link #AVAILABLE} field.
+ *        and its availability state can be checked via {@link #MEM_AVAILABLE} field.
  *      </li>
  * </ul>
  * </p>
@@ -53,10 +55,23 @@ public interface MemoryAccessor {
     MemoryAccessor MEM = MemoryAccessorProvider.getDefaultMemoryAccessor();
 
     /**
+     * The instance of {@link MemoryAccessor} which correctly handles only aligned memory access.
+     * Requesting unaligned memory access from this instance will result in low-level JVM crash on
+     * platforms which do not support it.
+     */
+    MemoryAccessor AMEM = MemoryAccessorProvider.getMemoryAccessor(STANDARD);
+
+    /**
      * If this constant is {@code true}, then {@link MEM} refers to a usable {@code MemoryAccessor}
      * instance.
      */
-    boolean AVAILABLE = MEM != null;
+    boolean MEM_AVAILABLE = MEM != null;
+
+    /**
+     * If this constant is {@code true}, then {@link AMEM} refers to a usable {@code MemoryAccessor}
+     * instance.
+     */
+    boolean AMEM_AVAILABLE = AMEM != null;
 
     /////////////////////////////////////////////////////////////////////////
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorProvider.java
@@ -23,7 +23,7 @@ import java.util.EnumMap;
 import java.util.Map;
 
 /**
- * Provides {@link MemoryAccessor} implementations as their {@link MemoryAccessorType}.
+ * Provides {@link MemoryAccessor} implementations by their {@link MemoryAccessorType}.
  */
 public final class MemoryAccessorProvider {
 
@@ -62,19 +62,14 @@ public final class MemoryAccessorProvider {
     }
 
     /**
-     * Gets the {@link MemoryAccessor} instance related with given {@link MemoryAccessorType}.
-     *
-     * @param memoryAccessorType the type of the requested {@link MemoryAccessor}
-     * @return the {@link MemoryAccessor} instance related with given {@link MemoryAccessorType}
+     * Returns the {@link MemoryAccessor} instance appropriate to the given {@link MemoryAccessorType}.
      */
     public static MemoryAccessor getMemoryAccessor(MemoryAccessorType memoryAccessorType) {
         return MEMORY_ACCESSOR_MAP.get(memoryAccessorType);
     }
 
     /**
-     * Gets the default {@link MemoryAccessor} instance.
-     *
-     * @return the default {@link MemoryAccessor} instance
+     * Returns the default {@link MemoryAccessor} instance.
      */
     public static MemoryAccessor getDefaultMemoryAccessor() {
         return MEMORY_ACCESSOR_MAP.get(MemoryAccessorType.PLATFORM_AWARE);

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorType.java
@@ -22,8 +22,9 @@ package com.hazelcast.internal.memory;
 public enum MemoryAccessorType {
 
     /**
-     * Represents the standard {@link MemoryAccessor} which directly uses
-     * {@link sun.misc.Unsafe} to access memory.
+     * Represents the standard {@link MemoryAccessor} which correctly handles only aligned memory access.
+     * Requesting unaligned memory access from this instance will result in low-level JVM crash on
+     * platforms which only support aligned access.
      *
      * @see com.hazelcast.internal.memory.impl.StandardMemoryAccessor
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorType.java
@@ -22,27 +22,29 @@ package com.hazelcast.internal.memory;
 public enum MemoryAccessorType {
 
     /**
-     * Represents standard {@link MemoryAccessor} directly uses {@link sun.misc.Unsafe} for accessing to memory.
+     * Represents the standard {@link MemoryAccessor} which directly uses
+     * {@link sun.misc.Unsafe} to access memory.
      *
      * @see com.hazelcast.internal.memory.impl.StandardMemoryAccessor
      */
     STANDARD,
 
     /**
-     * Represents aligned {@link MemoryAccessor} checks and handles unaligned memory accesses if possible
-     * by using {@link sun.misc.Unsafe} for accessing to memory.
+     * Represents the aligned {@link MemoryAccessor}, which checks for and handles unaligned memory access
+     * by splitting a larger-size memory operation into several smaller-size ones
+     * (which have finer-grained alignment requirements).
      *
      * @see com.hazelcast.internal.memory.impl.AlignmentAwareMemoryAccessor
      */
     ALIGNMENT_AWARE,
 
     /**
-     * Represents {@link MemoryAccessor} that checks underlying platform and behaves regarding to its architecture
-     * as aligned or standard.
-     *
-     * If the underlying platform supports unaligned memory accesses,
-     * it behaves as standard {@link MemoryAccessor} because no need to additional checks.
-     * Otherwise, it behaves as alignment-aware {@link MemoryAccessor}.
+     * Represents a {@link MemoryAccessor} that checks the underlying platform and behaves as either
+     * {@link #ALIGNMENT_AWARE} or {@link #STANDARD}, as appropriate to the platform's architecture.
+     * <p>
+     * If the underlying platform supports unaligned memory access,
+     * it behaves as the standard {@link MemoryAccessor} because there's no need for additional checks.
+     * Otherwise, it behaves as the alignment-aware {@link MemoryAccessor}.
      *
      * @see com.hazelcast.internal.memory.impl.PlatformAwareMemoryAccessor
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
@@ -33,17 +33,17 @@ public class StandardMemoryAccessor extends UnsafeBasedMemoryAccessor {
     /////////////////////////////////////////////////////////////////////////
 
     @Override
-    public long getObjectFieldOffset(Field field) {
+    public long objectFieldOffset(Field field) {
         return UNSAFE.objectFieldOffset(field);
     }
 
     @Override
-    public int getArrayBaseOffset(Class<?> arrayClass) {
+    public int arrayBaseOffset(Class<?> arrayClass) {
         return UNSAFE.arrayBaseOffset(arrayClass);
     }
 
     @Override
-    public int getArrayIndexScale(Class<?> arrayClass) {
+    public int arrayIndexScale(Class<?> arrayClass) {
         return UNSAFE.arrayIndexScale(arrayClass);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeBasedMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeBasedMemoryAccessor.java
@@ -30,7 +30,8 @@ abstract class UnsafeBasedMemoryAccessor implements MemoryAccessor {
     protected static final Unsafe UNSAFE = UnsafeUtil.UNSAFE;
 
     /**
-     * State about {@link sun.misc.Unsafe} is available to be used.
+     * If this constant is {@code true}, then {@link UNSAFE} refers to a usable {@code Unsafe}
+     * instance.
      */
     protected static final boolean AVAILABLE = UNSAFE != null;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
@@ -29,7 +29,7 @@ import java.security.PrivilegedAction;
 import static com.hazelcast.util.QuickMath.normalize;
 
 /**
- * Utility class on {@link sun.misc.Unsafe}.
+ * Utility class for {@link sun.misc.Unsafe}.
  */
 final class UnsafeUtil {
 
@@ -39,7 +39,8 @@ final class UnsafeUtil {
     static final Unsafe UNSAFE;
 
     /**
-     * State about {@link sun.misc.Unsafe} is available to be used.
+     * If this constant is {@code true}, then {@link UNSAFE} refers to a usable {@code Unsafe}
+     * instance.
      */
     static final boolean UNSAFE_AVAILABLE;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
@@ -52,7 +52,7 @@ import java.security.PrivilegedAction;
 public final class UnsafeHelper {
 
     /**
-     * @deprecated {@link com.hazelcast.internal.memory.MemoryAccessor#DEFAULT} instead
+     * @deprecated {@link com.hazelcast.internal.memory.MemoryAccessor#MEM} instead
      */
     @Deprecated
     public static final Unsafe UNSAFE;

--- a/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
@@ -58,7 +58,7 @@ public final class UnsafeHelper {
     public static final Unsafe UNSAFE;
 
     /**
-     * @deprecated {@link com.hazelcast.internal.memory.MemoryAccessor#AVAILABLE} instead
+     * @deprecated {@link com.hazelcast.internal.memory.MemoryAccessor#MEM_AVAILABLE} instead
      */
     @Deprecated
     public static final boolean UNSAFE_AVAILABLE;

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
@@ -45,76 +45,76 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     @Test
     public void test_getObjectFieldOffset() throws NoSuchFieldException {
         assertEquals(SampleObject.BOOLEAN_VALUE_OFFSET,
-                     memoryAccessor.getObjectFieldOffset(
+                     memoryAccessor.objectFieldOffset(
                         SampleObject.class.getDeclaredField("booleanValue")));
         assertEquals(SampleObject.BYTE_VALUE_OFFSET,
-                     memoryAccessor.getObjectFieldOffset(
+                     memoryAccessor.objectFieldOffset(
                         SampleObject.class.getDeclaredField("byteValue")));
         assertEquals(SampleObject.CHAR_VALUE_OFFSET,
-                     memoryAccessor.getObjectFieldOffset(
+                     memoryAccessor.objectFieldOffset(
                         SampleObject.class.getDeclaredField("charValue")));
         assertEquals(SampleObject.SHORT_VALUE_OFFSET,
-                     memoryAccessor.getObjectFieldOffset(
+                     memoryAccessor.objectFieldOffset(
                         SampleObject.class.getDeclaredField("shortValue")));
         assertEquals(SampleObject.INT_VALUE_OFFSET,
-                     memoryAccessor.getObjectFieldOffset(
+                     memoryAccessor.objectFieldOffset(
                         SampleObject.class.getDeclaredField("intValue")));
         assertEquals(SampleObject.FLOAT_VALUE_OFFSET,
-                     memoryAccessor.getObjectFieldOffset(
+                     memoryAccessor.objectFieldOffset(
                         SampleObject.class.getDeclaredField("floatValue")));
         assertEquals(SampleObject.LONG_VALUE_OFFSET,
-                     memoryAccessor.getObjectFieldOffset(
+                     memoryAccessor.objectFieldOffset(
                         SampleObject.class.getDeclaredField("longValue")));
         assertEquals(SampleObject.DOUBLE_VALUE_OFFSET,
-                     memoryAccessor.getObjectFieldOffset(
+                     memoryAccessor.objectFieldOffset(
                         SampleObject.class.getDeclaredField("doubleValue")));
         assertEquals(SampleObject.OBJECT_VALUE_OFFSET,
-                     memoryAccessor.getObjectFieldOffset(
+                     memoryAccessor.objectFieldOffset(
                         SampleObject.class.getDeclaredField("objectValue")));
     }
 
     @Test
     public void test_getArrayBaseOffset() {
         assertEquals(UNSAFE.arrayBaseOffset(boolean[].class),
-                     memoryAccessor.getArrayBaseOffset(boolean[].class));
+                     memoryAccessor.arrayBaseOffset(boolean[].class));
         assertEquals(UNSAFE.arrayBaseOffset(byte[].class),
-                     memoryAccessor.getArrayBaseOffset(byte[].class));
+                     memoryAccessor.arrayBaseOffset(byte[].class));
         assertEquals(UNSAFE.arrayBaseOffset(char[].class),
-                     memoryAccessor.getArrayBaseOffset(char[].class));
+                     memoryAccessor.arrayBaseOffset(char[].class));
         assertEquals(UNSAFE.arrayBaseOffset(short[].class),
-                     memoryAccessor.getArrayBaseOffset(short[].class));
+                     memoryAccessor.arrayBaseOffset(short[].class));
         assertEquals(UNSAFE.arrayBaseOffset(int[].class),
-                     memoryAccessor.getArrayBaseOffset(int[].class));
+                     memoryAccessor.arrayBaseOffset(int[].class));
         assertEquals(UNSAFE.arrayBaseOffset(float[].class),
-                     memoryAccessor.getArrayBaseOffset(float[].class));
+                     memoryAccessor.arrayBaseOffset(float[].class));
         assertEquals(UNSAFE.arrayBaseOffset(long[].class),
-                     memoryAccessor.getArrayBaseOffset(long[].class));
+                     memoryAccessor.arrayBaseOffset(long[].class));
         assertEquals(UNSAFE.arrayBaseOffset(double[].class),
-                     memoryAccessor.getArrayBaseOffset(double[].class));
+                     memoryAccessor.arrayBaseOffset(double[].class));
         assertEquals(UNSAFE.arrayBaseOffset(Object[].class),
-                     memoryAccessor.getArrayBaseOffset(Object[].class));
+                     memoryAccessor.arrayBaseOffset(Object[].class));
     }
 
     @Test
     public void test_getArrayIndexScale() {
         assertEquals(UNSAFE.arrayIndexScale(boolean[].class),
-                     memoryAccessor.getArrayIndexScale(boolean[].class));
+                     memoryAccessor.arrayIndexScale(boolean[].class));
         assertEquals(UNSAFE.arrayIndexScale(byte[].class),
-                     memoryAccessor.getArrayIndexScale(byte[].class));
+                     memoryAccessor.arrayIndexScale(byte[].class));
         assertEquals(UNSAFE.arrayIndexScale(char[].class),
-                     memoryAccessor.getArrayIndexScale(char[].class));
+                     memoryAccessor.arrayIndexScale(char[].class));
         assertEquals(UNSAFE.arrayIndexScale(short[].class),
-                     memoryAccessor.getArrayIndexScale(short[].class));
+                     memoryAccessor.arrayIndexScale(short[].class));
         assertEquals(UNSAFE.arrayIndexScale(int[].class),
-                     memoryAccessor.getArrayIndexScale(int[].class));
+                     memoryAccessor.arrayIndexScale(int[].class));
         assertEquals(UNSAFE.arrayIndexScale(float[].class),
-                     memoryAccessor.getArrayIndexScale(float[].class));
+                     memoryAccessor.arrayIndexScale(float[].class));
         assertEquals(UNSAFE.arrayIndexScale(long[].class),
-                     memoryAccessor.getArrayIndexScale(long[].class));
+                     memoryAccessor.arrayIndexScale(long[].class));
         assertEquals(UNSAFE.arrayIndexScale(double[].class),
-                     memoryAccessor.getArrayIndexScale(double[].class));
+                     memoryAccessor.arrayIndexScale(double[].class));
         assertEquals(UNSAFE.arrayIndexScale(Object[].class),
-                     memoryAccessor.getArrayIndexScale(Object[].class));
+                     memoryAccessor.arrayIndexScale(Object[].class));
     }
 
     ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
... making it convenient for import static.

Also improve some Javadoc.

There is an enterprise PR which depends on this one and cannot be merged until this is merged.