### PR TITLE
Fix fired events when initialMembersipListener is used on client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -23,7 +23,6 @@ import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.ClientImpl;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.ClientClusterService;
-import com.hazelcast.internal.cluster.impl.MemberSelectingCollection;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.Cluster;
@@ -34,6 +33,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MemberSelector;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
+import com.hazelcast.internal.cluster.impl.MemberSelectingCollection;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -49,6 +49,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -171,14 +172,6 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
         return id;
     }
 
-    private void initMembershipListeners() {
-        synchronized (initialMembershipListenerMutex) {
-            for (MembershipListener listener : listeners.values()) {
-                initMembershipListener(listener);
-            }
-        }
-    }
-
     private void initMembershipListener(MembershipListener listener) {
         if (listener instanceof InitialMembershipListener) {
             Cluster cluster = client.getCluster();
@@ -201,14 +194,25 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
     public void start() throws Exception {
         init();
         connectToCluster();
-        initMembershipListeners();
     }
 
     private ClientConfig getClientConfig() {
         return client.getClientConfig();
     }
 
-    void handleMembershipEvent(final MembershipEvent event) {
+    void handleInitialMembershipEvent(InitialMembershipEvent event) {
+        synchronized (initialMembershipListenerMutex) {
+            Set<Member> initialMembers = event.getMembers();
+            LinkedHashMap<Address, Member> newMap = new LinkedHashMap<Address, Member>();
+            for (Member initialMember : initialMembers) {
+                newMap.put(initialMember.getAddress(), initialMember);
+            }
+            members.set(Collections.unmodifiableMap(newMap));
+            fireInitialMembershipEvent(event);
+        }
+    }
+
+    void handleMembershipEvent(MembershipEvent event) {
         synchronized (initialMembershipListenerMutex) {
             Member member = event.getMember();
             if (event.getEventType() == MembershipEvent.MEMBER_ADDED) {
@@ -222,6 +226,12 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
             }
 
             fireMembershipEvent(event);
+        }
+    }
+
+    private void fireInitialMembershipEvent(InitialMembershipEvent event) {
+        for (MembershipListener listener : listeners.values()) {
+            ((InitialMembershipListener) listener).init(event);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientAddMembershipListenerCodec;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.cluster.MemberAttributeOperationType;
+import com.hazelcast.core.InitialMembershipEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
@@ -46,7 +47,7 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
 
     public static final int INITIAL_MEMBERS_TIMEOUT_SECONDS = 5;
     private final ILogger logger;
-    private final List<Member> members = new LinkedList<Member>();
+    private final Set<Member> members = new LinkedHashSet<Member>();
     private final HazelcastClientInstanceImpl client;
     private final ClientClusterServiceImpl clusterService;
     private final ClientPartitionServiceImpl partitionService;
@@ -92,10 +93,17 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
             members.add(initialMember);
         }
 
-        final List<MembershipEvent> events = detectMembershipEvents(prevMembers);
-        if (events.size() != 0) {
+        if (prevMembers.isEmpty()) {
+            //this means this is the first time client connected to server
             logger.info(membersString());
+            clusterService.handleInitialMembershipEvent(
+                    new InitialMembershipEvent(client.getCluster(), Collections.unmodifiableSet(members)));
+            initialListFetchedLatch.countDown();
+            return;
         }
+
+        List<MembershipEvent> events = detectMembershipEvents(prevMembers);
+        logger.info(membersString());
         fireMembershipEvent(events);
         initialListFetchedLatch.countDown();
     }
@@ -168,7 +176,7 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
             connectionManager.destroyConnection(connection);
         }
         MembershipEvent event = new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED,
-                Collections.unmodifiableSet(new LinkedHashSet<Member>(members)));
+                Collections.unmodifiableSet(members));
         clusterService.handleMembershipEvent(event);
     }
 
@@ -179,12 +187,12 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
     }
 
     private List<MembershipEvent> detectMembershipEvents(Map<String, Member> prevMembers) {
-        final List<MembershipEvent> events = new LinkedList<MembershipEvent>();
-        final Set<Member> eventMembers = Collections.unmodifiableSet(new LinkedHashSet<Member>(members));
+        List<MembershipEvent> events = new LinkedList<MembershipEvent>();
+        Set<Member> eventMembers = Collections.unmodifiableSet(members);
 
-        final List<Member> newMembers = new LinkedList<Member>();
+        List<Member> newMembers = new LinkedList<Member>();
         for (Member member : members) {
-            final Member former = prevMembers.remove(member.getUuid());
+            Member former = prevMembers.remove(member.getUuid());
             if (former == null) {
                 newMembers.add(member);
             }
@@ -195,7 +203,7 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
             events.add(new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED, eventMembers));
             Address address = member.getAddress();
             if (clusterService.getMember(address) == null) {
-                final Connection connection = connectionManager.getConnection(address);
+                Connection connection = connectionManager.getConnection(address);
                 if (connection != null) {
                     connectionManager.destroyConnection(connection);
                 }
@@ -212,8 +220,7 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
         members.add(member);
         logger.info(membersString());
         MembershipEvent event = new MembershipEvent(client.getCluster(), member,
-                MembershipEvent.MEMBER_ADDED,
-                Collections.unmodifiableSet(new LinkedHashSet<Member>(members)));
+                MembershipEvent.MEMBER_ADDED, Collections.unmodifiableSet(members));
         clusterService.handleMembershipEvent(event);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -85,46 +85,6 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         hazelcastFactory.terminateAll();
     }
 
-    @Test
-    public void testInitialMemberListener() throws InterruptedException {
-        hazelcastFactory.newHazelcastInstance();
-        hazelcastFactory.newHazelcastInstance();
-
-        final ClientConfig clientConfig = new ClientConfig();
-        final CountDownLatch latch1 = new CountDownLatch(1);
-        clientConfig.addListenerConfig(new ListenerConfig().setImplementation(new StaticMemberListener(latch1)));
-        final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
-
-        assertTrue("Before starting", latch1.await(5, TimeUnit.SECONDS));
-
-        final CountDownLatch latch2 = new CountDownLatch(1);
-        client.getCluster().addMembershipListener(new StaticMemberListener(latch2));
-
-        assertTrue("After starting", latch2.await(5, TimeUnit.SECONDS));
-    }
-
-    private static class StaticMemberListener implements MembershipListener, InitialMembershipListener {
-
-        final CountDownLatch latch;
-
-        StaticMemberListener(CountDownLatch latch) {
-            this.latch = latch;
-        }
-
-        public void init(InitialMembershipEvent event) {
-            latch.countDown();
-        }
-
-        public void memberAdded(MembershipEvent membershipEvent) {
-        }
-
-        public void memberRemoved(MembershipEvent membershipEvent) {
-        }
-
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-        }
-    }
-
     /**
      * Test for issues #267 and #493
      */
@@ -315,33 +275,6 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
-    /**
-     * add membership listener
-     */
-    @Test
-    public void testIssue1181() throws InterruptedException {
-        final CountDownLatch latch = new CountDownLatch(1);
-        hazelcastFactory.newHazelcastInstance();
-        final ClientConfig clientConfig = new ClientConfig();
-        clientConfig.addListenerConfig(new ListenerConfig().setImplementation(new InitialMembershipListener() {
-            public void init(InitialMembershipEvent event) {
-                for (int i = 0; i < event.getMembers().size(); i++) {
-                    latch.countDown();
-                }
-            }
-
-            public void memberAdded(MembershipEvent membershipEvent) {
-            }
-
-            public void memberRemoved(MembershipEvent membershipEvent) {
-            }
-
-            public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-            }
-        }));
-        hazelcastFactory.newHazelcastClient(clientConfig);
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
-    }
 
     @Test
     public void testInterceptor() throws InterruptedException {


### PR DESCRIPTION
When initial membership event added before client is started,
it was firing individual ADDED events for current memberlist,
along with InitialMembershipEvent. Only latter is preserved,
other events are removed.

Related tests are added.
Membershiplistener related tests in ClientRegressionWithMockNetworkTest
are moved to MembershipListenerTest.

fixes #7430