### PR TITLE
Get rid of `UnsafeHelper` and use `MemoryAccessor` instead

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -30,9 +30,9 @@ import com.hazelcast.cache.impl.nearcache.NearCacheRecordStore;
 import com.hazelcast.cache.impl.nearcache.impl.NearCacheRecordMap;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.internal.memory.MemoryAccessor;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.NearCacheStatsImpl;
-import com.hazelcast.nio.UnsafeHelper;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.util.Clock;
@@ -51,8 +51,8 @@ public abstract class AbstractNearCacheRecordStore<
      * by ignoring compressed-references disable mode on 64 bit JVM.
      */
     protected static final int REFERENCE_SIZE =
-            UnsafeHelper.UNSAFE_AVAILABLE
-                    ? UnsafeHelper.UNSAFE.arrayIndexScale(Object[].class)
+            MemoryAccessor.MEM_AVAILABLE
+                    ? MemoryAccessor.MEM.arrayIndexScale(Object[].class)
                     : (Integer.SIZE / Byte.SIZE);
 
     private static final int MILLI_SECONDS_IN_A_SECOND = 1000;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
@@ -17,11 +17,11 @@
 package com.hazelcast.client.impl.protocol.util;
 
 import com.hazelcast.nio.Bits;
-import com.hazelcast.nio.UnsafeHelper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import sun.misc.Unsafe;
 
 import java.nio.ByteOrder;
+
+import static com.hazelcast.internal.memory.MemoryAccessor.MEM;
 
 /**
  * Supports regular, byte ordered, access to an underlying buffer.
@@ -33,8 +33,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
 
     private static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
     private static final ByteOrder PROTOCOL_BYTE_ORDER = ByteOrder.LITTLE_ENDIAN;
-    private static final Unsafe UNSAFE = UnsafeHelper.UNSAFE;
-    private static final long ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+    private static final long ARRAY_BASE_OFFSET = MEM.arrayBaseOffset(byte[].class);
 
     private byte[] byteArray;
     private long addressOffset;
@@ -73,7 +72,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
     public long getLong(final int index) {
         boundsCheck(index, Bits.LONG_SIZE_IN_BYTES);
 
-        long bits = UNSAFE.getLong(byteArray, addressOffset + index);
+        long bits = MEM.getLong(byteArray, addressOffset + index);
         if (NATIVE_BYTE_ORDER != PROTOCOL_BYTE_ORDER) {
             bits = Long.reverseBytes(bits);
         }
@@ -90,7 +89,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
             bits = Long.reverseBytes(bits);
         }
 
-        UNSAFE.putLong(byteArray, addressOffset + index, bits);
+        MEM.putLong(byteArray, addressOffset + index, bits);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -99,7 +98,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
     public int getInt(final int index) {
         boundsCheck(index, Bits.INT_SIZE_IN_BYTES);
 
-        int bits = UNSAFE.getInt(byteArray, addressOffset + index);
+        int bits = MEM.getInt(byteArray, addressOffset + index);
         if (NATIVE_BYTE_ORDER != PROTOCOL_BYTE_ORDER) {
             bits = Integer.reverseBytes(bits);
         }
@@ -116,7 +115,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
             bits = Integer.reverseBytes(bits);
         }
 
-        UNSAFE.putInt(byteArray, addressOffset + index, bits);
+        MEM.putInt(byteArray, addressOffset + index, bits);
     }
 
 
@@ -126,7 +125,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
     public short getShort(final int index) {
         boundsCheck(index, Bits.SHORT_SIZE_IN_BYTES);
 
-        short bits = UNSAFE.getShort(byteArray, addressOffset + index);
+        short bits = MEM.getShort(byteArray, addressOffset + index);
         if (NATIVE_BYTE_ORDER != PROTOCOL_BYTE_ORDER) {
             bits = Short.reverseBytes(bits);
         }
@@ -143,21 +142,21 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
             bits = Short.reverseBytes(bits);
         }
 
-        UNSAFE.putShort(byteArray, addressOffset + index, bits);
+        MEM.putShort(byteArray, addressOffset + index, bits);
     }
 
     @Override
     public byte getByte(final int index) {
         boundsCheck(index, Bits.BYTE_SIZE_IN_BYTES);
 
-        return UNSAFE.getByte(byteArray, addressOffset + index);
+        return MEM.getByte(byteArray, addressOffset + index);
     }
 
     @Override
     public void putByte(final int index, final byte value) {
         boundsCheck(index, Bits.BYTE_SIZE_IN_BYTES);
 
-        UNSAFE.putByte(byteArray, addressOffset + index, value);
+        MEM.putByte(byteArray, addressOffset + index, value);
     }
 
     @Override
@@ -170,7 +169,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
         boundsCheck(index, length);
         boundsCheck(dst, offset, length);
 
-        UNSAFE.copyMemory(byteArray, addressOffset + index, dst, ARRAY_BASE_OFFSET + offset, length);
+        MEM.copyMemory(byteArray, addressOffset + index, dst, ARRAY_BASE_OFFSET + offset, length);
     }
 
     @Override
@@ -183,7 +182,7 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
         boundsCheck(index, length);
         boundsCheck(src, offset, length);
 
-        UNSAFE.copyMemory(src, ARRAY_BASE_OFFSET + offset, byteArray, addressOffset + index, length);
+        MEM.copyMemory(src, ARRAY_BASE_OFFSET + offset, byteArray, addressOffset + index, length);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
@@ -24,12 +24,12 @@ import com.hazelcast.core.ManagedContext;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.GroupProperty;
+import com.hazelcast.internal.memory.MemoryAccessor;
 import com.hazelcast.internal.serialization.InputOutputFactory;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceBuilder;
 import com.hazelcast.internal.serialization.impl.bufferpool.BufferPoolFactoryImpl;
 import com.hazelcast.nio.ClassLoaderUtil;
-import com.hazelcast.nio.UnsafeHelper;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
@@ -304,7 +304,7 @@ public class DefaultSerializationServiceBuilder
         }
         if (useNativeByteOrder || byteOrder == ByteOrder.nativeOrder()) {
             byteOrder = ByteOrder.nativeOrder();
-            if (allowUnsafe && UnsafeHelper.UNSAFE_AVAILABLE) {
+            if (allowUnsafe && MemoryAccessor.MEM_AVAILABLE) {
                 return new UnsafeInputOutputFactory();
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataInput.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.internal.memory.MemoryAccessor;
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.nio.UnsafeHelper;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -29,6 +29,7 @@ import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
+import static com.hazelcast.internal.memory.MemoryAccessor.MEM;
 
 class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
 
@@ -42,19 +43,19 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
 
     @Override
     public int read() throws IOException {
-        return (pos < size) ? UnsafeHelper.UNSAFE.getByte(data, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + pos++) & 0xFF : -1;
+        return (pos < size) ? MEM.getByte(data, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + pos++) & 0xFF : -1;
     }
 
     @Override
     public int read(int position) throws IOException {
-        return (position < size) ? UnsafeHelper.UNSAFE
-                .getByte(data, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position) : NULL_ARRAY_LENGTH;
+        return (position < size) ? MEM
+                .getByte(data, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position) : NULL_ARRAY_LENGTH;
     }
 
     @Override
     public char readChar(int position) throws IOException {
         checkAvailable(position, CHAR_SIZE_IN_BYTES);
-        return UnsafeHelper.UNSAFE.getChar(data, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position);
+        return MEM.getChar(data, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position);
     }
 
     @Override
@@ -67,7 +68,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
     @Override
     public double readDouble(int position) throws IOException {
         checkAvailable(position, DOUBLE_SIZE_IN_BYTES);
-        return UnsafeHelper.UNSAFE.getDouble(data, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position);
+        return MEM.getDouble(data, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position);
     }
 
     @Override
@@ -80,13 +81,13 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
     @Override
     public float readFloat(int position) throws IOException {
         checkAvailable(position, FLOAT_SIZE_IN_BYTES);
-        return UnsafeHelper.UNSAFE.getFloat(data, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position);
+        return MEM.getFloat(data, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position);
     }
 
     @Override
     public int readInt(int position) throws IOException {
         checkAvailable(position, INT_SIZE_IN_BYTES);
-        return UnsafeHelper.UNSAFE.getInt(data, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position);
+        return MEM.getInt(data, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position);
     }
 
     @Override
@@ -101,7 +102,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
     @Override
     public long readLong(int position) throws IOException {
         checkAvailable(position, LONG_SIZE_IN_BYTES);
-        return UnsafeHelper.UNSAFE.getLong(data, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position);
+        return MEM.getLong(data, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position);
     }
 
     @Override
@@ -116,7 +117,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
     @Override
     public short readShort(int position) throws IOException {
         checkAvailable(position, SHORT_SIZE_IN_BYTES);
-        return UnsafeHelper.UNSAFE.getShort(data, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position);
+        return MEM.getShort(data, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position);
     }
 
     @Override
@@ -136,7 +137,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
         }
         if (len > 0) {
             char[] values = new char[len];
-            memCopy(values, UnsafeHelper.CHAR_ARRAY_BASE_OFFSET, len, UnsafeHelper.CHAR_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_CHAR_BASE_OFFSET, len, MemoryAccessor.ARRAY_CHAR_INDEX_SCALE);
             return values;
         }
         return new char[0];
@@ -150,7 +151,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
         }
         if (len > 0) {
             boolean[] values = new boolean[len];
-            memCopy(values, UnsafeHelper.BOOLEAN_ARRAY_BASE_OFFSET, len, UnsafeHelper.BOOLEAN_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_BOOLEAN_BASE_OFFSET, len, MemoryAccessor.ARRAY_BOOLEAN_INDEX_SCALE);
             return values;
         }
         return new boolean[0];
@@ -164,7 +165,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
         }
         if (len > 0) {
             byte[] values = new byte[len];
-            memCopy(values, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET, len, UnsafeHelper.BYTE_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET, len, MemoryAccessor.ARRAY_BYTE_INDEX_SCALE);
             return values;
         }
         return new byte[0];
@@ -178,7 +179,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
         }
         if (len > 0) {
             int[] values = new int[len];
-            memCopy(values, UnsafeHelper.INT_ARRAY_BASE_OFFSET, len, UnsafeHelper.INT_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_INT_BASE_OFFSET, len, MemoryAccessor.ARRAY_INT_INDEX_SCALE);
             return values;
         }
         return new int[0];
@@ -192,7 +193,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
         }
         if (len > 0) {
             long[] values = new long[len];
-            memCopy(values, UnsafeHelper.LONG_ARRAY_BASE_OFFSET, len, UnsafeHelper.LONG_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_LONG_BASE_OFFSET, len, MemoryAccessor.ARRAY_LONG_INDEX_SCALE);
             return values;
         }
         return new long[0];
@@ -206,7 +207,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
         }
         if (len > 0) {
             double[] values = new double[len];
-            memCopy(values, UnsafeHelper.DOUBLE_ARRAY_BASE_OFFSET, len, UnsafeHelper.DOUBLE_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_DOUBLE_BASE_OFFSET, len, MemoryAccessor.ARRAY_DOUBLE_INDEX_SCALE);
             return values;
         }
         return new double[0];
@@ -220,7 +221,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
         }
         if (len > 0) {
             float[] values = new float[len];
-            memCopy(values, UnsafeHelper.FLOAT_ARRAY_BASE_OFFSET, len, UnsafeHelper.FLOAT_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_FLOAT_BASE_OFFSET, len, MemoryAccessor.ARRAY_FLOAT_INDEX_SCALE);
             return values;
         }
         return new float[0];
@@ -234,7 +235,7 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
         }
         if (len > 0) {
             short[] values = new short[len];
-            memCopy(values, UnsafeHelper.SHORT_ARRAY_BASE_OFFSET, len, UnsafeHelper.SHORT_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_SHORT_BASE_OFFSET, len, MemoryAccessor.ARRAY_SHORT_INDEX_SCALE);
             return values;
         }
         return new short[0];
@@ -250,8 +251,8 @@ class UnsafeObjectDataInput extends ByteArrayObjectDataInput {
         long offset = destOffset;
 
         while (remaining > 0) {
-            int chunk = (remaining > UnsafeHelper.MEM_COPY_THRESHOLD) ? UnsafeHelper.MEM_COPY_THRESHOLD : remaining;
-            UnsafeHelper.UNSAFE.copyMemory(data, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + pos, dest, offset, chunk);
+            int chunk = (remaining > MemoryAccessor.MEM_COPY_THRESHOLD) ? MemoryAccessor.MEM_COPY_THRESHOLD : remaining;
+            MEM.copyMemory(data, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + pos, dest, offset, chunk);
             remaining -= chunk;
             offset += chunk;
             pos += chunk;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/UnsafeObjectDataOutput.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.internal.memory.MemoryAccessor;
 import com.hazelcast.internal.serialization.SerializationService;
-import com.hazelcast.nio.UnsafeHelper;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -29,6 +29,7 @@ import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
+import static com.hazelcast.internal.memory.MemoryAccessor.MEM;
 
 class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
 
@@ -39,53 +40,53 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
     @Override
     public void writeChar(final int v) throws IOException {
         ensureAvailable(CHAR_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putChar(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + pos, (char) v);
+        MEM.putChar(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + pos, (char) v);
         pos += CHAR_SIZE_IN_BYTES;
     }
 
     @Override
     public void writeChar(int position, final int v) throws IOException {
         checkAvailable(position, CHAR_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putChar(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position, (char) v);
+        MEM.putChar(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position, (char) v);
     }
 
     @Override
     public void writeDouble(final double v) throws IOException {
         ensureAvailable(DOUBLE_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putDouble(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + pos, v);
+        MEM.putDouble(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + pos, v);
         pos += DOUBLE_SIZE_IN_BYTES;
     }
 
     @Override
     public void writeDouble(int position, final double v) throws IOException {
         checkAvailable(position, DOUBLE_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putDouble(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position, v);
+        MEM.putDouble(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position, v);
     }
 
     @Override
     public void writeFloat(final float v) throws IOException {
         ensureAvailable(FLOAT_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putFloat(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + pos, v);
+        MEM.putFloat(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + pos, v);
         pos += FLOAT_SIZE_IN_BYTES;
     }
 
     @Override
     public void writeFloat(int position, final float v) throws IOException {
         checkAvailable(position, FLOAT_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putFloat(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position, v);
+        MEM.putFloat(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position, v);
     }
 
     @Override
     public void writeInt(final int v) throws IOException {
         ensureAvailable(INT_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putInt(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + pos, v);
+        MEM.putInt(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + pos, v);
         pos += INT_SIZE_IN_BYTES;
     }
 
     @Override
     public void writeInt(int position, int v) throws IOException {
         checkAvailable(position, INT_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putInt(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position, v);
+        MEM.putInt(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position, v);
     }
 
     @Override
@@ -109,14 +110,14 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
     @Override
     public void writeLong(final long v) throws IOException {
         ensureAvailable(LONG_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putLong(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + pos, v);
+        MEM.putLong(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + pos, v);
         pos += LONG_SIZE_IN_BYTES;
     }
 
     @Override
     public void writeLong(int position, final long v) throws IOException {
         checkAvailable(position, LONG_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putLong(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position, v);
+        MEM.putLong(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position, v);
     }
 
     @Override
@@ -140,14 +141,14 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
     @Override
     public void writeShort(final int v) throws IOException {
         ensureAvailable(SHORT_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putShort(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + pos, (short) v);
+        MEM.putShort(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + pos, (short) v);
         pos += SHORT_SIZE_IN_BYTES;
     }
 
     @Override
     public void writeShort(int position, final int v) throws IOException {
         checkAvailable(position, SHORT_SIZE_IN_BYTES);
-        UnsafeHelper.UNSAFE.putShort(buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + position, (short) v);
+        MEM.putShort(buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + position, (short) v);
     }
 
     @Override
@@ -175,7 +176,7 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
         int len = (booleans != null) ? booleans.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {
-            memCopy(booleans, UnsafeHelper.BOOLEAN_ARRAY_BASE_OFFSET, len, UnsafeHelper.BOOLEAN_ARRAY_INDEX_SCALE);
+            memCopy(booleans, MemoryAccessor.ARRAY_BOOLEAN_BASE_OFFSET, len, MemoryAccessor.ARRAY_BOOLEAN_INDEX_SCALE);
         }
     }
 
@@ -184,7 +185,7 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
         int len = (bytes != null) ? bytes.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {
-            memCopy(bytes, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET, len, UnsafeHelper.BYTE_ARRAY_INDEX_SCALE);
+            memCopy(bytes, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET, len, MemoryAccessor.ARRAY_BYTE_INDEX_SCALE);
         }
     }
 
@@ -193,7 +194,7 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
         int len = values != null ? values.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {
-            memCopy(values, UnsafeHelper.CHAR_ARRAY_BASE_OFFSET, len, UnsafeHelper.CHAR_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_CHAR_BASE_OFFSET, len, MemoryAccessor.ARRAY_CHAR_INDEX_SCALE);
         }
     }
 
@@ -202,7 +203,7 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
         int len = values != null ? values.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {
-            memCopy(values, UnsafeHelper.SHORT_ARRAY_BASE_OFFSET, len, UnsafeHelper.SHORT_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_SHORT_BASE_OFFSET, len, MemoryAccessor.ARRAY_SHORT_INDEX_SCALE);
         }
     }
 
@@ -211,7 +212,7 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
         int len = values != null ? values.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {
-            memCopy(values, UnsafeHelper.INT_ARRAY_BASE_OFFSET, len, UnsafeHelper.INT_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_INT_BASE_OFFSET, len, MemoryAccessor.ARRAY_INT_INDEX_SCALE);
         }
     }
 
@@ -220,7 +221,7 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
         int len = values != null ? values.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {
-            memCopy(values, UnsafeHelper.FLOAT_ARRAY_BASE_OFFSET, len, UnsafeHelper.FLOAT_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_FLOAT_BASE_OFFSET, len, MemoryAccessor.ARRAY_FLOAT_INDEX_SCALE);
         }
     }
 
@@ -229,7 +230,7 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
         int len = values != null ? values.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {
-            memCopy(values, UnsafeHelper.LONG_ARRAY_BASE_OFFSET, len, UnsafeHelper.LONG_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_LONG_BASE_OFFSET, len, MemoryAccessor.ARRAY_LONG_INDEX_SCALE);
         }
     }
 
@@ -238,7 +239,7 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
         int len = values != null ? values.length : NULL_ARRAY_LENGTH;
         writeInt(len);
         if (len > 0) {
-            memCopy(values, UnsafeHelper.DOUBLE_ARRAY_BASE_OFFSET, len, UnsafeHelper.DOUBLE_ARRAY_INDEX_SCALE);
+            memCopy(values, MemoryAccessor.ARRAY_DOUBLE_BASE_OFFSET, len, MemoryAccessor.ARRAY_DOUBLE_INDEX_SCALE);
         }
     }
 
@@ -252,8 +253,8 @@ class UnsafeObjectDataOutput extends ByteArrayObjectDataOutput {
         ensureAvailable(remaining);
 
         while (remaining > 0) {
-            int chunk = (remaining > UnsafeHelper.MEM_COPY_THRESHOLD) ? UnsafeHelper.MEM_COPY_THRESHOLD : remaining;
-            UnsafeHelper.UNSAFE.copyMemory(src, offset, buffer, UnsafeHelper.BYTE_ARRAY_BASE_OFFSET + pos, chunk);
+            int chunk = (remaining > MemoryAccessor.MEM_COPY_THRESHOLD) ? MemoryAccessor.MEM_COPY_THRESHOLD : remaining;
+            MEM.copyMemory(src, offset, buffer, MemoryAccessor.ARRAY_BYTE_BASE_OFFSET + pos, chunk);
             remaining -= chunk;
             offset += chunk;
             pos += chunk;


### PR DESCRIPTION
`UnsafeHelper` is not removed because it is still used by other modules (for example hibernate modules) and so it is just deprecated.

This PR just replaces `UnsafeHelper` with `MemoryAccessor` and there is no renaming about **Unsafe** in properties, fields, classes, etc ... But I think they should be renamed later so there will be no **Unsafe** code, term, name, etc in our code base. 