### PR TITLE
Moved partition serializers to internal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
@@ -17,13 +17,13 @@
 package com.hazelcast.internal.partition;
 
 import com.hazelcast.internal.cluster.MemberInfo;
+import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.partition.PartitionDataSerializerHook;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.partition;
+package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionPortableHook.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.partition;
+package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.PortableFactory;

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -1,6 +1,6 @@
 com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook
 com.hazelcast.spi.impl.SpiDataSerializerHook
-com.hazelcast.partition.PartitionDataSerializerHook
+com.hazelcast.internal.partition.impl.PartitionDataSerializerHook
 com.hazelcast.map.impl.MapDataSerializerHook
 com.hazelcast.collection.impl.queue.QueueDataSerializerHook
 com.hazelcast.multimap.impl.MultiMapDataSerializerHook

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.PortableHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.PortableHook
@@ -1,5 +1,5 @@
 com.hazelcast.spi.impl.SpiPortableHook
-com.hazelcast.partition.PartitionPortableHook
+com.hazelcast.internal.partition.impl.PartitionPortableHook
 com.hazelcast.mapreduce.impl.MapReducePortableHook
 com.hazelcast.replicatedmap.impl.client.ReplicatedMapPortableHook
 com.hazelcast.ringbuffer.impl.client.RingbufferPortableHook


### PR DESCRIPTION
PartitionPortableHook and PartitionDataSerializerHook have been moved
to com.hazelcast.internal.partition.impl. They are not public API.