### PR TITLE
Add @RequireAssertEnabled where applicable

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionDistributionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionDistributionTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.AfterClass;
@@ -112,6 +113,7 @@ public class PartitionDistributionTest extends HazelcastTestSupport {
     }
 
     @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testThreeNodes_defaultPartitions_HostAware() throws InterruptedException {
         testPartitionDistribution(271, 3, 0, hostAwareConfig, hostAwareLiteMemberConfig);
     }
@@ -132,6 +134,7 @@ public class PartitionDistributionTest extends HazelcastTestSupport {
     }
 
     @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testFiveNodes_defaultPartitions_HostAware() throws InterruptedException {
         testPartitionDistribution(271, 5, 0, hostAwareConfig, hostAwareLiteMemberConfig);
     }
@@ -152,6 +155,7 @@ public class PartitionDistributionTest extends HazelcastTestSupport {
     }
 
     @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testFifteenNodes_defaultPartitions_HostAware() throws InterruptedException {
         testPartitionDistribution(271, 15, 0, hostAwareConfig, hostAwareLiteMemberConfig);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
@@ -7,6 +7,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.CallIdSequence.CallIdSequenceWithBackpressure;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -50,6 +51,7 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
     }
 
     @Test
+    @RequireAssertEnabled
     public void next_whenNot_0() {
         CallIdSequenceWithBackpressure sequence = new CallIdSequenceWithBackpressure(100, 60000);
         Invocation invocation = newInvocation(new DummyBackupAwareOperation());
@@ -200,6 +202,7 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
     }
 
     @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void complete_whenNoMatchingNext() {
         CallIdSequenceWithBackpressure sequence = new CallIdSequenceWithBackpressure(100, 60000);
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
@@ -6,6 +6,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.CallIdSequence.CallIdSequenceWithBackpressure;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -52,6 +53,7 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
     }
 
     @Test
+    @RequireAssertEnabled
     public void next_whenNot_0() {
         CallIdSequenceWithBackpressure sequence = new CallIdSequenceWithBackpressure(100, 60000);
         Invocation invocation = newInvocation(new DummyBackupAwareOperation());

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -8,6 +8,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,6 +79,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     }
 
     @Test
+    @RequireAssertEnabled
     public void register_whenAlreadyRegistered_thenAssertionError() {
         Operation op = new DummyBackupAwareOperation();
         Invocation invocation = newInvocation(op);


### PR DESCRIPTION
Recently a JUnit test rule was added which can filter out tests that depend on Java `assert` being enabled, when `assert` is not enabled. Those tests would otherwise inappropriately fail when the problem is not in the code, but in the test setup.

This PR applies the above test rule where applicable.