### PR TITLE
[BACKPORT] Prefer instance name property or instance name config over config url…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCachingProvider.java
@@ -74,7 +74,9 @@ public final class HazelcastServerCachingProvider
     private HazelcastInstance getOrCreateInstance(ClassLoader classLoader, Properties properties, boolean isDefaultURI)
             throws URISyntaxException, IOException {
         String location = properties.getProperty(HazelcastCachingProvider.HAZELCAST_CONFIG_LOCATION);
-        // If config location is specified, get instance through it.
+        String instanceName = properties.getProperty(HazelcastCachingProvider.HAZELCAST_INSTANCE_NAME);
+
+        // If config location is specified via properties, get instance through it.
         if (location != null) {
             URI uri = new URI(location);
             String scheme = uri.getScheme();
@@ -92,23 +94,20 @@ public final class HazelcastServerCachingProvider
                 throw new URISyntaxException(location, "Unsupported protocol in configuration location URL");
             }
             try {
-                Config config = new XmlConfigBuilder(configURL).build();
-                config.setClassLoader(theClassLoader);
-                config.setInstanceName(configURL.toString());
+                Config config = getConfig(configURL, theClassLoader, instanceName);
                 return HazelcastInstanceFactory.getOrCreateHazelcastInstance(config);
             } catch (Exception e) {
                 throw ExceptionUtil.rethrow(e);
             }
         }
 
-        // If config location is specified, get instance with its name.
-        String instanceName = properties.getProperty(HazelcastCachingProvider.HAZELCAST_INSTANCE_NAME);
+        // If instance name is specified via properties, get instance through it.
         if (instanceName != null) {
             return Hazelcast.getHazelcastInstanceByName(instanceName);
         }
 
         HazelcastInstance instance = null;
-        // No instance specified with name of config location,
+        // No instance specified with name or config location,
         // so we are going on with the default one if the URI is the default.
         if (isDefaultURI) {
             if (hazelcastInstance == null) {
@@ -122,6 +121,21 @@ public final class HazelcastServerCachingProvider
             }
         }
         return instance;
+    }
+
+    private Config getConfig(URL configURL, ClassLoader theClassLoader, String instanceName)
+            throws IOException {
+        Config config = new XmlConfigBuilder(configURL).build();
+        config.setClassLoader(theClassLoader);
+        if (instanceName != null) {
+            // If instance name is specified via properties use it
+            // even though instance name is specified in the config.
+            config.setInstanceName(instanceName);
+        } else if (config.getInstanceName() == null) {
+            // Use config url as instance name if instance name is not specified.
+            config.setInstanceName(configURL.toString());
+        }
+        return config;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cache/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/config/CacheConfigTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.config;
 
+import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.cache.impl.ICacheService;
@@ -331,7 +332,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
 
     @Test
     public void cacheManagerByInstanceNameTest() throws URISyntaxException {
-        final String instanceName = "instanceName66";
+        final String instanceName = randomName();
         Config config = new Config();
         config.setInstanceName(instanceName);
         Hazelcast.newHazelcastInstance(config);
@@ -343,6 +344,63 @@ public class CacheConfigTest extends HazelcastTestSupport {
         assertNotNull(cacheManager);
 
         assertEquals(1, Hazelcast.getAllHazelcastInstances().size());
+    }
+
+    @Test
+    public void instanceNameShouldBeUsedIfItIsSpecified()
+            throws URISyntaxException, IOException {
+        Config config = new XmlConfigBuilder(configUrl1).build();
+        URI uri = new URI("MY-SCOPE");
+        Properties properties = new Properties();
+        properties.setProperty(HazelcastCachingProvider.HAZELCAST_CONFIG_LOCATION, configUrl1.toString());
+        HazelcastCacheManager cacheManager =
+                (HazelcastCacheManager) Caching.getCachingProvider().getCacheManager(uri, null, properties);
+
+        assertNotNull(cacheManager);
+        assertEquals(config.getInstanceName(), cacheManager.getHazelcastInstance().getName());
+    }
+
+    @Test
+    public void configUrlShouldBeUsedAsInstanceNameIfInstanceNameIsNotSpecified()
+            throws URISyntaxException, IOException {
+        URI uri = new URI("MY-SCOPE");
+        Properties properties = new Properties();
+        properties.setProperty(HazelcastCachingProvider.HAZELCAST_CONFIG_LOCATION, configUrl2.toString());
+        HazelcastCacheManager cacheManager =
+                (HazelcastCacheManager) Caching.getCachingProvider().getCacheManager(uri, null, properties);
+
+        assertNotNull(cacheManager);
+        assertEquals(configUrl2.toString(), cacheManager.getHazelcastInstance().getName());
+    }
+
+    @Test
+    public void instanceNamePropertyShouldBeUsedWhenNoInstanceNameIsSpecified()
+            throws URISyntaxException, IOException {
+        String instanceName = randomName();
+        URI uri = new URI("MY-SCOPE");
+        Properties properties = new Properties();
+        properties.setProperty(HazelcastCachingProvider.HAZELCAST_CONFIG_LOCATION, configUrl2.toString());
+        properties.setProperty(HazelcastCachingProvider.HAZELCAST_INSTANCE_NAME, instanceName);
+        HazelcastCacheManager cacheManager =
+                (HazelcastCacheManager) Caching.getCachingProvider().getCacheManager(uri, null, properties);
+
+        assertNotNull(cacheManager);
+        assertEquals(instanceName, cacheManager.getHazelcastInstance().getName());
+    }
+
+    @Test
+    public void instanceNamePropertyShouldBeUsedEvenThoughInstanceNameIsSpecifiedInTheConfig()
+            throws URISyntaxException, IOException {
+        String instanceName = randomName();
+        URI uri = new URI("MY-SCOPE");
+        Properties properties = new Properties();
+        properties.setProperty(HazelcastCachingProvider.HAZELCAST_CONFIG_LOCATION, configUrl1.toString());
+        properties.setProperty(HazelcastCachingProvider.HAZELCAST_INSTANCE_NAME, instanceName);
+        HazelcastCacheManager cacheManager =
+                (HazelcastCacheManager) Caching.getCachingProvider().getCacheManager(uri, null, properties);
+
+        assertNotNull(cacheManager);
+        assertEquals(instanceName, cacheManager.getHazelcastInstance().getName());
     }
 
     @Test

--- a/hazelcast/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache.xml
@@ -19,6 +19,8 @@
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
+    <instance-name>test-hazelcast-jcache</instance-name>
+
     <group>
         <name>test-group1</name>
         <password>test-pass1</password>


### PR DESCRIPTION
… as name of backed hazelcast instance while creating `HazelcastServerCacheManager`

Backport of https://github.com/hazelcast/hazelcast/pull/7572