### PR TITLE
CheckStyle improvements

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -129,7 +129,9 @@
 
         <!-- Checks for imports                              -->
         <!-- See http://checkstyle.sf.net/config_import.html -->
-        <module name="AvoidStarImport"/>
+        <module name="AvoidStarImport">
+            <property name="excludes" value="java.awt,javax.swing"/>
+        </module>
         <!-- defaults to sun.* packages -->
         <module name="IllegalImport"/>
         <module name="RedundantImport"/>
@@ -256,7 +258,6 @@
         </module>
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>
-        <module name="InnerAssignment"/>
         <module name="MissingSwitchDefault"/>
 
         <!-- Checks for class design                         -->

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
@@ -26,7 +26,7 @@ import static com.hazelcast.internal.memory.MemoryAccessor.MEM;
 /**
  * Supports regular, byte ordered, access to an underlying buffer.
  */
-@SuppressFBWarnings({ "EI_EXPOSE_REP", "EI_EXPOSE_REP2" })
+@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class UnsafeBuffer implements ClientProtocolBuffer {
     private static final String DISABLE_BOUNDS_CHECKS_PROP_NAME = "hazelcast.disable.bounds.checks";
     private static final boolean SHOULD_BOUNDS_CHECK = !Boolean.getBoolean(DISABLE_BOUNDS_CHECKS_PROP_NAME);

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
@@ -57,14 +57,24 @@ public abstract class AbstractConfigBuilder extends AbstractXmlConfigHelper {
     private final XPath xpath;
 
     public AbstractConfigBuilder() {
-        final XPathFactory fac = XPathFactory.newInstance();
+        XPathFactory fac = XPathFactory.newInstance();
         this.xpath = fac.newXPath();
+
         xpath.setNamespaceContext(new NamespaceContext() {
-            @Override public String getNamespaceURI(String prefix) {
+            @Override
+            public String getNamespaceURI(String prefix) {
                 return "hz".equals(prefix) ? xmlns : null;
             }
-            @Override public String getPrefix(String namespaceURI) { return null; }
-            @Override public Iterator getPrefixes(String namespaceURI) { return null; }
+
+            @Override
+            public String getPrefix(String namespaceURI) {
+                return null;
+            }
+
+            @Override
+            public Iterator getPrefixes(String namespaceURI) {
+                return null;
+            }
         });
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 import static com.hazelcast.nio.IOUtil.copyToHeapBuffer;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
-@SuppressFBWarnings({"EI_EXPOSE_REP", "MS_MUTABLE_ARRAY", "MS_PKGPROTECT" })
+@SuppressFBWarnings({"EI_EXPOSE_REP", "MS_MUTABLE_ARRAY", "MS_PKGPROTECT"})
 public abstract class HttpCommand extends AbstractTextCommand {
 
     public static final String HEADER_CONTENT_TYPE = "content-type: ";

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -185,7 +185,7 @@ public abstract class AbstractJoiner implements Joiner {
     }
 
     @SuppressWarnings({"checkstyle:methodlength", "checkstyle:returncount",
-            "checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity" })
+            "checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
     boolean shouldMerge(JoinMessage joinMessage) {
         if (joinMessage == null) {
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -85,7 +85,7 @@ import static java.lang.String.format;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 
-@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity" })
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity"})
 public class ClusterServiceImpl implements ClusterService, ConnectionListener, ManagedService,
         EventPublishingService<MembershipEvent, MembershipListener>, TransactionalService {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/TcpIpJoiner.java
@@ -289,7 +289,7 @@ public class TcpIpJoiner extends AbstractJoiner {
         return blacklistedAddresses.keySet().containsAll(possibleAddresses);
     }
 
-    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity" })
+    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
     private void lookForMaster(Collection<Address> possibleAddresses) throws InterruptedException {
         int tryCount = 0;
         while (node.getMasterAddress() == null && tryCount++ < LOOK_FOR_MASTER_MAX_TRY_COUNT) {
@@ -392,7 +392,7 @@ public class TcpIpJoiner extends AbstractJoiner {
         return null;
     }
 
-    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity" })
+    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
     protected Collection<Address> getPossibleAddresses() {
         final Collection<String> possibleMembers = getMembers();
         final Set<Address> possibleAddresses = new HashSet<Address>();

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLog.java
@@ -141,7 +141,7 @@ final class PerformanceLog {
         return new BufferedWriter(new OutputStreamWriter(fos, encoder));
     }
 
-    @SuppressFBWarnings({"RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" })
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
     private void rollover() {
         closeResource(bufferedWriter);
         bufferedWriter = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
@@ -226,7 +226,7 @@ public final class JavaDefaultSerializers {
             return result;
         }
 
-        @SuppressFBWarnings({"OS_OPEN_STREAM" })
+        @SuppressFBWarnings("OS_OPEN_STREAM")
         @Override
         public void write(final ObjectDataOutput out, final Object obj) throws IOException {
             final ObjectOutputStream objectOutputStream;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ReadResultSetImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ReadResultSetImpl.java
@@ -76,7 +76,7 @@ public class ReadResultSetImpl<E> extends AbstractList<E>
         return size >= minSize;
     }
 
-    @SuppressFBWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public Data[] getDataItems() {
         return items;
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllBackupOperation.java
@@ -34,7 +34,7 @@ public class AddAllBackupOperation extends AbstractRingBufferOperation implement
     public AddAllBackupOperation() {
     }
 
-    @SuppressFBWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public AddAllBackupOperation(String name, Data[] items) {
         super(name);
         this.items = items;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddAllOperation.java
@@ -42,7 +42,7 @@ public class AddAllOperation extends AbstractRingBufferOperation
     public AddAllOperation() {
     }
 
-    @SuppressFBWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public AddAllOperation(String name, Data[] items, OverflowPolicy overflowPolicy) {
         super(name);
         this.items = items;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
@@ -191,13 +191,13 @@ public final class ClassicOperationExecutor implements OperationExecutor {
         return threads;
     }
 
-    @SuppressFBWarnings({ "EI_EXPOSE_REP" })
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     @Override
     public OperationRunner[] getPartitionOperationRunners() {
         return partitionOperationRunners;
     }
 
-    @SuppressFBWarnings({ "EI_EXPOSE_REP" })
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     @Override
     public OperationRunner[] getGenericOperationRunners() {
         return genericOperationRunners;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/PartitionOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/PartitionOperationThread.java
@@ -29,7 +29,7 @@ public final class PartitionOperationThread extends OperationThread {
 
     private final OperationRunner[] partitionOperationRunners;
 
-    @SuppressFBWarnings({"EI_EXPOSE_REP" })
+    @SuppressFBWarnings("EI_EXPOSE_REP")
     public PartitionOperationThread(String name, int threadId,
                                     ScheduleQueue scheduleQueue, ILogger logger,
                                     HazelcastThreadGroup threadGroup, NodeExtension nodeExtension,

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
@@ -70,7 +70,7 @@ public final class SlowOperationDetector {
 
     private boolean isFirstLog = true;
 
-    @SuppressFBWarnings({"EI_EXPOSE_REP2" })
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public SlowOperationDetector(LoggingService loggingServices,
                                  OperationRunner[] genericOperationRunners,
                                  OperationRunner[] partitionOperationRunners,

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandler.java
@@ -123,7 +123,7 @@ public class AsyncResponsePacketHandler implements PacketHandler {
             }
         }
 
-        @SuppressFBWarnings({"VO_VOLATILE_INCREMENT" })
+        @SuppressFBWarnings("VO_VOLATILE_INCREMENT")
         private void process(Packet responsePacket) {
             processedResponses++;
             try {

--- a/hazelcast/src/main/java/com/hazelcast/util/Base64.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/Base64.java
@@ -44,7 +44,7 @@ import static com.hazelcast.util.StringUtil.stringToBytes;
         "checkstyle:cyclomaticcomplexity",
         "checkstyle:methodlength",
         "checkstyle:returncount",
-        "checkstyle:innerassignment" })
+        "checkstyle:innerassignment"})
 public final class Base64 {
 
     private static final int BASELENGTH = 255;

--- a/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
@@ -29,14 +29,14 @@ import static java.lang.Math.abs;
 /**
  * Utility methods related to hashtables.
  */
-@SuppressFBWarnings({ "SF_SWITCH_FALLTHROUGH", "SF_SWITCH_NO_DEFAULT" })
+@SuppressFBWarnings({"SF_SWITCH_FALLTHROUGH", "SF_SWITCH_NO_DEFAULT"})
 @SuppressWarnings({
         "checkstyle:magicnumber",
         "checkstyle:methodname",
         "checkstyle:fallthrough",
         "checkstyle:cyclomaticcomplexity",
         "checkstyle:booleanexpressioncomplexity",
-        "checkstyle:methodlength" })
+        "checkstyle:methodlength"})
 public final class HashUtil {
 
     private static final boolean LITTLE_ENDIAN = ByteOrder.LITTLE_ENDIAN == ByteOrder.nativeOrder();

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
         <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>
 
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
-        <maven.failsafe.plugin.version>2.14</maven.failsafe.plugin.version>
-        <maven.findbugs.plugin.version>3.0.0</maven.findbugs.plugin.version>
-        <maven.checkstyle.plugin.version>2.12</maven.checkstyle.plugin.version>
+        <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
+        <maven.findbugs.plugin.version>3.0.1</maven.findbugs.plugin.version>
         <maven.sonar.plugin.version>2.6</maven.sonar.plugin.version>
         <maven.jacoco.plugin.version>0.7.4.201502262128</maven.jacoco.plugin.version>
-        <maven.cobertura.plugin.version>2.0</maven.cobertura.plugin.version>
+        <maven.failsafe.plugin.version>2.17</maven.failsafe.plugin.version>
+        <maven.cobertura.plugin.version>2.6</maven.cobertura.plugin.version>
 
         <log4j.version>1.2.12</log4j.version>
         <log4j2.version>2.0.1</log4j2.version>
@@ -395,7 +395,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
-                        <version>2.0</version>
+                        <version>${maven.cobertura.plugin.version}</version>
                         <configuration>
                             <instrumentation>
                                 <ignores/>


### PR DESCRIPTION
* Updated CheckStyle, Findbugs, Failsafe and Cobertura to latest versions.
* Removed duplicate InnerAssignment CheckStyle rule (already defined in line 231).
* Removed unnecessary whitespaces around brackets in suppress warnings annotations.

I've updated CheckStyle and Findbugs to the same versions we're using for a long time in Simulator (since May 2015, so they are battle proven). Failsafe and Cobertura are just used for the profile `test-coverage-Local`, so there is no implication on the CloudBees environment.

With this change we finally get rid of a false positive error regarding missing whitespaces in `@SuppressWarnings` and `@SuppressFBWarnings` annotations. This was very annoying when using a code formatter, which always removed those whitespaces and lead to a CheckStyle error in the PR builder.

I also checked FindBugs with a local run and it still compiled without errors (there are some new checks in 3.0.1, so that was important).