### PR TITLE
Adding configurable thresholds in HealthMonitor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -98,10 +98,10 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.health.monitoring.level", HealthMonitorLevel.SILENT.toString());
     public static final HazelcastProperty HEALTH_MONITORING_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.health.monitoring.delay.seconds", 20, SECONDS);
-    public static final HazelcastProperty HEALTH_MONITORING_THRESHOLD_PERCENTAGE_MEMORY
-            = new HazelcastProperty("hazelcast.health.monitoring.threshold.percentage.memory", 70);
-    public static final HazelcastProperty HEALTH_MONITORING_THRESHOLD_PERCENTAGE_CPU
-            = new HazelcastProperty("hazelcast.health.monitoring.threshold.percentage.cpu", 70);
+    public static final HazelcastProperty HEALTH_MONITORING_THRESHOLD_MEMORY_PERCENTAGE
+            = new HazelcastProperty("hazelcast.health.monitoring.threshold.memory.percentage", 70);
+    public static final HazelcastProperty HEALTH_MONITORING_THRESHOLD_CPU_PERCENTAGE
+            = new HazelcastProperty("hazelcast.health.monitoring.threshold.cpu.percentage", 70);
 
     /**
      * Use the performance monitor to see internal performance metrics. Currently this is quite

--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -98,6 +98,10 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.health.monitoring.level", HealthMonitorLevel.SILENT.toString());
     public static final HazelcastProperty HEALTH_MONITORING_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.health.monitoring.delay.seconds", 20, SECONDS);
+    public static final HazelcastProperty HEALTH_MONITORING_THRESHOLD_PERCENTAGE_MEMORY
+            = new HazelcastProperty("hazelcast.health.monitoring.threshold.percentage.memory", 70);
+    public static final HazelcastProperty HEALTH_MONITORING_THRESHOLD_PERCENTAGE_CPU
+            = new HazelcastProperty("hazelcast.health.monitoring.threshold.percentage.cpu", 70);
 
     /**
      * Use the performance monitor to see internal performance metrics. Currently this is quite

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
@@ -67,8 +67,8 @@ public class HealthMonitor {
     private final ILogger logger;
     private final Node node;
     private final HealthMonitorLevel monitorLevel;
-    private final int thresholdPercentageMemory;
-    private final int thresholdPercentageCPU;
+    private final int thresholdMemoryPercentage;
+    private final int thresholdCPUPercentage;
     private final MetricsRegistry metricRegistry;
     private final HealthMonitorThread monitorThread;
 
@@ -77,10 +77,10 @@ public class HealthMonitor {
         this.logger = node.getLogger(HealthMonitor.class);
         this.metricRegistry = node.nodeEngine.getMetricsRegistry();
         this.monitorLevel = getHealthMonitorLevel();
-        this.thresholdPercentageMemory
-                = node.getGroupProperties().getInteger(GroupProperty.HEALTH_MONITORING_THRESHOLD_PERCENTAGE_MEMORY);
-        this.thresholdPercentageCPU
-                = node.getGroupProperties().getInteger(GroupProperty.HEALTH_MONITORING_THRESHOLD_PERCENTAGE_CPU);
+        this.thresholdMemoryPercentage
+                = node.getGroupProperties().getInteger(GroupProperty.HEALTH_MONITORING_THRESHOLD_MEMORY_PERCENTAGE);
+        this.thresholdCPUPercentage
+                = node.getGroupProperties().getInteger(GroupProperty.HEALTH_MONITORING_THRESHOLD_CPU_PERCENTAGE);
         this.monitorThread = initMonitorThread();
         this.healthMetrics = new HealthMetrics();
     }
@@ -279,15 +279,15 @@ public class HealthMonitor {
         }
 
         public boolean exceedsThreshold() {
-            if (memoryUsedOfMaxPercentage > thresholdPercentageMemory) {
+            if (memoryUsedOfMaxPercentage > thresholdMemoryPercentage) {
                 return true;
             }
 
-            if (osProcessCpuLoad.read() > thresholdPercentageCPU) {
+            if (osProcessCpuLoad.read() > thresholdCPUPercentage) {
                 return true;
             }
 
-            if (osSystemCpuLoad.read() > thresholdPercentageCPU) {
+            if (osSystemCpuLoad.read() > thresholdCPUPercentage) {
                 return true;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/HealthMonitor.java
@@ -48,12 +48,18 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * <p/>
  * {@link com.hazelcast.instance.GroupProperty#HEALTH_MONITORING_DELAY_SECONDS}
  * Time between printing two logs of health monitor. Default values is 30 seconds.
+ * <p/>
+ * {@link com.hazelcast.instance.GroupProperty#HEALTH_MONITORING_THRESHOLD_PERCENTAGE_MEMORY}
+ * Threshold: Percentage of max memory currently in use
+ * <p/>
+ * {@link com.hazelcast.instance.GroupProperty#HEALTH_MONITORING_THRESHOLD_PERCENTAGE_CPU}
+ * Threshold: CPU system/process load
  */
 public class HealthMonitor {
 
     private static final String[] UNITS = new String[]{"", "K", "M", "G", "T", "P", "E"};
     private static final double PERCENTAGE_MULTIPLIER = 100d;
-    private static final double THRESHOLD_PERCENTAGE = 70;
+    private static final double THRESHOLD_PERCENTAGE_INVOCATIONS = 70;
     private static final double THRESHOLD_INVOCATIONS = 1000;
 
     final HealthMetrics healthMetrics;
@@ -61,6 +67,8 @@ public class HealthMonitor {
     private final ILogger logger;
     private final Node node;
     private final HealthMonitorLevel monitorLevel;
+    private final int thresholdPercentageMemory;
+    private final int thresholdPercentageCPU;
     private final MetricsRegistry metricRegistry;
     private final HealthMonitorThread monitorThread;
 
@@ -69,6 +77,10 @@ public class HealthMonitor {
         this.logger = node.getLogger(HealthMonitor.class);
         this.metricRegistry = node.nodeEngine.getMetricsRegistry();
         this.monitorLevel = getHealthMonitorLevel();
+        this.thresholdPercentageMemory
+                = node.getGroupProperties().getInteger(GroupProperty.HEALTH_MONITORING_THRESHOLD_PERCENTAGE_MEMORY);
+        this.thresholdPercentageCPU
+                = node.getGroupProperties().getInteger(GroupProperty.HEALTH_MONITORING_THRESHOLD_PERCENTAGE_CPU);
         this.monitorThread = initMonitorThread();
         this.healthMetrics = new HealthMetrics();
     }
@@ -267,19 +279,19 @@ public class HealthMonitor {
         }
 
         public boolean exceedsThreshold() {
-            if (memoryUsedOfMaxPercentage > THRESHOLD_PERCENTAGE) {
+            if (memoryUsedOfMaxPercentage > thresholdPercentageMemory) {
                 return true;
             }
 
-            if (osProcessCpuLoad.read() > THRESHOLD_PERCENTAGE) {
+            if (osProcessCpuLoad.read() > thresholdPercentageCPU) {
                 return true;
             }
 
-            if (osSystemCpuLoad.read() > THRESHOLD_PERCENTAGE) {
+            if (osSystemCpuLoad.read() > thresholdPercentageCPU) {
                 return true;
             }
 
-            if (operationServicePendingInvocationsPercentage.read() > THRESHOLD_PERCENTAGE) {
+            if (operationServicePendingInvocationsPercentage.read() > THRESHOLD_PERCENTAGE_INVOCATIONS) {
                 return true;
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/HealthMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/HealthMonitorTest.java
@@ -31,6 +31,8 @@ public class HealthMonitorTest extends HazelcastTestSupport {
         Config config = new Config();
         config.setProperty(GroupProperty.HEALTH_MONITORING_LEVEL, HealthMonitorLevel.NOISY.toString());
         config.setProperty(GroupProperty.HEALTH_MONITORING_DELAY_SECONDS, "1");
+        config.setProperty(GroupProperty.HEALTH_MONITORING_THRESHOLD_PERCENTAGE_MEMORY, "70");
+        config.setProperty(GroupProperty.HEALTH_MONITORING_THRESHOLD_PERCENTAGE_CPU, "70");
 
         HazelcastInstance hz = createHazelcastInstance(config);
         healthMonitor = new HealthMonitor(getNode(hz));

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/HealthMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/HealthMonitorTest.java
@@ -31,8 +31,8 @@ public class HealthMonitorTest extends HazelcastTestSupport {
         Config config = new Config();
         config.setProperty(GroupProperty.HEALTH_MONITORING_LEVEL, HealthMonitorLevel.NOISY.toString());
         config.setProperty(GroupProperty.HEALTH_MONITORING_DELAY_SECONDS, "1");
-        config.setProperty(GroupProperty.HEALTH_MONITORING_THRESHOLD_PERCENTAGE_MEMORY, "70");
-        config.setProperty(GroupProperty.HEALTH_MONITORING_THRESHOLD_PERCENTAGE_CPU, "70");
+        config.setProperty(GroupProperty.HEALTH_MONITORING_THRESHOLD_MEMORY_PERCENTAGE, "70");
+        config.setProperty(GroupProperty.HEALTH_MONITORING_THRESHOLD_CPU_PERCENTAGE, "70");
 
         HazelcastInstance hz = createHazelcastInstance(config);
         healthMonitor = new HealthMonitor(getNode(hz));


### PR DESCRIPTION
Possible solution for issue #7391 .

I've only made the thresholds for memory and CPU configurable, as I wanted to add the least amount of new configuration options as possible.

The new system properties are:
hazelcast.health.monitoring.threshold.percentage.memory
hazelcast.health.monitoring.threshold.percentage.cpu

Please tell me if I missed something, as this is the first time I've worked on your project. 