### PR TITLE
Fix wrong byte order in `HashUtil::MurmurHash3_x86_32_direct` while reading as little-endian

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/HashUtil.java
@@ -61,7 +61,6 @@ public final class HashUtil {
      * Returns the MurmurHash3_x86_32 hash.
      */
     public static int MurmurHash3_x86_32(byte[] data, int offset, int len, int seed) {
-
         int c1 = 0xcc9e2d51;
         int c2 = 0x1b873593;
 
@@ -71,7 +70,10 @@ public final class HashUtil {
 
         for (int i = offset; i < roundedEnd; i += 4) {
             // little endian load order
-            int k1 = (data[i] & 0xff) | ((data[i + 1] & 0xff) << 8) | ((data[i + 2] & 0xff) << 16) | (data[i + 3] << 24);
+            int k1 = (data[i] & 0xff)
+                    | ((data[i + 1] & 0xff) << 8)
+                    | ((data[i + 2] & 0xff) << 16)
+                    | (data[i + 3] << 24);
             k1 *= c1;
             // ROTL32(k1,15);
             k1 = (k1 << 15) | (k1 >>> 17);
@@ -117,7 +119,6 @@ public final class HashUtil {
      * Returns the MurmurHash3_x86_32 hash.
      */
     public static int MurmurHash3_x86_32_direct(long address, int offset, int len, int seed) {
-
         int c1 = 0xcc9e2d51;
         int c2 = 0x1b873593;
 
@@ -128,10 +129,10 @@ public final class HashUtil {
         for (int i = offset; i < roundedEnd; i += 4) {
             // little endian load order
             int k1 = LITTLE_ENDIAN ? MEM.getInt(address + i)
-                    : (MEM.getByte(address + i + 3) & 0xff)
-                    | ((MEM.getByte(address + i + 2) & 0xff) << 8)
-                    | ((MEM.getByte(address + i + 1) & 0xff) << 16)
-                    | (MEM.getByte(address + i) << 24);
+                    : (MEM.getByte(address + i) & 0xff)
+                    | ((MEM.getByte(address + i + 1) & 0xff) << 8)
+                    | ((MEM.getByte(address + i + 2) & 0xff) << 16)
+                    | (MEM.getByte(address + i + 3) << 24);
             k1 *= c1;
             // ROTL32(k1,15);
             k1 = (k1 << 15) | (k1 >>> 17);


### PR DESCRIPTION
Currently, this code block in `HashUtil::MurmurHash3_x86_32_direct` is wrong for reading as little-endian:
``` java
int k1 = LITTLE_ENDIAN ? MEM.getInt(address + i)
            : MEM.getByte(address + i + 3) & 0xff)
            | ((MEM.getByte(address + i + 2) & 0xff) << 8)
            | ((MEM.getByte(address + i + 1) & 0xff) << 16)
            | (MEM.getByte(address + i) << 24);
```
because it reads as big-endian not little-endian.

`HashUtil::MurmurHash3_x86_32` which is `byte[]` version of this method is true.

I have faced with this issue while running tests on a big-endian SPARC machine.

Also this fix should be backported 