### PR TITLE
Skip unaligned memory access tests if platform doesn't support unaligned memory access

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessorProvider.java
@@ -57,7 +57,7 @@ public final class MemoryAccessorProvider {
     private MemoryAccessorProvider() {
     }
 
-    static boolean isUnalignedAccessAllowed() {
+    public static boolean isUnalignedAccessAllowed() {
         // we can't use Unsafe to access memory on platforms where unaligned access is not allowed
         // see https://github.com/hazelcast/hazelcast/issues/5518 for details.
         String arch = System.getProperty("os.arch");

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
@@ -39,7 +39,7 @@ final class UnsafeUtil {
     static final Unsafe UNSAFE;
 
     /**
-     * If this constant is {@code true}, then {@link UNSAFE} refers to a usable {@code Unsafe}
+     * If this constant is {@code true}, then {@link Unsafe} refers to a usable {@code Unsafe}
      * instance.
      */
     static final boolean UNSAFE_AVAILABLE;

--- a/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import static com.hazelcast.util.QuickMath.normalize;
+
 /**
  * Unsafe accessor.
  * <p/>
@@ -128,15 +130,19 @@ public final class UnsafeHelper {
         try {
             // test if unsafe has required methods...
             if (unsafe != null) {
-                byte[] buffer = new byte[8];
-                unsafe.putChar(buffer, BYTE_ARRAY_BASE_OFFSET, '0');
-                unsafe.putBoolean(buffer, BYTE_ARRAY_BASE_OFFSET, false);
-                unsafe.putShort(buffer, BYTE_ARRAY_BASE_OFFSET, (short) 1);
-                unsafe.putInt(buffer, BYTE_ARRAY_BASE_OFFSET, 2);
-                unsafe.putFloat(buffer, BYTE_ARRAY_BASE_OFFSET, 3f);
-                unsafe.putLong(buffer, BYTE_ARRAY_BASE_OFFSET, 4L);
-                unsafe.putDouble(buffer, BYTE_ARRAY_BASE_OFFSET, 5d);
-                unsafe.copyMemory(new byte[8], BYTE_ARRAY_BASE_OFFSET, buffer, BYTE_ARRAY_BASE_OFFSET, buffer.length);
+                long arrayBaseOffset = unsafe.arrayBaseOffset(byte[].class);
+                byte[] buffer = new byte[(int) arrayBaseOffset + (2 * Bits.LONG_SIZE_IN_BYTES)];
+                unsafe.putByte(buffer, arrayBaseOffset, (byte) 0x00);
+                unsafe.putBoolean(buffer, arrayBaseOffset, false);
+                unsafe.putChar(buffer, normalize(arrayBaseOffset, Bits.CHAR_SIZE_IN_BYTES), '0');
+                unsafe.putShort(buffer, normalize(arrayBaseOffset, Bits.SHORT_SIZE_IN_BYTES), (short) 1);
+                unsafe.putInt(buffer, normalize(arrayBaseOffset, Bits.INT_SIZE_IN_BYTES), 2);
+                unsafe.putFloat(buffer, normalize(arrayBaseOffset, Bits.FLOAT_SIZE_IN_BYTES),  3f);
+                unsafe.putLong(buffer, normalize(arrayBaseOffset, Bits.LONG_SIZE_IN_BYTES), 4L);
+                unsafe.putDouble(buffer, normalize(arrayBaseOffset, Bits.DOUBLE_SIZE_IN_BYTES), 5d);
+                unsafe.copyMemory(new byte[buffer.length], arrayBaseOffset,
+                                  buffer, arrayBaseOffset,
+                                  buffer.length);
 
                 unsafeAvailable = true;
             }
@@ -188,7 +194,7 @@ public final class UnsafeHelper {
         return UNSAFE_EXPLICITLY_ENABLED.equals(mode);
     }
 
-    private static boolean isUnalignedAccessAllowed() {
+    static boolean isUnalignedAccessAllowed() {
         // we can't use Unsafe to access memory on platforms where unaligned access is not allowed
         // see https://github.com/hazelcast/hazelcast/issues/5518 for details.
         String arch = System.getProperty("os.arch");

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
@@ -125,6 +125,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_copyMemory_whenUnaligned() {
         do_test_copyMemory(false);
     }
@@ -177,6 +178,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_setMemory_whenUnaligned() {
         do_test_setMemory(false);
     }
@@ -273,6 +275,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_putGetChar_whenUnaligned() {
         do_test_putGetChar(false);
     }
@@ -315,6 +318,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_putGetShort_whenUnaligned() {
         do_test_putGetShort(false);
     }
@@ -357,6 +361,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_putGetInt_whenUnaligned() {
         do_test_putGetInt(false);
     }
@@ -399,6 +404,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_putGetFloat_whenUnaligned() {
         do_test_putGetFloat(false);
     }
@@ -441,6 +447,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_putGetLong_whenUnaligned() {
         do_test_putGetLong(false);
     }
@@ -483,6 +490,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_putGetDouble_whenUnaligned() {
         do_test_putGetDouble(false);
     }
@@ -548,6 +556,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_compareAndSwapInt_whenUnaligned() {
         do_test_compareAndSwapInt(false);
     }
@@ -590,6 +599,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_compareAndSwapLong_whenUnaligned() {
         do_test_compareAndSwapLong(false);
     }
@@ -655,6 +665,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_putOrderedInt_whenUnaligned() {
         do_test_putOrderedInt(false);
     }
@@ -689,6 +700,7 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     }
 
     @Test
+    @RequiresUnalignedMemoryAccessSupport
     public void test_putOrderedLong_whenUnaligned() {
         do_test_putOrderedLong(false);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/RequiresUnalignedMemoryAccessSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/RequiresUnalignedMemoryAccessSupport.java
@@ -1,0 +1,15 @@
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.test.AutoRegisteredTestRule;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(ElementType.METHOD)
+@AutoRegisteredTestRule(testRule = TestIgnoreRuleAccordingToUnalignedMemoryAccessSupport.class)
+public @interface RequiresUnalignedMemoryAccessSupport {
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnalignedMemoryAccessSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnalignedMemoryAccessSupport.java
@@ -1,0 +1,30 @@
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.internal.memory.MemoryAccessorProvider;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class TestIgnoreRuleAccordingToUnalignedMemoryAccessSupport implements TestRule {
+
+    private static final ILogger LOGGER
+            = Logger.getLogger(TestIgnoreRuleAccordingToUnalignedMemoryAccessSupport.class);
+
+    @Override
+    public Statement apply(Statement base, final Description description) {
+        if (description.getAnnotation(RequiresUnalignedMemoryAccessSupport.class) != null
+            && !MemoryAccessorProvider.isUnalignedAccessAllowed()) {
+                return new Statement() {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        LOGGER.finest("Ignoring `" + description.getClassName()
+                                + "` because unaligned memory access is not supported in this platform");
+                    }
+                };
+        }
+        return base;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnsafeAvailability.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/TestIgnoreRuleAccordingToUnsafeAvailability.java
@@ -11,27 +11,17 @@ public class TestIgnoreRuleAccordingToUnsafeAvailability implements TestRule {
     private static final ILogger LOGGER = Logger.getLogger(TestIgnoreRuleAccordingToUnsafeAvailability.class);
 
     @Override
-    public Statement apply(Statement base, Description description) {
-        if(UnsafeUtil.UNSAFE_AVAILABLE) {
+    public Statement apply(Statement base, final Description description) {
+        if (UnsafeUtil.UNSAFE_AVAILABLE) {
             return base;
         } else {
-            return new IgnoreStatement(description);
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    LOGGER.finest("Ignoring `" + description.getClassName() + "` because Unsafe is not available");
+                }
+            };
         }
-    }
-
-    private static class IgnoreStatement extends Statement {
-
-        private final Description description;
-
-        IgnoreStatement(Description description) {
-            this.description = description;
-        }
-
-        @Override
-        public void evaluate() {
-            LOGGER.finest("Ignoring `" + description.getClassName() + "` because Unsafe is not available");
-        }
-
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/UnsafeHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/UnsafeHelperTest.java
@@ -43,7 +43,11 @@ public class UnsafeHelperTest extends HazelcastTestSupport {
 
     @Test
     public void testFindUnsafeIfAllowed() {
-        assertNotNull(findUnsafeIfAllowed());
+        if (UnsafeHelper.isUnalignedAccessAllowed()) {
+            assertNotNull(findUnsafeIfAllowed());
+        } else {
+            assertNull(findUnsafeIfAllowed());
+        }
     }
 
     @Test


### PR DESCRIPTION
With this PR, all our OSS tests (core, client, spring) pass at SPARC.

EE is in progress ...