### PR TITLE
Renamed Packet.header to Packet.flags

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberReadHandler.java
@@ -64,7 +64,7 @@ public class MemberReadHandler implements ReadHandler {
     }
 
     protected void handlePacket(Packet packet) {
-        if (packet.isHeaderSet(Packet.HEADER_URGENT)) {
+        if (packet.isFlagSet(Packet.FLAG_URGENT)) {
             priorityPacketsRead.inc();
         } else {
             normalPacketsRead.inc();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -228,7 +228,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
 
     @Override
     public void handle(Packet packet) throws Exception {
-        assert packet.isHeaderSet(Packet.HEADER_BIND);
+        assert packet.isFlagSet(Packet.FLAG_BIND);
 
         BindMessage bind = ioService.getSerializationService().toObject(packet);
         bind((TcpIpConnection) packet.getConn(), bind.getLocalAddress(), bind.getTargetAddress(), bind.shouldReply());
@@ -322,7 +322,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
         BindMessage bind = new BindMessage(ioService.getThisAddress(), remoteEndPoint, replyBack);
         byte[] bytes = ioService.getSerializationService().toBytes(bind);
         Packet packet = new Packet(bytes);
-        packet.setHeader(Packet.HEADER_BIND);
+        packet.setFlag(Packet.FLAG_BIND);
         connection.write(packet);
         //now you can send anything...
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -394,7 +394,7 @@ public class EventServiceImpl implements InternalEventService {
             }
         } else {
             Packet packet = new Packet(serializationService.toBytes(eventEnvelope), orderKey);
-            packet.setHeader(Packet.HEADER_EVENT);
+            packet.setFlag(Packet.FLAG_EVENT);
 
             if (!nodeEngine.getNode().getConnectionManager().transmit(packet, subscriber)) {
                 if (nodeEngine.isRunning()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/ClassicOperationExecutor.java
@@ -374,8 +374,8 @@ public final class ClassicOperationExecutor implements OperationExecutor {
     }
 
     private void checkOpPacket(Packet packet) {
-        if (!packet.isHeaderSet(Packet.HEADER_OP)) {
-            throw new IllegalStateException("Packet " + packet + " doesn't have Packet.HEADER_OP set");
+        if (!packet.isFlagSet(Packet.FLAG_OP)) {
+            throw new IllegalStateException("Packet " + packet + " doesn't have Packet.FLAG_OP set");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandler.java
@@ -27,8 +27,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMemoryError;
-import static com.hazelcast.nio.Packet.HEADER_OP;
-import static com.hazelcast.nio.Packet.HEADER_RESPONSE;
+import static com.hazelcast.nio.Packet.FLAG_OP;
+import static com.hazelcast.nio.Packet.FLAG_RESPONSE;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkTrue;
 
@@ -68,8 +68,8 @@ public class AsyncResponsePacketHandler implements PacketHandler {
     @Override
     public void handle(Packet packet) {
         checkNotNull(packet, "packet can't be null");
-        checkTrue(packet.isHeaderSet(HEADER_OP), "HEADER_OP should be set");
-        checkTrue(packet.isHeaderSet(HEADER_RESPONSE), "HEADER_RESPONSE should be set");
+        checkTrue(packet.isFlagSet(FLAG_OP), "FLAG_OP should be set");
+        checkTrue(packet.isFlagSet(FLAG_RESPONSE), "FLAG_RESPONSE should be set");
 
         workQueue.add(packet);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -263,9 +263,9 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     @Override
     public void handle(Packet packet) throws Exception {
         checkNotNull(packet, "packet can't be null");
-        checkTrue(packet.isHeaderSet(Packet.HEADER_OP), "Packet.HEADER_OP should be set!");
+        checkTrue(packet.isFlagSet(Packet.FLAG_OP), "Packet.FLAG_OP should be set!");
 
-        if (packet.isHeaderSet(Packet.HEADER_RESPONSE)) {
+        if (packet.isFlagSet(Packet.FLAG_RESPONSE)) {
             responsePacketExecutor.handle(packet);
         } else {
             operationExecutor.execute(packet);
@@ -399,10 +399,10 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         byte[] bytes = serializationService.toBytes(op);
         int partitionId = op.getPartitionId();
         Packet packet = new Packet(bytes, partitionId);
-        packet.setHeader(Packet.HEADER_OP);
+        packet.setFlag(Packet.FLAG_OP);
 
         if (op instanceof UrgentSystemOperation) {
-            packet.setHeader(Packet.HEADER_URGENT);
+            packet.setFlag(Packet.FLAG_URGENT);
         }
 
         ConnectionManager connectionManager = node.getConnectionManager();
@@ -422,11 +422,11 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
 
         byte[] bytes = serializationService.toBytes(response);
         Packet packet = new Packet(bytes, -1);
-        packet.setHeader(Packet.HEADER_OP);
-        packet.setHeader(Packet.HEADER_RESPONSE);
+        packet.setFlag(Packet.FLAG_OP);
+        packet.setFlag(Packet.FLAG_RESPONSE);
 
         if (response.isUrgent()) {
-            packet.setHeader(Packet.HEADER_URGENT);
+            packet.setFlag(Packet.FLAG_URGENT);
         }
 
         ConnectionManager connectionManager = node.getConnectionManager();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImpl.java
@@ -22,10 +22,10 @@ import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.packetdispatcher.PacketDispatcher;
 
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutputMemoryError;
-import static com.hazelcast.nio.Packet.HEADER_BIND;
-import static com.hazelcast.nio.Packet.HEADER_EVENT;
-import static com.hazelcast.nio.Packet.HEADER_OP;
-import static com.hazelcast.nio.Packet.HEADER_WAN_REPLICATION;
+import static com.hazelcast.nio.Packet.FLAG_BIND;
+import static com.hazelcast.nio.Packet.FLAG_EVENT;
+import static com.hazelcast.nio.Packet.FLAG_OP;
+import static com.hazelcast.nio.Packet.FLAG_WAN_REPLICATION;
 
 /**
  * Default {@link PacketDispatcher} implementation.
@@ -53,16 +53,16 @@ public class PacketDispatcherImpl implements PacketDispatcher {
     @Override
     public void dispatch(Packet packet) {
         try {
-            if (packet.isHeaderSet(HEADER_OP)) {
+            if (packet.isFlagSet(FLAG_OP)) {
                 operationPacketHandler.handle(packet);
-            } else if (packet.isHeaderSet(HEADER_EVENT)) {
+            } else if (packet.isFlagSet(FLAG_EVENT)) {
                 eventPacketHandler.handle(packet);
-            } else if (packet.isHeaderSet(HEADER_WAN_REPLICATION)) {
+            } else if (packet.isFlagSet(FLAG_WAN_REPLICATION)) {
                 wanReplicationPacketHandler.handle(packet);
-            } else if (packet.isHeaderSet(HEADER_BIND)) {
+            } else if (packet.isFlagSet(FLAG_BIND)) {
                 connectionPacketHandler.handle(packet);
             } else {
-                logger.severe("Unknown packet type! Header: " + packet.getHeader());
+                logger.severe("Unknown packet type! Header: " + packet.getFlags());
             }
         } catch (Throwable t) {
             inspectOutputMemoryError(t);

--- a/hazelcast/src/test/java/com/hazelcast/nio/PacketTransportTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/PacketTransportTest.java
@@ -95,7 +95,7 @@ public class PacketTransportTest extends HazelcastTestSupport {
     }
 
     private void assertPacketEquals(Packet originalPacket, Packet clonedPacket) {
-        assertEquals(originalPacket.getHeader(), clonedPacket.getHeader());
+        assertEquals(originalPacket.getFlags(), clonedPacket.getFlags());
         assertArrayEquals(originalPacket.toByteArray(), clonedPacket.toByteArray());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberReadHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberReadHandlerTest.java
@@ -49,7 +49,7 @@ public class MemberReadHandlerTest extends TcpIpConnection_AbstractTest {
     public void whenPriorityPacket() throws Exception {
         ByteBuffer buffer = ByteBuffer.allocate(1000);
         Packet packet = new Packet(serializationService.toBytes("foobar"));
-        packet.setHeader(Packet.HEADER_URGENT);
+        packet.setFlag(Packet.FLAG_URGENT);
         packet.writeTo(buffer);
 
         buffer.flip();
@@ -92,7 +92,7 @@ public class MemberReadHandlerTest extends TcpIpConnection_AbstractTest {
         packet3.writeTo(buffer);
 
         Packet packet4 = new Packet(serializationService.toBytes("packet4"));
-        packet4.setHeader(Packet.HEADER_URGENT);
+        packet4.setFlag(Packet.FLAG_URGENT);
         packet4.writeTo(buffer);
 
         buffer.flip();

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -381,7 +381,7 @@ public class MockIOService implements IOService {
             @Override
             public void dispatch(Packet packet) {
                 try {
-                    if (packet.isHeaderSet(Packet.HEADER_BIND)) {
+                    if (packet.isFlagSet(Packet.FLAG_BIND)) {
                         connection.getConnectionManager().handle(packet);
                     } else {
                         PacketHandler handler = packetHandler;

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BaseTest.java
@@ -66,7 +66,7 @@ public abstract class TcpIpConnection_BaseTest extends TcpIpConnection_AbstractT
         TcpIpConnection c = connect(connManagerA, addressB);
 
         Packet packet = new Packet(serializationService.toBytes("foo"));
-        packet.setHeader(Packet.HEADER_URGENT);
+        packet.setFlag(Packet.FLAG_URGENT);
 
         boolean result = c.write(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressBaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressBaseTest.java
@@ -211,7 +211,7 @@ public abstract class TcpIpConnection_TransferStressBaseTest extends TcpIpConnec
             DummyPayload payload = payloads[random.nextInt(payloads.length)];
             Packet packet = new Packet(serializationService.toBytes(payload));
             if (payload.isUrgent()) {
-                packet.setHeader(Packet.HEADER_URGENT);
+                packet.setFlag(Packet.FLAG_URGENT);
             }
             return packet;
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/ExecutePacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/ExecutePacketTest.java
@@ -1,7 +1,6 @@
 package com.hazelcast.spi.impl.operationexecutor.classic;
 
 import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
@@ -34,8 +33,8 @@ public class ExecutePacketTest extends AbstractClassicOperationExecutorTest {
 
         final NormalResponse normalResponse = new NormalResponse(null, 1, 0, false);
         final Packet packet = new Packet(serializationService.toBytes(normalResponse), 0);
-        packet.setHeader(Packet.HEADER_RESPONSE);
-        packet.setHeader(Packet.HEADER_OP);
+        packet.setFlag(Packet.FLAG_RESPONSE);
+        packet.setFlag(Packet.FLAG_OP);
         executor.execute(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -54,7 +53,7 @@ public class ExecutePacketTest extends AbstractClassicOperationExecutorTest {
 
         final DummyOperation operation = new DummyOperation(0);
         final Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.setHeader(Packet.HEADER_OP);
+        packet.setFlag(Packet.FLAG_OP);
         executor.execute(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -73,7 +72,7 @@ public class ExecutePacketTest extends AbstractClassicOperationExecutorTest {
 
         final DummyOperation operation = new DummyOperation(Operation.GENERIC_PARTITION_ID);
         final Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.setHeader(Packet.HEADER_OP);
+        packet.setFlag(Packet.FLAG_OP);
         executor.execute(packet);
 
         assertTrueEventually(new AssertTask() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThreadTest.java
@@ -37,7 +37,7 @@ public class OperationThreadTest extends AbstractClassicOperationExecutorTest {
 
         DummyOperation operation = new DummyOperation(Operation.GENERIC_PARTITION_ID);
         Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.setHeader(Packet.HEADER_OP);
+        packet.setFlag(Packet.FLAG_OP);
 
         doThrow(new OutOfMemoryError()).when(handler).run(packet);
 
@@ -101,7 +101,7 @@ public class OperationThreadTest extends AbstractClassicOperationExecutorTest {
         final int partitionId = Integer.MAX_VALUE;
         Operation operation = new DummyPartitionOperation(partitionId);
         Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.setHeader(Packet.HEADER_OP);
+        packet.setFlag(Packet.FLAG_OP);
 
         testExecute_withInvalid_partitionId(packet);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponsePacketHandlerTest.java
@@ -44,8 +44,8 @@ public class AsyncResponsePacketHandlerTest extends HazelcastTestSupport {
     @Test
     public void whenNoProblemPacket() throws Exception {
         final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)));
-        packet.setHeader(Packet.HEADER_OP);
-        packet.setHeader(Packet.HEADER_RESPONSE);
+        packet.setFlag(Packet.FLAG_OP);
+        packet.setFlag(Packet.FLAG_RESPONSE);
         asyncHandler.handle(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -59,12 +59,12 @@ public class AsyncResponsePacketHandlerTest extends HazelcastTestSupport {
     @Test
     public void whenPacketThrowsException() throws Exception {
         final Packet badPacket = new Packet(serializationService.toBytes(new NormalResponse("bad", 1, 0, false)));
-        badPacket.setHeader(Packet.HEADER_OP);
-        badPacket.setHeader(Packet.HEADER_RESPONSE);
+        badPacket.setFlag(Packet.FLAG_OP);
+        badPacket.setFlag(Packet.FLAG_RESPONSE);
 
         final Packet goodPacket = new Packet(serializationService.toBytes(new NormalResponse("good", 1, 0, false)));
-        goodPacket.setHeader(Packet.HEADER_OP);
-        goodPacket.setHeader(Packet.HEADER_RESPONSE);
+        goodPacket.setFlag(Packet.FLAG_OP);
+        goodPacket.setFlag(Packet.FLAG_RESPONSE);
 
         doThrow(new ExpectedRuntimeException()).when(responsePacketHandler).handle(badPacket);
 
@@ -84,8 +84,8 @@ public class AsyncResponsePacketHandlerTest extends HazelcastTestSupport {
         asyncHandler.shutdown();
 
         final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)));
-        packet.setHeader(Packet.HEADER_OP);
-        packet.setHeader(Packet.HEADER_RESPONSE);
+        packet.setFlag(Packet.FLAG_OP);
+        packet.setFlag(Packet.FLAG_RESPONSE);
         asyncHandler.handle(packet);
 
         assertTrueFiveSeconds(new AssertTask() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
@@ -47,7 +47,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenOperationPacket() throws Exception {
         Packet packet = new Packet();
-        packet.setHeader(Packet.HEADER_OP);
+        packet.setFlag(Packet.FLAG_OP);
 
         packetDispatcher.dispatch(packet);
 
@@ -60,7 +60,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenWanReplicationPacket() throws Exception {
         Packet packet = new Packet();
-        packet.setHeader(Packet.HEADER_WAN_REPLICATION);
+        packet.setFlag(Packet.FLAG_WAN_REPLICATION);
 
         packetDispatcher.dispatch(packet);
 
@@ -73,7 +73,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenEventPacket() throws Exception {
         Packet packet = new Packet();
-        packet.setHeader(Packet.HEADER_EVENT);
+        packet.setFlag(Packet.FLAG_EVENT);
 
         packetDispatcher.dispatch(packet);
 
@@ -86,7 +86,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenBindPacket() throws Exception {
         Packet packet = new Packet();
-        packet.setHeader(Packet.HEADER_BIND);
+        packet.setFlag(Packet.FLAG_BIND);
 
         packetDispatcher.dispatch(packet);
 
@@ -113,7 +113,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenProblemHandlingPacket_thenSwallowed() throws Exception {
         Packet packet = new Packet();
-        packet.setHeader(Packet.HEADER_OP);
+        packet.setFlag(Packet.FLAG_OP);
 
         Mockito.doThrow(new ExpectedRuntimeException()).when(operationPacketHandler).handle(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -172,7 +172,7 @@ public abstract class HazelcastTestSupport {
         ConnectionManager connectionManager = getConnectionManager(local);
 
         Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.setHeader(Packet.HEADER_OP);
+        packet.setFlag(Packet.FLAG_OP);
         packet.setConn(connectionManager.getConnection(getAddress(remote)));
         return packet;
     }


### PR DESCRIPTION
The problem with header is that it isn't the full header of the Packet; there
are more things in there like size, version etc.

I renamed header to flags, similar as in TCP