### PR TITLE
Move joiner back to com.hazelcast.cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/Joiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/Joiner.java
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.cluster;
+package com.hazelcast.cluster;
 
 import com.hazelcast.nio.Address;
 
+/**
+ * This interface is deprecated and will be removed in 3.8. Look for the {@link com.hazelcast.spi.discovery}
+ * module as alternative.
+ */
+@Deprecated
 public interface Joiner {
 
     void join();

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.cluster.impl;
+package com.hazelcast.cluster.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InterfacesConfig;
@@ -22,6 +22,9 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.impl.AbstractJoiner;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.operations.MasterClaimOperation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -43,6 +46,9 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.AddressUtil.AddressHolder;
 
+/**
+ * @deprecated this class is deprecated since 3.7 and will be (re)moved in 3.8.
+ */
 public class TcpIpJoiner extends AbstractJoiner {
 
     private static final long JOIN_RETRY_WAIT_TIME = 1000L;

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.instance;
 
-import com.hazelcast.internal.cluster.impl.TcpIpJoiner;
+import com.hazelcast.cluster.impl.TcpIpJoiner;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.instance;
 
-import com.hazelcast.internal.cluster.Joiner;
+import com.hazelcast.cluster.Joiner;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.NodeIOService;
 import com.hazelcast.nio.tcp.IOThreadingModel;

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -18,7 +18,7 @@ package com.hazelcast.instance;
 
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.cluster.Joiner;
+import com.hazelcast.cluster.Joiner;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ConfigCheck;
 import com.hazelcast.internal.cluster.impl.DiscoveryJoiner;
@@ -26,7 +26,7 @@ import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.JoinRequest;
 import com.hazelcast.internal.cluster.impl.MulticastJoiner;
 import com.hazelcast.internal.cluster.impl.MulticastService;
-import com.hazelcast.internal.cluster.impl.TcpIpJoiner;
+import com.hazelcast.cluster.impl.TcpIpJoiner;
 import com.hazelcast.cluster.memberselector.MemberSelectors;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.DiscoveryConfig;

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeContext.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.instance;
 
-import com.hazelcast.internal.cluster.Joiner;
+import com.hazelcast.cluster.Joiner;
 import com.hazelcast.nio.ConnectionManager;
 
 import java.nio.channels.ServerSocketChannel;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -17,13 +17,13 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.cluster.Joiner;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.internal.cluster.Joiner;
 import com.hazelcast.internal.cluster.impl.operations.JoinCheckOperation;
 import com.hazelcast.internal.cluster.impl.operations.MemberRemoveOperation;
 import com.hazelcast.internal.cluster.impl.operations.MergeClustersOperation;
@@ -62,8 +62,8 @@ public abstract class AbstractJoiner implements Joiner {
     protected final ILogger logger;
 
     // map blacklisted endpoints. Boolean value represents if blacklist is temporary or permanent
-    final ConcurrentMap<Address, Boolean> blacklistedAddresses = new ConcurrentHashMap<Address, Boolean>();
-    final ClusterJoinManager clusterJoinManager;
+    protected final ConcurrentMap<Address, Boolean> blacklistedAddresses = new ConcurrentHashMap<Address, Boolean>();
+    protected final ClusterJoinManager clusterJoinManager;
 
     private final AtomicLong joinStartTime = new AtomicLong(Clock.currentTimeMillis());
     private final AtomicInteger tryCount = new AtomicInteger(0);
@@ -172,11 +172,11 @@ public abstract class AbstractJoiner implements Joiner {
         }
     }
 
-    final long getMaxJoinMillis() {
+    protected final long getMaxJoinMillis() {
         return node.getGroupProperties().getMillis(GroupProperty.MAX_JOIN_SECONDS);
     }
 
-    final long getMaxJoinTimeToMasterNode() {
+    protected final long getMaxJoinTimeToMasterNode() {
         // max join time to found master node,
         // this should be significantly greater than MAX_WAIT_SECONDS_BEFORE_JOIN property
         // hence we add 10 seconds more
@@ -186,7 +186,7 @@ public abstract class AbstractJoiner implements Joiner {
 
     @SuppressWarnings({"checkstyle:methodlength", "checkstyle:returncount",
             "checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
-    boolean shouldMerge(JoinMessage joinMessage) {
+    protected boolean shouldMerge(JoinMessage joinMessage) {
         if (joinMessage == null) {
             return false;
         }
@@ -278,7 +278,7 @@ public abstract class AbstractJoiner implements Joiner {
         return false;
     }
 
-    JoinMessage sendSplitBrainJoinMessage(Address target) {
+    protected JoinMessage sendSplitBrainJoinMessage(Address target) {
         if (logger.isFinestEnabled()) {
             logger.finest(node.getThisAddress() + " is connecting to " + target);
         }
@@ -320,7 +320,7 @@ public abstract class AbstractJoiner implements Joiner {
         tryCount.set(0);
     }
 
-    void startClusterMerge(final Address targetAddress) {
+    protected void startClusterMerge(final Address targetAddress) {
         ClusterServiceImpl clusterService = node.clusterService;
 
         if (!prepareClusterState(clusterService)) {
@@ -385,7 +385,7 @@ public abstract class AbstractJoiner implements Joiner {
         return true;
     }
 
-    Address getTargetAddress() {
+    protected Address getTargetAddress() {
         final Address target = targetAddress;
         targetAddress = null;
         return target;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl;
 
+import com.hazelcast.cluster.impl.TcpIpJoiner;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Address;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl;
 
-import com.hazelcast.internal.cluster.Joiner;
+import com.hazelcast.cluster.Joiner;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainHandler.java
@@ -17,7 +17,7 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.cluster.Joiner;
+import com.hazelcast.cluster.Joiner;
 import com.hazelcast.instance.Node;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterClaimOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterClaimOperation.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.internal.cluster.Joiner;
-import com.hazelcast.internal.cluster.impl.TcpIpJoiner;
+import com.hazelcast.cluster.Joiner;
+import com.hazelcast.cluster.impl.TcpIpJoiner;
 import com.hazelcast.instance.Node;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
@@ -1,7 +1,7 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.cache.impl.ICacheService;
-import com.hazelcast.internal.cluster.Joiner;
+import com.hazelcast.cluster.Joiner;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Address;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -17,7 +17,7 @@
 
 package com.hazelcast.test.mocknetwork;
 
-import com.hazelcast.internal.cluster.Joiner;
+import com.hazelcast.cluster.Joiner;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeContext;


### PR DESCRIPTION
The Joiner and TcpIpJoiner have been moved back to their original locations to prevent incompatibilities with the aws module. The classes have been deprecated to prevent any future usage.