### PR TITLE
Partially revert #7377

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -80,14 +81,18 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
     @Override
     public ClientMessage get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (response == null) {
+            int heartBeatInterval = invocation.getHeartBeatInterval();
             long waitMillis = unit.toMillis(timeout);
             if (waitMillis > 0) {
                 synchronized (this) {
                     while (waitMillis > 0 && response == null) {
                         long start = Clock.currentTimeMillis();
-                        this.wait(waitMillis);
+                        this.wait(Math.min(heartBeatInterval, waitMillis));
                         long elapsed = Clock.currentTimeMillis() - start;
                         waitMillis -= elapsed;
+                        if (!invocation.isConnectionHealthy(elapsed)) {
+                            invocation.notifyException(new TargetDisconnectedException());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Heartbeat fix in #7377 removed a workaround for another bug.

This bug is a race condition when a connection is closed.
It is possible to not be able to set exception to invocations that are
send right before connection closed.

Although it is not the best way, to not to take a new risk,
we are reverting the change that works as workaround for  this bug.