### PR TITLE
Moved a test class for jmx to internal

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/LocalStatsDelegateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/LocalStatsDelegateTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.jmx;
+package com.hazelcast.internal.jmx;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;


### PR DESCRIPTION
Since the jmx package is moved to internal, this class should be there as well.