### PR TITLE
Add metaspace stats to HealthMonitor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/memory/DefaultMemoryStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/DefaultMemoryStats.java
@@ -77,6 +77,16 @@ public class DefaultMemoryStats implements MemoryStats {
     }
 
     @Override
+    public long getMaxMetadata() {
+        return 0;
+    }
+
+    @Override
+    public long getUsedMetadata() {
+        return 0;
+    }
+
+    @Override
     public GarbageCollectorStats getGCStats() {
         GCStatsSupport.fill(gcStats);
         return gcStats;

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemoryStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemoryStats.java
@@ -113,9 +113,19 @@ public interface MemoryStats {
     long getFreeNativeMemory();
 
     /**
+     * Returns the amount of native memory reserved for metadata. This memory
+     * is separate and not accounted for by the {@code ...NativeMemory} statistics.
+     */
+    long getMaxMetadata();
+
+    /**
+     * @return amount of used metadata memory
+     */
+    long getUsedMetadata();
+
+    /**
      * Returns the garbage collector statistics for the JVM
      * @return GC statistics
      */
     GarbageCollectorStats getGCStats();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMemoryStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMemoryStatsImpl.java
@@ -40,6 +40,10 @@ public class LocalMemoryStatsImpl implements LocalMemoryStats {
 
     private long freeNativeMemory;
 
+    private long maxMetadata;
+
+    private long usedMetadata;
+
     private long maxHeap;
 
     private long committedHeap;
@@ -58,6 +62,8 @@ public class LocalMemoryStatsImpl implements LocalMemoryStats {
         setCommittedNativeMemory(memoryStats.getCommittedNativeMemory());
         setUsedNativeMemory(memoryStats.getUsedNativeMemory());
         setFreeNativeMemory(memoryStats.getFreeNativeMemory());
+        setMaxMetadata(memoryStats.getMaxMetadata());
+        setUsedMetadata(memoryStats.getUsedMetadata());
         setMaxHeap(memoryStats.getMaxHeap());
         setCommittedHeap(memoryStats.getCommittedHeap());
         setUsedHeap(memoryStats.getUsedHeap());
@@ -116,6 +122,24 @@ public class LocalMemoryStatsImpl implements LocalMemoryStats {
 
     public void setFreeNativeMemory(long freeNativeMemory) {
         this.freeNativeMemory = freeNativeMemory;
+    }
+
+    @Override
+    public long getMaxMetadata() {
+        return maxMetadata;
+    }
+
+    public void setMaxMetadata(long maxMetadata) {
+        this.maxMetadata = maxMetadata;
+    }
+
+    @Override
+    public long getUsedMetadata() {
+        return usedMetadata;
+    }
+
+    public void setUsedMetadata(long usedMetadata) {
+        this.usedMetadata = usedMetadata;
     }
 
     @Override
@@ -210,6 +234,8 @@ public class LocalMemoryStatsImpl implements LocalMemoryStats {
                 + ", maxNativeMemory=" + maxNativeMemory
                 + ", committedNativeMemory=" + committedNativeMemory
                 + ", usedNativeMemory=" + usedNativeMemory
+                + ", maxMetadata=" + maxMetadata
+                + ", usedUsedMetadata=" + usedMetadata
                 + ", maxHeap=" + maxHeap
                 + ", committedHeap=" + committedHeap
                 + ", usedHeap=" + usedHeap


### PR DESCRIPTION
The optimal configuration of native memory metadata percentage is difficult to determine without the support of runtime statistics. This PR therefore adds the key metrics to the output of Health Monitor:

1. used metadata memory;
2. free metadata memory;
3. current metadata percentage (used metadata memory / used "main" native memory).