### PR TITLE
Added probes to let handlers show their thread.id

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
@@ -18,6 +18,7 @@ package com.hazelcast.nio.tcp.nonblocking;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.internal.util.counters.SwCounter;
@@ -39,6 +40,11 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
     // WARNING: This value has significant effect on idle CPU usage!
     private static final int SELECT_WAIT_TIME_MILLIS = 5000;
     private static final int SELECT_FAILURE_PAUSE_MILLIS = 1000;
+
+    // this field is set during construction and is meant for the probes so that the read/write handler can
+    // indicate which thread they are currently bound to.
+    @Probe(name = "ioThreadId", level = ProbeLevel.INFO)
+    int id;
 
     @Probe(name = "taskQueueSize")
     private final Queue<Runnable> taskQueue = new ConcurrentLinkedQueue<Runnable>();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
@@ -124,6 +124,7 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
                     oomeHandler,
                     inputSelectNow
             );
+            thread.id = i;
             inputThreads[i] = thread;
             metricsRegistry.scanAndRegister(thread, "tcp." + thread.getName());
             thread.start();
@@ -136,6 +137,7 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
                     ioService.getLogger(NonBlockingIOThread.class.getName()),
                     oomeHandler,
                     outputSelectNow);
+            thread.id = i;
             outputThreads[i] = thread;
             metricsRegistry.scanAndRegister(thread, "tcp." + thread.getName());
             thread.start();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -53,13 +53,13 @@ import static com.hazelcast.util.StringUtil.bytesToString;
  */
 public final class NonBlockingSocketReader extends AbstractHandler implements SocketReader {
 
-    @Probe(name = "in.eventCount")
+    @Probe(name = "eventCount")
     private final SwCounter eventCount = newSwCounter();
-    @Probe(name = "in.bytesRead")
+    @Probe(name = "bytesRead")
     private final SwCounter bytesRead = newSwCounter();
-    @Probe(name = "in.normalFramesRead")
+    @Probe(name = "normalFramesRead")
     private final SwCounter normalFramesRead = newSwCounter();
-    @Probe(name = "in.priorityFramesRead")
+    @Probe(name = "priorityFramesRead")
     private final SwCounter priorityFramesRead = newSwCounter();
     private final MetricsRegistry metricRegistry;
 
@@ -74,21 +74,21 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
         super(connection, ioThread, SelectionKey.OP_READ);
         this.ioThread = ioThread;
         this.metricRegistry = metricsRegistry;
-        metricRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "]");
+        metricRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].in");
     }
 
-    @Probe(name = "in.idleTimeMs", level = DEBUG)
+    @Probe(name = "idleTimeMs", level = DEBUG)
     private long idleTimeMs() {
         return Math.max(System.currentTimeMillis() - lastReadTime, 0);
     }
 
-    @Probe(name = "in.interestedOps", level = DEBUG)
+    @Probe(name = "interestedOps", level = DEBUG)
     private long interestOps() {
         SelectionKey selectionKey = this.selectionKey;
         return selectionKey == null ? -1 : selectionKey.interestOps();
     }
 
-    @Probe(name = "in.readyOps", level = DEBUG)
+    @Probe(name = "readyOps", level = DEBUG)
     private long readyOps() {
         SelectionKey selectionKey = this.selectionKey;
         return selectionKey == null ? -1 : selectionKey.readyOps();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -57,20 +57,20 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
     private static final long TIMEOUT = 3;
 
     @SuppressWarnings("checkstyle:visibilitymodifier")
-    @Probe(name = "out.writeQueueSize")
+    @Probe(name = "writeQueueSize")
     public final Queue<OutboundFrame> writeQueue = new ConcurrentLinkedQueue<OutboundFrame>();
     @SuppressWarnings("checkstyle:visibilitymodifier")
-    @Probe(name = "out.priorityWriteQueueSize")
+    @Probe(name = "priorityWriteQueueSize")
     public final Queue<OutboundFrame> urgentWriteQueue = new ConcurrentLinkedQueue<OutboundFrame>();
-    @Probe(name = "out.eventCount")
+    @Probe(name = "eventCount")
     private final SwCounter eventCount = newSwCounter();
     private final AtomicBoolean scheduled = new AtomicBoolean(false);
     private ByteBuffer outputBuffer;
-    @Probe(name = "out.bytesWritten")
+    @Probe(name = "bytesWritten")
     private final SwCounter bytesWritten = newSwCounter();
-    @Probe(name = "out.normalFramesWritten")
+    @Probe(name = "normalFramesWritten")
     private final SwCounter normalFramesWritten = newSwCounter();
-    @Probe(name = "out.priorityFramesWritten")
+    @Probe(name = "priorityFramesWritten")
     private final SwCounter priorityFramesWritten = newSwCounter();
     private final MetricsRegistry metricsRegistry;
 
@@ -89,16 +89,16 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
 
         // sensors
         this.metricsRegistry = metricsRegistry;
-        metricsRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "]");
+        metricsRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].out");
     }
 
-    @Probe(name = "out.interestedOps", level = DEBUG)
+    @Probe(name = "interestedOps", level = DEBUG)
     private long interestOps() {
         SelectionKey selectionKey = this.selectionKey;
         return selectionKey == null ? -1 : selectionKey.interestOps();
     }
 
-    @Probe(name = "out.readyOps", level = DEBUG)
+    @Probe(name = "readyOps", level = DEBUG)
     private long readyOps() {
         SelectionKey selectionKey = this.selectionKey;
         return selectionKey == null ? -1 : selectionKey.readyOps();
@@ -119,12 +119,12 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         return writeHandler;
     }
 
-    @Probe(name = "out.writeQueuePendingBytes", level = DEBUG)
+    @Probe(name = "writeQueuePendingBytes", level = DEBUG)
     public long bytesPending() {
         return bytesPending(writeQueue);
     }
 
-    @Probe(name = "out.priorityWriteQueuePendingBytes", level = DEBUG)
+    @Probe(name = "priorityWriteQueuePendingBytes", level = DEBUG)
     public long priorityBytesPending() {
         return bytesPending(urgentWriteQueue);
     }
@@ -139,12 +139,12 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         return bytesPending;
     }
 
-    @Probe(name = "out.idleTimeMs", level = DEBUG)
+    @Probe(name = "idleTimeMs", level = DEBUG)
     private long idleTimeMs() {
         return max(System.currentTimeMillis() - lastWriteTime, 0);
     }
 
-    @Probe(name = "out.isScheduled", level = DEBUG)
+    @Probe(name = "isScheduled", level = DEBUG)
     private long isScheduled() {
         return scheduled.get() ? 1 : 0;
     }


### PR DESCRIPTION
Each handler is run on an io thread and with these probes in place,
in the metrics one can see which iothread a handler is using. This
is very useful to figure out of there are any imbalances.