### PR TITLE
Fixed broken replication logic in putAll operation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
@@ -81,7 +81,7 @@ public class PutAllOperation extends AbstractOperation {
         Collection<Member> members = getNodeEngine().getClusterService().getMembers();
         for (Member member : members) {
             Address address = member.getAddress();
-            if (address.equals(getCallerAddress()) || address.equals(getNodeEngine().getThisAddress())) {
+            if (address.equals(getNodeEngine().getThisAddress())) {
                 continue;
             }
             ReplicateUpdateOperation updateOperation = new ReplicateUpdateOperation(name, key, value, 0, response,

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
@@ -18,10 +18,12 @@ package com.hazelcast.replicatedmap;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import java.util.HashMap;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -33,6 +35,31 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(value = {QuickTest.class, ParallelTest.class})
 public class ReplicatedMapReadYourWritesTest extends ReplicatedMapBaseTest {
+
+    @Test
+    public void testReadYourWritesBySize() throws Exception {
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory();
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance();
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance();
+        final ReplicatedMap<Integer, Integer> map1 = instance1.getReplicatedMap("default");
+        final ReplicatedMap<Integer, Integer> map2 = instance2.getReplicatedMap("default");
+
+
+        HashMap<Integer, Integer> map = new HashMap<Integer, Integer>();
+        final int count = 100;
+        for (int i = 0; i < count; i++) {
+            map.put(i, i);
+        }
+        map1.putAll(map);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(count, map1.size());
+                assertEquals(count, map2.size());
+            }
+        }, 15);
+    }
 
     @Test
     public void testReadYourWritesByGet() throws Exception {


### PR DESCRIPTION
Fixes #7617

The `PutAllOperation` is issued for `putAll` calls to the replicated map on the keys' partition owners. After value is put to the record store, update should be replicated to all members excluding the partition owner node itself. But the buggy implementation was also excluding the caller member which is the source of the bug that blocks the replication of the update. When the replication of update is blocked, it might take 30(default period of anti-entropy check) seconds for anti-entropy system to kick in and sync the values of replicas with partition owner.

In this PR the exclusion of caller members are removed.

Thanks @sabag for reporting the issue and providing a reproducer.