### PR TITLE
Thread id isn't set in construction of AbstractHandler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractHandler.java
@@ -53,6 +53,7 @@ public abstract class AbstractHandler implements MigratableHandler {
     public AbstractHandler(TcpIpConnection connection, NonBlockingIOThread ioThread, int initialOps) {
         this.connection = connection;
         this.ioThread = ioThread;
+        this.ioThreadId = ioThread.id;
         this.selector = ioThread.getSelector();
         this.socketChannel = connection.getSocketChannelWrapper();
         this.connectionManager = connection.getConnectionManager();


### PR DESCRIPTION
Fixed problem with not assigning thread id in AbstractHandler on cons…truction.

This is a debugging aid and has no impact on the system, so I'll merge this one directly.