### PR TITLE
[DONT-MERGE] Fixes a race when client connection is closed.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_INTERVAL;
 import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECONDS;
 
 /**
@@ -59,7 +58,6 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
     private final ClientInvocationService invocationService;
     private final ClientExecutionService executionService;
     private final ClientMessage clientMessage;
-    private final int heartBeatInterval;
 
     private final Address address;
     private final int partitionId;
@@ -89,9 +87,6 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
 
         logger = ((ClientInvocationServiceSupport) invocationService).invocationLogger;
         clientInvocationFuture = new ClientInvocationFuture(this, client, clientMessage, logger);
-
-        int interval = clientProperties.getInteger(HEARTBEAT_INTERVAL);
-        this.heartBeatInterval = interval > 0 ? interval : Integer.parseInt(HEARTBEAT_INTERVAL.getDefaultValue());
     }
 
     public ClientInvocation(HazelcastClientInstanceImpl client, ClientMessage clientMessage) {
@@ -228,27 +223,12 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
         return connection != null;
     }
 
-    boolean isConnectionHealthy(long elapsed) {
-        if (elapsed >= heartBeatInterval) {
-            if (sendConnection != null) {
-                return sendConnection.isHeartBeating();
-            } else {
-                return true;
-            }
-        }
-        return true;
-    }
-
     public EventHandler getEventHandler() {
         return handler;
     }
 
     public void setEventHandler(EventHandler handler) {
         this.handler = handler;
-    }
-
-    public int getHeartBeatInterval() {
-        return heartBeatInterval;
     }
 
     public boolean shouldBypassHeartbeatCheck() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -106,23 +106,25 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         if (isShutdown) {
             throw new HazelcastClientNotActiveException("Client is shut down");
         }
-        registerInvocation(invocation);
+        synchronized (connection) {
+            registerInvocation(invocation);
 
-        ClientMessage clientMessage = invocation.getClientMessage();
-        if (!isAllowedToSendRequest(connection, invocation) || !writeToConnection(connection, clientMessage)) {
-            final long callId = clientMessage.getCorrelationId();
-            ClientInvocation clientInvocation = deRegisterCallId(callId);
-            if (clientInvocation != null) {
-                callIdSequence.complete();
-                throw new IOException("Packet not send to " + connection.getRemoteEndpoint());
-            } else {
-                if (invocationLogger.isFinestEnabled()) {
-                    invocationLogger.finest("Invocation not found to deregister for call id " + callId);
+            ClientMessage clientMessage = invocation.getClientMessage();
+            if (!isAllowedToSendRequest(connection, invocation) || !writeToConnection(connection, clientMessage)) {
+                final long callId = clientMessage.getCorrelationId();
+                ClientInvocation clientInvocation = deRegisterCallId(callId);
+                if (clientInvocation != null) {
+                    callIdSequence.complete();
+                    throw new IOException("Packet not send to " + connection.getRemoteEndpoint());
+                } else {
+                    if (invocationLogger.isFinestEnabled()) {
+                        invocationLogger.finest("Invocation not found to deregister for call id " + callId);
+                    }
                 }
             }
-        }
 
-        invocation.setSendConnection(connection);
+            invocation.setSendConnection(connection);
+        }
     }
 
     private boolean writeToConnection(ClientConnection connection, ClientMessage clientMessage) {
@@ -167,13 +169,15 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     }
 
     public void cleanResources(ConstructorFunction<Object, Throwable> responseCtor, ClientConnection connection) {
-        final Iterator<Map.Entry<Long, ClientInvocation>> iter = callIdMap.entrySet().iterator();
-        while (iter.hasNext()) {
-            final Map.Entry<Long, ClientInvocation> entry = iter.next();
-            final ClientInvocation invocation = entry.getValue();
-            if (connection.equals(invocation.getSendConnection())) {
-                iter.remove();
-                invocation.notifyException(responseCtor.createNew(null));
+        synchronized (connection) {
+            final Iterator<Map.Entry<Long, ClientInvocation>> iter = callIdMap.entrySet().iterator();
+            while (iter.hasNext()) {
+                final Map.Entry<Long, ClientInvocation> entry = iter.next();
+                final ClientInvocation invocation = entry.getValue();
+                if (connection.equals(invocation.getSendConnection())) {
+                    iter.remove();
+                    invocation.notifyException(responseCtor.createNew(null));
+                }
             }
         }
     }


### PR DESCRIPTION
When connection closed, it was possible to endup with invocations
that are not notified. These invocations was causing infinite
wait. With a sync block race is fixed.

There was a workaround for this in ClientInvcationFuture.get
which is waking up every hearbeatTimeout milliseconds and checking
if connection is still there. This workaround is removed in a
previous pr because when async api is used that workaround is
does not work.

fixes #7582 , #7527.