### PR TITLE
Fix hazelcast osgi Import-Package statement

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -124,6 +124,7 @@
                                 </Export-Package>
                                 <Import-Package>
                                     !org.junit,
+                                    !com.hazelcast.*,
                                     !com.eclipsesource.json,
                                     sun.misc;resolution:=optional,
                                     javax.cache;resolution:=optional,


### PR DESCRIPTION
With the latest `3.6.1` release, the hazelcast bundle cannot be imported in an osgi platform.
This issue occurs because there is an unwanted osgi `Import-Package` statement (`Import-Package: com.hazelcast.client.impl.protocol.codec`).

To fix this issue, I propose to exclude every `com.hazelcast.*` package from the `Import-Package` statement.

Can you integrate my PR ?

Thanks

Mathieu