### PR TITLE
[DONT-MERGE] Fixes a race when client connection is closed.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_INTERVAL;
 import static com.hazelcast.client.config.ClientProperty.INVOCATION_TIMEOUT_SECONDS;
 
 /**
@@ -60,7 +59,6 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
     private final ClientInvocationService invocationService;
     private final ClientExecutionService executionService;
     private final ClientMessage clientMessage;
-    private final int heartBeatInterval;
 
     private final Address address;
     private final int partitionId;
@@ -89,10 +87,6 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
         retryTimeoutPointInMillis = System.currentTimeMillis() + waitTimeResolved;
 
         clientInvocationFuture = new ClientInvocationFuture(this, client, clientMessage);
-
-
-        int interval = clientProperties.getInteger(HEARTBEAT_INTERVAL);
-        this.heartBeatInterval = interval > 0 ? interval : Integer.parseInt(HEARTBEAT_INTERVAL.getDefaultValue());
     }
 
     public ClientInvocation(HazelcastClientInstanceImpl client, ClientMessage clientMessage) {
@@ -229,27 +223,12 @@ public class ClientInvocation implements Runnable, ExecutionCallback {
         return connection != null;
     }
 
-    boolean isConnectionHealthy(long elapsed) {
-        if (elapsed >= heartBeatInterval) {
-            if (sendConnection != null) {
-                return sendConnection.isHeartBeating();
-            } else {
-                return true;
-            }
-        }
-        return true;
-    }
-
     public EventHandler getEventHandler() {
         return handler;
     }
 
     public void setEventHandler(EventHandler handler) {
         this.handler = handler;
-    }
-
-    public int getHeartBeatInterval() {
-        return heartBeatInterval;
     }
 
     public boolean shouldBypassHeartbeatCheck() {


### PR DESCRIPTION
When connection closed, it was possible to endup with invocations
that are not notified. These invocations was causing infinite
wait. With a sync block race is fixed.

There was a workaround for this in ClientInvcationFuture.get
which is waking up every hearbeatTimeout milliseconds and checking
if connection is still there. This workaround is removed in a
previous pr because when async api is used that workaround is
does not work.

fixes #7582 , #7527.