### PR TITLE
Fixes a race when connection is closed.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -61,6 +61,7 @@ public class ClientConnection implements Connection {
     private volatile Address remoteEndpoint;
     private volatile boolean heartBeating = true;
     private boolean isAuthenticatedAsOwner;
+    private volatile long closedTime;
 
     public ClientConnection(HazelcastClientInstanceImpl client, NonBlockingIOThread in, NonBlockingIOThread out,
                             int connectionId, SocketChannelWrapper socketChannelWrapper) throws IOException {
@@ -209,6 +210,7 @@ public class ClientConnection implements Connection {
         if (!live.compareAndSet(true, false)) {
             return;
         }
+        closedTime = System.currentTimeMillis();
         String message = "Connection [" + getRemoteSocketAddress() + "] lost. Reason: ";
         if (t != null) {
             message += t.getClass().getName() + '[' + t.getMessage() + ']';
@@ -283,5 +285,9 @@ public class ClientConnection implements Connection {
                 + ", socketChannel=" + socketChannelWrapper
                 + ", remoteEndpoint=" + remoteEndpoint
                 + '}';
+    }
+
+    public long getClosedTime() {
+        return closedTime;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -362,10 +362,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             for (ConnectionListener connectionListener : connectionListeners) {
                 connectionListener.connectionRemoved(conn);
             }
-
-        } else {
-            ClientInvocationService invocationService = client.getInvocationService();
-            invocationService.cleanConnectionResources((ClientConnection) connection);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
@@ -45,6 +45,4 @@ public interface ClientInvocationService {
 
     void handleClientMessage(ClientMessage message, Connection connection);
 
-    void cleanConnectionResources(ClientConnection connection);
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -31,27 +31,25 @@ import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
-import com.hazelcast.util.ConstructorFunction;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.client.config.ClientProperty.MAX_CONCURRENT_INVOCATIONS;
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.onOutOfMemory;
 
 
-abstract class ClientInvocationServiceSupport implements ClientInvocationService, ConnectionListener
-        , ConnectionHeartbeatListener {
+abstract class ClientInvocationServiceSupport implements ClientInvocationService {
 
-    private static final int WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED = 10;
     private static final int WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD = 5000;
     protected final HazelcastClientInstanceImpl client;
     protected ClientConnectionManager connectionManager;
@@ -67,7 +65,6 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     private ClientExceptionFactory clientExceptionFactory;
     private volatile boolean isShutdown;
 
-
     public ClientInvocationServiceSupport(HazelcastClientInstanceImpl client) {
         this.client = client;
         int maxAllowedConcurrentInvocations = client.getClientProperties().getInteger(MAX_CONCURRENT_INVOCATIONS);
@@ -80,13 +77,12 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         connectionManager = client.getConnectionManager();
         executionService = client.getClientExecutionService();
         clientListenerService = (ClientListenerServiceImpl) client.getListenerService();
-        connectionManager.addConnectionListener(this);
-        connectionManager.addConnectionHeartbeatListener(this);
         partitionService = client.getClientPartitionService();
         clientExceptionFactory = initClientExceptionFactory();
         responseThread = new ResponseThread(client.getThreadGroup(), client.getName() + ".response-",
                 client.getClientConfig().getClassLoader());
         responseThread.start();
+        executionService.scheduleWithRepetition(new CleanResourcesTask(), 1, 1, TimeUnit.SECONDS);
     }
 
 
@@ -165,55 +161,6 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         return callIdMap.remove(callId);
     }
 
-    public void cleanResources(ConstructorFunction<Object, Throwable> responseCtor, ClientConnection connection) {
-        final Iterator<Map.Entry<Long, ClientInvocation>> iter = callIdMap.entrySet().iterator();
-        while (iter.hasNext()) {
-            final Map.Entry<Long, ClientInvocation> entry = iter.next();
-            final ClientInvocation invocation = entry.getValue();
-            if (connection.equals(invocation.getSendConnection())) {
-                iter.remove();
-                invocation.notifyException(responseCtor.createNew(null));
-            }
-        }
-    }
-
-    @Override
-    public void connectionAdded(Connection connection) {
-
-    }
-
-    @Override
-    public void connectionRemoved(Connection connection) {
-        cleanConnectionResources((ClientConnection) connection);
-    }
-
-    @Override
-    public void heartBeatStarted(Connection connection) {
-
-    }
-
-    @Override
-    public void heartBeatStopped(Connection connection) {
-        cleanConnectionResources((ClientConnection) connection);
-    }
-
-    @Override
-    public void cleanConnectionResources(ClientConnection connection) {
-        if (connectionManager.isAlive()) {
-            try {
-                ((ClientExecutionServiceImpl) executionService).executeInternal(new CleanResourcesTask(connection));
-            } catch (RejectedExecutionException e) {
-                invocationLogger.warning("Execution rejected ", e);
-            }
-        } else {
-            cleanResources(new ConstructorFunction<Object, Throwable>() {
-                @Override
-                public Throwable createNew(Object arg) {
-                    return new HazelcastClientNotActiveException("Client is shutting down!");
-                }
-            }, connection);
-        }
-    }
 
     public boolean isShutdown() {
         return isShutdown;
@@ -222,47 +169,61 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     public void shutdown() {
         isShutdown = true;
         responseThread.interrupt();
+        callIdMap.clear();
     }
 
     private class CleanResourcesTask implements Runnable {
 
-        private final ClientConnection connection;
-
-        CleanResourcesTask(ClientConnection connection) {
-            this.connection = connection;
-        }
-
         @Override
         public void run() {
-            waitForPacketsProcessed();
-            cleanResources(new ConstructorFunction<Object, Throwable>() {
-                @Override
-                public Throwable createNew(Object arg) {
-                    return new TargetDisconnectedException(connection.getRemoteEndpoint());
+            Iterator<Map.Entry<Long, ClientInvocation>> iter = callIdMap.entrySet().iterator();
+            Collection<ClientConnection> expiredConnections = null;
+            while (iter.hasNext()) {
+                Map.Entry<Long, ClientInvocation> entry = iter.next();
+                ClientInvocation invocation = entry.getValue();
+                ClientConnection connection = invocation.getSendConnection();
+                if (connection == null) {
+                    continue;
                 }
-            }, connection);
+                if (connection.isHeartBeating()) {
+                    continue;
+                }
+
+                int pendingPacketCount = connection.getPendingPacketCount();
+                if (pendingPacketCount != 0) {
+                    long closedTime = connection.getClosedTime();
+                    long elapsed = System.currentTimeMillis() - closedTime;
+                    if (elapsed < WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD) {
+                        continue;
+                    } else {
+                        if (expiredConnections == null) {
+                            expiredConnections = new LinkedList<ClientConnection>();
+                        }
+                        expiredConnections.add(connection);
+                    }
+                }
+
+
+                iter.remove();
+                invocation.notifyException(new TargetDisconnectedException(connection.getRemoteEndpoint()));
+            }
+            if (expiredConnections != null) {
+                logExpiredConnections(expiredConnections);
+            }
         }
 
-        private void waitForPacketsProcessed() {
-            final long begin = System.currentTimeMillis();
-            int count = connection.getPendingPacketCount();
-            while (count != 0) {
-                try {
-                    Thread.sleep(WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED);
-                } catch (InterruptedException e) {
-                    invocationLogger.warning(e);
-                    break;
+        private void logExpiredConnections(Collection<ClientConnection> expiredConnections) {
+            for (ClientConnection expiredConnection : expiredConnections) {
+                int pendingPacketCount = expiredConnection.getPendingPacketCount();
+                if (pendingPacketCount != 0) {
+                    invocationLogger.warning("There are " + pendingPacketCount
+                            + " packets which are not processed "
+                            + " on " + expiredConnection.getRemoteEndpoint());
                 }
-                long elapsed = System.currentTimeMillis() - begin;
-                if (elapsed > WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD) {
-                    invocationLogger.warning("There are packets which are not processed " + count);
-                    break;
-                }
-                count = connection.getPendingPacketCount();
+
             }
         }
     }
-
 
     @Override
     public void handleClientMessage(ClientMessage message, Connection connection) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -49,7 +49,6 @@ import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -742,7 +741,6 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         }
     }
 
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/7582
     @Test
     public void testClusterShutdown_thenCheckOperationsNotHanging() throws Exception {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -257,7 +256,6 @@ public class CacheListenerTest extends HazelcastTestSupport {
         cache.getAndRemove(randomString());
     }
 
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/7527
     @Test
     public void testSyncListener_shouldNotHang_whenHazelcastInstanceShutdown() {
         CachingProvider provider = getCachingProvider();


### PR DESCRIPTION
When connection closed, it was possible to endup with invocations
that are not notified. These invocations was causing infinite
wait. We let the race happen and check the callIdMap from another
thread every seconds to cleanup unlucky invocations.

There was a workaround for this in ClientInvcationFuture.get
which is waking up every hearbeatTimeout milliseconds and checking
if connection is still there. This workaround is removed in a
previous pr because when async api is used that workaround is
does not work.

fixes #7582 , #7527.