### PR TITLE
Empty set fix for executeOnKeys() #7631

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -149,7 +149,6 @@ import static java.util.Collections.emptyMap;
 public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
-    protected static final String EMPTY_COLLECTION_IS_NOT_ALLOWED = "Empty collection is not allowed!";
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
     protected static final String NULL_LISTENER_IS_NOT_ALLOWED = "Null listener is not allowed!";
     protected static final String NULL_PREDICATE_IS_NOT_ALLOWED = "Predicate should not be null!";
@@ -1322,8 +1321,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     @Override
     public Map<K, Object> executeOnKeys(Set<K> keys, EntryProcessor entryProcessor) {
         checkNotNull(keys, NULL_KEY_IS_NOT_ALLOWED);
-        if (keys.size() == 0) {
-            throw new IllegalArgumentException(EMPTY_COLLECTION_IS_NOT_ALLOWED);
+        if (keys.isEmpty()) {
+            return emptyMap();
         }
         Collection<Data> dataCollection = objectToDataCollection(keys, getSerializationService());
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/MapPreconditionsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/MapPreconditionsTest.java
@@ -29,6 +29,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class MapPreconditionsTest {
@@ -578,35 +582,32 @@ public class MapPreconditionsTest {
 
     @Test(expected = NullPointerException.class)
     public void testExecuteOnKey() throws Exception {
-        map.executeOnKey(null, new EntryProcessor() {
-            @Override
-            public Object process(Map.Entry entry) {
-                return null;
-            }
-
-            @Override
-            public EntryBackupProcessor getBackupProcessor() {
-                return null;
-            }
-        });
+        map.executeOnKey(null, new NoOpEntryProcessor());
     }
 
     @Test(expected = NullPointerException.class)
     public void testExecuteOnKeys() throws Exception {
         Set set = new HashSet();
         set.add(null);
+        map.executeOnKeys(set, new NoOpEntryProcessor());
+    }
 
-        map.executeOnKeys(set, new EntryProcessor() {
-            @Override
-            public Object process(Map.Entry entry) {
-                return null;
-            }
+    @Test
+    public void testIssue7631_emptyKeysSupported() {
+        Map<Object, Object> res = map.executeOnKeys(emptySet(), new NoOpEntryProcessor());
+        assertEquals(emptyMap(), res);
+    }
 
-            @Override
-            public EntryBackupProcessor getBackupProcessor() {
-                return null;
-            }
-        });
+    private static class NoOpEntryProcessor implements EntryProcessor {
+        @Override
+        public Object process(Map.Entry entry) {
+            return null;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
     }
 
     private class TestEntryListener implements EntryListener {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -687,8 +687,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
         if (keys == null || keys.contains(null)) {
             throw new NullPointerException(NULL_KEY_IS_NOT_ALLOWED);
         }
-        if (keys.size() == 0) {
-            throw new IllegalArgumentException(EMPTY_COLLECTION_IS_NOT_ALLOWED);
+        if (keys.isEmpty()) {
+            return Collections.emptyMap();
         }
         Set<Data> dataKeys = new HashSet<Data>(keys.size());
         for (K key : keys) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -115,7 +115,6 @@ import static java.util.logging.Level.WARNING;
 abstract class MapProxySupport extends AbstractDistributedObject<MapService> implements InitializingObject {
 
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
-    protected static final String EMPTY_COLLECTION_IS_NOT_ALLOWED = "Empty Collection is not allowed!";
 
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
     protected static final String NULL_PREDICATE_IS_NOT_ALLOWED = "Predicate should not be null!";

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.map.TempData.DeleteEntryProcessor;
 import static com.hazelcast.map.TempData.LoggingEntryProcessor;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -994,6 +995,13 @@ public class EntryProcessorTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testIssue7631_emptyKeysSupported() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        IMap<Object, Object> map = factory.newHazelcastInstance().getMap("default");
+        assertEquals(emptyMap(), map.executeOnEntries(new NoOpEntryProcessor()));
+    }
+
+    @Test
     public void testSubmitToKey() throws InterruptedException, ExecutionException {
         HazelcastInstance instance1 = createHazelcastInstance(getConfig());
         IMap<Integer, Integer> map = instance1.getMap("testMapEntryProcessor");
@@ -1321,6 +1329,18 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         public void readData(ObjectDataInput in) throws IOException {
             serializedCount = in.readInt();
             deserializedCount = in.readInt() + 1;
+        }
+    }
+
+    private static class NoOpEntryProcessor implements EntryProcessor {
+        @Override
+        public Object process(final Map.Entry entry) {
+            return null;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
         }
     }
 


### PR DESCRIPTION
Modified ClientMapProxy and MapProxyImpl to accept an empty set of keys over which to execute an entry processor, with early return of an empty map. Added test cases over both classes. 