### PR TITLE
InvocationRegistry implements Iterable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PendingInvocationsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PendingInvocationsPlugin.java
@@ -71,7 +71,7 @@ public final class PendingInvocationsPlugin extends PerformanceMonitorPlugin {
     }
 
     private void scan() {
-        for (Invocation invocation : invocationRegistry.invocations()) {
+        for (Invocation invocation : invocationRegistry) {
             occurrenceMap.add(invocation.op.getClass(), 1);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -279,7 +279,7 @@ public class InvocationMonitor {
 
         @Override
         public void run() {
-            for (Invocation invocation : invocationRegistry.invocations()) {
+            for (Invocation invocation : invocationRegistry) {
                 if (hasMemberLeft(invocation)) {
                     invocation.notifyError(new MemberLeftException(leftMember));
                 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
@@ -19,12 +19,14 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import java.lang.reflect.Field;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.concurrent.Future;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -93,17 +95,16 @@ public class Invocation_RetryTest extends HazelcastTestSupport {
                 , op, remoteNodeEngine.getThisAddress());
         Field invocationField = InvocationFuture.class.getDeclaredField("invocation");
         invocationField.setAccessible(true);
-        Invocation invocation = (Invocation) invocationField.get(future);
+        final Invocation invocation = (Invocation) invocationField.get(future);
 
         invocation.notifyError(new RetryableHazelcastException());
         invocation.notifyError(new RetryableHazelcastException());
-
 
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                Collection<Invocation> invocations = operationService.invocationsRegistry.invocations();
-                assertEquals(0, invocations.size());
+                Iterator<Invocation> invocations = operationService.invocationsRegistry.iterator();
+                assertFalse(invocations.hasNext());
             }
         });
     }


### PR DESCRIPTION
Instead of exposing the underlying collection, an iterator is now returned.
This way the original collection is shield from the outside. This makes it easier
to change the collection.

This PR is needed for another PR where I used multiple collections (arrays) to store
invocations.