### PR TITLE
Fixed leaking memory from ItemCounter on LoadTracker

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
@@ -103,27 +103,13 @@ public class IOBalancer {
     }
 
     public void connectionAdded(TcpIpConnection connection) {
-        NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
-        NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
-
-        if (logger.isFinestEnabled()) {
-            logger.finest("Added handlers for: " + connection);
-        }
-
-        inLoadTracker.addHandler(socketReader);
-        outLoadTracker.addHandler(socketWriter);
+        inLoadTracker.notifyConnectionAdded(connection);
+        outLoadTracker.notifyConnectionAdded(connection);
     }
 
     public void connectionRemoved(TcpIpConnection connection) {
-        NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
-        NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
-
-        if (logger.isFinestEnabled()) {
-            logger.finest("Removing handlers from: " + connection);
-        }
-
-        inLoadTracker.removeHandler(socketReader);
-        outLoadTracker.removeHandler(socketWriter);
+        inLoadTracker.notifyConnectionRemoved(connection);
+        outLoadTracker.notifyConnectionRemoved(connection);
     }
 
     public void start() {
@@ -211,4 +197,5 @@ public class IOBalancer {
     public void signalMigrationComplete() {
         migrationCompletedCount.inc();
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/LoadTracker.java
@@ -17,15 +17,19 @@
 package com.hazelcast.nio.tcp.nonblocking.iobalancer;
 
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketReader;
+import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketWriter;
 import com.hazelcast.util.ItemCounter;
-
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 
@@ -52,9 +56,11 @@ class LoadTracker {
     private final ItemCounter<MigratableHandler> handlerEventsCounter = new ItemCounter<MigratableHandler>();
 
     //contains all known handlers
-    private final Set<MigratableHandler> handlers = new CopyOnWriteArraySet<MigratableHandler>();
+    private final Set<MigratableHandler> handlers = new HashSet<MigratableHandler>();
 
     private final LoadImbalance imbalance;
+
+    private final Queue<Runnable> tasks = new LinkedBlockingQueue<Runnable>();
 
     LoadTracker(NonBlockingIOThread[] ioThreads, ILogger logger) {
         this.logger = logger;
@@ -76,6 +82,7 @@ class LoadTracker {
      * @return recalculated imbalance
      */
     LoadImbalance updateImbalance() {
+        handleAddedOrRemovedConnections();
         clearWorkingImbalance();
         updateNewWorkingImbalance();
         updateNewFinalImbalance();
@@ -83,9 +90,28 @@ class LoadTracker {
         return imbalance;
     }
 
+    private void handleAddedOrRemovedConnections() {
+        Iterator<Runnable> iterator = tasks.iterator();
+        while (iterator.hasNext()) {
+            Runnable task = iterator.next();
+            task.run();
+            iterator.remove();
+        }
+    }
+
     // just for testing
     Set<MigratableHandler> getHandlers() {
         return handlers;
+    }
+
+    // just for testing
+    ItemCounter<MigratableHandler> getLastEventCounter() {
+        return lastEventCounter;
+    }
+
+    // just for testing
+    ItemCounter<MigratableHandler> getHandlerEventsCounter() {
+        return handlerEventsCounter;
     }
 
     private void updateNewFinalImbalance() {
@@ -111,6 +137,17 @@ class LoadTracker {
             }
         }
     }
+
+    public void notifyConnectionAdded(TcpIpConnection connection) {
+        ConnectionAddedTask connectionAddedTask = new ConnectionAddedTask(connection);
+        tasks.offer(connectionAddedTask);
+    }
+
+    public void notifyConnectionRemoved(TcpIpConnection connection) {
+        ConnectionRemovedTask connectionRemovedTask = new ConnectionRemovedTask(connection);
+        tasks.offer(connectionRemovedTask);
+    }
+
 
     private void updateNewWorkingImbalance() {
         for (MigratableHandler handler : handlers) {
@@ -147,6 +184,8 @@ class LoadTracker {
 
     void removeHandler(MigratableHandler handler) {
         handlers.remove(handler);
+        handlerEventsCounter.remove(handler);
+        lastEventCounter.remove(handler);
     }
 
     private void printDebugTable() {
@@ -217,4 +256,49 @@ class LoadTracker {
         }
         sb.append(LINE_SEPARATOR);
     }
+
+    class ConnectionRemovedTask implements Runnable {
+
+        private TcpIpConnection connection;
+
+        public ConnectionRemovedTask(TcpIpConnection connection) {
+            this.connection = connection;
+        }
+
+        @Override
+        public void run() {
+            NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
+            NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
+
+            if (logger.isFinestEnabled()) {
+                logger.finest("Removing handlers from: " + connection);
+            }
+
+            removeHandler(socketReader);
+            removeHandler(socketWriter);
+        }
+    }
+
+    class ConnectionAddedTask implements Runnable {
+
+        private TcpIpConnection connection;
+
+        public ConnectionAddedTask(TcpIpConnection connection) {
+            this.connection = connection;
+        }
+
+        @Override
+        public void run() {
+            NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
+            NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
+
+            if (logger.isFinestEnabled()) {
+                logger.finest("Added handlers for: " + connection);
+            }
+
+            addHandler(socketReader);
+            addHandler(socketWriter);
+        }
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
@@ -113,6 +113,10 @@ public final class ItemCounter<T> {
         return oldValue;
     }
 
+    public void remove(T item) {
+        map.remove(item);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerMemoryLeakTest.java
@@ -22,12 +22,15 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceManager;
 import com.hazelcast.internal.ascii.HTTPCommunicator;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
 import java.io.IOException;
+import java.net.Socket;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,10 +49,12 @@ public class IOBalancerMemoryLeakTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testMemoryLeak() throws IOException {
+    public void testMemoryLeak_with_RestConnections() throws IOException {
         Config config = new Config();
         config.getGroupConfig().setName(randomName());
         config.setProperty(GroupProperty.REST_ENABLED, "true");
+        config.setProperty(GroupProperty.IO_BALANCER_INTERVAL_SECONDS, "1");
+
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         TcpIpConnectionManager connectionManager = (TcpIpConnectionManager) getConnectionManager(instance);
@@ -67,5 +72,65 @@ public class IOBalancerMemoryLeakTest extends HazelcastTestSupport {
             }
         });
     }
+
+
+    @Test
+    public void testMemoryLeak_with_SocketConnections() throws IOException {
+        Config config = new Config();
+        config.getGroupConfig().setName(randomName());
+        config.setProperty(GroupProperty.IO_BALANCER_INTERVAL_SECONDS, "1");
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        final Address address = instance.getCluster().getLocalMember().getAddress();
+        int threadCount = 10;
+        final int connectionCountPerThread = 100;
+
+        Runnable runnable = new Runnable() {
+            public void run() {
+                for (int i = 0; i < connectionCountPerThread; i++) {
+                    Socket socket = null;
+                    try {
+                        socket = new Socket(address.getHost(), address.getPort());
+                        socket.getOutputStream().write(Protocols.CLUSTER.getBytes());
+                        sleepMillis(1000);
+                        socket.close();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        };
+
+        Thread[] threads = new Thread[threadCount];
+        for (int i = 0; i < threadCount; i++) {
+            threads[i] = new Thread(runnable);
+            threads[i].start();
+        }
+
+        assertJoinable(threads);
+
+
+        TcpIpConnectionManager connectionManager = (TcpIpConnectionManager) getConnectionManager(instance);
+        final IOBalancer ioBalancer = connectionManager.getIoBalancer();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                LoadTracker inLoadTracker = ioBalancer.getInLoadTracker();
+                LoadTracker outLoadTracker = ioBalancer.getOutLoadTracker();
+                int inHandlerSize = inLoadTracker.getHandlers().size();
+                int outHandlerSize = outLoadTracker.getHandlers().size();
+                int inHandlerEventsCount = inLoadTracker.getHandlerEventsCounter().keySet().size();
+                int outHandlerEventsCount = outLoadTracker.getHandlerEventsCounter().keySet().size();
+                int inLastEventsCount = inLoadTracker.getLastEventCounter().keySet().size();
+                int outLastEventsCount = outLoadTracker.getLastEventCounter().keySet().size();
+                Assert.assertEquals(0, inHandlerSize);
+                Assert.assertEquals(0, outHandlerSize);
+                Assert.assertEquals(0, inHandlerEventsCount);
+                Assert.assertEquals(0, outHandlerEventsCount);
+                Assert.assertEquals(0, inLastEventsCount);
+                Assert.assertEquals(0, outLastEventsCount);
+            }
+        });
+    }
+
 
 }


### PR DESCRIPTION
ItemCounters are leaking memory by holding references to the SocketReader/SocketWriters. When a connection is added/removed a task is created on the queue of IOBalancer, and IOBalancer will process these tasks to notify LoadTrackers to make necessary cleanups . By doing that LoadTrackers will only accessed by IOBalancer thread which eliminates the requirement of thread-safe ItemCounters.

Memory Usage before this fix : 
![screen shot 2016-03-02 at 12 02 47 pm](https://cloud.githubusercontent.com/assets/378108/13457543/70f70478-e071-11e5-8599-85b17d142ef8.png)

Memory Usage after this fix : 
![screen shot 2016-03-02 at 12 03 00 pm](https://cloud.githubusercontent.com/assets/378108/13457549/76228634-e071-11e5-9f51-c5bbe5ba41a3.png)

Thanks @mahileeb for reporting this issue.

Fixes #6496 #6199 