### PR TITLE
[Backport] Fixed leaking memory from ItemCounter on LoadTracker by holding refer…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
@@ -103,27 +103,13 @@ public class IOBalancer {
     }
 
     public void connectionAdded(TcpIpConnection connection) {
-        NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
-        NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
-
-        if (logger.isFinestEnabled()) {
-            logger.finest("Added handlers for: " + connection);
-        }
-
-        inLoadTracker.addHandler(socketReader);
-        outLoadTracker.addHandler(socketWriter);
+        inLoadTracker.notifyConnectionAdded(connection);
+        outLoadTracker.notifyConnectionAdded(connection);
     }
 
     public void connectionRemoved(TcpIpConnection connection) {
-        NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
-        NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
-
-        if (logger.isFinestEnabled()) {
-            logger.finest("Removing handlers from: " + connection);
-        }
-
-        inLoadTracker.removeHandler(socketReader);
-        outLoadTracker.removeHandler(socketWriter);
+        inLoadTracker.notifyConnectionRemoved(connection);
+        outLoadTracker.notifyConnectionRemoved(connection);
     }
 
     public void start() {
@@ -211,4 +197,6 @@ public class IOBalancer {
     public void signalMigrationComplete() {
         migrationCompletedCount.inc();
     }
+
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
@@ -18,6 +18,7 @@ package com.hazelcast.util;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Non Thread-Safe Counter of things. It allows to count items without worrying about nulls.
@@ -26,6 +27,16 @@ import java.util.Map;
  */
 public final class ItemCounter<T> {
     private final Map<T, MutableLong> map = new HashMap<T, MutableLong>();
+
+    /**
+     * Returns a set of all keys in this counter.
+     *
+     * @return the set of all keys.
+     */
+    public Set<T> keySet() {
+        return map.keySet();
+    }
+
 
     /**
      * Get current counter for an item item
@@ -101,6 +112,10 @@ public final class ItemCounter<T> {
         long oldValue = entry.value;
         entry.value = value;
         return oldValue;
+    }
+
+    public void remove(T item) {
+        map.remove(item);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerMemoryLeakTest.java
@@ -22,12 +22,15 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.internal.ascii.HTTPCommunicator;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
 import java.io.IOException;
+import java.net.Socket;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,10 +49,12 @@ public class IOBalancerMemoryLeakTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testMemoryLeak() throws IOException {
+    public void testMemoryLeak_with_RestConnections() throws IOException {
         Config config = new Config();
         config.getGroupConfig().setName(randomName());
         config.setProperty(GroupProperty.REST_ENABLED, "true");
+        config.setProperty(GroupProperty.IO_BALANCER_INTERVAL_SECONDS, "1");
+
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         TcpIpConnectionManager connectionManager = (TcpIpConnectionManager) getConnectionManager(instance);
@@ -67,5 +72,65 @@ public class IOBalancerMemoryLeakTest extends HazelcastTestSupport {
             }
         });
     }
+
+
+    @Test
+    public void testMemoryLeak_with_SocketConnections() throws IOException {
+        Config config = new Config();
+        config.getGroupConfig().setName(randomName());
+        config.setProperty(GroupProperty.IO_BALANCER_INTERVAL_SECONDS, "1");
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        final Address address = instance.getCluster().getLocalMember().getAddress();
+        int threadCount = 10;
+        final int connectionCountPerThread = 100;
+
+        Runnable runnable = new Runnable() {
+            public void run() {
+                for (int i = 0; i < connectionCountPerThread; i++) {
+                    Socket socket = null;
+                    try {
+                        socket = new Socket(address.getHost(), address.getPort());
+                        socket.getOutputStream().write(Protocols.CLUSTER.getBytes());
+                        sleepMillis(1000);
+                        socket.close();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        };
+
+        Thread[] threads = new Thread[threadCount];
+        for (int i = 0; i < threadCount; i++) {
+            threads[i] = new Thread(runnable);
+            threads[i].start();
+        }
+
+        assertJoinable(threads);
+
+
+        TcpIpConnectionManager connectionManager = (TcpIpConnectionManager) getConnectionManager(instance);
+        final IOBalancer ioBalancer = connectionManager.getIoBalancer();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                LoadTracker inLoadTracker = ioBalancer.getInLoadTracker();
+                LoadTracker outLoadTracker = ioBalancer.getOutLoadTracker();
+                int inHandlerSize = inLoadTracker.getHandlers().size();
+                int outHandlerSize = outLoadTracker.getHandlers().size();
+                int inHandlerEventsCount = inLoadTracker.getHandlerEventsCounter().keySet().size();
+                int outHandlerEventsCount = outLoadTracker.getHandlerEventsCounter().keySet().size();
+                int inLastEventsCount = inLoadTracker.getLastEventCounter().keySet().size();
+                int outLastEventsCount = outLoadTracker.getLastEventCounter().keySet().size();
+                Assert.assertEquals(0, inHandlerSize);
+                Assert.assertEquals(0, outHandlerSize);
+                Assert.assertEquals(0, inHandlerEventsCount);
+                Assert.assertEquals(0, outHandlerEventsCount);
+                Assert.assertEquals(0, inLastEventsCount);
+                Assert.assertEquals(0, outLastEventsCount);
+            }
+        });
+    }
+
 
 }


### PR DESCRIPTION
ItemCounters are leaking memory by holding references to the SocketReader/SocketWriters. When a connection is added/removed a task is created on the queue of IOBalancer, and IOBalancer will process these tasks to notify LoadTrackers to make necessary cleanups . By doing that LoadTrackers will only accessed by IOBalancer thread which eliminates the requirement of thread-safe ItemCounters.

Memory Usage before this fix : 
![screen shot 2016-03-02 at 12 02 47 pm](https://cloud.githubusercontent.com/assets/378108/13457543/70f70478-e071-11e5-8599-85b17d142ef8.png)

Memory Usage after this fix : 
![screen shot 2016-03-02 at 12 03 00 pm](https://cloud.githubusercontent.com/assets/378108/13457549/76228634-e071-11e5-9f51-c5bbe5ba41a3.png)

Fixes #6496 #6199 