### PR TITLE
Renamed WaitSupport to BlockingOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/OfferOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 import java.io.IOException;
 
@@ -35,7 +35,7 @@ import java.io.IOException;
  * Contains offer operation for the Queue.
  */
 public final class OfferOperation extends QueueBackupAwareOperation
-        implements WaitSupport, Notifier, IdentifiedDataSerializable {
+        implements BlockingOperation, Notifier, IdentifiedDataSerializable {
 
     private Data data;
     private long itemId;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/PollOperation.java
@@ -25,13 +25,13 @@ import com.hazelcast.collection.impl.queue.QueueItem;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 /**
  * Pool operation for Queue.
  */
 public final class PollOperation extends QueueBackupAwareOperation
-        implements WaitSupport, Notifier, IdentifiedDataSerializable {
+        implements BlockingOperation, Notifier, IdentifiedDataSerializable {
 
     private QueueItem item;
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPeekOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnPeekOperation.java
@@ -23,14 +23,14 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.collection.impl.queue.operations.QueueOperation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 import java.io.IOException;
 
 /**
  * Peek operation for the transactional queue.
  */
-public class TxnPeekOperation extends QueueOperation implements WaitSupport {
+public class TxnPeekOperation extends QueueOperation implements BlockingOperation {
 
     private long itemId;
     private String transactionId;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReserveOfferOperation.java
@@ -23,14 +23,14 @@ import com.hazelcast.collection.impl.queue.QueueContainer;
 import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 import java.io.IOException;
 
 /**
  * Reserve offer operation for the transactional queue.
  */
-public class TxnReserveOfferOperation extends QueueBackupAwareOperation implements WaitSupport {
+public class TxnReserveOfferOperation extends QueueBackupAwareOperation implements BlockingOperation {
 
     private int txSize;
     private String transactionId;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/operations/TxnReservePollOperation.java
@@ -24,14 +24,14 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 import java.io.IOException;
 
 /**
  * Reserve poll operation for the transactional queue.
  */
-public class TxnReservePollOperation extends QueueBackupAwareOperation implements WaitSupport {
+public class TxnReservePollOperation extends QueueBackupAwareOperation implements BlockingOperation {
 
     private long reservedOfferId;
     private String transactionId;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
@@ -20,9 +20,9 @@ import com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializerHook;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
-public class AwaitOperation extends BaseCountDownLatchOperation implements WaitSupport, IdentifiedDataSerializable {
+public class AwaitOperation extends BaseCountDownLatchOperation implements BlockingOperation, IdentifiedDataSerializable {
 
     public AwaitOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -25,12 +25,12 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 import java.io.IOException;
 
 public class AwaitOperation extends BaseLockOperation
-        implements WaitSupport, BackupAwareOperation {
+        implements BlockingOperation, BackupAwareOperation {
 
     private String conditionId;
     private boolean expired;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -25,9 +25,9 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
-public class LockOperation extends BaseLockOperation implements WaitSupport, BackupAwareOperation {
+public class LockOperation extends BaseLockOperation implements BlockingOperation, BackupAwareOperation {
 
     public LockOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
@@ -22,10 +22,10 @@ import com.hazelcast.concurrent.semaphore.SemaphoreWaitNotifyKey;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 public class AcquireOperation extends SemaphoreBackupAwareOperation
-        implements WaitSupport, IdentifiedDataSerializable {
+        implements BlockingOperation, IdentifiedDataSerializable {
 
     public AcquireOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AwaitMapFlushOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AwaitMapFlushOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 import java.io.IOException;
 
@@ -37,7 +37,7 @@ import java.io.IOException;
  * @see NotifyMapFlushOperation
  */
 public class AwaitMapFlushOperation
-        extends MapOperation implements PartitionAwareOperation, ReadonlyOperation, WaitSupport {
+        extends MapOperation implements PartitionAwareOperation, ReadonlyOperation, BlockingOperation {
 
     /**
      * Flush will end after execution of this sequenced store-operation.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -23,9 +23,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
-public class ContainsKeyOperation extends KeyBasedMapOperation implements ReadonlyOperation, WaitSupport {
+public class ContainsKeyOperation extends KeyBasedMapOperation implements ReadonlyOperation, BlockingOperation {
 
     private boolean containsKey;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
@@ -28,9 +28,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
-public class GetEntryViewOperation extends KeyBasedMapOperation implements ReadonlyOperation, WaitSupport {
+public class GetEntryViewOperation extends KeyBasedMapOperation implements ReadonlyOperation, BlockingOperation {
 
     private EntryView<Data, Data> result;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -26,10 +26,10 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 public final class GetOperation extends KeyBasedMapOperation
-        implements IdentifiedDataSerializable, WaitSupport, ReadonlyOperation {
+        implements IdentifiedDataSerializable, BlockingOperation, ReadonlyOperation {
 
     private Data result;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
@@ -21,9 +21,9 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
-public abstract class LockAwareOperation extends KeyBasedMapOperation implements WaitSupport {
+public abstract class LockAwareOperation extends KeyBasedMapOperation implements BlockingOperation {
 
     protected LockAwareOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ContainsEntryOperation.java
@@ -26,10 +26,10 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 import java.io.IOException;
 
-public class ContainsEntryOperation extends MultiMapOperation implements WaitSupport {
+public class ContainsEntryOperation extends MultiMapOperation implements BlockingOperation {
 
     private Data key;
     private Data value;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
@@ -25,9 +25,9 @@ import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
-public class CountOperation extends MultiMapKeyBasedOperation implements WaitSupport {
+public class CountOperation extends MultiMapKeyBasedOperation implements BlockingOperation {
 
     public CountOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
@@ -26,10 +26,10 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 import java.util.Collection;
 
-public class GetAllOperation extends MultiMapKeyBasedOperation implements WaitSupport {
+public class GetAllOperation extends MultiMapKeyBasedOperation implements BlockingOperation {
 
     public GetAllOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MultiMapBackupAwareOperation.java
@@ -24,12 +24,12 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 import java.io.IOException;
 
 public abstract class MultiMapBackupAwareOperation extends MultiMapKeyBasedOperation
-        implements BackupAwareOperation, WaitSupport {
+        implements BackupAwareOperation, BlockingOperation {
 
 
     protected MultiMapBackupAwareOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
@@ -29,12 +29,12 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.transaction.TransactionException;
 import java.io.IOException;
 import java.util.Collection;
 
-public class TxnLockAndGetOperation extends MultiMapKeyBasedOperation implements WaitSupport {
+public class TxnLockAndGetOperation extends MultiMapKeyBasedOperation implements BlockingOperation {
 
     private long ttl;
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -24,7 +24,7 @@ import com.hazelcast.ringbuffer.impl.ReadResultSetImpl;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.ringbuffer.impl.client.PortableReadResultSet;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +32,7 @@ import java.util.List;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.READ_MANY_OPERATION;
 
-public class ReadManyOperation extends AbstractRingBufferOperation implements WaitSupport {
+public class ReadManyOperation extends AbstractRingBufferOperation implements BlockingOperation {
 
     long startSequence;
     transient ReadResultSetImpl resultSet;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
@@ -21,13 +21,13 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 
 import java.io.IOException;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.READ_ONE_OPERATION;
 
-public class ReadOneOperation extends AbstractRingBufferOperation implements WaitSupport {
+public class ReadOneOperation extends AbstractRingBufferOperation implements BlockingOperation {
 
     private long sequence;
     private Data result;

--- a/hazelcast/src/main/java/com/hazelcast/spi/BlockingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/BlockingOperation.java
@@ -16,8 +16,19 @@
 
 package com.hazelcast.spi;
 
+
 /**
- * @deprecated this class is deprecated since 3.7. Use {@link BlockingOperation} instead.
+ * A interface that can be implemented to participate in the Wait/Notify System.
+ *
+ * See {@link  com.hazelcast.spi.WaitNotifyService}.
  */
-public interface WaitSupport extends BlockingOperation {
+public interface BlockingOperation {
+
+    WaitNotifyKey getWaitKey();
+
+    boolean shouldWait();
+
+    long getWaitTimeout();
+
+    void onWaitExpire();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/WaitNotifyService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/WaitNotifyService.java
@@ -25,23 +25,23 @@ public interface WaitNotifyService {
     /**
      * Causes the current operation to wait in WaitNotifyService until it is notified
      * by a {@link com.hazelcast.spi.Notifier} operation or timeout specified by
-     * {@link WaitSupport#getWaitTimeout()} passes.
+     * {@link BlockingOperation#getWaitTimeout()} passes.
      * <p/>
-     * {@link com.hazelcast.spi.WaitSupport} operation will be registered using {@link com.hazelcast.spi.WaitNotifyKey}
-     * returned from method {@link WaitSupport#getWaitKey()}.
+     * {@link BlockingOperation} operation will be registered using {@link com.hazelcast.spi.WaitNotifyKey}
+     * returned from method {@link BlockingOperation#getWaitKey()}.
      * <p/>
      * When operation is notified, it's re-executed by related scheduled mechanism.
      * <p/>
-     * If wait time-outs, {@link WaitSupport#onWaitExpire()} method is called.
+     * If wait time-outs, {@link BlockingOperation#onWaitExpire()} method is called.
      * <p/>
-     * This method should be called in the thread executes the actual {@link com.hazelcast.spi.WaitSupport} operation.
+     * This method should be called in the thread executes the actual {@link BlockingOperation} operation.
      *
-     * @param waitSupport operation which will wait for notification
+     * @param blockingOperation operation which will wait for notification
      */
-    void await(WaitSupport waitSupport);
+    void await(BlockingOperation blockingOperation);
 
     /**
-     * Notifies the waiting {@link com.hazelcast.spi.WaitSupport} operation to wake-up and continue executing.
+     * Notifies the waiting {@link BlockingOperation} operation to wake-up and continue executing.
      * <p/>
      * A waiting operation registered with the {@link Notifier#getNotifiedKey()} will be notified and deregistered.
      * This method has no effect if there isn't any operation registered

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -33,7 +33,7 @@ import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.RetryableIOException;
@@ -158,7 +158,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         }
 
         long defaultCallTimeout = operationService.defaultCallTimeoutMillis;
-        if (!(op instanceof WaitSupport)) {
+        if (!(op instanceof BlockingOperation)) {
             return defaultCallTimeout;
         }
 
@@ -466,7 +466,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
                     + toString());
         }
 
-        if (op instanceof WaitSupport) {
+        if (op instanceof BlockingOperation) {
             // decrement wait-timeout by call-timeout
             long waitTimeout = op.getWaitTimeout();
             waitTimeout -= callTimeout;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -36,7 +36,7 @@ import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.ReadonlyOperation;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.exception.CallerNotMemberException;
 import com.hazelcast.spi.exception.PartitionMigratingException;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
@@ -215,13 +215,13 @@ class OperationRunnerImpl extends OperationRunner {
     }
 
     private boolean waitingNeeded(Operation op) {
-        if (!(op instanceof WaitSupport)) {
+        if (!(op instanceof BlockingOperation)) {
             return false;
         }
 
-        WaitSupport waitSupport = (WaitSupport) op;
-        if (waitSupport.shouldWait()) {
-            nodeEngine.getWaitNotifyService().await(waitSupport);
+        BlockingOperation blockingOperation = (BlockingOperation) op;
+        if (blockingOperation.shouldWait()) {
+            nodeEngine.getWaitNotifyService().await(blockingOperation);
             return true;
         }
         return false;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitingOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.PartitionAwareOperation;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
@@ -38,22 +38,22 @@ import static com.hazelcast.util.EmptyStatement.ignore;
 class WaitingOperation extends AbstractOperation implements Delayed, PartitionAwareOperation {
     final Queue<WaitingOperation> queue;
     final Operation op;
-    final WaitSupport waitSupport;
+    final BlockingOperation blockingOperation;
     final long expirationTime;
     volatile boolean valid = true;
     volatile Object cancelResponse;
 
-    WaitingOperation(Queue<WaitingOperation> queue, WaitSupport waitSupport) {
-        this.op = (Operation) waitSupport;
-        this.waitSupport = waitSupport;
+    WaitingOperation(Queue<WaitingOperation> queue, BlockingOperation blockingOperation) {
+        this.op = (Operation) blockingOperation;
+        this.blockingOperation = blockingOperation;
         this.queue = queue;
-        this.expirationTime = getExpirationTime(waitSupport);
+        this.expirationTime = getExpirationTime(blockingOperation);
 
         setPartitionId(op.getPartitionId());
     }
 
-    private long getExpirationTime(WaitSupport waitSupport) {
-        long waitTimeout = waitSupport.getWaitTimeout();
+    private long getExpirationTime(BlockingOperation blockingOperation) {
+        long waitTimeout = blockingOperation.getWaitTimeout();
         if (waitTimeout < 0) {
             return -1;
         }
@@ -99,7 +99,7 @@ class WaitingOperation extends AbstractOperation implements Delayed, PartitionAw
     }
 
     public boolean shouldWait() {
-        return waitSupport.shouldWait();
+        return blockingOperation.shouldWait();
     }
 
     @Override
@@ -136,7 +136,7 @@ class WaitingOperation extends AbstractOperation implements Delayed, PartitionAw
 
         valid = false;
         if (expired) {
-            waitSupport.onWaitExpire();
+            blockingOperation.onWaitExpire();
         } else {
             OperationResponseHandler responseHandler = op.getOperationResponseHandler();
             responseHandler.sendResponse(op, cancelResponse);
@@ -185,7 +185,7 @@ class WaitingOperation extends AbstractOperation implements Delayed, PartitionAw
     }
 
     public void onExpire() {
-        waitSupport.onWaitExpire();
+        blockingOperation.onWaitExpire();
     }
 
     public void cancel(Object error) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.waitnotifyservice.impl.WaitNotifyServiceImpl;
 import com.hazelcast.test.AssertTask;
@@ -188,7 +188,7 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
         return config;
     }
 
-    private static class AlwaysBlockingOperation extends AbstractOperation implements WaitSupport {
+    private static class AlwaysBlockingOperation extends AbstractOperation implements BlockingOperation {
 
         @Override
         public void run() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
@@ -8,7 +8,7 @@ import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
-import com.hazelcast.spi.WaitSupport;
+import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -208,7 +208,7 @@ public class OperationRunnerImplTest extends HazelcastTestSupport {
         operationRunner.run(packet);
     }
 
-    public abstract class DummyWaitingOperation extends AbstractOperation implements WaitSupport {
+    public abstract class DummyWaitingOperation extends AbstractOperation implements BlockingOperation {
         WaitNotifyKey waitNotifyKey = new WaitNotifyKey() {
             @Override
             public String getServiceName() {


### PR DESCRIPTION
This new name is in line with other Operations we have like BackupOperation,
PartitionAwareOperation, ReadonlyOperation and it immidiately shows it is
an interface that is implemented by Operations. The old naming was not
self explanatory.

WaitSupport is still there to prevent causing incompatibilities, But is deprecated.