### PR TITLE
Cleaned up Packet flags logic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -36,12 +36,12 @@ public final class Packet extends HeapData implements OutboundFrame {
 
     public static final byte VERSION = 4;
 
-    public static final int FLAG_OP = 0;
-    public static final int FLAG_RESPONSE = 1;
-    public static final int FLAG_EVENT = 2;
-    public static final int FLAG_WAN_REPLICATION = 3;
-    public static final int FLAG_URGENT = 4;
-    public static final int FLAG_BIND = 5;
+    public static final int FLAG_OP = 1 << 0;
+    public static final int FLAG_RESPONSE = 1 << 1;
+    public static final int FLAG_EVENT = 1 << 2;
+    public static final int FLAG_WAN_REPLICATION = 1 << 3;
+    public static final int FLAG_URGENT = 1 << 4;
+    public static final int FLAG_BIND = 1 << 5;
 
     private static final int HEADER_SIZE = BYTE_SIZE_IN_BYTES + SHORT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES;
 
@@ -88,12 +88,35 @@ public final class Packet extends HeapData implements OutboundFrame {
         this.conn = conn;
     }
 
-    public void setFlag(int bit) {
-        flags |= 1 << bit;
+    /**
+     * Sets a particular flag. The other flags will not be touched.
+     *
+     * @param flag the flag to set
+     */
+    public void setFlag(int flag) {
+        flags = (short) (flags | flag);
     }
 
-    public boolean isFlagSet(int bit) {
-        return (flags & 1 << bit) != 0;
+    /**
+     * Sets all flags in 1 go. The old flags will be completely overwritten by the new flags.
+     *
+     * The reason this method accepts an int instead of a short, is that unfortunately Java immediately converts to ints and
+     * it makes doing bit shifting logic since you need to down cast to a short all the time.*
+     *
+     * @param flags the flags.
+     */
+    public void setAllFlags(int flags) {
+        this.flags = (short) flags;
+    }
+
+    /**
+     * Checks if a flag is set.
+     *
+     * @param flag the flag to check
+     * @return true if the flag is set, false otherwise.
+     */
+    public boolean isFlagSet(int flag) {
+        return (flags & flag) != 0;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
@@ -18,8 +18,8 @@ package com.hazelcast.nio.serialization;
 
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceBuilder;
-import com.hazelcast.nio.Packet;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.Packet;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -28,13 +28,18 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
 
+import static com.hazelcast.nio.Packet.FLAG_EVENT;
+import static com.hazelcast.nio.Packet.FLAG_OP;
+import static com.hazelcast.nio.Packet.FLAG_URGENT;
 import static com.hazelcast.nio.serialization.SerializationConcurrencyTest.Address;
 import static com.hazelcast.nio.serialization.SerializationConcurrencyTest.FACTORY_ID;
 import static com.hazelcast.nio.serialization.SerializationConcurrencyTest.Person;
 import static com.hazelcast.nio.serialization.SerializationConcurrencyTest.PortableAddress;
 import static com.hazelcast.nio.serialization.SerializationConcurrencyTest.PortablePerson;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -44,7 +49,7 @@ public class PacketTest {
     private final Person person = new Person(111, 123L, 89.56d, "test-person", new Address("street", 987));
 
     private final PortablePerson portablePerson = new PortablePerson(222, 456L, "portable-person",
-                                                             new PortableAddress("street", 567));
+            new PortableAddress("street", 567));
 
     private SerializationServiceBuilder createSerializationServiceBuilder() {
         final PortableFactory portableFactory = new PortableFactory() {
@@ -88,5 +93,33 @@ public class PacketTest {
 
         assertEquals(originalPacket, clonedPacket);
         assertEquals(originalObject, clonedObject);
+    }
+
+    @Test
+    public void setFlag() {
+        Packet packet = new Packet();
+        packet.setFlag(FLAG_OP);
+        packet.setFlag(FLAG_URGENT);
+
+        assertEquals(FLAG_OP | FLAG_URGENT, packet.getFlags());
+    }
+
+    @Test
+    public void isFlagSet() {
+        Packet packet = new Packet();
+        packet.setFlag(FLAG_OP);
+        packet.setFlag(FLAG_URGENT);
+
+        assertTrue(packet.isFlagSet(FLAG_OP));
+        assertTrue(packet.isFlagSet(FLAG_URGENT));
+        assertFalse(packet.isFlagSet(FLAG_EVENT));
+    }
+
+    @Test
+    public void setAllFlags() {
+        Packet packet = new Packet();
+        packet.setAllFlags(FLAG_OP | FLAG_URGENT);
+
+        assertEquals(FLAG_OP | FLAG_URGENT, packet.getFlags());
     }
 }


### PR DESCRIPTION
The Packet flags logic has been cleaned up so that all flags can be set in one go
using 
```
FLAGS_OP | FLAGS_URGENT. 
```

The bit shifting logic is the the same as used in e.g.  the SelectionKey where you can register interested ops using 
```
interestedOps(OP_READ | OP_WRITE)
```