### PR TITLE
Removed OperationResponseHandler.isLocal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
@@ -94,10 +94,5 @@ public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data
                 }
             }
         }
-
-        @Override
-        public boolean isLocal() {
-            return true;
-        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PostJoinOperation.java
@@ -70,11 +70,6 @@ public class PostJoinOperation extends AbstractOperation implements UrgentSystem
                             }
                         }
                     }
-
-                    @Override
-                    public boolean isLocal() {
-                        return true;
-                    }
                 });
 
                 OperationAccessor.setCallerAddress(op, getCallerAddress());

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -48,11 +48,6 @@ public final class MigrationOperation extends BaseMigrationOperation {
         public void sendResponse(Operation op, Object obj) {
             throw new HazelcastException("Migration operations can not send response!");
         }
-
-        @Override
-        public boolean isLocal() {
-            return true;
-        }
     };
 
     private long[] replicaVersions;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
@@ -230,11 +230,6 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
                     loaded.set(true);
                 }
             }
-
-            @Override
-            public boolean isLocal() {
-                return true;
-            }
         });
         operation.setPartitionId(partitionId);
         OperationAccessor.setCallerAddress(operation, nodeEngine.getThisAddress());

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
@@ -24,7 +24,6 @@ import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.DefaultObjectNamespace;
-import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.BlockingOperation;
 import java.util.Collection;
@@ -45,8 +44,8 @@ public class GetAllOperation extends MultiMapKeyBasedOperation implements Blocki
         Collection coll = null;
         if (multiMapValue != null) {
             multiMapValue.incrementHit();
-            OperationResponseHandler responseHandler = getOperationResponseHandler();
-            coll = multiMapValue.getCollection(responseHandler.isLocal());
+            boolean isLocal = getCallerAddress().equals(getNodeEngine().getClusterService().getLocalMember().getAddress());
+            coll = multiMapValue.getCollection(isLocal);
         }
         response = new MultiMapResponse(coll, getValueCollectionType(container));
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
@@ -40,7 +40,8 @@ public class RemoveAllOperation extends MultiMapBackupAwareOperation {
     @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        coll = remove(getOperationResponseHandler().isLocal());
+        boolean isLocal = getCallerAddress().equals(getNodeEngine().getClusterService().getLocalMember().getAddress());
+        coll = remove(isLocal);
         response = new MultiMapResponse(coll, getValueCollectionType(container));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
@@ -55,7 +55,7 @@ public class TxnLockAndGetOperation extends MultiMapKeyBasedOperation implements
             throw new TransactionException("Transaction couldn't obtain lock!");
         }
         MultiMapValue multiMapValue = getMultiMapValueOrNull();
-        final boolean isLocal = getOperationResponseHandler().isLocal();
+        boolean isLocal = getCallerAddress().equals(getNodeEngine().getClusterService().getLocalMember().getAddress());
         Collection<MultiMapRecord> collection = multiMapValue == null ? null : multiMapValue.getCollection(isLocal);
         final MultiMapResponse multiMapResponse = new MultiMapResponse(collection, getValueCollectionType(container));
         multiMapResponse.setNextRecordId(container.nextId());

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationResponseHandler.java
@@ -20,9 +20,6 @@ package com.hazelcast.spi;
  * A handler for the {@link com.hazelcast.spi.OperationService} when it has calculated a response. This way you can hook
  * into the Operation execution and decide what to do with it: for example, send it to the right machine.
  *
- * The difference between the {@link ResponseHandler} and the OperationResponseHandler is that the OperationResponseHandler
- * can be re-used since it isn't tied to a particular execution.
- *
  * Also during the development of Hazelcast 3.6 additional methods will be added to the OperationResponseHandler for certain
  * types of responses like exceptions, backup complete etc.
  *
@@ -37,11 +34,4 @@ public interface OperationResponseHandler<O extends Operation> {
      * @param response the response of the operation that got executed.
      */
     void sendResponse(O op, Object response);
-
-    /**
-     * Checks if this OperationResponseHandler is for a local invocation.
-     *
-     * @return true if local, false otherwise.
-     */
-    boolean isLocal();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
@@ -37,11 +37,6 @@ public final class OperationResponseHandlerFactory {
         @Override
         public void sendResponse(Operation op, Object obj) {
         }
-
-        @Override
-        public boolean isLocal() {
-            return false;
-        }
     }
 
     public static OperationResponseHandler createErrorLoggingResponseHandler(ILogger logger) {
@@ -61,11 +56,6 @@ public final class OperationResponseHandlerFactory {
                 Throwable t = (Throwable) obj;
                 logger.severe(t);
             }
-        }
-
-        @Override
-        public boolean isLocal() {
-            return true;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -16,22 +16,23 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.internal.cluster.ClusterClock;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.instance.GroupProperties;
 import com.hazelcast.instance.GroupProperty;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.ClusterClock;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.InvocationBuilder;
@@ -48,7 +49,6 @@ import com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperat
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
 import com.hazelcast.util.EmptyStatement;
-import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.util.executor.ExecutorType;
 import com.hazelcast.util.executor.ManagedExecutorService;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -130,11 +130,6 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
         public Object get() throws InterruptedException {
             return b.take();
         }
-
-        @Override
-        public boolean isLocal() {
-            return true;
-        }
     }
 
     @Override


### PR DESCRIPTION
Also the RemoteOperationResponseHandler is not throwing an exception anymore, but just
logging the fact that the response isn't send. There is no added value in showing
big stack traces here.