### PR TITLE
Removed instanceof checks SocketWriter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
@@ -241,7 +241,7 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
     private void executeTask(Runnable task) {
         completedTaskCount.inc();
 
-        NonBlockingIOThread target = getTargetIoThread(task);
+        NonBlockingIOThread target = getTargetIOThread(task);
         if (target == this) {
             task.run();
         } else {
@@ -249,7 +249,7 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
         }
     }
 
-    private NonBlockingIOThread getTargetIoThread(Runnable task) {
+    private NonBlockingIOThread getTargetIOThread(Runnable task) {
         if (task instanceof MigratableHandler) {
             return ((MigratableHandler) task).getOwner();
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -18,6 +18,7 @@ package com.hazelcast.nio.tcp.nonblocking;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.OutboundFrame;
 import com.hazelcast.nio.Packet;
@@ -26,7 +27,6 @@ import com.hazelcast.nio.tcp.NewClientWriteHandler;
 import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.WriteHandler;
-import com.hazelcast.internal.util.counters.SwCounter;
 
 import java.io.IOException;
 import java.net.SocketException;
@@ -40,13 +40,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
 import static com.hazelcast.nio.Protocols.CLUSTER;
 import static com.hazelcast.util.Clock.currentTimeMillis;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.StringUtil.stringToBytes;
-import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static java.lang.Math.max;
 
 /**
@@ -224,8 +224,9 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
                 return null;
             }
 
-            if (frame instanceof TaskFrame) {
-                ((TaskFrame) frame).run();
+            if (frame.getClass() == TaskFrame.class) {
+                TaskFrame taskFrame = (TaskFrame) frame;
+                taskFrame.task.run();
                 continue;
             }
 
@@ -431,7 +432,7 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         urgentWriteQueue.clear();
 
         ShutdownTask shutdownTask = new ShutdownTask();
-        offer(shutdownTask);
+        offer(new TaskFrame(shutdownTask));
         shutdownTask.awaitCompletion();
     }
 
@@ -442,7 +443,7 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
 
     @Override
     public void requestMigration(NonBlockingIOThread newOwner) {
-        offer(new StartMigrationTask(newOwner));
+        offer(new TaskFrame(new StartMigrationTask(newOwner)));
     }
 
     @Override
@@ -456,8 +457,13 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
      * - multiple NonBlockingIOThread-tasks for a SocketWriter on multiple NonBlockingIOThread
      * - multiple NonBlockingIOThread-tasks for a SocketWriter on the same NonBlockingIOThread.
      */
-    private abstract class TaskFrame implements OutboundFrame {
-        abstract void run();
+    private static final class TaskFrame implements OutboundFrame {
+
+        private final Runnable task;
+
+        private TaskFrame(Runnable task) {
+            this.task = task;
+        }
 
         @Override
         public boolean isUrgent() {
@@ -471,7 +477,7 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
      *
      * If the current ioThread is the same as 'theNewOwner' then the call is ignored.
      */
-    private class StartMigrationTask extends TaskFrame {
+    private final class StartMigrationTask implements Runnable {
         // field is called 'theNewOwner' to prevent any ambiguity problems with the writeHandler.newOwner.
         // Else you get a lot of ugly WriteHandler.this.newOwner is ...
         private final NonBlockingIOThread theNewOwner;
@@ -481,7 +487,7 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         }
 
         @Override
-        void run() {
+        public void run() {
             assert newOwner == null : "No migration can be in progress";
 
             if (ioThread == theNewOwner) {
@@ -493,11 +499,11 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         }
     }
 
-    private class ShutdownTask extends TaskFrame {
+    private class ShutdownTask implements Runnable {
         private final CountDownLatch latch = new CountDownLatch(1);
 
         @Override
-        void run() {
+        public void run() {
             shutdown = true;
             try {
                 socketChannel.closeOutbound();


### PR DESCRIPTION
Instanceof checks can be very expensive. This is replaced by a simple
frame.getClass()=FrameTask.class since that is the only type of task frame being
used with this change. The actuall runnable is wrapped inside of this
TaskFrame.