### PR TITLE
ByteAccessStrategy has been added to the MemoryAccessor interface

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
@@ -155,17 +155,24 @@ public interface MemoryAccessor {
      *
      * @param srcAddress  the source address to be copied from
      * @param destAddress the destination address to be copied to
-     * @param lengthBytes       the number of bytes to be copied
+     * @param lengthBytes the number of bytes to be copied
      */
     void copyMemory(long srcAddress, long destAddress, long lengthBytes);
 
     /**
      * Sets memory with given value from specified address as given size.
      *
-     * @param address the start address of the memory region
-     *                which will be set with given value
-     * @param lengthBytes   the number of bytes to be set
-     * @param value   the value to be set
+     * @param address     the start address of the memory region
+     *                    which will be set with given value
+     * @param lengthBytes the number of bytes to be set
+     * @param value       the value to be set
      */
     void setMemory(long address, long lengthBytes, byte value);
+
+    /**
+     * Return default byte access strategy implementation;
+     *
+     * @return - instance of the byte access strategy;
+     */
+    ByteAccessStrategy<Void> asByteAccessStrategy();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/DefaultByteAccessStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/DefaultByteAccessStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.internal.memory.ByteAccessStrategy;
+
+public class DefaultByteAccessStrategy implements ByteAccessStrategy<Void> {
+    private final MemoryAccessor memoryAccessor;
+
+    public DefaultByteAccessStrategy(MemoryAccessor memoryAccessor) {
+        this.memoryAccessor = memoryAccessor;
+    }
+
+    @Override
+    public byte getByte(Void resource, long offset) {
+        return memoryAccessor.getByte(offset);
+    }
+
+    @Override
+    public void putByte(Void resource, long offset, byte value) {
+        memoryAccessor.putByte(offset, value);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/EndianAccessorBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/EndianAccessorBase.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.memory.impl;
 
+import com.hazelcast.internal.memory.ByteAccessStrategy;
 import com.hazelcast.internal.memory.EndianMemoryAccessor;
 
 import java.lang.reflect.Field;
@@ -26,6 +27,7 @@ import static com.hazelcast.internal.memory.GlobalMemoryAccessorRegistry.MEM;
  * Base class for big- and little-endian implementations.
  */
 abstract class EndianAccessorBase implements EndianMemoryAccessor {
+    private final ByteAccessStrategy<Void> defaultByteAccessStrategy = new DefaultByteAccessStrategy(this);
 
     @Override
     public long objectFieldOffset(Field field) {
@@ -95,5 +97,10 @@ abstract class EndianAccessorBase implements EndianMemoryAccessor {
     @Override
     public void putByte(long address, byte x) {
         MEM.putByte(address, x);
+    }
+
+    @Override
+    public ByteAccessStrategy<Void> asByteAccessStrategy() {
+        return defaultByteAccessStrategy;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeBasedMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeBasedMemoryAccessor.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.memory.impl;
 
+import com.hazelcast.internal.memory.ByteAccessStrategy;
 import com.hazelcast.internal.memory.GlobalMemoryAccessor;
 
 import static com.hazelcast.internal.memory.impl.AlignmentUtil.IS_PLATFORM_BIG_ENDIAN;
@@ -25,6 +26,7 @@ import static com.hazelcast.internal.memory.impl.UnsafeUtil.UNSAFE_AVAILABLE;
  * Base class for {@link sun.misc.Unsafe} backed {@link GlobalMemoryAccessor} implementations.
  */
 abstract class UnsafeBasedMemoryAccessor implements GlobalMemoryAccessor {
+    private final ByteAccessStrategy<Void> defaultByteAccessStrategy = new DefaultByteAccessStrategy(this);
 
     /**
      * Returns whether memory accessors of type {@link UnsafeBasedMemoryAccessor} are available or not.
@@ -36,5 +38,10 @@ abstract class UnsafeBasedMemoryAccessor implements GlobalMemoryAccessor {
     @Override
     public boolean isBigEndian() {
         return IS_PLATFORM_BIG_ENDIAN;
+    }
+
+    @Override
+    public ByteAccessStrategy<Void> asByteAccessStrategy() {
+        return defaultByteAccessStrategy;
     }
 }


### PR DESCRIPTION
Every memory accessor should return some implementation of default ByteAccessStrategy<Void>