### PR TITLE
TCP: Replacing Clock.currentTimeMs by System

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionMonitor.java
@@ -19,7 +19,8 @@ package com.hazelcast.nio.tcp;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.IOService;
-import com.hazelcast.util.Clock;
+
+import static java.lang.System.currentTimeMillis;
 
 public class TcpIpConnectionMonitor {
 
@@ -46,7 +47,7 @@ public class TcpIpConnectionMonitor {
     public synchronized void onError(Throwable t) {
         String errorMessage = "An error occurred on connection to " + endPoint + getCauseDescription(t);
         logger.finest(errorMessage);
-        final long now = Clock.currentTimeMillis();
+        final long now = currentTimeMillis();
         final long last = lastFaultTime;
         if (now - last > minInterval) {
             if (faults++ >= maxFaults) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -41,8 +41,8 @@ import static com.hazelcast.nio.ConnectionType.MEMBER;
 import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
 import static com.hazelcast.nio.Protocols.CLUSTER;
-import static com.hazelcast.util.Clock.currentTimeMillis;
 import static com.hazelcast.util.StringUtil.bytesToString;
+import static java.lang.System.currentTimeMillis;
 
 /**
  * A {@link SocketReader} tailored for non blocking IO.
@@ -79,7 +79,7 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
 
     @Probe(name = "idleTimeMs", level = DEBUG)
     private long idleTimeMs() {
-        return Math.max(System.currentTimeMillis() - lastReadTime, 0);
+        return Math.max(currentTimeMillis() - lastReadTime, 0);
     }
 
     @Probe(name = "interestedOps", level = DEBUG)

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -44,10 +44,10 @@ import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
 import static com.hazelcast.nio.Protocols.CLUSTER;
-import static com.hazelcast.util.Clock.currentTimeMillis;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 import static java.lang.Math.max;
+import static java.lang.System.currentTimeMillis;
 
 /**
  * The writing side of the {@link TcpIpConnection}.
@@ -141,7 +141,7 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
 
     @Probe(name = "idleTimeMs", level = DEBUG)
     private long idleTimeMs() {
-        return max(System.currentTimeMillis() - lastWriteTime, 0);
+        return max(currentTimeMillis() - lastWriteTime, 0);
     }
 
     @Probe(name = "isScheduled", level = DEBUG)


### PR DESCRIPTION
No need for the abstraction here. Just more work for the io thread
to deal with. Fastest call is directly to System.