### PR TITLE
SocketReaders/Writers don't check shutdown any longer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -150,11 +150,6 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
         // the connection is going to be closed anyway.
         lastReadTime = currentTimeMillis();
 
-        if (!connection.isAlive()) {
-            logger.finest("We are being asked to read, but connection is not live so we won't");
-            return;
-        }
-
         if (readHandler == null) {
             initReadHandler();
             if (readHandler == null) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -78,7 +78,6 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
     private WriteHandler writeHandler;
     private volatile long lastWriteTime;
 
-    private boolean shutdown;
     // this field will be accessed by the NonBlockingIOThread or
     // it is accessed by any other thread but only that thread managed to cas the scheduled flag to true.
     // This prevents running into an NonBlockingIOThread that is migrating.
@@ -324,10 +323,6 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
         eventCount.inc();
         lastWriteTime = currentTimeMillis();
 
-        if (shutdown) {
-            return;
-        }
-
         if (writeHandler == null) {
             logger.log(Level.WARNING, "SocketWriter is not set, creating SocketWriter with CLUSTER protocol!");
             createWriterHandler(CLUSTER);
@@ -504,7 +499,6 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
 
         @Override
         public void run() {
-            shutdown = true;
             try {
                 socketChannel.closeOutbound();
             } catch (IOException e) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
@@ -18,6 +18,8 @@ package com.hazelcast.nio.tcp.spinning;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.util.counters.Counter;
+import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.Protocols;
@@ -28,20 +30,18 @@ import com.hazelcast.nio.tcp.SocketChannelWrapper;
 import com.hazelcast.nio.tcp.SocketReader;
 import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.TcpIpConnection;
-import com.hazelcast.internal.util.counters.Counter;
-import com.hazelcast.internal.util.counters.SwCounter;
 
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
 
+import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.nio.ConnectionType.MEMBER;
 import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
 import static com.hazelcast.nio.Protocols.CLUSTER;
 import static com.hazelcast.util.StringUtil.bytesToString;
-import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
@@ -227,10 +227,6 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
     }
 
     public void write() throws Exception {
-        if (!connection.isAlive()) {
-            return;
-        }
-
         if (writeHandler == null) {
             logger.log(Level.WARNING, "SocketWriter is not set, creating SocketWriter with CLUSTER protocol!");
             createWriter(CLUSTER);


### PR DESCRIPTION
There is no need to check this. If the connection is going to shut down,
the socket channel is closed eventually and you'll get a
ClosedSocketChannelException in case of reading or writing from/to the SocketChannel. 

So the checking is already done at a lower level. No need to obfuscate the flow with repeated checking.