### PR TITLE
Fixes a race when a client connection is closed

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -59,6 +59,7 @@ public class ClientConnection implements Connection, Closeable {
     private volatile Address remoteEndpoint;
     private volatile boolean heartBeating = true;
     private boolean isAuthenticatedAsOwner;
+    private volatile long closedTime;
 
     public ClientConnection(HazelcastClientInstanceImpl client, NonBlockingIOThread in, NonBlockingIOThread out,
                             int connectionId, SocketChannelWrapper socketChannelWrapper) throws IOException {
@@ -209,6 +210,7 @@ public class ClientConnection implements Connection, Closeable {
         if (!live.compareAndSet(true, false)) {
             return;
         }
+        closedTime = System.currentTimeMillis();
         String message = "Connection [" + getRemoteSocketAddress() + "] lost. Reason: ";
         if (t != null) {
             message += t.getClass().getName() + '[' + t.getMessage() + ']';
@@ -283,5 +285,9 @@ public class ClientConnection implements Connection, Closeable {
                 + ", socketChannel=" + socketChannelWrapper
                 + ", remoteEndpoint=" + remoteEndpoint
                 + '}';
+    }
+
+    public long getClosedTime() {
+        return closedTime;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -361,10 +361,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             for (ConnectionListener connectionListener : connectionListeners) {
                 connectionListener.connectionRemoved(conn);
             }
-
-        } else {
-            ClientInvocationService invocationService = client.getInvocationService();
-            invocationService.cleanConnectionResources((ClientConnection) connection);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
@@ -45,6 +45,4 @@ public interface ClientInvocationService {
 
     void handleClientMessage(ClientMessage message, Connection connection);
 
-    void cleanConnectionResources(ClientConnection connection);
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -32,27 +32,25 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
-import com.hazelcast.util.ConstructorFunction;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.client.config.ClientProperty.MAX_CONCURRENT_INVOCATIONS;
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.onOutOfMemory;
 
 
-abstract class ClientInvocationServiceSupport implements ClientInvocationService, ConnectionListener
-        , ConnectionHeartbeatListener {
+abstract class ClientInvocationServiceSupport implements ClientInvocationService {
 
-    private static final int WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED = 10;
     private static final int WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD = 5000;
     protected final HazelcastClientInstanceImpl client;
     protected ClientConnectionManager connectionManager;
@@ -68,7 +66,6 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     private ClientExceptionFactory clientExceptionFactory;
     private volatile boolean isShutdown;
 
-
     public ClientInvocationServiceSupport(HazelcastClientInstanceImpl client) {
         this.client = client;
         int maxAllowedConcurrentInvocations = client.getClientProperties().getInteger(MAX_CONCURRENT_INVOCATIONS);
@@ -80,13 +77,12 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         connectionManager = client.getConnectionManager();
         executionService = client.getClientExecutionService();
         clientListenerService = (ClientListenerServiceImpl) client.getListenerService();
-        connectionManager.addConnectionListener(this);
-        connectionManager.addConnectionHeartbeatListener(this);
         partitionService = client.getClientPartitionService();
         clientExceptionFactory = initClientExceptionFactory();
         responseThread = new ResponseThread(client.getThreadGroup(), client.getName() + ".response-",
                 client.getClientConfig().getClassLoader());
         responseThread.start();
+        executionService.scheduleWithFixedDelay(new CleanResourcesTask(), 1, 1, TimeUnit.SECONDS);
     }
 
 
@@ -165,56 +161,6 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         return callIdMap.remove(callId);
     }
 
-    public void cleanResources(ConstructorFunction<Object, Throwable> responseCtor, ClientConnection connection) {
-        final Iterator<Map.Entry<Long, ClientInvocation>> iter = callIdMap.entrySet().iterator();
-        while (iter.hasNext()) {
-            final Map.Entry<Long, ClientInvocation> entry = iter.next();
-            final ClientInvocation invocation = entry.getValue();
-            if (connection.equals(invocation.getSendConnection())) {
-                iter.remove();
-                invocation.notifyException(responseCtor.createNew(null));
-            }
-        }
-    }
-
-    @Override
-    public void connectionAdded(Connection connection) {
-
-    }
-
-    @Override
-    public void connectionRemoved(Connection connection) {
-        cleanConnectionResources((ClientConnection) connection);
-    }
-
-    @Override
-    public void heartBeatStarted(Connection connection) {
-
-    }
-
-    @Override
-    public void heartBeatStopped(Connection connection) {
-        cleanConnectionResources((ClientConnection) connection);
-    }
-
-    @Override
-    public void cleanConnectionResources(ClientConnection connection) {
-        if (connectionManager.isAlive()) {
-            try {
-                ((ClientExecutionServiceImpl) executionService).executeInternal(new CleanResourcesTask(connection));
-            } catch (RejectedExecutionException e) {
-                logger.warning("Execution rejected ", e);
-            }
-        } else {
-            cleanResources(new ConstructorFunction<Object, Throwable>() {
-                @Override
-                public Throwable createNew(Object arg) {
-                    return new HazelcastClientNotActiveException("Client is shutting down!");
-                }
-            }, connection);
-        }
-    }
-
     public boolean isShutdown() {
         return isShutdown;
     }
@@ -222,47 +168,61 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     public void shutdown() {
         isShutdown = true;
         responseThread.interrupt();
+        callIdMap.clear();
     }
 
     private class CleanResourcesTask implements Runnable {
 
-        private final ClientConnection connection;
-
-        CleanResourcesTask(ClientConnection connection) {
-            this.connection = connection;
-        }
-
         @Override
         public void run() {
-            waitForPacketsProcessed();
-            cleanResources(new ConstructorFunction<Object, Throwable>() {
-                @Override
-                public Throwable createNew(Object arg) {
-                    return new TargetDisconnectedException(connection.getRemoteEndpoint());
+            Iterator<Map.Entry<Long, ClientInvocation>> iter = callIdMap.entrySet().iterator();
+            Collection<ClientConnection> expiredConnections = null;
+            while (iter.hasNext()) {
+                Map.Entry<Long, ClientInvocation> entry = iter.next();
+                ClientInvocation invocation = entry.getValue();
+                ClientConnection connection = invocation.getSendConnection();
+                if (connection == null) {
+                    continue;
                 }
-            }, connection);
+
+                if (connection.isHeartBeating()) {
+                    continue;
+                }
+
+                int pendingPacketCount = connection.getPendingPacketCount();
+                if (pendingPacketCount != 0) {
+                    long closedTime = connection.getClosedTime();
+                    long elapsed = System.currentTimeMillis() - closedTime;
+                    if (elapsed < WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD) {
+                        continue;
+                    } else {
+                        if (expiredConnections == null) {
+                            expiredConnections = new LinkedList<ClientConnection>();
+                        }
+                    }
+                }
+
+
+                iter.remove();
+                invocation.notifyException(new TargetDisconnectedException(connection.getRemoteEndpoint()));
+            }
+            if (expiredConnections != null) {
+                logExpiredConnections(expiredConnections);
+            }
         }
 
-        private void waitForPacketsProcessed() {
-            final long begin = System.currentTimeMillis();
-            int count = connection.getPendingPacketCount();
-            while (count != 0) {
-                try {
-                    Thread.sleep(WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED);
-                } catch (InterruptedException e) {
-                    logger.warning(e);
-                    break;
+        private void logExpiredConnections(Collection<ClientConnection> expiredConnections) {
+            for (ClientConnection expiredConnection : expiredConnections) {
+                int pendingPacketCount = expiredConnection.getPendingPacketCount();
+                if (pendingPacketCount != 0) {
+                    logger.warning("There are " + pendingPacketCount
+                            + " packets which are not processed "
+                            + " on " + expiredConnection.getRemoteEndpoint());
                 }
-                long elapsed = System.currentTimeMillis() - begin;
-                if (elapsed > WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD) {
-                    logger.warning("There are packets which are not processed " + count);
-                    break;
-                }
-                count = connection.getPendingPacketCount();
+
             }
         }
     }
-
 
     @Override
     public void handleClientMessage(ClientMessage message, Connection connection) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -49,7 +49,6 @@ import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -743,7 +742,6 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/7582
     public void testClusterShutdown_thenCheckOperationsNotHanging() throws Exception {
         HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheListenerTest.java
@@ -23,8 +23,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -110,15 +108,15 @@ public class CacheListenerTest extends HazelcastTestSupport {
             shutdown.set(true);
             if (!latch.await(shutdownWaitTimeInSeconds, TimeUnit.SECONDS)) {
                 fail("Cache operations have not finished in "
-                     + (ASSERT_TRUE_EVENTUALLY_TIMEOUT + shutdownWaitTimeInSeconds)
-                     + " seconds when sync listener is present!");
+                        + (ASSERT_TRUE_EVENTUALLY_TIMEOUT + shutdownWaitTimeInSeconds)
+                        + " seconds when sync listener is present!");
             }
         }
         assertEquals(actualPutCount.get(), counter.get());
     }
 
     @Test(timeout = 30000)
-    public void testPutIfAbsentWithSyncListener_whenEntryExists(){
+    public void testPutIfAbsentWithSyncListener_whenEntryExists() {
         CachingProvider cachingProvider = getCachingProvider();
         CacheManager cacheManager = cachingProvider.getCacheManager();
 
@@ -135,7 +133,7 @@ public class CacheListenerTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 30000)
-    public void testReplaceWithSyncListener_whenEntryNotExists(){
+    public void testReplaceWithSyncListener_whenEntryNotExists() {
         CachingProvider cachingProvider = getCachingProvider();
         CacheManager cacheManager = cachingProvider.getCacheManager();
 
@@ -150,7 +148,7 @@ public class CacheListenerTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 30000)
-    public void testReplaceIfSameWithSyncListener_whenEntryNotExists(){
+    public void testReplaceIfSameWithSyncListener_whenEntryNotExists() {
         CachingProvider cachingProvider = getCachingProvider();
         CacheManager cacheManager = cachingProvider.getCacheManager();
 
@@ -165,7 +163,7 @@ public class CacheListenerTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 30000)
-    public void testReplaceIfSameWithSyncListener_whenValueIsNotSame(){
+    public void testReplaceIfSameWithSyncListener_whenValueIsNotSame() {
         CachingProvider cachingProvider = getCachingProvider();
         CacheManager cacheManager = cachingProvider.getCacheManager();
 
@@ -182,7 +180,7 @@ public class CacheListenerTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 30000)
-    public void testRemoveWithSyncListener_whenEntryNotExists(){
+    public void testRemoveWithSyncListener_whenEntryNotExists() {
         CachingProvider cachingProvider = getCachingProvider();
         CacheManager cacheManager = cachingProvider.getCacheManager();
 
@@ -197,7 +195,7 @@ public class CacheListenerTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 30000)
-    public void testRemoveIfSameWithSyncListener_whenEntryNotExists(){
+    public void testRemoveIfSameWithSyncListener_whenEntryNotExists() {
         CachingProvider cachingProvider = getCachingProvider();
         CacheManager cacheManager = cachingProvider.getCacheManager();
 
@@ -212,7 +210,7 @@ public class CacheListenerTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 30000)
-    public void testRemoveIfSameWithSyncListener_whenValueIsNotSame(){
+    public void testRemoveIfSameWithSyncListener_whenValueIsNotSame() {
         CachingProvider cachingProvider = getCachingProvider();
         CacheManager cacheManager = cachingProvider.getCacheManager();
 
@@ -229,7 +227,7 @@ public class CacheListenerTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 30000)
-    public void testGetAndReplaceWithSyncListener_whenEntryNotExists(){
+    public void testGetAndReplaceWithSyncListener_whenEntryNotExists() {
         CachingProvider cachingProvider = getCachingProvider();
         CacheManager cacheManager = cachingProvider.getCacheManager();
 
@@ -244,7 +242,7 @@ public class CacheListenerTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 30000)
-    public void testGetAndRemoveWithSyncListener_whenEntryNotExists(){
+    public void testGetAndRemoveWithSyncListener_whenEntryNotExists() {
         CachingProvider cachingProvider = getCachingProvider();
         CacheManager cacheManager = cachingProvider.getCacheManager();
 
@@ -258,7 +256,6 @@ public class CacheListenerTest extends HazelcastTestSupport {
         cache.getAndRemove(randomString());
     }
 
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/7527
     @Test
     public void testSyncListener_shouldNotHang_whenHazelcastInstanceShutdown() {
         CachingProvider provider = getCachingProvider();
@@ -301,9 +298,9 @@ public class CacheListenerTest extends HazelcastTestSupport {
         CacheManager cacheManager = provider.getCacheManager();
 
         CompleteConfiguration<String, String> config = new MutableConfiguration<String, String>()
-                        .addCacheEntryListenerConfiguration(new MutableCacheEntryListenerConfiguration<String, String>(
-                                        FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true,
-                                        true));
+                .addCacheEntryListenerConfiguration(new MutableCacheEntryListenerConfiguration<String, String>(
+                        FactoryBuilder.factoryOf(new TestListener(new AtomicInteger())), null, true,
+                        true));
 
         final Cache<String, String> cache = cacheManager.createCache(cacheName, config);
 
@@ -335,8 +332,8 @@ public class CacheListenerTest extends HazelcastTestSupport {
 
     public static class TestListener
             implements CacheEntryCreatedListener<String, String>,
-                       CacheEntryUpdatedListener<String, String>,
-                       Serializable {
+            CacheEntryUpdatedListener<String, String>,
+            Serializable {
 
         private final AtomicInteger counter;
 


### PR DESCRIPTION
When connection closed, it was possible to endup with invocations
that are not notified. These invocations was causing infinite
wait. We let the race happen and check the callIdMap from another
thread every seconds to cleanup unlucky invocations.

There was a workaround for this in ClientInvcationFuture.get
which is waking up every hearbeatTimeout milliseconds and checking
if connection is still there. This workaround is removed in a
previous pr because when async api is used that workaround is
does not work.

fixes #7582 , #7527.