### PR TITLE
SchedulingExecutorServiceDelegate does not implement j.u.c.ScheduledExecutorService

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -193,8 +193,8 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         }
 
         @Override
-        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-            return clientExecutionService.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+        public ScheduledFuture<?> scheduleWithRepetition(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+            return clientExecutionService.scheduleWithRepetition(command, initialDelay, delay, unit);
         }
 
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -188,7 +188,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         alive = true;
         startSelectors();
         HeartBeat heartBeat = new HeartBeat();
-        executionService.scheduleWithFixedDelay(heartBeat, heartBeatInterval, heartBeatInterval, TimeUnit.MILLISECONDS);
+        executionService.scheduleWithRepetition(heartBeat, heartBeatInterval, heartBeatInterval, TimeUnit.MILLISECONDS);
     }
 
     protected void startSelectors() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
@@ -42,9 +42,7 @@ public interface ClientExecutionService extends Executor {
 
     ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
 
-    ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit);
-
-    ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long period, TimeUnit unit);
+    ScheduledFuture<?> scheduleWithRepetition(Runnable command, long initialDelay, long period, TimeUnit unit);
 
     /**
      * @return executorService that alien(user code) runs on

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
+import com.hazelcast.spi.impl.executionservice.impl.SkipOnConcurrentExecutionDecorator;
 import com.hazelcast.util.executor.CompletableFutureTask;
 import com.hazelcast.util.executor.PoolExecutorThreadFactory;
 import com.hazelcast.util.executor.SingleExecutorThreadFactory;
@@ -149,19 +150,11 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     }
 
     @Override
-    public ScheduledFuture<?> scheduleAtFixedRate(final Runnable command, long initialDelay, long period, TimeUnit unit) {
+    public ScheduledFuture<?> scheduleWithRepetition(final Runnable command, long initialDelay, long period, TimeUnit unit) {
+        final Runnable decoratedCommand = new SkipOnConcurrentExecutionDecorator(command);
         return scheduledExecutor.scheduleAtFixedRate(new Runnable() {
             public void run() {
-                executeInternalSafely(command, failureLoggingExecutionCallback);
-            }
-        }, initialDelay, period, unit);
-    }
-
-    @Override
-    public ScheduledFuture<?> scheduleWithFixedDelay(final Runnable command, long initialDelay, long period, TimeUnit unit) {
-        return scheduledExecutor.scheduleWithFixedDelay(new Runnable() {
-            public void run() {
-                executeInternalSafely(command, failureLoggingExecutionCallback);
+                executeInternalSafely(decoratedCommand, failureLoggingExecutionCallback);
             }
         }, initialDelay, period, unit);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -71,7 +71,7 @@ public final class ClientPartitionServiceImpl
         ClientExecutionServiceImpl clientExecutionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
         // Use internal execution service for all partition refresh process (Do not use the user executor thread)
         ExecutorService internalExecutor = clientExecutionService.getInternalExecutor();
-        clientExecutionService.scheduleWithFixedDelay(new RefreshTask(internalExecutor), INITIAL_DELAY, PERIOD, TimeUnit.SECONDS);
+        clientExecutionService.scheduleWithRepetition(new RefreshTask(internalExecutor), INITIAL_DELAY, PERIOD, TimeUnit.SECONDS);
     }
 
     public void refreshPartitions() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
@@ -352,7 +352,7 @@ abstract class AbstractCacheProxy<K, V>
                     .invokeOnAllPartitions(getServiceName(), operationFactory);
             int total = 0;
             for (Object result : results.values()) {
-                total += (Integer) serializationService.toObject(result);
+                total += (Integer) getNodeEngine().toObject(result);
             }
             return total;
         } catch (Throwable t) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
@@ -69,7 +69,7 @@ class CacheEventHandler {
             CacheBatchInvalidationMessageSender batchInvalidationMessageSender
                     = new CacheBatchInvalidationMessageSender();
             cacheBatchInvalidationMessageSenderScheduler = executionService
-                    .scheduleAtFixedRate(ICacheService.SERVICE_NAME + ":cacheBatchInvalidationMessageSender",
+                    .scheduleWithRepetition(ICacheService.SERVICE_NAME + ":cacheBatchInvalidationMessageSender",
                                          batchInvalidationMessageSender,
                                          invalidationMessageBatchFreq,
                                          invalidationMessageBatchFreq,

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheExecutor.java
@@ -37,7 +37,7 @@ public interface NearCacheExecutor {
      *
      * @return the {@link ScheduledFuture} instance representing the pending completion of the task.
      */
-    ScheduledFuture<?> scheduleWithFixedDelay(Runnable command,
+    ScheduledFuture<?> scheduleWithRepetition(Runnable command,
                                               long initialDelay,
                                               long delay,
                                               TimeUnit unit);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/DefaultNearCache.java
@@ -87,7 +87,7 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
 
     protected ScheduledFuture scheduleExpirationTask(NearCacheExecutor nearCacheExecutor,
                                                      ExpirationTask expirationTask) {
-        return nearCacheExecutor.scheduleWithFixedDelay(expirationTask,
+        return nearCacheExecutor.scheduleWithRepetition(expirationTask,
                 DEFAULT_EXPIRATION_TASK_INITIAL_DELAY_IN_SECONDS,
                 DEFAULT_EXPIRATION_TASK_DELAY_IN_SECONDS,
                 TimeUnit.SECONDS);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -65,7 +65,7 @@ public class ClientHeartbeatMonitor implements Runnable {
     }
 
     public void start() {
-        executionService.scheduleWithFixedDelay(this, HEART_BEAT_CHECK_INTERVAL_SECONDS,
+        executionService.scheduleWithRepetition(this, HEART_BEAT_CHECK_INTERVAL_SECONDS,
                 HEART_BEAT_CHECK_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -47,6 +47,7 @@ import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
+import com.hazelcast.spi.TaskScheduler;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
@@ -63,7 +64,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 
 /**
@@ -93,11 +93,10 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
     public QueueService(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
-        ScheduledExecutorService defaultScheduledExecutor
-                = nodeEngine.getExecutionService().getDefaultScheduledExecutor();
+        TaskScheduler globalScheduler = nodeEngine.getExecutionService().getGlobalTaskScheduler();
         QueueEvictionProcessor entryProcessor = new QueueEvictionProcessor(nodeEngine, this);
         this.queueEvictionScheduler = EntryTaskSchedulerFactory.newScheduler(
-                defaultScheduledExecutor, entryProcessor, ScheduleType.POSTPONE);
+                globalScheduler, entryProcessor, ScheduleType.POSTPONE);
         this.logger = nodeEngine.getLogger(QueueService.class);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreContainer.java
@@ -18,6 +18,7 @@ package com.hazelcast.concurrent.lock;
 
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.TaskScheduler;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.scheduler.EntryTaskScheduler;
@@ -28,7 +29,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ScheduledExecutorService;
 
 public final class LockStoreContainer {
 
@@ -100,9 +100,8 @@ public final class LockStoreContainer {
     private EntryTaskScheduler createScheduler(ObjectNamespace namespace) {
         NodeEngine nodeEngine = lockService.getNodeEngine();
         LockEvictionProcessor entryProcessor = new LockEvictionProcessor(nodeEngine, namespace);
-        ScheduledExecutorService scheduledExecutor =
-                nodeEngine.getExecutionService().getDefaultScheduledExecutor();
+        TaskScheduler globalScheduler = nodeEngine.getExecutionService().getGlobalTaskScheduler();
         return EntryTaskSchedulerFactory
-                .newScheduler(scheduledExecutor, entryProcessor, ScheduleType.FOR_EACH);
+                .newScheduler(globalScheduler, entryProcessor, ScheduleType.FOR_EACH);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -113,7 +113,7 @@ public class ClusterHeartbeatManager {
     void init() {
         ExecutionService executionService = nodeEngine.getExecutionService();
 
-        executionService.scheduleWithFixedDelay(EXECUTOR_NAME, new Runnable() {
+        executionService.scheduleWithRepetition(EXECUTOR_NAME, new Runnable() {
             public void run() {
                 heartBeat();
             }
@@ -121,7 +121,7 @@ public class ClusterHeartbeatManager {
 
         long masterConfirmationInterval = node.groupProperties.getSeconds(GroupProperty.MASTER_CONFIRMATION_INTERVAL_SECONDS);
         masterConfirmationInterval = (masterConfirmationInterval > 0 ? masterConfirmationInterval : 1);
-        executionService.scheduleWithFixedDelay(EXECUTOR_NAME, new Runnable() {
+        executionService.scheduleWithRepetition(EXECUTOR_NAME, new Runnable() {
             public void run() {
                 sendMasterConfirmation();
             }
@@ -129,7 +129,7 @@ public class ClusterHeartbeatManager {
 
         long memberListPublishInterval = node.groupProperties.getSeconds(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS);
         memberListPublishInterval = (memberListPublishInterval > 0 ? memberListPublishInterval : 1);
-        executionService.scheduleWithFixedDelay(EXECUTOR_NAME, new Runnable() {
+        executionService.scheduleWithRepetition(EXECUTOR_NAME, new Runnable() {
             public void run() {
                 sendMemberListToOthers();
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -195,7 +195,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
         long mergeNextRunDelayMs = node.groupProperties.getMillis(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS);
         mergeNextRunDelayMs = (mergeNextRunDelayMs > 0 ? mergeNextRunDelayMs : DEFAULT_MERGE_RUN_DELAY_MILLIS);
-        executionService.scheduleWithFixedDelay(EXECUTOR_NAME, new SplitBrainHandler(node), mergeFirstRunDelayMs,
+        executionService.scheduleWithRepetition(EXECUTOR_NAME, new SplitBrainHandler(node), mergeFirstRunDelayMs,
                 mergeNextRunDelayMs, TimeUnit.MILLISECONDS);
 
         clusterHeartbeatManager.init();

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -95,7 +95,7 @@ public class TimedMemberStateFactory {
     }
 
     public void init() {
-        instance.node.nodeEngine.getExecutionService().scheduleAtFixedRate(new Runnable() {
+        instance.node.nodeEngine.getExecutionService().scheduleWithRepetition(new Runnable() {
             @Override
             public void run() {
                 memberStateSafe = instance.getPartitionService().isLocalMemberSafe();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
@@ -59,7 +59,7 @@ public class ExpirationManager {
 
     public void start() {
         nodeEngine.getExecutionService()
-                .scheduleAtFixedRate(new ClearExpiredRecordsTask(), INITIAL_DELAY, PERIOD, UNIT);
+                .scheduleWithRepetition(new ClearExpiredRecordsTask(), INITIAL_DELAY, PERIOD, UNIT);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindManager.java
@@ -26,9 +26,9 @@ import com.hazelcast.map.impl.mapstore.writebehind.entry.DelayedEntry;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.TaskScheduler;
 import com.hazelcast.util.executor.ExecutorType;
 
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.map.impl.mapstore.writebehind.WriteBehindProcessors.createWriteBehindProcessor;
@@ -42,7 +42,7 @@ public class WriteBehindManager implements MapStoreManager {
 
     private static final int EXECUTOR_DEFAULT_QUEUE_CAPACITY = 10000;
 
-    private final ScheduledExecutorService scheduledExecutor;
+    private final TaskScheduler taskScheduler;
 
     private final WriteBehindProcessor writeBehindProcessor;
 
@@ -58,12 +58,12 @@ public class WriteBehindManager implements MapStoreManager {
         this.storeWorker = new StoreWorker(mapStoreContext, writeBehindProcessor);
         this.executorName = EXECUTOR_NAME_PREFIX + mapStoreContext.getMapName();
         final MapServiceContext mapServiceContext = mapStoreContext.getMapServiceContext();
-        this.scheduledExecutor = getScheduledExecutorService(mapServiceContext);
+        this.taskScheduler = getTaskScheduler(mapServiceContext);
     }
 
     @Override
     public void start() {
-        scheduledExecutor.scheduleAtFixedRate(storeWorker, 1, 1, TimeUnit.SECONDS);
+        taskScheduler.scheduleWithRepetition(storeWorker, 1, 1, TimeUnit.SECONDS);
     }
 
     @Override
@@ -86,11 +86,11 @@ public class WriteBehindManager implements MapStoreManager {
         return writeBehindProcessor;
     }
 
-    private ScheduledExecutorService getScheduledExecutorService(MapServiceContext mapServiceContext) {
+    private TaskScheduler getTaskScheduler(MapServiceContext mapServiceContext) {
         final NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         final ExecutionService executionService = nodeEngine.getExecutionService();
         executionService.register(executorName, 1, EXECUTOR_DEFAULT_QUEUE_CAPACITY, ExecutorType.CACHED);
-        return executionService.getScheduledExecutor(executorName);
+        return executionService.getTaskScheduler(executorName);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchInvalidator.java
@@ -260,7 +260,7 @@ public class BatchInvalidator extends AbstractNearCacheInvalidator {
     private void startBackgroundBatchProcessor() {
         int periodSeconds = getBackgroundProcessorRunPeriodSeconds();
         ExecutionService executionService = nodeEngine.getExecutionService();
-        executionService.scheduleAtFixedRate(INVALIDATION_EXECUTOR_NAME,
+        executionService.scheduleWithRepetition(INVALIDATION_EXECUTOR_NAME,
                 new MapBatchInvalidationEventSender(), periodSeconds, periodSeconds, TimeUnit.SECONDS);
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
@@ -38,6 +38,7 @@ import com.hazelcast.mapreduce.impl.operation.RequestPartitionResult;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.TaskScheduler;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.executor.ManagedExecutorService;
 
@@ -52,7 +53,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
@@ -401,8 +401,8 @@ public class JobSupervisor {
 
     private void asyncCancelRemoteOperations(final Set<Address> addresses) {
         final NodeEngine nodeEngine = mapReduceService.getNodeEngine();
-        ScheduledExecutorService executor = nodeEngine.getExecutionService().getDefaultScheduledExecutor();
-        executor.submit(new Runnable() {
+        TaskScheduler taskScheduler = nodeEngine.getExecutionService().getGlobalTaskScheduler();
+        taskScheduler.submit(new Runnable() {
 
             @Override
             public void run() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -120,7 +120,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
         for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
             partitionContainers[i] = new PartitionContainer(this, i);
         }
-        nodeEngine.getExecutionService().getDefaultScheduledExecutor().scheduleWithFixedDelay(new Runnable() {
+        nodeEngine.getExecutionService().getGlobalTaskScheduler().scheduleWithRepetition(new Runnable() {
             @Override
             public void run() {
                 if (clusterService.getSize() == 1) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
@@ -66,7 +66,7 @@ public abstract class AbstractBaseReplicatedRecordStore<K, V> implements Replica
         this.storageRef = new AtomicReference<InternalReplicatedMapStorage<K, V>>();
         this.storageRef.set(new InternalReplicatedMapStorage<K, V>());
         this.ttlEvictionScheduler = EntryTaskSchedulerFactory
-                .newScheduler(nodeEngine.getExecutionService().getDefaultScheduledExecutor(),
+                .newScheduler(nodeEngine.getExecutionService().getGlobalTaskScheduler(),
                         new ReplicatedMapEvictionProcessor(this, nodeEngine, partitionId), ScheduleType.POSTPONE);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -22,7 +22,6 @@ import com.hazelcast.util.executor.ManagedExecutorService;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -92,17 +91,13 @@ public interface ExecutionService {
 
     ScheduledFuture<?> schedule(String name, Runnable command, long delay, TimeUnit unit);
 
-    ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit);
+    ScheduledFuture<?> scheduleWithRepetition(Runnable command, long initialDelay, long period, TimeUnit unit);
 
-    ScheduledFuture<?> scheduleAtFixedRate(String name, Runnable command, long initialDelay, long period, TimeUnit unit);
+    ScheduledFuture<?> scheduleWithRepetition(String name, Runnable command, long initialDelay, long period, TimeUnit unit);
 
-    ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long period, TimeUnit unit);
+    TaskScheduler getGlobalTaskScheduler();
 
-    ScheduledFuture<?> scheduleWithFixedDelay(String name, Runnable command, long initialDelay, long period, TimeUnit unit);
-
-    ScheduledExecutorService getDefaultScheduledExecutor();
-
-    ScheduledExecutorService getScheduledExecutor(String name);
+    TaskScheduler getTaskScheduler(String name);
 
     <V> ICompletableFuture<V> asCompletableFuture(Future<V> future);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/TaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TaskScheduler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * {@link ExecutorService} which can schedule a command to run after a given delay or to execute it periodically.
+ *
+ * The {@link #scheduleWithRepetition(Runnable, long, long, TimeUnit)} has similar semantic
+ * to {@link java.util.concurrent.ScheduledExecutorService#scheduleAtFixedRate(Runnable, long, long, TimeUnit)}. It
+ * guarantees a task won't be executed by multiple threads concurrently. The difference is that this service will simply
+ * skip a scheduled execution if another thread is still running the same task instead of postponing its execution.
+ * To emphasize this difference the method is called <code>scheduleWithRepetition</code>
+ * instead of <code>scheduleAtFixedRate</code>
+ *
+ * The other difference is this service does not offer an equivalent of
+ * {@link java.util.concurrent.ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}
+ *
+ */
+public interface TaskScheduler extends ExecutorService {
+
+    /**
+     * Creates and executes a one-shot action that becomes enabled
+     * after the given delay.
+     *
+     * @param command the task to execute
+     * @param delay the time from now to delay execution
+     * @param unit the time unit of the delay parameter
+     * @return a ScheduledFuture representing pending completion of
+     *         the task and whose {@code get()} method will return
+     *         {@code null} upon completion
+     * @throws RejectedExecutionException if the task cannot be
+     *         scheduled for execution
+     * @throws NullPointerException if command is null
+     */
+    ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
+
+    /**
+     * Creates and executes a periodic action that becomes enabled first
+     * after the given initial delay, and subsequently with the given
+     * period; that is executions will commence after
+     * {@code initialDelay} then {@code initialDelay+period}, then
+     * {@code initialDelay + 2 * period}, and so on.
+     * If any execution of this task
+     * takes longer than its period, then subsequent execution will be skipped.
+     *
+     * @param command the task to execute
+     * @param initialDelay the time to delay first execution
+     * @param period the period between successive executions
+     * @param unit the time unit of the initialDelay and period parameters
+     * @return a ScheduledFuture representing pending completion of
+     *         the task, and whose {@code get()} method will throw an
+     *         exception upon cancellation
+     * @throws RejectedExecutionException if the task cannot be
+     *         scheduled for execution
+     * @throws NullPointerException if command is null
+     * @throws IllegalArgumentException if period less than or equal to zero
+     */
+    ScheduledFuture<?> scheduleWithRepetition(Runnable command, long initialDelay, long period, TimeUnit unit);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskDecorator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.executionservice.impl;
+
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Delegates task execution to a given Executor.
+ *
+ * This is convenient when you want to start a task, do not want the task to block a caller thread.
+ *
+ */
+class DelegatingTaskDecorator implements Runnable {
+
+    private final Executor executor;
+    private final Runnable runnable;
+
+    /**
+     * @param runnable Task to be executed
+     * @param executor Executor the task to be delegated to
+     */
+    public DelegatingTaskDecorator(Runnable runnable, Executor executor) {
+        this.executor = executor;
+        this.runnable = runnable;
+    }
+
+    @Override
+    public void run() {
+        try {
+            executor.execute(runnable);
+        } catch (Throwable t) {
+            ExceptionUtil.sneakyThrow(t);
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -25,6 +25,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
+import com.hazelcast.spi.TaskScheduler;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.executor.CachedExecutorServiceDelegate;
@@ -67,7 +68,7 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
     private final NodeEngineImpl nodeEngine;
     private final ExecutorService cachedExecutorService;
     private final ScheduledExecutorService scheduledExecutorService;
-    private final ScheduledExecutorService defaultScheduledExecutorServiceDelegate;
+    private final TaskScheduler globalTaskScheduler;
     private final ILogger logger;
     private final CompletableFutureTask completableFutureTask;
 
@@ -112,11 +113,11 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
         // default executors
         register(SYSTEM_EXECUTOR, coreSize, Integer.MAX_VALUE, ExecutorType.CACHED);
         register(SCHEDULED_EXECUTOR, coreSize * POOL_MULTIPLIER, coreSize * QUEUE_MULTIPLIER, ExecutorType.CACHED);
-        defaultScheduledExecutorServiceDelegate = getScheduledExecutor(SCHEDULED_EXECUTOR);
+        globalTaskScheduler = getTaskScheduler(SCHEDULED_EXECUTOR);
 
         // Register CompletableFuture task
         completableFutureTask = new CompletableFutureTask();
-        scheduleWithFixedDelay(completableFutureTask, INITIAL_DELAY, PERIOD, TimeUnit.MILLISECONDS);
+        scheduleWithRepetition(completableFutureTask, INITIAL_DELAY, PERIOD, TimeUnit.MILLISECONDS);
     }
 
     private void enableRemoveOnCancelIfAvailable() {
@@ -214,44 +215,33 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
 
     @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-        return defaultScheduledExecutorServiceDelegate.schedule(command, delay, unit);
+        return globalTaskScheduler.schedule(command, delay, unit);
     }
 
     @Override
     public ScheduledFuture<?> schedule(String name, Runnable command, long delay, TimeUnit unit) {
-        return getScheduledExecutor(name).schedule(command, delay, unit);
+        return getTaskScheduler(name).schedule(command, delay, unit);
     }
 
     @Override
-    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-        return defaultScheduledExecutorServiceDelegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+    public ScheduledFuture<?> scheduleWithRepetition(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return globalTaskScheduler.scheduleWithRepetition(command, initialDelay, period, unit);
     }
 
     @Override
-    public ScheduledFuture<?> scheduleAtFixedRate(String name, Runnable command, long initialDelay,
-                                                  long period, TimeUnit unit) {
-        return getScheduledExecutor(name).scheduleAtFixedRate(command, initialDelay, period, unit);
-    }
-
-    @Override
-    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long period, TimeUnit unit) {
-        return defaultScheduledExecutorServiceDelegate.scheduleWithFixedDelay(command, initialDelay, period, unit);
-    }
-
-    @Override
-    public ScheduledFuture<?> scheduleWithFixedDelay(String name, Runnable command, long initialDelay,
+    public ScheduledFuture<?> scheduleWithRepetition(String name, Runnable command, long initialDelay,
                                                      long period, TimeUnit unit) {
-        return getScheduledExecutor(name).scheduleWithFixedDelay(command, initialDelay, period, unit);
+        return getTaskScheduler(name).scheduleWithRepetition(command, initialDelay, period, unit);
     }
 
     @Override
-    public ScheduledExecutorService getDefaultScheduledExecutor() {
-        return defaultScheduledExecutorServiceDelegate;
+    public TaskScheduler getGlobalTaskScheduler() {
+        return globalTaskScheduler;
     }
 
     @Override
-    public ScheduledExecutorService getScheduledExecutor(String name) {
-        return new ScheduledExecutorServiceDelegate(scheduledExecutorService, getExecutor(name));
+    public TaskScheduler getTaskScheduler(String name) {
+        return new DelegatingTaskScheduler(scheduledExecutorService, getExecutor(name));
     }
 
     public void shutdown() {

--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -72,7 +72,7 @@ public final class PhoneHome {
             return;
         }
         try {
-            hazelcastNode.nodeEngine.getExecutionService().scheduleAtFixedRate(new Runnable() {
+            hazelcastNode.nodeEngine.getExecutionService().scheduleWithRepetition(new Runnable() {
                 public void run() {
                     phoneHome(hazelcastNode, version, isEnterprise);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/EntryTaskSchedulerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/EntryTaskSchedulerFactory.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.util.scheduler;
 
-import java.util.concurrent.ScheduledExecutorService;
+import com.hazelcast.spi.TaskScheduler;
 
 /**
  * Factory for EntryTaskSchedulers.
@@ -40,14 +40,14 @@ public final class EntryTaskSchedulerFactory {
      * <p/>
      * EntryTaskScheduler implementation is thread-safe.
      *
-     * @param scheduledExecutorService ScheduledExecutorService instance to execute the second
+     * @param taskScheduler ScheduledExecutorService instance to execute the second
      * @param entryProcessor           bulk processor
      * @return EntryTaskScheduler that will run all second operations in bulk
      */
-    public static <K, V> EntryTaskScheduler<K, V> newScheduler(ScheduledExecutorService scheduledExecutorService,
+    public static <K, V> EntryTaskScheduler<K, V> newScheduler(TaskScheduler taskScheduler,
                                                                ScheduledEntryProcessor<K, V> entryProcessor,
                                                                ScheduleType scheduleType) {
-        return new SecondsBasedEntryTaskScheduler<K, V>(scheduledExecutorService, entryProcessor, scheduleType);
+        return new SecondsBasedEntryTaskScheduler<K, V>(taskScheduler, entryProcessor, scheduleType);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskScheduler.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.util.scheduler;
 
+import com.hazelcast.spi.TaskScheduler;
 import com.hazelcast.util.Clock;
 
 import java.util.ArrayList;
@@ -26,7 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -70,16 +70,16 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
     private final Map<Object, Integer> secondsOfKeys = new HashMap<Object, Integer>(1000);
     private final Map<Integer, Map<Object, ScheduledEntry<K, V>>> scheduledEntries
             = new HashMap<Integer, Map<Object, ScheduledEntry<K, V>>>(1000);
-    private final ScheduledExecutorService scheduledExecutorService;
+    private final TaskScheduler taskScheduler;
     private final ScheduledEntryProcessor<K, V> entryProcessor;
     private final ScheduleType scheduleType;
     private final Map<Integer, ScheduledFuture> scheduledTaskMap = new HashMap<Integer, ScheduledFuture>(1000);
     private final AtomicLong uniqueIdGenerator = new AtomicLong();
     private final Object mutex = new Object();
 
-    SecondsBasedEntryTaskScheduler(ScheduledExecutorService scheduledExecutorService,
+    SecondsBasedEntryTaskScheduler(TaskScheduler taskScheduler,
                                    ScheduledEntryProcessor<K, V> entryProcessor, ScheduleType scheduleType) {
-        this.scheduledExecutorService = scheduledExecutorService;
+        this.taskScheduler = taskScheduler;
         this.entryProcessor = entryProcessor;
         this.scheduleType = scheduleType;
     }
@@ -339,7 +339,7 @@ final class SecondsBasedEntryTaskScheduler<K, V> implements EntryTaskScheduler<K
 
     private void schedule(Integer second, int delaySeconds) {
         EntryProcessorExecutor command = new EntryProcessorExecutor(second);
-        ScheduledFuture scheduledFuture = scheduledExecutorService.schedule(command, delaySeconds, TimeUnit.SECONDS);
+        ScheduledFuture scheduledFuture = taskScheduler.schedule(command, delaySeconds, TimeUnit.SECONDS);
         scheduledTaskMap.put(second, scheduledFuture);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/nearcache/CommonNearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/nearcache/CommonNearCacheTestSupport.java
@@ -47,7 +47,7 @@ public abstract class CommonNearCacheTestSupport extends HazelcastTestSupport {
         scheduledExecutorServices.add(scheduledExecutorService);
         return new NearCacheExecutor() {
             @Override
-            public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
+            public ScheduledFuture<?> scheduleWithRepetition(Runnable command, long initialDelay,
                                                              long delay, TimeUnit unit) {
                 return scheduledExecutorService.scheduleWithFixedDelay(command, initialDelay, delay, unit);
             }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/SkipOnConcurrentExecutionDecoratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/SkipOnConcurrentExecutionDecoratorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.executionservice.impl;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class SkipOnConcurrentExecutionDecoratorTest extends HazelcastTestSupport {
+
+    @Test
+    public void givenTheTaskIsNotRunning_whenThreadAttemptToExecuteIt_theTaskWillBeExecuted() throws InterruptedException {
+        ResumableCountingRunnable task = new ResumableCountingRunnable();
+        decorateAndStartOnDifferentThread(task);
+
+        task.awaitExecutionStarted();
+        task.resumeExecution();
+
+        assertEquals(1, task.getExecutionCount());
+    }
+
+
+    @Test
+    public void givenTheTaskIsAlreadyRunning_whenThreadAttemptToExecuteIt_theExutionWillBeSkipped() throws InterruptedException {
+        final ResumableCountingRunnable task = new ResumableCountingRunnable();
+
+        //start first task
+        SkipOnConcurrentExecutionDecorator decoratedTask = decorateAndStartOnDifferentThread(task);
+
+        //wait until the task is running
+        task.awaitExecutionStarted();
+
+        //attempt to start execution from the test thread. this execution should be skipped -> it won't block
+        decoratedTask.run();
+
+        //resume the original task
+        task.resumeExecution();
+
+        assertEquals(1, task.getExecutionCount());
+    }
+
+
+    private SkipOnConcurrentExecutionDecorator decorateAndStartOnDifferentThread(Runnable task) {
+        SkipOnConcurrentExecutionDecorator decoratedTask = new SkipOnConcurrentExecutionDecorator(task);
+        new Thread(decoratedTask).start();
+        return decoratedTask;
+    }
+
+    private class ResumableCountingRunnable implements Runnable {
+        private final AtomicInteger executionCount = new AtomicInteger();
+        private final Semaphore resumeSemaphore = new Semaphore(0);
+        private final Semaphore startedSemaphore = new Semaphore(0);
+
+
+        @Override
+        public void run() {
+            executionCount.incrementAndGet();
+            startedSemaphore.release();
+            try {
+                resumeSemaphore.acquire();
+            } catch (InterruptedException e) {
+                fail("Thread interrupted while waiting on latch");
+            }
+        }
+
+        public void awaitExecutionStarted() throws InterruptedException {
+            startedSemaphore.acquire();
+        }
+
+        public void resumeExecution() {
+            resumeSemaphore.release();
+        }
+
+        public int getExecutionCount() {
+            return executionCount.get();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerStressTest.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.util.scheduler;
 
+import com.hazelcast.spi.TaskScheduler;
+import com.hazelcast.spi.impl.executionservice.impl.DelegatingTaskScheduler;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -46,11 +49,18 @@ public class SecondsBasedEntryTaskSchedulerStressTest {
     private static final int NUMBER_OF_EVENTS_PER_THREAD = 10000;
 
     // scheduler is single threaded
-    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private TaskScheduler executorService;
+    private ScheduledExecutorService scheduledExecutorService;
+
+    @Before
+    public void setUp() {
+        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        executorService = new DelegatingTaskScheduler(scheduledExecutorService, Executors.newSingleThreadExecutor());
+    }
 
     @After
     public void tearDown() {
-        executorService.shutdownNow();
+        scheduledExecutorService.shutdownNow();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.util.scheduler;
 
+import com.hazelcast.spi.TaskScheduler;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -11,7 +12,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 public class SecondsBasedEntryTaskSchedulerTest {
 
     @Mock
-    private ScheduledExecutorService executorService = mock(ScheduledExecutorService.class);
+    private TaskScheduler executorService = mock(TaskScheduler.class);
 
     @Mock
     private ScheduledEntryProcessor<Integer, Integer> entryProcessor = mock(ScheduledEntryProcessor.class);


### PR DESCRIPTION
Fixes #7611

Our scheduler has a different contract hence it should not
implement the interface from JDK.

I renamed it to the SchedulingExecutorServiceDelegate to avoid confusion.
Also I changed the method name from scheduleAtFixedRate to scheduleWithRepetition
to emphasize it has a different semantic.

The scheduleWithFixedDelay was removed as it never worked and it
effectively behaved as the scheduleAtFixedRate anyway.