### PR TITLE
NodeEngine.getSerializationService deprecated

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -77,6 +77,8 @@ public interface NodeEngine {
      * Gets the SerializationService.
      *
      * @return the SerializationService.
+     * @deprecated since 3.7. Use {@link #toObject(Object)} or {@link #toData(Object)} to (de)serialize. The SerializationService
+     * is an internal API.
      */
     SerializationService getSerializationService();
 
@@ -233,6 +235,7 @@ public interface NodeEngine {
 
     /**
      * Indicates that node is not shutting down or it has not already shut down
+     *
      * @return true if node is not shutting down or it has not already shut down
      */
     boolean isRunning();


### PR DESCRIPTION
This method is deprecated since SerializationService is not an SPI, but an internal API. Exposing it through the NodeEngine causes a leak of the internal being exposes to the outside.