### PR TITLE
NodeEngine.getService is added

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -245,6 +245,15 @@ public interface NodeEngine {
     HazelcastInstance getHazelcastInstance();
 
     /**
+     * Gets the service with the given name.
+     *
+     * @param serviceName the name of the service
+     * @param <T> the type of the service.
+     * @return the found service, or HazelcastException in case of failure. Null will not be returned.
+     */
+    <T> T getService(String serviceName);
+
+    /**
      * Gets the {@link SharedService} for the given serviceName.
      *
      * @param serviceName the name of the shared service to get.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -290,6 +290,7 @@ public class NodeEngineImpl implements NodeEngine {
         return node.getGroupProperties();
     }
 
+    @Override
     public <T> T getService(String serviceName) {
         T service = serviceManager.getService(serviceName);
         if (service == null) {


### PR DESCRIPTION
By adding a getService method, services can be added without needing to add them to the NodeEngine interface. For example WanReplicationService doesn't need to be added as explicit method on NodeEngine, but
```
WanReplicatioService service = nodeEngine.getService(WanReplicationService.SERVICE_NAME)
```
can be used

This is a much more flexible approach and make it a lot easier to add all kinds of new services, without needing to change the HZ core.