### PR TITLE
Deprecated SharedService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapManagedService.java
@@ -40,7 +40,7 @@ public class MapManagedService implements ManagedService {
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
-        final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        final LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
         if (lockService != null) {
             lockService.registerLockStoreConstructor(MapService.SERVICE_NAME,
                     new ObjectNamespaceLockStoreInfoConstructorFunction());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -140,7 +140,7 @@ public class PartitionContainer {
 
     private void clearLockStore(String name) {
         final NodeEngine nodeEngine = mapService.getMapServiceContext().getNodeEngine();
-        final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        final LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
         if (lockService != null) {
             final DefaultObjectNamespace namespace = new DefaultObjectNamespace(MapService.SERVICE_NAME, name);
             lockService.clearLockStore(partitionId, namespace);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -180,7 +180,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
 
     protected LockStore createLockStore() {
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        final LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
         if (lockService == null) {
             return null;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -237,7 +237,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public void clearPartition(boolean onShutdown) {
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-        LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
         if (lockService != null) {
             final DefaultObjectNamespace namespace
                     = new DefaultObjectNamespace(MapService.SERVICE_NAME, name);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -56,7 +56,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         super(name, service.getNodeEngine());
         this.partitionId = partitionId;
         this.lockNamespace = new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, name);
-        final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        final LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
         this.lockStore = lockService == null ? null : lockService.createLockStore(partitionId, lockNamespace);
         this.creationTime = currentTimeMillis();
     }
@@ -181,7 +181,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     }
 
     public void destroy() {
-        final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        final LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
         if (lockService != null) {
             lockService.clearLockStore(partitionId, lockNamespace);
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapPartitionContainer.java
@@ -79,7 +79,7 @@ public class MultiMapPartitionContainer {
 
     private void clearLockStore(String name) {
         NodeEngine nodeEngine = service.getNodeEngine();
-        LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
         if (lockService != null) {
             DefaultObjectNamespace namespace = new DefaultObjectNamespace(MultiMapService.SERVICE_NAME, name);
             lockService.clearLockStore(partitionId, namespace);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -100,7 +100,7 @@ public class MultiMapService implements ManagedService, RemoteService, Migration
         for (int partition = 0; partition < partitionCount; partition++) {
             partitionContainers[partition] = new MultiMapPartitionContainer(this, partition);
         }
-        final LockService lockService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
+        final LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
         if (lockService != null) {
             lockService.registerLockStoreConstructor(SERVICE_NAME,
                     new ConstructorFunction<ObjectNamespace, LockStoreInfo>() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -245,6 +245,15 @@ public interface NodeEngine {
     HazelcastInstance getHazelcastInstance();
 
     /**
+     * Gets the service with the given name.
+     *
+     * @param serviceName the name of the service
+     * @param <T> the type of the service.
+     * @return the found service, or HazelcastException in case of failure. Null will not be returned.
+     */
+    <T> T getService(String serviceName);
+
+    /**
      * Gets the {@link SharedService} for the given serviceName.
      *
      * @param serviceName the name of the shared service to get.

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -260,6 +260,7 @@ public interface NodeEngine {
      * @param <T>
      * @return the found service, or null if the service was not found.
      * @throws NullPointerException if the serviceName is null.
+     * @deprecated since 3.7. Use {@link #getService(String)} instead.
      */
     <T extends SharedService> T getSharedService(String serviceName);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/SharedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/SharedService.java
@@ -23,6 +23,8 @@ package com.hazelcast.spi;
  * otherwise it will be an isolated service.
  * <p/>
  * Shared services are accessible via {@link NodeEngine#getSharedService(String)}.
+ *
+ * @deprecated since 3.7. A service can be retrieved using {@link NodeEngine#getService(String)}
  */
 public interface SharedService {
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -290,6 +290,7 @@ public class NodeEngineImpl implements NodeEngine {
         return node.getGroupProperties();
     }
 
+    @Override
     public <T> T getService(String serviceName) {
         T service = serviceManager.getService(serviceName);
         if (service == null) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/NodeEngineTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/NodeEngineTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.concurrent.lock.LockService;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -49,6 +50,22 @@ public class NodeEngineTest extends HazelcastTestSupport {
         SharedService sharedService = nodeEngine.getSharedService(LockService.SERVICE_NAME);
         assertNotNull(sharedService);
         assertTrue(sharedService instanceof LockService);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void getService_whenNullName() {
+        nodeEngine.getService(null);
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void getService_whenNonExistingService() {
+        nodeEngine.getService("notexist");
+    }
+
+    @Test
+    public void getService_whenExistingService() {
+        Object sharedService = nodeEngine.getService(LockService.SERVICE_NAME);
+        assertInstanceOf(LockService.class, sharedService);
     }
 
     @Test


### PR DESCRIPTION
All services can be access using NodeEngine.getService(name). No need for the SharedService marker interface