### PR TITLE
Organized imports in Spring module.

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringAware.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/context/SpringAware.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.spring.context;
 
-import java.lang.annotation.Target;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Documented;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Annotates a class for injection of Spring dependencies.

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumFunction.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyQuorumFunction.java
@@ -18,6 +18,7 @@ package com.hazelcast.spring;
 
 import com.hazelcast.core.Member;
 import com.hazelcast.quorum.QuorumFunction;
+
 import java.util.Collection;
 
 public class DummyQuorumFunction implements QuorumFunction {

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummySocketInterceptor.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummySocketInterceptor.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spring;
 
-import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.nio.MemberSocketInterceptor;
 
 import java.io.IOException;

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientNetworkConfig.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientNetworkConfig.java
@@ -17,8 +17,8 @@
 package com.hazelcast.spring;
 
 import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.SocketInterceptorConfig;

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/CacheMapLoader.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/CacheMapLoader.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spring.cache;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MapLoader;
 import com.hazelcast.core.MapLoaderLifecycleSupport;
 import com.hazelcast.core.MapStore;
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/TestCacheManager.java
@@ -16,7 +16,12 @@
 
 package com.hazelcast.spring.cache;
 
-import com.hazelcast.core.*;
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.DistributedObjectEvent;
+import com.hazelcast.core.DistributedObjectListener;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/DummyTransactionManager.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/DummyTransactionManager.java
@@ -17,7 +17,12 @@
 package com.hazelcast.spring.context;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.*;
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.UnexpectedRollbackException;
 import org.springframework.transaction.support.SimpleTransactionStatus;
 
 /**

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeTask.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/SomeTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.spring.context;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import org.junit.Assert;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/replicatedmap/TestReplicatedMapApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/replicatedmap/TestReplicatedMapApplicationContext.java
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
-
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummyPermissionPolicy.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/security/DummyPermissionPolicy.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spring.security;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.SecurityConfig;
 import com.hazelcast.security.IPermissionPolicy;
 
 import javax.security.auth.Subject;

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestDisabledSpringAwareAnnotation.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestDisabledSpringAwareAnnotation.java
@@ -21,7 +21,6 @@ import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
-import com.hazelcast.spring.context.SpringManagedContext;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -32,9 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"springAware-disabled-applicationContext-hazelcast.xml"})

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestEnabledSpringAwareAnnotation.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/springaware/TestEnabledSpringAwareAnnotation.java
@@ -32,7 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)


### PR DESCRIPTION
I just used the "organize imports" function of IDEA to clean up the imports of Hazelcast. I think that we don't have to discuss the outcome in the Java files much.

But I didn't know that XML files are also cleaned up by this. Do we want those changes?