### PR TITLE
Move HashSlotArray code from EE

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -594,7 +594,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         connectionManager.shutdown();
         invocationService.shutdown();
         listenerService.shutdown();
-        serializationService.destroy();
+        serializationService.dispose();
         nearCacheManager.destroyAllNearCaches();
         if (discoveryService != null) {
             discoveryService.destroy();

--- a/hazelcast/src/main/java/com/hazelcast/elastic/CapacityUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/elastic/CapacityUtil.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.elastic;
+
+import com.hazelcast.util.QuickMath;
+
+/**
+ * Utility functions related to data structure capacity calculation.
+ */
+public final class CapacityUtil {
+
+    /** Maximum length of a Java array that is a power of two. */
+    @SuppressWarnings("checkstyle:magicnumber")
+    public static final int MAX_INT_CAPACITY = 1 << 30;
+
+    /** Maximum length of an off-heap array that is a power of two. */
+    @SuppressWarnings("checkstyle:magicnumber")
+    public static final long MAX_LONG_CAPACITY = 1L << 62;
+
+    /** Minimum capacity for a hash container. */
+    public static final int MIN_CAPACITY = 4;
+
+    /** Default capacity for a hash container. */
+    public static final int DEFAULT_CAPACITY = 16;
+
+    /** Default load factor. */
+    public static final float DEFAULT_LOAD_FACTOR = 0.6f;
+
+
+    private CapacityUtil() { }
+
+    /** Round the capacity to the next allowed value. */
+    public static long roundCapacity(long requestedCapacity) {
+        if (requestedCapacity > MAX_LONG_CAPACITY) {
+            throw new IllegalArgumentException(requestedCapacity + " is greater than max allowed capacity["
+                    + MAX_LONG_CAPACITY + "].");
+        }
+
+        return Math.max(MIN_CAPACITY, QuickMath.nextPowerOfTwo(requestedCapacity));
+    }
+
+    /** Round the capacity to the next allowed value. */
+    public static int roundCapacity(int requestedCapacity) {
+        if (requestedCapacity > MAX_INT_CAPACITY) {
+            throw new IllegalArgumentException(requestedCapacity + " is greater than max allowed capacity["
+                + MAX_INT_CAPACITY + "].");
+        }
+
+        return Math.max(MIN_CAPACITY, QuickMath.nextPowerOfTwo(requestedCapacity));
+    }
+
+    /** Returns the next possible capacity, counting from the current buffers' size. */
+    public static int nextCapacity(int current) {
+        assert current > 0 && Long.bitCount(current) == 1 : "Capacity must be a power of two.";
+
+        if (current < MIN_CAPACITY / 2) {
+            current = MIN_CAPACITY / 2;
+        }
+
+        current <<= 1;
+        if (current < 0) {
+            throw new RuntimeException("Maximum capacity exceeded.");
+        }
+        return current;
+    }
+
+    /** Returns the next possible capacity, counting from the current buffers' size. */
+    public static long nextCapacity(long current) {
+        assert current > 0 && Long.bitCount(current) == 1 : "Capacity must be a power of two.";
+
+        if (current < MIN_CAPACITY / 2) {
+            current = MIN_CAPACITY / 2;
+        }
+
+        current <<= 1;
+        if (current < 0) {
+            throw new RuntimeException("Maximum capacity exceeded.");
+        }
+        return current;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -436,7 +436,7 @@ public class Node {
             securityContext.destroy();
         }
         logger.finest("Destroying serialization service...");
-        serializationService.destroy();
+        serializationService.dispose();
 
         hazelcastThreadGroup.destroy();
         nodeExtension.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/SerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/SerializationService.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.ManagedContext;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.nio.Disposable;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -28,7 +29,7 @@ import com.hazelcast.nio.serialization.PortableReader;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
-public interface SerializationService {
+public interface SerializationService extends Disposable {
 
     byte VERSION_1 = 1;
 
@@ -67,6 +68,4 @@ public interface SerializationService {
     ByteOrder getByteOrder();
 
     byte getVersion();
-
-    void destroy();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -100,21 +100,21 @@ public abstract class AbstractSerializationService implements SerializationServi
 
     //region Serialization Service
     @Override
-    public final Data toData(Object obj) {
+    public final <B extends Data> B toData(Object obj) {
         return toData(obj, globalPartitioningStrategy);
     }
 
     @Override
-    public final Data toData(Object obj, PartitioningStrategy strategy) {
+    public final <B extends Data> B toData(Object obj, PartitioningStrategy strategy) {
         if (obj == null) {
             return null;
         }
         if (obj instanceof Data) {
-            return (Data) obj;
+            return (B) obj;
         }
 
         byte[] bytes = toBytes(obj, strategy);
-        return new HeapData(bytes);
+        return (B) new HeapData(bytes);
     }
 
     @Override
@@ -179,7 +179,7 @@ public abstract class AbstractSerializationService implements SerializationServi
         }
     }
 
-    private HazelcastSerializationException newHazelcastSerializationException(int typeId) {
+    private static HazelcastSerializationException newHazelcastSerializationException(int typeId) {
         return new HazelcastSerializationException("There is no suitable de-serializer for type " + typeId + ". "
                 + "This exception is likely to be caused by differences in the serialization configuration between members "
                 + "or between clients and members.");
@@ -263,7 +263,7 @@ public abstract class AbstractSerializationService implements SerializationServi
         return version;
     }
 
-    public void destroy() {
+    public void dispose() {
         active = false;
         for (SerializerAdapter serializer : typeMap.values()) {
             serializer.destroy();

--- a/hazelcast/src/main/java/com/hazelcast/memory/HeapMemoryManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/HeapMemoryManager.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.memory;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.internal.memory.impl.EndiannessUtil;
+
+import java.util.Arrays;
+
+import static com.hazelcast.internal.memory.impl.EndiannessUtil.BYTE_ARRAY_ACCESS;
+
+/**
+ * Manages memory in Java byte arrays. For testing only.
+ */
+public class HeapMemoryManager implements MemoryManager {
+
+    private final Allocator malloc = new Allocator();
+
+    private final Accessor mem = new Accessor();
+
+    private final byte[] storage;
+
+    private static final int HEAP_BOTTOM = 8;
+
+    private int heapTop = HEAP_BOTTOM;
+
+    public HeapMemoryManager(int size) {
+        this.storage = new byte[size];
+    }
+
+    @Override
+    public MemoryAllocator getAllocator() {
+        return malloc;
+    }
+
+    @Override
+    public MemoryAccessor getAccessor() {
+        return mem;
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+    class Allocator implements MemoryAllocator {
+
+        @Override
+        public long allocate(long size) {
+            final long bytesFree = storage.length - toStorageIndex(heapTop);
+            if (size > bytesFree) {
+                throw new OutOfMemoryError(String.format("Asked to allocate %d, free bytes left %d", size, bytesFree));
+            }
+            final long addr = heapTop;
+            heapTop += size;
+            return addr;
+        }
+
+        @Override
+        public long reallocate(long address, long currentSize, long newSize) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void free(long address, long size) {
+        }
+
+        @Override
+        public void dispose() {
+        }
+    }
+
+    private static long toStorageIndex(long addr) {
+        return addr - HEAP_BOTTOM;
+    }
+
+    class Accessor implements MemoryAccessor {
+
+        @Override
+        public int getInt(long address) {
+            return EndiannessUtil.readIntL(BYTE_ARRAY_ACCESS, storage, toStorageIndex(address));
+        }
+
+        @Override
+        public void putInt(long address, int x) {
+            EndiannessUtil.writeIntL(BYTE_ARRAY_ACCESS, storage, toStorageIndex(address), x);
+        }
+
+        @Override
+        public long getLong(long address) {
+            return EndiannessUtil.readLongL(BYTE_ARRAY_ACCESS, storage, toStorageIndex(address));
+        }
+
+        @Override
+        public void putLong(long address, long x) {
+            EndiannessUtil.writeLongL(BYTE_ARRAY_ACCESS, storage, toStorageIndex(address), x);
+        }
+
+        @Override
+        public void copyMemory(long srcAddress, long destAddress, long lengthBytes) {
+            System.arraycopy(storage, (int) toStorageIndex(srcAddress),
+                    storage, (int) toStorageIndex(destAddress), (int) lengthBytes);
+        }
+
+        @Override
+        public void setMemory(long address, long lengthBytes, byte value) {
+            final int fromIndex = (int) toStorageIndex(address);
+            Arrays.fill(storage, fromIndex, fromIndex + (int) lengthBytes, value);
+        }
+
+        @Override public boolean getBoolean(long address) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public void putBoolean(long address, boolean x) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public byte getByte(long address) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public void putByte(long address, byte x) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public char getChar(long address) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public void putChar(long address, char x) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public short getShort(long address) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public void putShort(long address, short x) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public float getFloat(long address) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public void putFloat(long address, float x) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public double getDouble(long address) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public void putDouble(long address, double x) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemoryAllocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemoryAllocator.java
@@ -16,10 +16,12 @@
 
 package com.hazelcast.memory;
 
+import com.hazelcast.nio.Disposable;
+
 /**
  * Memory Allocator allocates/free memory blocks from/to OS like C malloc()/free()
  */
-public interface MemoryAllocator {
+public interface MemoryAllocator extends Disposable {
 
     /**
      * NULL pointer address.

--- a/hazelcast/src/main/java/com/hazelcast/memory/MemoryManagerBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/MemoryManagerBean.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.memory;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+
+/**
+ * Simp]e implementation of {@link MemoryManager} which aggregates the
+ * {@link MemoryAllocator} and {@link MemoryAccessor} supplied at construction time.
+ */
+public class MemoryManagerBean implements MemoryManager {
+
+    private final MemoryAllocator allocator;
+    private final MemoryAccessor accessor;
+
+    public MemoryManagerBean(MemoryAllocator allocator, MemoryAccessor accessor) {
+        this.allocator = allocator;
+        this.accessor = accessor;
+    }
+
+    @Override
+    public MemoryAllocator getAllocator() {
+        return allocator;
+    }
+
+    @Override
+    public MemoryAccessor getAccessor() {
+        return accessor;
+    }
+
+    @Override
+    public void dispose() {
+        allocator.dispose();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/CapacityUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/CapacityUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.elastic;
+package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.util.QuickMath;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/CapacityUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/CapacityUtil.java
@@ -80,7 +80,7 @@ public final class CapacityUtil {
 
     /** Returns the next possible capacity, counting from the current buffers' size. */
     public static long nextCapacity(long current) {
-        assert current > 0 && Long.bitCount(current) == 1 : "Capacity must be a power of two.";
+        assert current > 0 && Long.bitCount(current) == 1 : "Capacity must be a power of two, but was " + current;
 
         if (current < MIN_CAPACITY / 2) {
             current = MIN_CAPACITY / 2;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArray.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArray.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.nio.Disposable;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArray.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArray.java
@@ -1,0 +1,65 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.nio.Disposable;
+
+/** <p>
+ * Manages the backbone array of an off-heap open-addressed hashtable. The backbone consists
+ * of <i>slots</i>, where each slot has a key part and an optional value part. The key part
+ * is a {@code long} value and the value part is a block whose size is a multiple of 8. A block
+ * of zero size is also possible.
+ * </p><p>
+ * The update operations on this class only ensure that a slot for a given key exists/doesn't exist
+ * and it is up to the caller to manage the contents of the value part. The caller will be provided
+ * with the raw address of the value, suitable for accessing with {@code Unsafe} memory operations.
+ * <b>The returned address is valid only up to the next map update operation</b>.
+ * </p>
+ */
+public interface HashSlotArray extends Disposable {
+
+    /**
+     * Ensures that there is a mapping from the given key to a slot in the array.
+     * The {@code abs} of the returned integer is the address of the slot's value block.
+     * The returned integer is positive if a new slot had to be assigned and negative
+     * if the slot was already assigned.
+     *
+     * @param key the key
+     * @return address of value block
+     */
+    long ensure(long key);
+
+    /**
+     * Returns the address of the value block mapped by the given key.
+     *
+     * @param key the key
+     * @return address of the value block or {@link com.hazelcast.memory.MemoryAllocator#NULL_ADDRESS}
+     * if no mapping for key exists.
+     */
+    long get(long key);
+
+    /**
+     * Removes the mapping for the given key.
+     *
+     * @param key the key
+     * @return true if a mapping existed and was removed, false otherwise
+     */
+    boolean remove(long key);
+
+    /**
+     * After this method returns, no key has a mapping in this hash slot array.
+     */
+    void clear();
+
+    /** Compact the array if allowed by the current size.
+     * @return true if the array was compacted; false if no action was taken. */
+    boolean trimToSize();
+
+    /**
+     * Returns the number of keys in the hash slot array.
+     */
+    long size();
+
+    /**
+     * Returns a cursor over all assigned slots in this array.
+     */
+    HashSlotCursor cursor();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.internal.memory.MemoryAccessor;
@@ -61,6 +77,12 @@ abstract class HashSlotArrayBase {
     private final int valueLength;
 
     /**
+     * The maximum load factor ({@link #size} / {@link #capacity}) for this hash slot array.
+     * The array will be expanded as needed to enforce this limit.
+     */
+    private final float loadFactor;
+
+    /**
      * Capacity (in terms of slots) of the currently allocated memory region.
      */
     private long capacity;
@@ -74,12 +96,6 @@ abstract class HashSlotArrayBase {
      * Number of assigned hash slots.
      */
     private long size;
-
-    /**
-     * The maximum load factor ({@link #size} / {@link #capacity}) for this hash slot array.
-     * The array will be expanded as needed to enforce this limit.
-     */
-    private final float loadFactor;
 
     /**
      * Resize buffers when {@link #size} hits this value.

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
@@ -4,9 +4,9 @@ import com.hazelcast.internal.memory.MemoryAccessor;
 import com.hazelcast.memory.MemoryAllocator;
 import com.hazelcast.memory.MemoryManager;
 
-import static com.hazelcast.elastic.CapacityUtil.DEFAULT_LOAD_FACTOR;
-import static com.hazelcast.elastic.CapacityUtil.nextCapacity;
-import static com.hazelcast.elastic.CapacityUtil.roundCapacity;
+import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_LOAD_FACTOR;
+import static com.hazelcast.spi.hashslot.CapacityUtil.nextCapacity;
+import static com.hazelcast.spi.hashslot.CapacityUtil.roundCapacity;
 import static com.hazelcast.memory.MemoryAllocator.NULL_ADDRESS;
 import static com.hazelcast.util.HashUtil.fastLongMix;
 import static com.hazelcast.util.QuickMath.modPowerOfTwo;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
@@ -1,0 +1,419 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.memory.MemoryAllocator;
+import com.hazelcast.memory.MemoryManager;
+
+import static com.hazelcast.elastic.CapacityUtil.DEFAULT_LOAD_FACTOR;
+import static com.hazelcast.elastic.CapacityUtil.nextCapacity;
+import static com.hazelcast.elastic.CapacityUtil.roundCapacity;
+import static com.hazelcast.memory.MemoryAllocator.NULL_ADDRESS;
+import static com.hazelcast.util.HashUtil.fastLongMix;
+import static com.hazelcast.util.QuickMath.modPowerOfTwo;
+
+/**
+ * Common implementation base for {@link HashSlotArray} and {@link HashSlotArrayTwinKey}.
+ */
+abstract class HashSlotArrayBase {
+
+    protected static final int KEY_1_OFFSET = 0;
+    private static final int KEY_2_OFFSET = 8;
+    private static final int VALUE_LENGTH_GRANULARITY = 8;
+
+    /**
+     * Base address of the backing memory region of this hash slot array.
+     */
+    protected long baseAddress;
+
+    /**
+     * Sentinel value that marks a slot as "unassigned".
+     */
+    protected final long unassignedSentinel;
+
+    /**
+     * Offset (from the slot's base address) where the unassigned sentinel value is to be found.
+     */
+    protected final long offsetOfUnassignedSentinel;
+
+    /**
+     * Allows access to memory allocated from {@link #malloc}
+     */
+    protected final MemoryAccessor mem;
+
+    /**
+     * Memory allocator
+     */
+    private final MemoryAllocator malloc;
+
+    /**
+     * Total length of an array slot in bytes.
+     */
+    private final int slotLength;
+
+    /**
+     * Offset of the value block from the slot's base address.
+     */
+    private final int valueOffset;
+
+    /**
+     * Length of the value block in bytes.
+     */
+    private final int valueLength;
+
+    /**
+     * Capacity (in terms of slots) of the currently allocated memory region.
+     */
+    private long capacity;
+
+    /**
+     * Bit mask used to compute the slot index.
+     */
+    private long mask;
+
+    /**
+     * Number of assigned hash slots.
+     */
+    private long size;
+
+    /**
+     * The maximum load factor ({@link #size} / {@link #capacity}) for this hash slot array.
+     * The array will be expanded as needed to enforce this limit.
+     */
+    private final float loadFactor;
+
+    /**
+     * Resize buffers when {@link #size} hits this value.
+     */
+    private long expandAt;
+
+    /**
+     * Constructs a new {@code HashSlotArrayImpl} with the given initial capacity and the load factor.
+     * {@code valueLength} must be a factor of 8.
+     *
+     * @param unassignedSentinel the value to be used to mark an unassigned slot
+     * @param offsetOfUnassignedSentinel offset (from each slot's base address) where the unassigned sentinel is kept
+     * @param mm the memory manager
+     * @param keyLength length of key in bytes
+     * @param valueLength length of value in bytes
+     * @param initialCapacity Initial capacity of map (will be rounded to closest power of 2, if not already)
+     */
+    protected HashSlotArrayBase(long unassignedSentinel, long offsetOfUnassignedSentinel, MemoryManager mm,
+                                int keyLength, int valueLength, int initialCapacity
+    ) {
+        assert modPowerOfTwo(valueLength, VALUE_LENGTH_GRANULARITY) == 0
+                : "Value length should be a positive multiple of 8";
+        this.unassignedSentinel = unassignedSentinel;
+        this.offsetOfUnassignedSentinel = offsetOfUnassignedSentinel;
+        this.malloc = mm.getAllocator();
+        this.mem = mm.getAccessor();
+        this.valueOffset = keyLength;
+        this.valueLength = valueLength;
+        this.slotLength = keyLength + valueLength;
+        this.loadFactor = DEFAULT_LOAD_FACTOR;
+
+        allocateArrayAndAdjustFields(roundCapacity((int) (initialCapacity / loadFactor)));
+    }
+
+
+    // These public final methods will automatically fit as interface implementation in subclasses
+
+    public final long size() {
+        return size;
+    }
+
+    public final void clear() {
+        ensureLive();
+        markAllUnassigned();
+        size = 0;
+    }
+
+    public final boolean trimToSize() {
+        final long minCapacity = minCapacityForSize(size, loadFactor);
+        if (capacity <= minCapacity) {
+            return false;
+        }
+        resizeTo(minCapacity);
+        assert expandAt >= size : String.format(
+                "trimToSize() shrunk the capacity to %,d and expandAt to %,d, which is less than the current size %,d",
+                capacity, expandAt, size);
+        return true;
+    }
+
+    public final void dispose() {
+        if (baseAddress <= 0L) {
+            return;
+        }
+        malloc.free(baseAddress, capacity * slotLength);
+        baseAddress = -1L;
+        capacity = 0;
+        mask = 0;
+        expandAt = 0;
+        size = 0;
+    }
+
+
+    // These protected final methods will be called from the subclasses
+
+    protected final long slotBase(long baseAddr, long slot) {
+        return baseAddr + slotLength * slot;
+    }
+
+    protected final long ensure0(long key1, long key2) {
+        ensureLive();
+        // Check if we need to grow. If so, reallocate new data and rehash.
+        if (size == expandAt) {
+            resizeTo(nextCapacity(capacity));
+        }
+        long slot = maskedHash(key1, key2);
+        while (isAssigned(slot)) {
+            if (equal(key1OfSlot(slot), key2OfSlot(slot), key1, key2)) {
+                return -valueAddrOfSlot(slot);
+            }
+            slot = (slot + 1) & mask;
+        }
+        size++;
+        putKey(slot, key1, key2);
+        return valueAddrOfSlot(slot);
+    }
+
+    protected final long get0(long key1, long key2) {
+        ensureLive();
+        long slot = maskedHash(key1, key2);
+        final long wrappedAround = slot;
+        while (isAssigned(slot)) {
+            if (equal(key1OfSlot(slot), key2OfSlot(slot), key1, key2)) {
+                return valueAddrOfSlot(slot);
+            }
+            slot = (slot + 1) & mask;
+            if (slot == wrappedAround) {
+                break;
+            }
+        }
+        return NULL_ADDRESS;
+    }
+
+    protected final boolean remove0(long key1, long key2) {
+        ensureLive();
+        long slot = maskedHash(key1, key2);
+        final long wrappedAround = slot;
+        while (isAssigned(slot)) {
+            if (equal(key1OfSlot(slot), key2OfSlot(slot), key1, key2)) {
+                size--;
+                shiftConflictingKeys(slot);
+                return true;
+            }
+            slot = (slot + 1) & mask;
+            if (slot == wrappedAround) {
+                break;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Shift all the slot-conflicting keys allocated to (and including) <code>slot</code>.
+     */
+    @SuppressWarnings("checkstyle:innerassignment")
+    protected final void shiftConflictingKeys(long slotCurr) {
+        long slotPrev;
+        long slotOther;
+        while (true) {
+            slotCurr = ((slotPrev = slotCurr) + 1) & mask;
+            while (isAssigned(slotCurr)) {
+                slotOther = maskedHash(key1OfSlot(slotCurr), key2OfSlot(slotCurr));
+                if (slotPrev <= slotCurr) {
+                    // we're on the right of the original slot.
+                    if (slotPrev >= slotOther || slotOther > slotCurr) {
+                        break;
+                    }
+                } else {
+                    // we've wrapped around.
+                    if (slotPrev >= slotOther && slotOther > slotCurr) {
+                        break;
+                    }
+                }
+                slotCurr = (slotCurr + 1) & mask;
+            }
+            if (!isAssigned(slotCurr)) {
+                break;
+            }
+            // Shift key/value pair.
+            putKey(slotPrev, key1OfSlot(slotCurr), key2OfSlot(slotCurr));
+            mem.copyMemory(valueAddrOfSlot(slotCurr), valueAddrOfSlot(slotPrev), valueLength);
+        }
+        final long slotBase = slotBase(slotPrev);
+        mem.setMemory(slotBase, slotLength, (byte) 0);
+        mem.putLong(slotBase + offsetOfUnassignedSentinel, unassignedSentinel);
+    }
+
+    protected final void ensureLive() {
+        if (baseAddress <= 0L) {
+            throw new IllegalStateException("Map is already disposed!");
+        }
+    }
+
+    protected final long slotBase(long slot) {
+        return slotBase(baseAddress, slot);
+    }
+
+
+    // These protected methods will be overridden in some subclasses
+
+    protected long key2OfSlot(long slot) {
+        return mem.getLong(slotBase(baseAddress, slot) + KEY_2_OFFSET);
+    }
+
+    protected long key2OfSlot(long baseAddress, long slot) {
+        return mem.getLong(slotBase(baseAddress, slot) + KEY_2_OFFSET);
+    }
+
+    protected long hash(long key1, long key2) {
+        return fastLongMix(fastLongMix(key1) + key2);
+    }
+
+    protected boolean equal(long key1a, long key2a, long key1b, long key2b) {
+        return key1a == key1b && key2a == key2b;
+    }
+
+    protected void putKey(long slot, long key1, long key2) {
+        final long slotBase = slotBase(baseAddress, slot);
+        mem.putLong(slotBase + KEY_1_OFFSET, key1);
+        mem.putLong(slotBase + KEY_2_OFFSET, key2);
+    }
+
+
+    // These are private instance methods
+
+    private long maskedHash(long key1, long key2) {
+        return hash(key1, key2) & mask;
+    }
+
+    private boolean isAssigned(long baseAddr, long slot) {
+        return mem.getLong(slotBase(baseAddr, slot) + offsetOfUnassignedSentinel) != unassignedSentinel;
+    }
+
+    private boolean isAssigned(long slot) {
+        return isAssigned(baseAddress, slot);
+    }
+
+    private long key1OfSlot(long slot) {
+        return mem.getLong(slotBase(baseAddress, slot) + KEY_1_OFFSET);
+    }
+
+    private long valueAddrOfSlot(long slot) {
+        return slotBase(baseAddress, slot) + valueOffset;
+    }
+
+    private long key1OfSlot(long baseAddress, long slot) {
+        return mem.getLong(slotBase(baseAddress, slot) + KEY_1_OFFSET);
+    }
+
+    private void allocateArrayAndAdjustFields(long newCapacity) {
+        baseAddress = malloc.allocate(newCapacity * slotLength);
+        capacity = newCapacity;
+        mask = newCapacity - 1;
+        expandAt = maxSizeForCapacity(newCapacity, loadFactor);
+        markAllUnassigned();
+    }
+
+    private void markAllUnassigned() {
+        mem.setMemory(baseAddress, capacity * slotLength, (byte) 0);
+        if (unassignedSentinel == 0) {
+            return;
+        }
+        final long addrOfFirstSentinel = baseAddress + offsetOfUnassignedSentinel;
+        final int stride = slotLength;
+        for (long i = 0; i < capacity; i++) {
+            mem.putLong(addrOfFirstSentinel + stride * i, unassignedSentinel);
+        }
+    }
+
+    /**
+     * Allocate a new slot array with the requested size and move all the
+     * assigned slots from the current array into the new one.
+     */
+    private void resizeTo(long newCapacity) {
+        // Allocate new array first, ensuring that the possible OOME
+        // does not ruin the consistency of the existing data structure.
+        final long oldAddress = baseAddress;
+        final long oldCapacity = capacity;
+        allocateArrayAndAdjustFields(newCapacity);
+        // Put the assigned slots into the new array.
+        for (long slot = oldCapacity; --slot >= 0;) {
+            if (isAssigned(oldAddress, slot)) {
+                long key1 = key1OfSlot(oldAddress, slot);
+                long key2 = key2OfSlot(oldAddress, slot);
+                long valueAddress = slotBase(oldAddress, slot) + valueOffset;
+                long newSlot = maskedHash(key1, key2);
+                while (isAssigned(newSlot)) {
+                    newSlot = (newSlot + 1) & mask;
+                }
+                putKey(newSlot, key1, key2);
+                mem.copyMemory(valueAddress, valueAddrOfSlot(newSlot), valueLength);
+            }
+        }
+        malloc.free(oldAddress, oldCapacity * slotLength);
+    }
+
+
+    private static long maxSizeForCapacity(long capacity, float loadFactor) {
+        return Math.max(2, (long) Math.ceil(capacity * loadFactor)) - 1;
+    }
+
+    private static long minCapacityForSize(long size, float loadFactor) {
+        return roundCapacity((long) Math.ceil(size / loadFactor));
+    }
+
+    protected final class Cursor implements HashSlotCursor, HashSlotCursorTwinKey {
+
+        private long currentSlot = -1L;
+
+        @Override public boolean advance() {
+            ensureLive();
+            if (currentSlot == Long.MIN_VALUE) {
+                throw new IllegalStateException("Cursor is invalid!");
+            }
+            if (tryAdvance()) {
+                return true;
+            }
+            currentSlot = Long.MIN_VALUE;
+            return false;
+        }
+
+        @Override public long key() {
+            return key1();
+        }
+
+        @Override public long key1() {
+            ensureValid();
+            return key1OfSlot(currentSlot);
+        }
+
+        @Override public long key2() {
+            ensureValid();
+            return key2OfSlot(currentSlot);
+        }
+
+        @Override public long valueAddress() {
+            ensureValid();
+            return valueAddrOfSlot(currentSlot);
+        }
+
+        private void ensureValid() {
+            ensureLive();
+            if (currentSlot < 0) {
+                throw new IllegalStateException("Cursor is invalid!");
+            }
+        }
+
+        private boolean tryAdvance() {
+            for (long slot = currentSlot + 1; slot < capacity; slot++) {
+                if (isAssigned(slot)) {
+                    currentSlot = slot;
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.memory.MemoryManager;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.hashslot;
 import com.hazelcast.memory.MemoryManager;
 
 import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_LOAD_FACTOR;
 import static com.hazelcast.util.HashUtil.fastLongMix;
 
 /**
@@ -49,7 +50,8 @@ public class HashSlotArrayImpl extends HashSlotArrayBase implements HashSlotArra
     protected HashSlotArrayImpl(long unassignedSentinel, long offsetOfUnassignedSentinel,
                                 MemoryManager mm, int valueLength, int initialCapacity
     ) {
-        super(unassignedSentinel, offsetOfUnassignedSentinel, mm, KEY_LENGTH, valueLength, initialCapacity);
+        super(unassignedSentinel, offsetOfUnassignedSentinel, mm, null, KEY_LENGTH, valueLength,
+                initialCapacity, DEFAULT_LOAD_FACTOR);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayImpl.java
@@ -1,0 +1,76 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.memory.MemoryManager;
+
+import static com.hazelcast.elastic.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.util.HashUtil.fastLongMix;
+
+/**
+ * Implementation of {@link HashSlotArray} as a restriction of {@link HashSlotArrayBase}
+ * to a case where just {@code key1} is used.
+ * <p>
+ * This class uses the first 8 bytes of the value block for the unassigned sentinel.
+ * <strong>It is the responsibility of the caller to ensure that the unassigned sentinel
+ * is overwritten with a non-sentinel value as soon as a new slot is assigned (after calling
+ * {@link #ensure(long)} and getting a positive return value).</strong>
+ * For the same reason this class must not be instantiated with zero value length. Use
+ * {@link HashSlotArrayNoValue} as a zero-length key implementation.
+ */
+public class HashSlotArrayImpl extends HashSlotArrayBase implements HashSlotArray {
+
+    private static final int KEY_LENGTH = 8;
+
+    public HashSlotArrayImpl(long unassignedSentinel, MemoryManager mm, int valueLength, int initialCapacity) {
+        this(unassignedSentinel, KEY_LENGTH, mm, valueLength, initialCapacity);
+        assert valueLength > 0 : "Attempted to instantiate HashSlotArrayImpl with zero value length";
+    }
+
+    public HashSlotArrayImpl(long unassignedSentinel, MemoryManager mm, int valueLength) {
+        this(unassignedSentinel, mm, valueLength, DEFAULT_CAPACITY);
+        assert valueLength > 0 : "Attempted to instantiate HashSlotArrayImpl with zero value length";
+    }
+
+    protected HashSlotArrayImpl(long unassignedSentinel, long offsetOfUnassignedSentinel,
+                                MemoryManager mm, int valueLength, int initialCapacity
+    ) {
+        super(unassignedSentinel, offsetOfUnassignedSentinel, mm, KEY_LENGTH, valueLength, initialCapacity);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Whenever this method returns a positive value, the caller must ensure that the null-sentinel value
+     * at the returned address is overwritten with a non-sentinel value.
+     */
+    @Override public long ensure(long key) {
+        return super.ensure0(key, 0);
+    }
+
+    @Override public long get(long key) {
+        return super.get0(key, 0);
+    }
+
+    @Override public boolean remove(long key) {
+        return super.remove0(key, 0);
+    }
+
+    @Override public HashSlotCursor cursor() {
+        return new Cursor();
+    }
+
+    @Override protected long key2OfSlot(long baseAddress, long slot) {
+        return 0;
+    }
+
+    @Override protected long key2OfSlot(long slot) {
+        return 0;
+    }
+
+    @Override protected long hash(long key, long ignored) {
+        return fastLongMix(key);
+    }
+
+    @Override protected void putKey(long slot, long key, long ignored) {
+        mem.putLong(slotBase(slot) + KEY_1_OFFSET, key);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayImpl.java
@@ -2,7 +2,7 @@ package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.memory.MemoryManager;
 
-import static com.hazelcast.elastic.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_CAPACITY;
 import static com.hazelcast.util.HashUtil.fastLongMix;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayNoValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.memory.MemoryManager;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayNoValue.java
@@ -1,0 +1,21 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.memory.MemoryManager;
+
+import static com.hazelcast.elastic.CapacityUtil.DEFAULT_CAPACITY;
+
+/**
+ * Specialization of {@link HashSlotArrayImpl} to the case of zero-length value. Suitable for a {@code long} set
+ * implementation. Unassigned sentinel is kept at the start of the slot, i.e., in the key part.
+ * Therefore the sentinel value cannot be used as a key.
+ */
+public class HashSlotArrayNoValue extends HashSlotArrayImpl {
+
+    public HashSlotArrayNoValue(long unassignedSentinel, MemoryManager mm, int valueLength, int initialCapacity) {
+        super(unassignedSentinel, 0L, mm, valueLength, initialCapacity);
+    }
+
+    public HashSlotArrayNoValue(long unassignedSentinel, MemoryManager mm, int valueLength) {
+        super(unassignedSentinel, 0L, mm, valueLength, DEFAULT_CAPACITY);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayNoValue.java
@@ -2,7 +2,7 @@ package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.memory.MemoryManager;
 
-import static com.hazelcast.elastic.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_CAPACITY;
 
 /**
  * Specialization of {@link HashSlotArrayImpl} to the case of zero-length value. Suitable for a {@code long} set

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKey.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.nio.Disposable;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKey.java
@@ -38,9 +38,32 @@ import com.hazelcast.nio.Disposable;
  * pointing to invalid data. The <code>(nativeAddress, sequenceId)</code> pair is expected to be
  * acquired from a native data structure which complies with this concept and stores the relevant
  * key data.
+ * </p><p>
+ * Since this is a <i>Flyweight</i>-style object, the same instance can be used to manage many
+ * hashtables, one at a time. The {@link #gotoAddress(long)} method resets the instance to work
+ * with the hashtable at the provided address and {@link #gotoNew()} allocates a new hashtable.
+ * It is the caller's duty to ensure against memory leaks by keeping track of all existing hashtables'
+ * base addresses. Since an update operation may trigger a new allocation, freeing the old block,
+ * it is the caller's duty to save the new address before moving on to another base address.
  * </p>
  */
 public interface HashSlotArrayTwinKey extends Disposable {
+
+    /**
+     * @return current base address of this flyweight
+     */
+    long address();
+
+    /**
+     * Position this flyweight to the supplied base address.
+     */
+    void gotoAddress(long address);
+
+    /**
+     * Allocate a new array and position this flyweight to its base address.
+     * @return the base address of the new array.
+     */
+    long gotoNew();
 
     /**
      * Ensures that there is a mapping from {@code (key1, key2)} to a slot in the array.

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKey.java
@@ -1,0 +1,78 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.nio.Disposable;
+
+/** <p>
+ * Manages the backbone array of an off-heap open-addressed hashtable. The backbone consists
+ * of <i>slots</i>, where each slot has a key part and an optional value part. The key part
+ * consists of two {@code long} values and the value part is a block whose size is a multiple of 8.
+ * </p><p>
+ * The update operations on this class only ensure that a slot for a given key exists/doesn't exist
+ * and it is up to the caller to manage the contents of the value part. The caller will be provided
+ * with the raw address of the value, suitable for accessing with {@code Unsafe} memory operations.
+ * <b>The returned address is valid only up to the next map update operation</b>.
+ * </p><p>
+ * This class makes no assumptions about the key's semantics; it just uses them as the literal
+ * 16 bytes of data. However, a major use case is where the key represents a "safe pointer" to
+ * a native memory block. It consists of a pair <code>(nativeAddress, sequenceId)</code>, where
+ * <code>nativeAddress</code> is the address of a native memory block containing key data and
+ * <code>sequenceId</code> is a number unique to the particular allocation event of that memory block.
+ * This avoids the "ABA problem": the block at <code>nativeAddress</code> could be deallocated, then
+ * reallocated for another purpose. Then <code>nativeAddress</code> would represent a valid pointer
+ * pointing to invalid data. The <code>(nativeAddress, sequenceId)</code> pair is expected to be
+ * acquired from a native data structure which complies with this concept and stores the relevant
+ * key data.
+ * </p>
+ */
+public interface HashSlotArrayTwinKey extends Disposable {
+
+    /**
+     * Ensures that there is a mapping from {@code (key1, key2)} to a slot in the array.
+     * The {@code abs} of the returned integer is the address of the slot's value block.
+     * The returned integer is positive if a new slot had to be assigned and negative
+     * if the slot was already assigned.
+     *
+     * @param key1 key part 1
+     * @param key2 key part 2
+     * @return address of value block
+     */
+    long ensure(long key1, long key2);
+
+    /**
+     * Returns the address of the value block mapped by {@code (key1, key2)}.
+     *
+     * @param key1 key part 1
+     * @param key2 key part 2
+     * @return address of the value block or {@link com.hazelcast.memory.MemoryAllocator#NULL_ADDRESS}
+     * if no mapping for {@code (key1, key2)} exists.
+     */
+    long get(long key1, long key2);
+
+    /**
+     * Removes the mapping for {@code (key1, key2)}, if any.
+     *
+     * @param key1 key part 1
+     * @param key2 key part 2
+     * @return true if there was a mapping, false otherwise
+     */
+    boolean remove(long key1, long key2);
+
+    /**
+     * Clears the map.
+     */
+    void clear();
+
+    /** Compact the slot array if allowed by the current size.
+     * @return true if the array was compacted; false if no action was taken. */
+    boolean trimToSize();
+
+    /**
+     * Returns the number of keys in this hash slot array.
+     */
+    long size();
+
+    /**
+     * Returns a cursor over all assigned slots in this array.
+     */
+    HashSlotCursorTwinKey cursor();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.memory.MemoryManager;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
@@ -1,0 +1,61 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.memory.MemoryManager;
+
+import static com.hazelcast.elastic.CapacityUtil.DEFAULT_CAPACITY;
+
+/**
+ * Implementation of {@link HashSlotArrayTwinKey}.
+ * <p>
+ * This class uses the first 8 bytes of the value block for the unassigned sentinel.
+ * <strong>It is the responsibility of the caller to ensure that the unassigned sentinel
+ * is overwritten with a non-sentinel value as soon as a new slot is assigned (after calling
+ * {@link #ensure(long, long)} and getting a positive return value).</strong>
+ * For the same reason this class must not be instantiated with zero value length. Use
+ * {@link HashSlotArrayTwinKeyNoValue} as a zero-length key implementation.
+ */
+public class HashSlotArrayTwinKeyImpl extends HashSlotArrayBase implements HashSlotArrayTwinKey {
+
+    private static final int KEY_LENGTH = 16;
+
+    public HashSlotArrayTwinKeyImpl(long nullSentinel, MemoryManager mm, int valueLength, int initialCapacity) {
+        this(nullSentinel, KEY_LENGTH, mm, valueLength, initialCapacity);
+        assert valueLengthValid(valueLength) : "Invalid value length: " + valueLength;
+    }
+
+    public HashSlotArrayTwinKeyImpl(long nullSentinel, MemoryManager mm, int valueLength) {
+        this(nullSentinel, mm, valueLength, DEFAULT_CAPACITY);
+    }
+
+    protected HashSlotArrayTwinKeyImpl(long nullSentinel, long offsetOfNullSentinel, MemoryManager mm,
+                                       int valueLength, int initialCapacity
+    ) {
+        super(nullSentinel, offsetOfNullSentinel, mm, KEY_LENGTH, valueLength, initialCapacity);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Whenever this method returns a positive value, the caller must ensure that the null-sentinel value
+     * at the returned address is overwritten with a non-null-sentinel value.
+     */
+    @Override public long ensure(long key1, long key2) {
+        return super.ensure0(key1, key2);
+    }
+
+    @Override public long get(long key1, long key2) {
+        return super.get0(key1, key2);
+    }
+
+    @Override public boolean remove(long key1, long key2) {
+        return super.remove0(key1, key2);
+    }
+
+    @Override public HashSlotCursorTwinKey cursor() {
+        return new Cursor();
+    }
+
+    protected boolean valueLengthValid(int valueLength) {
+        return valueLength > 0;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
@@ -2,7 +2,7 @@ package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.memory.MemoryManager;
 
-import static com.hazelcast.elastic.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_CAPACITY;
 
 /**
  * Implementation of {@link HashSlotArrayTwinKey}.

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.spi.hashslot;
 
+import com.hazelcast.memory.MemoryAllocator;
 import com.hazelcast.memory.MemoryManager;
 
 import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_LOAD_FACTOR;
 
 /**
  * Implementation of {@link HashSlotArrayTwinKey}.
@@ -34,20 +36,24 @@ public class HashSlotArrayTwinKeyImpl extends HashSlotArrayBase implements HashS
 
     private static final int KEY_LENGTH = 16;
 
-    public HashSlotArrayTwinKeyImpl(long nullSentinel, MemoryManager mm, int valueLength, int initialCapacity) {
-        this(nullSentinel, KEY_LENGTH, mm, valueLength, initialCapacity);
+    public HashSlotArrayTwinKeyImpl(long nullSentinel, MemoryManager mm, int valueLength,
+                                    int initialCapacity, float loadFactor) {
+        this(nullSentinel, KEY_LENGTH, mm, null, valueLength, initialCapacity, loadFactor);
         assert valueLengthValid(valueLength) : "Invalid value length: " + valueLength;
     }
 
     public HashSlotArrayTwinKeyImpl(long nullSentinel, MemoryManager mm, int valueLength) {
-        this(nullSentinel, mm, valueLength, DEFAULT_CAPACITY);
+        this(nullSentinel, mm, valueLength, DEFAULT_CAPACITY, DEFAULT_LOAD_FACTOR);
     }
 
-    protected HashSlotArrayTwinKeyImpl(long nullSentinel, long offsetOfNullSentinel, MemoryManager mm,
-                                       int valueLength, int initialCapacity
+    protected HashSlotArrayTwinKeyImpl(
+            long nullSentinel, long offsetOfNullSentinel, MemoryManager mm, MemoryAllocator auxMalloc,
+            int valueLength, int initialCapacity, float loadFactor
     ) {
-        super(nullSentinel, offsetOfNullSentinel, mm, KEY_LENGTH, valueLength, initialCapacity);
+        super(nullSentinel, offsetOfNullSentinel, mm, auxMalloc, KEY_LENGTH, valueLength,
+                initialCapacity, loadFactor);
     }
+
 
     /**
      * {@inheritDoc}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.memory.MemoryManager;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValue.java
@@ -1,0 +1,47 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.memory.MemoryManager;
+
+import static com.hazelcast.elastic.CapacityUtil.DEFAULT_CAPACITY;
+
+/**
+ * Twin-key hash slot array with zero-width value. Suitable for a twin-long set implementation.
+ * Stores the null-sentinel value into the {@code key1} field, therefore the chosen null-sentinel value
+ * is not valid as the value of {@code key1}.
+ */
+public class HashSlotArrayTwinKeyNoValue extends HashSlotArrayTwinKeyImpl {
+
+    /**
+     * @param nullKey1 the null-sentinel value checked against the {@code key1} field.
+     */
+    public HashSlotArrayTwinKeyNoValue(long nullKey1, MemoryManager mm, int initialCapacity) {
+        super(nullKey1, 0L, mm, 0, initialCapacity);
+    }
+
+    /**
+     * @param nullKey1 the null-sentinel value checked against the {@code key1} field.
+     */
+    public HashSlotArrayTwinKeyNoValue(long nullKey1, MemoryManager mm) {
+        this(nullKey1, mm, DEFAULT_CAPACITY);
+    }
+
+    // Value length is always zero (not under user's control)
+    @Override protected boolean valueLengthValid(int valueLength) {
+        return true;
+    }
+
+    @Override public long ensure(long key1, long key2) {
+        assert key1 != unassignedSentinel : "ensure() called with key1 == nullKey1 (" + unassignedSentinel + ')';
+        return super.ensure0(key1, key2);
+    }
+
+    @Override public long get(long key1, long key2) {
+        assert key1 != unassignedSentinel : "get() called with key1 == nullKey1 (" + unassignedSentinel + ')';
+        return super.get0(key1, key2);
+    }
+
+    @Override public boolean remove(long key1, long key2) {
+        assert key1 != unassignedSentinel : "remove() called with key1 == nullKey1 (" + unassignedSentinel + ')';
+        return super.remove0(key1, key2);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValue.java
@@ -2,7 +2,7 @@ package com.hazelcast.spi.hashslot;
 
 import com.hazelcast.memory.MemoryManager;
 
-import static com.hazelcast.elastic.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_CAPACITY;
 
 /**
  * Twin-key hash slot array with zero-width value. Suitable for a twin-long set implementation.

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValue.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.hashslot;
 import com.hazelcast.memory.MemoryManager;
 
 import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.spi.hashslot.CapacityUtil.DEFAULT_LOAD_FACTOR;
 
 /**
  * Twin-key hash slot array with zero-width value. Suitable for a twin-long set implementation.
@@ -30,15 +31,15 @@ public class HashSlotArrayTwinKeyNoValue extends HashSlotArrayTwinKeyImpl {
     /**
      * @param nullKey1 the null-sentinel value checked against the {@code key1} field.
      */
-    public HashSlotArrayTwinKeyNoValue(long nullKey1, MemoryManager mm, int initialCapacity) {
-        super(nullKey1, 0L, mm, 0, initialCapacity);
+    public HashSlotArrayTwinKeyNoValue(long nullKey1, MemoryManager mm, int initialCapacity, float loadFactor) {
+        super(nullKey1, 0L, mm, null, 0, initialCapacity, loadFactor);
     }
 
     /**
      * @param nullKey1 the null-sentinel value checked against the {@code key1} field.
      */
     public HashSlotArrayTwinKeyNoValue(long nullKey1, MemoryManager mm) {
-        this(nullKey1, mm, DEFAULT_CAPACITY);
+        this(nullKey1, mm, DEFAULT_CAPACITY, DEFAULT_LOAD_FACTOR);
     }
 
     // Value length is always zero (not under user's control)

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursor.java
@@ -1,0 +1,26 @@
+package com.hazelcast.spi.hashslot;
+
+/**
+ * Cursor over assigned hash slots in a {@link HashSlotArray}.
+ * Initially the cursor's location is before the first slot and the cursor is invalid.
+ */
+public interface HashSlotCursor {
+    /**
+     * Advance to the next assigned slot.
+     * @return {@code true} if the cursor advanced. If {@code false} is returned, the cursor is now invalid.
+     * @throws IllegalStateException if a previous call to advance() already returned false.
+     */
+    boolean advance();
+
+    /**
+     * @return the key of the current slot.
+     * @throws IllegalStateException if the cursor is invalid.
+     */
+    long key();
+
+    /**
+     * @return Address of the current slot's value block.
+     * @throws IllegalStateException if the cursor is invalid.
+     */
+    long valueAddress();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi.hashslot;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursor.java
@@ -22,6 +22,11 @@ package com.hazelcast.spi.hashslot;
  */
 public interface HashSlotCursor {
     /**
+     * Resets the cursor to the initial state.
+     */
+    void reset();
+
+    /**
      * Advance to the next assigned slot.
      * @return {@code true} if the cursor advanced. If {@code false} is returned, the cursor is now invalid.
      * @throws IllegalStateException if a previous call to advance() already returned false.

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursorTwinKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursorTwinKey.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi.hashslot;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursorTwinKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursorTwinKey.java
@@ -1,0 +1,32 @@
+package com.hazelcast.spi.hashslot;
+
+/**
+ * Cursor over assigned slots in a {@link HashSlotArrayTwinKey}. Initially the cursor's location is
+ * before the first map entry and the cursor is invalid.
+ */
+public interface HashSlotCursorTwinKey {
+    /**
+     * Advances to the next assigned slot.
+     * @return true if the cursor advanced. If false is returned, the cursor is now invalid.
+     * @throws IllegalStateException if a previous call to advance() already returned false.
+     */
+    boolean advance();
+
+    /**
+     * @return key part 1 of current slot.
+     * @throws IllegalStateException if the cursor is invalid.
+     */
+    long key1();
+
+    /**
+     * @return key part 2 of current slot.
+     * @throws IllegalStateException if the cursor is invalid.
+     */
+    long key2();
+
+    /**
+     * @return Address of the current slot's value block.
+     * @throws IllegalStateException if the cursor is invalid.
+     */
+    long valueAddress();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursorTwinKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotCursorTwinKey.java
@@ -22,6 +22,11 @@ package com.hazelcast.spi.hashslot;
  */
 public interface HashSlotCursorTwinKey {
     /**
+     * Resets the cursor to the initial state.
+     */
+    void reset();
+
+    /**
      * Advances to the next assigned slot.
      * @return true if the cursor advanced. If false is returned, the cursor is now invalid.
      * @throws IllegalStateException if a previous call to advance() already returned false.

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Off-heap hash slot arrays.
+ */
+package com.hazelcast.spi.hashslot;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/package-info.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Off-heap hash slot arrays.
  */

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
@@ -52,7 +52,7 @@ public class CacheSerializationTest extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
-        service.destroy();
+        service.dispose();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -111,7 +111,7 @@ public class AbstractSerializationServiceTest {
 
         abstractSerializationService.register(StringBuffer.class, new StringBufferSerializer(false));
         Data data = abstractSerializationService.toData(new StringBuffer());
-        abstractSerializationService.destroy();
+        abstractSerializationService.dispose();
         abstractSerializationService.toObject(data);
     }
 
@@ -129,7 +129,7 @@ public class AbstractSerializationServiceTest {
 
         abstractSerializationService.register(StringBuffer.class, new StringBufferSerializer(false));
         Data data = abstractSerializationService.toData(new StringBuffer());
-        abstractSerializationService.destroy();
+        abstractSerializationService.dispose();
 
         BufferObjectDataInput in = abstractSerializationService.createObjectDataInput(data);
         in.position(HeapData.TYPE_OFFSET);
@@ -179,7 +179,7 @@ public class AbstractSerializationServiceTest {
 
     @Test(expected = HazelcastInstanceNotActiveException.class)
     public void testSerializerFor_ServiceInactive() throws Exception {
-        abstractSerializationService.destroy();
+        abstractSerializationService.dispose();
         abstractSerializationService.serializerFor(new CustomSerializationTest.Foo());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/MorphingPortableReaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/MorphingPortableReaderTest.java
@@ -61,8 +61,8 @@ public class MorphingPortableReaderTest {
 
     @After
     public void after() throws Exception {
-        service1.destroy();
-        service2.destroy();
+        service1.dispose();
+        service2.dispose();
     }
 
     @Test
@@ -311,4 +311,4 @@ public class MorphingPortableReaderTest {
         reader.readByteArray("byte");
     }
 
-} 
+}

--- a/hazelcast/src/test/java/com/hazelcast/memory/HeapMemoryManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/memory/HeapMemoryManager.java
@@ -28,13 +28,13 @@ import static com.hazelcast.internal.memory.impl.EndiannessUtil.BYTE_ARRAY_ACCES
  */
 public class HeapMemoryManager implements MemoryManager {
 
+    private static final int HEAP_BOTTOM = 8;
+
     private final Allocator malloc = new Allocator();
 
     private final Accessor mem = new Accessor();
 
-    private final byte[] storage;
-
-    private static final int HEAP_BOTTOM = 8;
+    private byte[] storage;
 
     private int heapTop = HEAP_BOTTOM;
 
@@ -54,6 +54,7 @@ public class HeapMemoryManager implements MemoryManager {
 
     @Override
     public void dispose() {
+        storage = null;
     }
 
     class Allocator implements MemoryAllocator {
@@ -80,6 +81,7 @@ public class HeapMemoryManager implements MemoryManager {
 
         @Override
         public void dispose() {
+            storage = null;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationWithSafeV1CompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationWithSafeV1CompatibilityTest.java
@@ -42,7 +42,7 @@ public class SerializationWithSafeV1CompatibilityTest extends AbstractSerializat
 
     @After
     public void tearDown() {
-        serializationService.destroy();
+        serializationService.dispose();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationWithUnSafeV1CompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationWithUnSafeV1CompatibilityTest.java
@@ -42,7 +42,7 @@ public class SerializationWithUnSafeV1CompatibilityTest extends AbstractSerializ
 
     @After
     public void tearDown() {
-        serializationService.destroy();
+        serializationService.dispose();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
@@ -74,7 +74,7 @@ public class StringSerializationTest {
 
     @After
     public void tearDown() {
-        serializationService.destroy();
+        serializationService.dispose();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
@@ -59,7 +59,7 @@ public class QueryEntryTest extends HazelcastTestSupport {
 
     @After
     public void after() {
-        serializationService.destroy();
+        serializationService.dispose();
     }
 
     // ========================== getAttribute ===========================================

--- a/hazelcast/src/test/java/com/hazelcast/spi/hashslot/CapacityUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/hashslot/CapacityUtilTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.spi.hashslot.CapacityUtil;
+import com.hazelcast.test.AssertEnabledFilterRule;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.hashslot.CapacityUtil.nextCapacity;
+import static com.hazelcast.spi.hashslot.CapacityUtil.roundCapacity;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CapacityUtilTest extends HazelcastTestSupport {
+
+    @Rule
+    public final TestRule assertEnabledRule = new AssertEnabledFilterRule();
+
+    @Test
+    public void testConstructor() throws Exception {
+        assertUtilityConstructor(CapacityUtil.class);
+    }
+
+    @Test
+    public void testRoundCapacity() {
+        int capacity = 2342;
+
+        int roundedCapacity = roundCapacity(capacity);
+
+        assertEquals(4096, roundedCapacity);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRoundCapacity_shouldThrowIfMaximumCapacityIsExceeded() {
+        roundCapacity(CapacityUtil.MAX_INT_CAPACITY + 1);
+    }
+
+    @Test
+    public void testNextCapacity_withInt() {
+        int capacity = 16;
+
+        int nextCapacity = nextCapacity(capacity);
+
+        assertEquals(32, nextCapacity);
+    }
+
+    @Test
+    public void testNextCapacity_withInt_shouldIncreaseToHalfOfMinCapacity() {
+        int capacity = 1;
+
+        int nextCapacity = nextCapacity(capacity);
+
+        assertEquals(4, nextCapacity);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testNextCapacity_withInt_shouldThrowIfMaxCapacityReached() {
+        int capacity = Integer.highestOneBit(Integer.MAX_VALUE - 1);
+
+        nextCapacity(capacity);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testNextCapacity_withInt_shouldThrowIfCapacityNoPowerOfTwo() {
+        int capacity = 23;
+
+        nextCapacity(capacity);
+    }
+
+    @Test
+    public void testNextCapacity_withLong() {
+        long capacity = 16;
+
+        long nextCapacity = nextCapacity(capacity);
+
+        assertEquals(32, nextCapacity);
+    }
+
+    @Test
+    public void testNextCapacity_withLong_shouldIncreaseToHalfOfMinCapacity() {
+        long capacity = 1;
+
+        long nextCapacity = nextCapacity(capacity);
+
+        assertEquals(4, nextCapacity);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testNextCapacity_withLong_shouldThrowIfMaxCapacityReached() {
+        long capacity = Long.highestOneBit(Long.MAX_VALUE - 1);
+
+        nextCapacity(capacity);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testNextCapacity_withLong_shouldThrowIfCapacityNoPowerOfTwo() {
+        long capacity = 23;
+
+        nextCapacity(capacity);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/hashslot/CapacityUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/hashslot/CapacityUtilTest.java
@@ -37,9 +37,6 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelTest.class})
 public class CapacityUtilTest extends HazelcastTestSupport {
 
-    @Rule
-    public final TestRule assertEnabledRule = new AssertEnabledFilterRule();
-
     @Test
     public void testConstructor() throws Exception {
         assertUtilityConstructor(CapacityUtil.class);

--- a/hazelcast/src/test/java/com/hazelcast/spi/hashslot/HashSlotArrayImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/hashslot/HashSlotArrayImplTest.java
@@ -1,0 +1,286 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.memory.HeapMemoryManager;
+import com.hazelcast.memory.MemoryManager;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static com.hazelcast.memory.MemoryAllocator.NULL_ADDRESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HashSlotArrayImplTest {
+
+    private static final int VALUE_LENGTH = 32;
+
+    private final Random random = new Random();
+    private MemoryManager memMgr;
+    private MemoryAccessor mem;
+    private HashSlotArray hsa;
+
+    @Before
+    public void setUp() throws Exception {
+        memMgr = new HeapMemoryManager(32 << 20);
+        mem = memMgr.getAccessor();
+        hsa = new HashSlotArrayImpl(0L, memMgr, VALUE_LENGTH);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        hsa.dispose();
+        memMgr.dispose();
+    }
+
+    @Test
+    public void testPut() throws Exception {
+        final long key = random.nextLong();
+        final long valueAddress = insert(key);
+
+        final long valueAddress2 = hsa.ensure(key);
+        assertEquals(-valueAddress, valueAddress2);
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        final long key = random.nextLong();
+        final long valueAddress = insert(key);
+
+        final long valueAddress2 = hsa.get(key);
+        assertEquals(valueAddress, valueAddress2);
+    }
+
+    @Test
+    public void testRemove() throws Exception {
+        final long key = random.nextLong();
+        insert(key);
+
+        assertTrue(hsa.remove(key));
+        assertFalse(hsa.remove(key));
+    }
+
+    @Test
+    public void testSize() throws Exception {
+        final long key = random.nextLong();
+
+        insert(key);
+        assertEquals(1, hsa.size());
+
+        assertTrue(hsa.remove(key));
+        assertEquals(0, hsa.size());
+    }
+
+    @Test
+    public void testClear() throws Exception {
+        final long key = random.nextLong();
+
+        insert(key);
+        hsa.clear();
+
+        assertEquals(NULL_ADDRESS, hsa.get(key));
+        assertEquals(0, hsa.size());
+    }
+
+    @Test
+    public void testPutGetMany() {
+        final int k = 1000;
+
+        for (int i = 1; i <= k; i++) {
+            long key = (long) i;
+            insert(key);
+        }
+
+        for (int i = 1; i <= k; i++) {
+            long key = (long) i;
+            long valueAddress = hsa.get(key);
+
+            assertEquals(key, mem.getLong(valueAddress));
+        }
+    }
+
+    @Test
+    public void testPutRemoveGetMany() {
+        final int k = 5000;
+        final int mod = 100;
+
+        for (int i = 1; i <= k; i++) {
+            long key = (long) i;
+            insert(key);
+        }
+
+        for (int i = mod; i <= k ; i += mod) {
+            long key = (long) i;
+            assertTrue(hsa.remove(key));
+        }
+
+        for (int i = 1; i <= k; i++) {
+            long key = (long) i;
+            long valueAddress = hsa.get(key);
+
+            if (i % mod == 0) {
+                assertEquals(NULL_ADDRESS, valueAddress);
+            } else {
+                verifyValue(key, valueAddress);
+            }
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testPut_whenDisposed() throws Exception {
+        hsa.dispose();
+        hsa.ensure(1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGet_whenDisposed() throws Exception {
+        hsa.dispose();
+        hsa.get(1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRemove_whenDisposed() throws Exception {
+        hsa.dispose();
+        hsa.remove(1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testClear_whenDisposed() throws Exception {
+        hsa.dispose();
+        hsa.clear();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key_withoutAdvance() {
+        HashSlotCursor cursor = hsa.cursor();
+        cursor.key();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_valueAddress_withoutAdvance() {
+        HashSlotCursor cursor = hsa.cursor();
+        cursor.valueAddress();
+    }
+
+    @Test
+    public void testCursor_advance_whenEmpty() {
+        HashSlotCursor cursor = hsa.cursor();
+        assertFalse(cursor.advance());
+    }
+
+    @Test
+    public void testCursor_advance() {
+        insert(random.nextLong());
+
+        HashSlotCursor cursor = hsa.cursor();
+        assertTrue(cursor.advance());
+        assertFalse(cursor.advance());
+    }
+
+    @Test
+    public void testCursor_advance_afterAdvanceReturnsFalse() {
+        insert(random.nextLong());
+
+        HashSlotCursor cursor = hsa.cursor();
+        cursor.advance();
+        cursor.advance();
+
+        try {
+            cursor.advance();
+            fail("cursor.advance() should throw IllegalStateException, because previous advance() returned false!");
+        } catch (IllegalStateException ignored) {
+        }
+    }
+
+    @Test
+    public void testCursor_key() {
+        final long key = random.nextLong();
+        insert(key);
+
+        HashSlotCursor cursor = hsa.cursor();
+        cursor.advance();
+        assertEquals(key, cursor.key());
+    }
+
+    @Test
+    public void testCursor_valueAddress() {
+        final long valueAddress = insert(random.nextLong());
+
+        HashSlotCursor cursor = hsa.cursor();
+        cursor.advance();
+        assertEquals(valueAddress, cursor.valueAddress());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_advance_whenDisposed() {
+        HashSlotCursor cursor = hsa.cursor();
+        hsa.dispose();
+        cursor.advance();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key_whenDisposed() {
+        HashSlotCursor cursor = hsa.cursor();
+        hsa.dispose();
+        cursor.key();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_valueAddress_whenDisposed() {
+        HashSlotCursor cursor = hsa.cursor();
+        hsa.dispose();
+        cursor.valueAddress();
+    }
+
+    @Test
+    public void testCursor_withManyValues() {
+        final int k = 1000;
+
+        for (int i = 1; i <= k; i++) {
+            long key = (long) i;
+            insert(key);
+        }
+
+        boolean[] verifyKeys = new boolean[k];
+        Arrays.fill(verifyKeys, false);
+
+        HashSlotCursor cursor = hsa.cursor();
+        while (cursor.advance()) {
+            long key = cursor.key();
+            long valueAddress = cursor.valueAddress();
+
+            verifyValue(key, valueAddress);
+
+            verifyKeys[((int) key) - 1] = true;
+        }
+
+        for (int i = 0; i < k; i++) {
+            assertTrue("Haven't read " + k + "th key!", verifyKeys[i]);
+        }
+    }
+
+    private long insert(long key) {
+        final long valueAddress = hsa.ensure(key);
+        assertTrue(valueAddress > 0);
+        mem.putLong(valueAddress, key);
+        return valueAddress;
+    }
+
+    private void verifyValue(long key, long valueAddress) {
+        // pre-check to avoid SIGSEGV
+        assertNotEquals(NULL_ADDRESS, valueAddress);
+        assertEquals(key, mem.getLong(valueAddress));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImplTest.java
@@ -1,0 +1,335 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.memory.HeapMemoryManager;
+import com.hazelcast.memory.MemoryManager;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static com.hazelcast.memory.MemoryAllocator.NULL_ADDRESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HashSlotArrayTwinKeyImplTest {
+
+    // Value length must be at least 16 bytes, as required by the test's logic
+    private static final int VALUE_LENGTH = 32;
+
+    private final Random random = new Random();
+    private MemoryManager memMgr;
+    private MemoryAccessor mem;
+    private HashSlotArrayTwinKey hsa;
+
+    @Before
+    public void setUp() throws Exception {
+        memMgr = new HeapMemoryManager(32 << 20);
+        mem = memMgr.getAccessor();
+        hsa = new HashSlotArrayTwinKeyImpl(0L, memMgr, VALUE_LENGTH);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        hsa.dispose();
+        memMgr.dispose();
+    }
+
+    @Test
+    public void testPut() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        final long valueAddress = insert(key1, key2);
+
+        assertEquals(-valueAddress, hsa.ensure(key1, key2));
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        final long valueAddress = insert(key1, key2);
+
+        final long valueAddress2 = hsa.get(key1, key2);
+        assertEquals(valueAddress, valueAddress2);
+    }
+
+    @Test
+    public void testRemove() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        insert(key1, key2);
+
+        assertTrue(hsa.remove(key1, key2));
+        assertFalse(hsa.remove(key1, key2));
+    }
+
+    @Test
+    public void testSize() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+
+        insert(key1, key2);
+        assertEquals(1, hsa.size());
+
+        assertTrue(hsa.remove(key1, key2));
+        assertEquals(0, hsa.size());
+    }
+
+    @Test
+    public void testClear() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+
+        insert(key1, key2);
+        hsa.clear();
+
+        assertEquals(NULL_ADDRESS, hsa.get(key1, key2));
+        assertEquals(0, hsa.size());
+    }
+
+    @Test
+    public void testPutGetMany() {
+        final long factor = 123456;
+        final int k = 1000;
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            insert(key1, key2);
+        }
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            long valueAddress = hsa.get(key1, key2);
+
+            assertEquals(key1, mem.getLong(valueAddress));
+            assertEquals(key2, mem.getLong(valueAddress + 8L));
+        }
+    }
+
+    @Test
+    public void testPutRemoveGetMany() {
+        final long factor = 123456;
+        final int k = 5000;
+        final int mod = 100;
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            insert(key1, key2);
+        }
+
+        for (int i = mod; i <= k ; i += mod) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            assertTrue(hsa.remove(key1, key2));
+        }
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            long valueAddress = hsa.get(key1, key2);
+
+            if (i % mod == 0) {
+                assertEquals(NULL_ADDRESS, valueAddress);
+            } else {
+                verifyValue(key1, key2, valueAddress);
+            }
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testPut_whenDisposed() throws Exception {
+        hsa.dispose();
+        hsa.ensure(1, 1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGet_whenDisposed() throws Exception {
+        hsa.dispose();
+        hsa.get(1, 1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRemove_whenDisposed() throws Exception {
+        hsa.dispose();
+        hsa.remove(1, 1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testClear_whenDisposed() throws Exception {
+        hsa.dispose();
+        hsa.clear();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key1_withoutAdvance() {
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        cursor.key1();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key2_withoutAdvance() {
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        cursor.key2();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_valueAddress_withoutAdvance() {
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        cursor.valueAddress();
+    }
+
+    @Test
+    public void testCursor_advance_whenEmpty() {
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        assertFalse(cursor.advance());
+    }
+
+    @Test
+    public void testCursor_advance() {
+        insert(randomKey(), randomKey());
+
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        assertTrue(cursor.advance());
+        assertFalse(cursor.advance());
+    }
+
+    @Test
+    public void testCursor_advance_afterAdvanceReturnsFalse() {
+        insert(randomKey(), randomKey());
+
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        cursor.advance();
+        cursor.advance();
+
+        try {
+            cursor.advance();
+            fail("cursor.advance() should throw IllegalStateException, because previous advance() returned false!");
+        } catch (IllegalStateException ignored) {
+        }
+    }
+
+    @Test
+    public void testCursor_key1() {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        insert(key1, key2);
+
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        cursor.advance();
+        assertEquals(key1, cursor.key1());
+    }
+
+    @Test
+    public void testCursor_key2() {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        insert(key1, key2);
+
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        cursor.advance();
+        assertEquals(key2, cursor.key2());
+    }
+
+    @Test
+    public void testCursor_valueAddress() {
+        final long valueAddress = insert(randomKey(), randomKey());
+
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        cursor.advance();
+        assertEquals(valueAddress, cursor.valueAddress());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_advance_whenDisposed() {
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        hsa.dispose();
+        cursor.advance();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key1_whenDisposed() {
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        hsa.dispose();
+        cursor.key1();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key2_whenDisposed() {
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        hsa.dispose();
+        cursor.key2();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_valueAddress_whenDisposed() {
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        hsa.dispose();
+        cursor.valueAddress();
+    }
+
+    @Test
+    public void testCursor_withManyValues() {
+        final long factor = 123456;
+        final int k = 1000;
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            long valueAddress = insert(key1, key2);
+        }
+
+        boolean[] verifyKeys = new boolean[k];
+        Arrays.fill(verifyKeys, false);
+
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        while (cursor.advance()) {
+            long key1 = cursor.key1();
+            long key2 = cursor.key2();
+            long valueAddress = cursor.valueAddress();
+
+            assertEquals(key1 * factor, key2);
+            verifyValue(key1, key2, valueAddress);
+
+            verifyKeys[((int) key1) - 1] = true;
+        }
+
+        for (int i = 0; i < k; i++) {
+            assertTrue("Haven't read " + k + "th key!", verifyKeys[i]);
+        }
+    }
+
+    private long randomKey() {
+        return random.nextInt(Integer.MAX_VALUE) + 1;
+    }
+
+    private long insert(long key1, long key2) {
+        final long valueAddress = hsa.ensure(key1, key2);
+        assertTrue(valueAddress > 0);
+        // Value length must be at least 16 bytes
+        mem.putLong(valueAddress, key1);
+        mem.putLong(valueAddress + 8L, key2);
+        return valueAddress;
+    }
+
+    private void verifyValue(long key1, long key2, long valueAddress) {
+        // pre-check to avoid SIGSEGV
+        assertNotEquals(NULL_ADDRESS, valueAddress);
+        assertEquals(key1, mem.getLong(valueAddress));
+        assertEquals(key2, mem.getLong(valueAddress + 8L));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValueTest.java
@@ -1,0 +1,312 @@
+package com.hazelcast.spi.hashslot;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.memory.HeapMemoryManager;
+import com.hazelcast.memory.MemoryManager;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static com.hazelcast.memory.MemoryAllocator.NULL_ADDRESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HashSlotArrayTwinKeyNoValueTest {
+
+    private final Random random = new Random();
+    private MemoryManager memMgr;
+    private MemoryAccessor mem;
+    private HashSlotArrayTwinKey map;
+
+    @Before
+    public void setUp() throws Exception {
+        memMgr = new HeapMemoryManager(32 << 20);
+        mem = memMgr.getAccessor();
+        map = new HashSlotArrayTwinKeyNoValue(0L, memMgr);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        map.dispose();
+        memMgr.dispose();
+    }
+
+    @Test
+    public void testPut() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        final long valueAddress = map.ensure(key1, key2);
+        assertNotEquals(NULL_ADDRESS, valueAddress);
+
+        final long valueAddress2 = map.ensure(key1, key2);
+        assertEquals(valueAddress, -valueAddress2);
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        final long valueAddress = map.ensure(key1, key2);
+
+        final long valueAddress2 = map.get(key1, key2);
+        assertEquals(valueAddress, valueAddress2);
+    }
+
+    @Test
+    public void testRemove() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        map.ensure(key1, key2);
+
+        assertTrue(map.remove(key1, key2));
+        assertFalse(map.remove(key1, key2));
+    }
+
+    @Test
+    public void testSize() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+
+        map.ensure(key1, key2);
+        assertEquals(1, map.size());
+
+        assertTrue(map.remove(key1, key2));
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    public void testClear() throws Exception {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+
+        map.ensure(key1, key2);
+        map.clear();
+
+        assertEquals(NULL_ADDRESS, map.get(key1, key2));
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    public void testPutGetMany() {
+        final long factor = 123456;
+        final int k = 1000;
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            assertTrue(map.ensure(key1, key2) > 0);
+        }
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            assertNotEquals(NULL_ADDRESS, map.get(key1, key2));
+        }
+    }
+
+    @Test
+    public void testPutRemoveGetMany() {
+        final long factor = 123456;
+        final int k = 5000;
+        final int mod = 100;
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            assertTrue(map.ensure(key1, key2) > 0);
+        }
+
+        for (int i = mod; i <= k ; i += mod) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            assertTrue(map.remove(key1, key2));
+        }
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            long valueAddress = map.get(key1, key2);
+
+            if (i % mod == 0) {
+                assertEquals(NULL_ADDRESS, valueAddress);
+            } else {
+                assertNotEquals(NULL_ADDRESS, valueAddress);
+            }
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testPut_whenDisposed() throws Exception {
+        map.dispose();
+        map.ensure(1, 1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGet_whenDisposed() throws Exception {
+        map.dispose();
+        map.get(1, 1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testRemove_whenDisposed() throws Exception {
+        map.dispose();
+        map.remove(1, 1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testClear_whenDisposed() throws Exception {
+        map.dispose();
+        map.clear();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key1_withoutAdvance() {
+        HashSlotCursorTwinKey cursor = map.cursor();
+        cursor.key1();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key2_withoutAdvance() {
+        HashSlotCursorTwinKey cursor = map.cursor();
+        cursor.key2();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_valueAddress_withoutAdvance() {
+        HashSlotCursorTwinKey cursor = map.cursor();
+        cursor.valueAddress();
+    }
+
+    @Test
+    public void testCursor_advance_whenEmpty() {
+        HashSlotCursorTwinKey cursor = map.cursor();
+        assertFalse(cursor.advance());
+    }
+
+    @Test
+    public void testCursor_advance() {
+        map.ensure(randomKey(), randomKey());
+
+        HashSlotCursorTwinKey cursor = map.cursor();
+        assertTrue(cursor.advance());
+        assertFalse(cursor.advance());
+    }
+
+    @Test
+    public void testCursor_advance_afterAdvanceReturnsFalse() {
+        map.ensure(randomKey(), randomKey());
+
+        HashSlotCursorTwinKey cursor = map.cursor();
+        cursor.advance();
+        cursor.advance();
+
+        try {
+            cursor.advance();
+            fail("cursor.advance() should throw IllegalStateException, because previous advance() returned false!");
+        } catch (IllegalStateException ignored) {
+        }
+    }
+
+    @Test
+    public void testCursor_key1() {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        map.ensure(key1, key2);
+
+        HashSlotCursorTwinKey cursor = map.cursor();
+        cursor.advance();
+        assertEquals(key1, cursor.key1());
+    }
+
+    @Test
+    public void testCursor_key2() {
+        final long key1 = randomKey();
+        final long key2 = randomKey();
+        map.ensure(key1, key2);
+
+        HashSlotCursorTwinKey cursor = map.cursor();
+        cursor.advance();
+        assertEquals(key2, cursor.key2());
+    }
+
+    @Test
+    public void testCursor_valueAddress() {
+        final long valueAddress = map.ensure(randomKey(), randomKey());
+
+        HashSlotCursorTwinKey cursor = map.cursor();
+        cursor.advance();
+        assertEquals(valueAddress, cursor.valueAddress());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_advance_whenDisposed() {
+        HashSlotCursorTwinKey cursor = map.cursor();
+        map.dispose();
+        cursor.advance();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key1_whenDisposed() {
+        HashSlotCursorTwinKey cursor = map.cursor();
+        map.dispose();
+        cursor.key1();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_key2_whenDisposed() {
+        HashSlotCursorTwinKey cursor = map.cursor();
+        map.dispose();
+        cursor.key2();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCursor_valueAddress_whenDisposed() {
+        HashSlotCursorTwinKey cursor = map.cursor();
+        map.dispose();
+        cursor.valueAddress();
+    }
+
+    @Test
+    public void testCursor_withManyValues() {
+        final long factor = 123456;
+        final int k = 1000;
+
+        for (int i = 1; i <= k; i++) {
+            long key1 = (long) i;
+            long key2 = key1 * factor;
+            map.ensure(key1, key2);
+        }
+
+        boolean[] verifyKeys = new boolean[k];
+        Arrays.fill(verifyKeys, false);
+
+        HashSlotCursorTwinKey cursor = map.cursor();
+        while (cursor.advance()) {
+            long key1 = cursor.key1();
+            long key2 = cursor.key2();
+
+            assertEquals(key1 * factor, key2);
+            verifyKeys[((int) key1) - 1] = true;
+        }
+
+        for (int i = 0; i < k; i++) {
+            assertTrue("Haven't read " + k + "th key!", verifyKeys[i]);
+        }
+    }
+
+    private long randomKey() {
+        return random.nextInt(Integer.MAX_VALUE) + 1;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyNoValueTest.java
@@ -1,9 +1,9 @@
 package com.hazelcast.spi.hashslot;
 
-import com.hazelcast.internal.memory.MemoryAccessor;
 import com.hazelcast.memory.HeapMemoryManager;
 import com.hazelcast.memory.MemoryManager;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -27,19 +27,18 @@ public class HashSlotArrayTwinKeyNoValueTest {
 
     private final Random random = new Random();
     private MemoryManager memMgr;
-    private MemoryAccessor mem;
-    private HashSlotArrayTwinKey map;
+    private HashSlotArrayTwinKey hsa;
 
     @Before
     public void setUp() throws Exception {
         memMgr = new HeapMemoryManager(32 << 20);
-        mem = memMgr.getAccessor();
-        map = new HashSlotArrayTwinKeyNoValue(0L, memMgr);
+        hsa = new HashSlotArrayTwinKeyNoValue(0L, memMgr);
+        hsa.gotoNew();
     }
 
     @After
     public void tearDown() throws Exception {
-        map.dispose();
+        hsa.dispose();
         memMgr.dispose();
     }
 
@@ -47,10 +46,10 @@ public class HashSlotArrayTwinKeyNoValueTest {
     public void testPut() throws Exception {
         final long key1 = randomKey();
         final long key2 = randomKey();
-        final long valueAddress = map.ensure(key1, key2);
+        final long valueAddress = hsa.ensure(key1, key2);
         assertNotEquals(NULL_ADDRESS, valueAddress);
 
-        final long valueAddress2 = map.ensure(key1, key2);
+        final long valueAddress2 = hsa.ensure(key1, key2);
         assertEquals(valueAddress, -valueAddress2);
     }
 
@@ -58,9 +57,9 @@ public class HashSlotArrayTwinKeyNoValueTest {
     public void testGet() throws Exception {
         final long key1 = randomKey();
         final long key2 = randomKey();
-        final long valueAddress = map.ensure(key1, key2);
+        final long valueAddress = hsa.ensure(key1, key2);
 
-        final long valueAddress2 = map.get(key1, key2);
+        final long valueAddress2 = hsa.get(key1, key2);
         assertEquals(valueAddress, valueAddress2);
     }
 
@@ -68,10 +67,10 @@ public class HashSlotArrayTwinKeyNoValueTest {
     public void testRemove() throws Exception {
         final long key1 = randomKey();
         final long key2 = randomKey();
-        map.ensure(key1, key2);
+        hsa.ensure(key1, key2);
 
-        assertTrue(map.remove(key1, key2));
-        assertFalse(map.remove(key1, key2));
+        assertTrue(hsa.remove(key1, key2));
+        assertFalse(hsa.remove(key1, key2));
     }
 
     @Test
@@ -79,11 +78,11 @@ public class HashSlotArrayTwinKeyNoValueTest {
         final long key1 = randomKey();
         final long key2 = randomKey();
 
-        map.ensure(key1, key2);
-        assertEquals(1, map.size());
+        hsa.ensure(key1, key2);
+        assertEquals(1, hsa.size());
 
-        assertTrue(map.remove(key1, key2));
-        assertEquals(0, map.size());
+        assertTrue(hsa.remove(key1, key2));
+        assertEquals(0, hsa.size());
     }
 
     @Test
@@ -91,11 +90,11 @@ public class HashSlotArrayTwinKeyNoValueTest {
         final long key1 = randomKey();
         final long key2 = randomKey();
 
-        map.ensure(key1, key2);
-        map.clear();
+        hsa.ensure(key1, key2);
+        hsa.clear();
 
-        assertEquals(NULL_ADDRESS, map.get(key1, key2));
-        assertEquals(0, map.size());
+        assertEquals(NULL_ADDRESS, hsa.get(key1, key2));
+        assertEquals(0, hsa.size());
     }
 
     @Test
@@ -106,13 +105,13 @@ public class HashSlotArrayTwinKeyNoValueTest {
         for (int i = 1; i <= k; i++) {
             long key1 = (long) i;
             long key2 = key1 * factor;
-            assertTrue(map.ensure(key1, key2) > 0);
+            assertTrue(hsa.ensure(key1, key2) > 0);
         }
 
         for (int i = 1; i <= k; i++) {
             long key1 = (long) i;
             long key2 = key1 * factor;
-            assertNotEquals(NULL_ADDRESS, map.get(key1, key2));
+            assertNotEquals(NULL_ADDRESS, hsa.get(key1, key2));
         }
     }
 
@@ -125,19 +124,19 @@ public class HashSlotArrayTwinKeyNoValueTest {
         for (int i = 1; i <= k; i++) {
             long key1 = (long) i;
             long key2 = key1 * factor;
-            assertTrue(map.ensure(key1, key2) > 0);
+            assertTrue(hsa.ensure(key1, key2) > 0);
         }
 
         for (int i = mod; i <= k ; i += mod) {
             long key1 = (long) i;
             long key2 = key1 * factor;
-            assertTrue(map.remove(key1, key2));
+            assertTrue(hsa.remove(key1, key2));
         }
 
         for (int i = 1; i <= k; i++) {
             long key1 = (long) i;
             long key2 = key1 * factor;
-            long valueAddress = map.get(key1, key2);
+            long valueAddress = hsa.get(key1, key2);
 
             if (i % mod == 0) {
                 assertEquals(NULL_ADDRESS, valueAddress);
@@ -147,75 +146,82 @@ public class HashSlotArrayTwinKeyNoValueTest {
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testPut_whenDisposed() throws Exception {
-        map.dispose();
-        map.ensure(1, 1);
+        hsa.dispose();
+        hsa.ensure(1, 1);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testGet_whenDisposed() throws Exception {
-        map.dispose();
-        map.get(1, 1);
+        hsa.dispose();
+        hsa.get(1, 1);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testRemove_whenDisposed() throws Exception {
-        map.dispose();
-        map.remove(1, 1);
+        hsa.dispose();
+        hsa.remove(1, 1);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testClear_whenDisposed() throws Exception {
-        map.dispose();
-        map.clear();
+        hsa.dispose();
+        hsa.clear();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testCursor_key1_withoutAdvance() {
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         cursor.key1();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testCursor_key2_withoutAdvance() {
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         cursor.key2();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testCursor_valueAddress_withoutAdvance() {
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         cursor.valueAddress();
     }
 
     @Test
     public void testCursor_advance_whenEmpty() {
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         assertFalse(cursor.advance());
     }
 
     @Test
     public void testCursor_advance() {
-        map.ensure(randomKey(), randomKey());
+        hsa.ensure(randomKey(), randomKey());
 
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         assertTrue(cursor.advance());
         assertFalse(cursor.advance());
     }
 
     @Test
     public void testCursor_advance_afterAdvanceReturnsFalse() {
-        map.ensure(randomKey(), randomKey());
+        hsa.ensure(randomKey(), randomKey());
 
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         cursor.advance();
         cursor.advance();
 
         try {
             cursor.advance();
-            fail("cursor.advance() should throw IllegalStateException, because previous advance() returned false!");
-        } catch (IllegalStateException ignored) {
+            fail("cursor.advance() returned false, but subsequent call did not throw AssertionError");
+        } catch (AssertionError ignored) {
         }
     }
 
@@ -223,9 +229,9 @@ public class HashSlotArrayTwinKeyNoValueTest {
     public void testCursor_key1() {
         final long key1 = randomKey();
         final long key2 = randomKey();
-        map.ensure(key1, key2);
+        hsa.ensure(key1, key2);
 
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         cursor.advance();
         assertEquals(key1, cursor.key1());
     }
@@ -234,47 +240,51 @@ public class HashSlotArrayTwinKeyNoValueTest {
     public void testCursor_key2() {
         final long key1 = randomKey();
         final long key2 = randomKey();
-        map.ensure(key1, key2);
+        hsa.ensure(key1, key2);
 
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         cursor.advance();
         assertEquals(key2, cursor.key2());
     }
 
     @Test
     public void testCursor_valueAddress() {
-        final long valueAddress = map.ensure(randomKey(), randomKey());
+        final long valueAddress = hsa.ensure(randomKey(), randomKey());
 
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         cursor.advance();
         assertEquals(valueAddress, cursor.valueAddress());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testCursor_advance_whenDisposed() {
-        HashSlotCursorTwinKey cursor = map.cursor();
-        map.dispose();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        hsa.dispose();
         cursor.advance();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testCursor_key1_whenDisposed() {
-        HashSlotCursorTwinKey cursor = map.cursor();
-        map.dispose();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        hsa.dispose();
         cursor.key1();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testCursor_key2_whenDisposed() {
-        HashSlotCursorTwinKey cursor = map.cursor();
-        map.dispose();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        hsa.dispose();
         cursor.key2();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
     public void testCursor_valueAddress_whenDisposed() {
-        HashSlotCursorTwinKey cursor = map.cursor();
-        map.dispose();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
+        hsa.dispose();
         cursor.valueAddress();
     }
 
@@ -286,13 +296,13 @@ public class HashSlotArrayTwinKeyNoValueTest {
         for (int i = 1; i <= k; i++) {
             long key1 = (long) i;
             long key2 = key1 * factor;
-            map.ensure(key1, key2);
+            hsa.ensure(key1, key2);
         }
 
         boolean[] verifyKeys = new boolean[k];
         Arrays.fill(verifyKeys, false);
 
-        HashSlotCursorTwinKey cursor = map.cursor();
+        HashSlotCursorTwinKey cursor = hsa.cursor();
         while (cursor.advance()) {
             long key1 = cursor.key1();
             long key2 = cursor.key2();


### PR DESCRIPTION
Motivated by a use case in Jet, HashSlotArray API is moved to OSS side. It is also decoupled from native memory access via the MemoryAccessor abstraction.

This PR also contains a minor change in SerializationService API: `destroy` was renamed to `dispose` and retrofitted to the `Disposable` interface.