### PR TITLE
Node info is logged before `NodeExtension:beforeStart` 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -174,6 +174,7 @@ public class Node {
             hazelcastThreadGroup = new HazelcastThreadGroup(hazelcastInstance.getName(), logger, configClassLoader);
 
             this.nodeExtension = createNodeExtension(nodeContext);
+            nodeExtension.printNodeInfo();
             nodeExtension.beforeStart();
 
             serializationService = nodeExtension.createSerializationService();
@@ -186,7 +187,6 @@ public class Node {
             partitionService = new InternalPartitionServiceImpl(this);
             clusterService = new ClusterServiceImpl(this);
             textCommandService = new TextCommandServiceImpl(this);
-            nodeExtension.printNodeInfo();
             multicastService = createMulticastService(addressPicker.getBindAddress(), this, config, logger);
             discoveryService = createDiscoveryService(config);
             joiner = nodeContext.createJoiner(this);

--- a/hazelcast/src/test/java/com/hazelcast/instance/NodeExtensionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/NodeExtensionTest.java
@@ -54,9 +54,9 @@ public class NodeExtensionTest extends HazelcastTestSupport {
 
         InOrder inOrder = inOrder(nodeExtension);
 
+        inOrder.verify(nodeExtension, times(1)).printNodeInfo();
         inOrder.verify(nodeExtension, times(1)).beforeStart();
         inOrder.verify(nodeExtension, times(1)).createSerializationService();
-        inOrder.verify(nodeExtension, times(1)).printNodeInfo();
         inOrder.verify(nodeExtension, times(1)).createExtensionServices();
         inOrder.verify(nodeExtension, times(1)).beforeJoin();
         inOrder.verify(nodeExtension, times(1)).afterStart();


### PR DESCRIPTION
so that if sth goes wrong during `beforeStart` user can see build info.
Also fixes https://github.com/hazelcast/hazelcast-enterprise/issues/714