### PR TITLE
Follow up to fix for non blocking Authentication in clients

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -63,7 +63,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -78,18 +77,6 @@ import static com.hazelcast.client.config.SocketOptions.DEFAULT_BUFFER_SIZE_BYTE
 import static com.hazelcast.client.config.SocketOptions.KILO_BYTE;
 
 public class ClientConnectionManagerImpl implements ClientConnectionManager {
-
-    private static final AuthenticationCallback dummyAuthCallback = new AuthenticationCallback() {
-        @Override
-        public void onSuccess(Connection connection) {
-
-        }
-
-        @Override
-        public void onFailure(Throwable exception) {
-
-        }
-    };
 
     private final NonBlockingIOThreadOutOfMemoryHandler OUT_OF_MEMORY_HANDLER = new NonBlockingIOThreadOutOfMemoryHandler() {
         @Override
@@ -114,8 +101,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     private final AddressTranslator addressTranslator;
     private final ConcurrentMap<Address, ClientConnection> connections
             = new ConcurrentHashMap<Address, ClientConnection>();
-    private final Set<Address> connectionsInProgress =
-            Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
+    private final ConcurrentMap<Address, AuthenticationFuture> connectionsInProgress =
+            new ConcurrentHashMap<Address, AuthenticationFuture>();
     private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<ConnectionListener>();
 
     private final Set<ConnectionHeartbeatListener> heartbeatListeners =
@@ -225,31 +212,39 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
     @Override
     public Connection getOrConnect(Address address, boolean asOwner) throws IOException {
-        BlockingCallback blockingCallback = new BlockingCallback();
-        Connection connection = getOrTriggerConnectInternal(address, asOwner, blockingCallback);
-        if (connection != null) {
-            return connection;
-        }
         try {
-            return blockingCallback.get();
+            while (true) {
+                Connection connection = getConnection(address, asOwner);
+                if (connection != null) {
+                    return connection;
+                }
+                AuthenticationFuture firstCallback = triggerConnect(address, asOwner);
+                connection = firstCallback.get();
+                if (!asOwner) {
+                    return connection;
+                }
+                if (firstCallback.authenticatedAsOwner) {
+                    return connection;
+                }
+            }
         } catch (Throwable e) {
             throw ExceptionUtil.rethrow(e);
         }
     }
 
-    private static class BlockingCallback implements AuthenticationCallback {
+    private static class AuthenticationFuture {
 
         private final CountDownLatch countDownLatch = new CountDownLatch(1);
         private Connection connection;
         private Throwable throwable;
+        private boolean authenticatedAsOwner;
 
-        @Override
-        public void onSuccess(Connection connection) {
+        public void onSuccess(Connection connection, boolean asOwner) {
             this.connection = connection;
+            this.authenticatedAsOwner = asOwner;
             countDownLatch.countDown();
         }
 
-        @Override
         public void onFailure(Throwable throwable) {
             this.throwable = throwable;
             countDownLatch.countDown();
@@ -264,19 +259,17 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         }
     }
 
-    interface AuthenticationCallback {
-        void onSuccess(Connection connection);
-
-        void onFailure(Throwable exception);
-    }
-
     @Override
     public Connection getOrTriggerConnect(Address target, boolean asOwner) {
-        return getOrTriggerConnectInternal(target, asOwner, dummyAuthCallback);
+        Connection connection = getConnection(target, asOwner);
+        if (connection != null) {
+            return connection;
+        }
+        triggerConnect(target, asOwner);
+        return null;
     }
 
-    private Connection getOrTriggerConnectInternal(Address target, boolean asOwner,
-                                                   AuthenticationCallback callback) {
+    private Connection getConnection(Address target, boolean asOwner) {
         target = addressTranslator.translate(target);
 
         if (target == null) {
@@ -286,20 +279,25 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         ClientConnection connection = connections.get(target);
 
         if (connection != null) {
-            if (asOwner && connection.isAuthenticatedAsOwner()) {
-                return connection;
-            }
             if (!asOwner) {
                 return connection;
             }
+            if (connection.isAuthenticatedAsOwner()) {
+                return connection;
+            }
         }
+        return null;
+    }
 
-        if (connectionsInProgress.add(target)) {
+    private AuthenticationFuture triggerConnect(Address target, boolean asOwner) {
+        AuthenticationFuture callback = new AuthenticationFuture();
+        AuthenticationFuture firstCallback = connectionsInProgress.putIfAbsent(target, callback);
+        if (firstCallback == null) {
             ClientExecutionServiceImpl executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
             executionService.executeInternal(new InitConnectionTask(target, asOwner, callback));
+            return callback;
         }
-
-        return null;
+        return firstCallback;
     }
 
     private void fireConnectionAddedEvent(ClientConnection connection) {
@@ -440,7 +438,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
     private void authenticate(final Address target, final ClientConnection connection,
                               final boolean asOwner,
-                              final AuthenticationCallback callback) {
+                              final AuthenticationFuture callback) {
         SerializationService ss = client.getSerializationService();
         final ClientClusterServiceImpl clusterService = (ClientClusterServiceImpl) client.getClientClusterService();
         ClientPrincipal principal = clusterService.getPrincipal();
@@ -479,7 +477,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                             clusterService.setPrincipal(new ClientPrincipal(result.uuid, result.ownerUuid));
                         }
                         authenticated(target, connection);
-                        callback.onSuccess(connection);
+                        callback.onSuccess(connection, asOwner);
                         break;
                     case CREDENTIALS_FAILED:
                         AuthenticationException e = new AuthenticationException("Invalid credentials!");
@@ -507,9 +505,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
         private final Address target;
         private final boolean asOwner;
-        private final AuthenticationCallback callback;
+        private final AuthenticationFuture callback;
 
-        InitConnectionTask(Address target, boolean asOwner, AuthenticationCallback callback) {
+        InitConnectionTask(Address target, boolean asOwner, AuthenticationFuture callback) {
             this.target = target;
             this.asOwner = asOwner;
             this.callback = callback;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
@@ -32,7 +32,6 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,7 +49,6 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_P
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
-@Ignore //https://github.com/hazelcast/hazelcast/issues/7693
 public class ClientTransactionalMapQuorumTest extends HazelcastTestSupport {
 
     static PartitionedCluster cluster;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXAStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXAStressTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -70,7 +69,6 @@ public class ClientXAStressTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/7709
     public void testCommitConcurrently() throws InterruptedException, XAException {
         int count = 10000;
         String name = randomString();


### PR DESCRIPTION
Original fix was #7673 for master, #7674 for maintenance-3.x

Recent test failures revealed that some corner cases for that
implementation was missing. One obvious case is if getOrConnect
don't trigger a ConnectTask its Callback is not registered. And
it waits on that callback which will never be called.

fixes #7718
fixes #7709
fixes #7693 