### PR TITLE
Follow up to fix for non blocking Authentication in clients

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
@@ -37,7 +37,6 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,7 +49,6 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_P
 @RunParallel
 @RunWith(HazelcastTestRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-@Ignore //https://github.com/hazelcast/hazelcast/issues/7693
 public class ClientTransactionalMapQuorumTest extends HazelcastTestSupport {
 
     static PartitionedCluster cluster;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXAStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXAStressTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -70,7 +69,6 @@ public class ClientXAStressTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/7709
     public void testCommitConcurrently() throws InterruptedException, XAException {
         int count = 10000;
         String name = randomString();


### PR DESCRIPTION
Original fix was #7673 for master, #7674 for maintenance-3.x

Recent test failures revealed that some corner cases for that
implementation was missing. One obvious case is if getOrConnect
don't trigger a ConnectTask its Callback is not registered. And
it waits on that callback which will never be called.

fixes #7718
fixes #7709
fixes #7693