### PR TITLE
Minor improvement in HashSlotArray API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
@@ -33,7 +33,7 @@ import static com.hazelcast.util.QuickMath.modPowerOfTwo;
 abstract class HashSlotArrayBase {
 
     protected static final int KEY_1_OFFSET = 0;
-    private static final int KEY_2_OFFSET = 8;
+    protected static final int KEY_2_OFFSET = 8;
     private static final int VALUE_LENGTH_GRANULARITY = 8;
     private static final int HEADER_SIZE = 0x18;
     private static final int CAPACITY_OFFSET = -0x8;

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayBase.java
@@ -405,10 +405,6 @@ abstract class HashSlotArrayBase {
 
     private void markAllUnassigned() {
         final long capacity = capacity();
-        mem.setMemory(baseAddress, capacity * slotLength, (byte) 0);
-        if (unassignedSentinel == 0) {
-            return;
-        }
         final long addrOfFirstSentinel = baseAddress + offsetOfUnassignedSentinel;
         final int stride = slotLength;
         for (long i = 0; i < capacity; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/hashslot/HashSlotArrayTwinKeyImpl.java
@@ -36,14 +36,19 @@ public class HashSlotArrayTwinKeyImpl extends HashSlotArrayBase implements HashS
 
     private static final int KEY_LENGTH = 16;
 
-    public HashSlotArrayTwinKeyImpl(long nullSentinel, MemoryManager mm, int valueLength,
+    public HashSlotArrayTwinKeyImpl(long nullSentinel, MemoryManager memMgr, MemoryAllocator auxMalloc, int valueLength,
                                     int initialCapacity, float loadFactor) {
-        this(nullSentinel, KEY_LENGTH, mm, null, valueLength, initialCapacity, loadFactor);
+        this(nullSentinel, KEY_LENGTH, memMgr, auxMalloc, valueLength, initialCapacity, loadFactor);
         assert valueLengthValid(valueLength) : "Invalid value length: " + valueLength;
     }
 
+    public HashSlotArrayTwinKeyImpl(long nullSentinel, MemoryManager memMgr, int valueLength,
+                                    int initialCapacity, float loadFactor) {
+        this(nullSentinel, memMgr, null, valueLength, initialCapacity, loadFactor);
+    }
+
     public HashSlotArrayTwinKeyImpl(long nullSentinel, MemoryManager mm, int valueLength) {
-        this(nullSentinel, mm, valueLength, DEFAULT_CAPACITY, DEFAULT_LOAD_FACTOR);
+        this(nullSentinel, mm, null, valueLength, DEFAULT_CAPACITY, DEFAULT_LOAD_FACTOR);
     }
 
     protected HashSlotArrayTwinKeyImpl(
@@ -79,5 +84,21 @@ public class HashSlotArrayTwinKeyImpl extends HashSlotArrayBase implements HashS
 
     protected boolean valueLengthValid(int valueLength) {
         return valueLength > 0;
+    }
+
+    public static long addrOfKey1At(long slotBase) {
+        return slotBase + KEY_1_OFFSET;
+    }
+
+    public static long addrOfKey2At(long slotBase) {
+        return slotBase + KEY_2_OFFSET;
+    }
+
+    public static long addrOfValueAt(long slotBase) {
+        return slotBase + KEY_LENGTH;
+    }
+
+    public static long valueAddr2slotBase(long valueAddr) {
+        return valueAddr - KEY_LENGTH;
     }
 }


### PR DESCRIPTION
There were a few methods missing which were introduced on the Hot Restart suicide branch.

Also optimized `markAllUnassigned` method by reducing amount of memory written. Now, instead of zeroing out all memory, just the "free slot" markers are written.