### PR TITLE
Two improvements in memory access code

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/MemoryAccessor.java
@@ -160,6 +160,26 @@ public interface MemoryAccessor {
     void copyMemory(long srcAddress, long destAddress, long lengthBytes);
 
     /**
+     * Copies bytes from a Java byte array into this accessor's address space.
+     *
+     * @param source the source byte array
+     * @param offset index of the first byte to copy
+     * @param destAddress address where the first byte will be written
+     * @param length number of bytes to copy
+     */
+    void copyFromByteArray(byte[] source, int offset, long destAddress, int length);
+
+    /**
+     * Copies bytes from this accessor's address space to a Java byte array.
+     *
+     * @param srcAddress address of the first byte to copy
+     * @param destination the destination byte array
+     * @param offset array index wher the first byte will be written
+     * @param length number of bytes to copy
+     */
+    void copyToByteArray(long srcAddress, byte[] destination, int offset, int length);
+
+    /**
      * Sets memory with given value from specified address as given size.
      *
      * @param address the start address of the memory region

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/BigEndianMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/BigEndianMemoryAccessor.java
@@ -157,6 +157,16 @@ public class BigEndianMemoryAccessor extends EndianAccessorBase {
     }
 
     @Override
+    public void copyFromByteArray(byte[] source, int offset, long destAddress, int length) {
+        MEM.copyMemory(source, ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * offset, null, destAddress, length);
+    }
+
+    @Override
+    public void copyToByteArray(long srcAddress, byte[] destination, int offset, int length) {
+        MEM.copyMemory(null, srcAddress, destination, ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * offset, length);
+    }
+
+    @Override
     public void setMemory(long address, long lengthBytes, byte value) {
         MEM.setMemory(address, lengthBytes, value);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/LittleEndianMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/LittleEndianMemoryAccessor.java
@@ -157,6 +157,16 @@ public class LittleEndianMemoryAccessor extends EndianAccessorBase {
     }
 
     @Override
+    public void copyFromByteArray(byte[] source, int offset, long destAddress, int length) {
+        MEM.copyMemory(source, ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * offset, null, destAddress, length);
+    }
+
+    @Override
+    public void copyToByteArray(long srcAddress, byte[] destination, int offset, int length) {
+        MEM.copyMemory(null, srcAddress, destination, ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * offset, length);
+    }
+
+    @Override
     public void setMemory(long address, long lengthBytes, byte value) {
         MEM.setMemory(address, lengthBytes, value);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
@@ -125,6 +125,16 @@ public class StandardMemoryAccessor extends UnsafeBasedMemoryAccessor {
     }
 
     @Override
+    public void copyFromByteArray(byte[] source, int offset, long destAddress, int length) {
+        copyMemory(source, ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * offset, null, destAddress, length);
+    }
+
+    @Override
+    public void copyToByteArray(long srcAddress, byte[] destination, int offset, int length) {
+        copyMemory(null, srcAddress, destination, ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * offset, length);
+    }
+
+    @Override
     public void setMemory(long address, long lengthBytes, byte value) {
         UNSAFE.setMemory(address, lengthBytes, value);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/memory/impl/BaseMemoryAccessorTest.java
@@ -201,6 +201,27 @@ public abstract class BaseMemoryAccessorTest extends UnsafeDependentMemoryAccess
     ////////////////////////////////////////////////////////////////////////////////
 
     @Test
+    public void test_copyFromByteArray() {
+        final byte[] ary = {2, 3};
+        memoryAccessor.copyFromByteArray(ary, 0, baseAddress1, 2);
+        for (int i = 0; i < ary.length; i++) {
+            assertEquals(ary[i], memoryAccessor.getByte(baseAddress1 + i));
+        }
+    }
+
+    @Test
+    public void test_copyToByteArray() {
+        final byte[] ary = new byte[2];
+        for (int i = 0; i < ary.length; i++) {
+            memoryAccessor.putByte(baseAddress1 + i, (byte) i);
+        }
+        memoryAccessor.copyToByteArray(baseAddress1, ary, 0, 2);
+        for (int i = 0; i < ary.length; i++) {
+            assertEquals(ary[i], memoryAccessor.getByte(baseAddress1 + i));
+        }
+    }
+
+    @Test
     public void test_putGetBoolean() {
         final long address = baseAddress1;
 

--- a/hazelcast/src/test/java/com/hazelcast/memory/HeapMemoryManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/memory/HeapMemoryManager.java
@@ -52,7 +52,7 @@ public class HeapMemoryManager implements MemoryManager {
     // Suports the testing of HashSlotArray#migrateTo()
     public HeapMemoryManager(HeapMemoryManager that) {
         this.storage = that.storage;
-        this.heapTop = that.heapTop;
+        this.heapTop = storage.length / 2;
     }
 
     @Override
@@ -143,6 +143,16 @@ public class HeapMemoryManager implements MemoryManager {
         public void copyMemory(long srcAddress, long destAddress, long lengthBytes) {
             System.arraycopy(storage, (int) toStorageIndex(srcAddress),
                     storage, (int) toStorageIndex(destAddress), (int) lengthBytes);
+        }
+
+        @Override
+        public void copyFromByteArray(byte[] source, int offset, int length, long destAddress) {
+            System.arraycopy(source, offset, storage, (int) toStorageIndex(destAddress), length);
+        }
+
+        @Override
+        public void copyToByteArray(long srcAddress, byte[] destination, int offset, int length) {
+            System.arraycopy(storage, (int) toStorageIndex(srcAddress), destination, offset, length);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/memory/HeapMemoryManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/memory/HeapMemoryManager.java
@@ -19,7 +19,6 @@ package com.hazelcast.memory;
 import com.hazelcast.internal.memory.MemoryAccessor;
 import com.hazelcast.internal.memory.impl.EndiannessUtil;
 import com.hazelcast.util.collection.Long2LongHashMap;
-import com.hazelcast.util.collection.LongHashSet;
 import junit.framework.AssertionFailedError;
 
 import java.util.Arrays;
@@ -146,7 +145,7 @@ public class HeapMemoryManager implements MemoryManager {
         }
 
         @Override
-        public void copyFromByteArray(byte[] source, int offset, int length, long destAddress) {
+        public void copyFromByteArray(byte[] source, int offset, long destAddress, int length) {
             System.arraycopy(source, offset, storage, (int) toStorageIndex(destAddress), length);
         }
 


### PR DESCRIPTION
1. Add a regression test for the recently fixed segfault bug in HashSlotArrayBase.
2. Add `byte[]`-oriented methods to `MemoryAccessor` to allow the transfer of data between accessor's address space and plain `byte[]`.