### PR TITLE
Fixes invocation stracktrace problems

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
@@ -35,7 +35,6 @@ public class MemberLeftException extends ExecutionException implements Retryable
     public MemberLeftException() {
     }
 
-
     public MemberLeftException(String message) {
         super(message);
     }
@@ -47,6 +46,7 @@ public class MemberLeftException extends ExecutionException implements Retryable
 
     /**
      * Returns the member that left the cluster
+     *
      * @return the member that left the cluster
      */
     public Member getMember() {
@@ -56,24 +56,26 @@ public class MemberLeftException extends ExecutionException implements Retryable
     private void writeObject(ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
 
-        Address address = member.getAddress();
-        String host  = address.getHost();
-        int port = address.getPort();
-
-        out.writeUTF(member.getUuid());
-        out.writeUTF(host);
-        out.writeInt(port);
-        out.writeBoolean(member.isLiteMember());
+        if (member == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeUTF(member.getUuid());
+            out.writeUTF(member.getAddress().getHost());
+            out.writeInt(member.getAddress().getPort());
+            out.writeBoolean(member.isLiteMember());
+        }
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
 
-        String uuid = in.readUTF();
-        String host = in.readUTF();
-        int port = in.readInt();
-        boolean liteMember = in.readBoolean();
-
-        member = new MemberImpl(new Address(host, port), false, uuid, null, null, liteMember);
+        if (in.readBoolean()) {
+            String uuid = in.readUTF();
+            String host = in.readUTF();
+            int port = in.readInt();
+            boolean liteMember = in.readBoolean();
+            member = new MemberImpl(new Address(host, port), false, uuid, null, null, liteMember);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -121,11 +121,11 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     final OperationBackupHandler operationBackupHandler;
     final BackpressureRegulator backpressureRegulator;
     final long defaultCallTimeoutMillis;
+    final SerializationService serializationService;
 
     private final SlowOperationDetector slowOperationDetector;
     private final IsStillRunningService isStillRunningService;
     private final AsyncResponsePacketHandler responsePacketExecutor;
-    private final SerializationService serializationService;
     private final InvocationMonitor invocationMonitor;
 
     public OperationServiceImpl(NodeEngineImpl nodeEngine) {

--- a/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
@@ -28,7 +28,10 @@ import java.util.concurrent.ExecutionException;
  */
 public final class ExceptionUtil {
 
-    private static final String EXCEPTION_SEPARATOR = "------ End remote and begin local stack-trace ------";
+    /**
+     * Separator for local/remote stacktrace.
+     */
+    public static final String EXCEPTION_SEPARATOR = "------ End remote and begin local stack-trace ------";
     private static final String EXCEPTION_MESSAGE_SEPARATOR = "------ %MSG% ------";
 
     //we don't want instances

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_ExceptionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_ExceptionTest.java
@@ -1,0 +1,83 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.test.ExpectedRuntimeException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static com.hazelcast.util.ExceptionUtil.EXCEPTION_SEPARATOR;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class InvocationFuture_ExceptionTest extends HazelcastTestSupport {
+
+    @Test
+    public void testExceptionIsCloned() {
+        HazelcastInstance hz = createHazelcastInstance();
+        final ExpectedRuntimeException original = new ExpectedRuntimeException("foobar");
+        Operation op = new DummyOperation(new Runnable() {
+            @Override
+            public void run() {
+                throw original;
+            }
+        });
+
+        InternalCompletableFuture<Object> f = getOperationService(hz).invokeOnPartition(null, op, 1);
+
+        ExpectedRuntimeException e1 = getExpectedRuntimeException(f);
+        ExpectedRuntimeException e2 = getExpectedRuntimeException(f);
+        assertNotSame(e1, e2);
+        assertNotSame(original, e1);
+        assertNotSame(original, e2);
+    }
+
+    @Test
+    public void testStacktraceAlwaysFixed() {
+        HazelcastInstance hz = createHazelcastInstance();
+        final ExpectedRuntimeException original = new ExpectedRuntimeException("foobar");
+        Operation op = new DummyOperation(new Runnable() {
+            @Override
+            public void run() {
+                throw original;
+            }
+        });
+
+        InternalCompletableFuture<Object> f = getOperationService(hz).invokeOnPartition(null, op, 1);
+
+        ExpectedRuntimeException found = getExpectedRuntimeException(f);
+        assertTrue(stacktraceToString(found).contains(EXCEPTION_SEPARATOR));
+        assertFalse(stacktraceToString(original).contains(EXCEPTION_SEPARATOR));
+    }
+
+    private String stacktraceToString(Throwable t) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        t.printStackTrace(pw);
+        return sw.toString();
+    }
+
+    private ExpectedRuntimeException getExpectedRuntimeException(InternalCompletableFuture<Object> f) {
+        try {
+            f.getSafely();
+            fail();
+            // won't get executed
+            return null;
+        } catch (ExpectedRuntimeException e) {
+            return e;
+        }
+    }
+}


### PR DESCRIPTION
Fixes stacktrace being modified by multiple threads by cloning the exception.
Fixes that the stacktrace is only rewritten for remote calls; but fails to do so for local calls. So stacktraces are now always rewritten.

fixes #6247