### PR TITLE
Removing JavaDoc checkstyle suppressions for hazelcast-client

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -93,9 +93,6 @@
     <suppress checks="MethodCount" files="com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl"/>
 
     <!-- Client -->
-    <!-- TODO: these JavaDoc issues need to be addressed -->
-    <suppress checks="JavadocMethod" files="com/hazelcast/client/"/>
-    <suppress checks="JavadocType" files="com/hazelcast/client/"/>
     <!-- TODO: we need to get these wildcard suppressions fixed -->
     <suppress checks="" files="com/hazelcast/client/proxy/ClientQueueProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientListProxy"/>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientFactory.java
@@ -24,6 +24,10 @@ import com.hazelcast.client.impl.HazelcastClientProxy;
 /***
  * This is interface which provides capability for Hazelcast client factories customization;
  * It's implementation can be changed and passed to the HazelcastClientManager's constructors;
+ *
+ * @param <T> type of {@link HazelcastClientInstanceImpl}
+ * @param <V> type of {@link HazelcastClientProxy}
+ * @param <C> type of {@link ClientConfig}
  */
 public interface HazelcastClientFactory<T extends HazelcastClientInstanceImpl,
         V extends HazelcastClientProxy,

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
@@ -24,6 +24,11 @@ import static com.hazelcast.topic.TopicOverloadPolicy.BLOCK;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkPositive;
 
+/**
+ * Contains the ReliableTopic configuration for a client.
+ *
+ * @see com.hazelcast.client.proxy.ClientReliableTopicProxy
+ */
 public class ClientReliableTopicConfig {
     /**
      * The default read batch size.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/AbstractClientSelectionHandler.java
@@ -25,6 +25,10 @@ import com.hazelcast.nio.tcp.nonblocking.SelectionHandler;
 
 import java.nio.channels.SelectionKey;
 
+/**
+ * The AbstractClientSelectionHandler gets called by an IO-thread when there data available to read,
+ * or space available to write.
+ */
 public abstract class AbstractClientSelectionHandler implements SelectionHandler, Runnable {
 
     protected final ILogger logger;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -42,6 +42,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
+/**
+ * Client implementation of {@link Connection}.
+ * ClientConnection is a connection between a Hazelcast Client and a Hazelcast Member.
+ */
 public class ClientConnection implements Connection {
 
     protected final int connectionId;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientNonBlockingOutputThread.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientNonBlockingOutputThread.java
@@ -23,7 +23,9 @@ import com.hazelcast.nio.tcp.nonblocking.SelectionHandler;
 
 import java.nio.channels.SelectionKey;
 
-
+/**
+ * ClientNonBlockingOutputThread facilitates non-blocking writing for Hazelcast Clients.
+ */
 public final class ClientNonBlockingOutputThread extends NonBlockingIOThread {
 
     public ClientNonBlockingOutputThread(ThreadGroup threadGroup, String threadName, ILogger logger,

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
@@ -27,6 +27,11 @@ import java.io.EOFException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 
+/**
+ * ClientReadHandler gets called by an IO-thread when there is data available to read.
+ * It then reads out the data from the socket into a bytebuffer and hands it over to the {@link ClientMessageBuilder}
+ * to get processed.
+ */
 public class ClientReadHandler
         extends AbstractClientSelectionHandler {
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientWriteHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientWriteHandler.java
@@ -30,6 +30,10 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * ClientReadHandler gets called by an IO-thread when there is space available to write to.
+ * It then writes some of its enqueued data to the socket from a bytebuffer.
+ */
 public class ClientWriteHandler extends AbstractClientSelectionHandler implements Runnable {
 
     private final Queue<ClientMessage> writeQueue = new ConcurrentLinkedQueue<ClientMessage>();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
@@ -35,6 +35,9 @@ import com.hazelcast.core.IFunction;
 
 import static com.hazelcast.util.Preconditions.isNotNull;
 
+/**
+ * Proxy implementation of {@link IAtomicLong}.
+ */
 public class ClientAtomicLongProxy extends PartitionSpecificClientProxy implements IAtomicLong {
 
     public ClientAtomicLongProxy(String serviceName, String objectId) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
@@ -34,6 +34,11 @@ import com.hazelcast.core.IFunction;
 
 import static com.hazelcast.util.Preconditions.isNotNull;
 
+/**
+ * Proxy implementation of {@link IAtomicReference}.
+ *
+ * @param <E> type of referenced object
+ */
 public class ClientAtomicReferenceProxy<E> extends PartitionSpecificClientProxy implements IAtomicReference<E> {
 
     public ClientAtomicReferenceProxy(String serviceName, String objectId) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
@@ -31,6 +31,9 @@ import com.hazelcast.util.ThreadUtil;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Proxy implementation of {@link ICondition}.
+ */
 public class ClientConditionProxy extends PartitionSpecificClientProxy implements ICondition {
 
     private final String conditionId;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCountDownLatchProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCountDownLatchProxy.java
@@ -25,6 +25,9 @@ import com.hazelcast.core.ICountDownLatch;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Proxy implementation of {@link ICountDownLatch}.
+ */
 public class ClientCountDownLatchProxy extends PartitionSpecificClientProxy implements ICountDownLatch {
 
     public ClientCountDownLatchProxy(String serviceName, String objectId) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
@@ -21,6 +21,9 @@ import com.hazelcast.concurrent.idgen.IdGeneratorImpl;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IdGenerator;
 
+/**
+ * Proxy implementation of {@link IdGenerator}.
+ */
 public class ClientIdGeneratorProxy extends ClientProxy implements IdGenerator {
 
     private final IdGeneratorImpl idGeneratorImpl;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -60,6 +60,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+/**
+ * Proxy implementation of {@link IList}.
+ *
+ * @param <E> the type of elements in this list
+ */
 public class ClientListProxy<E> extends PartitionSpecificClientProxy implements IList<E> {
 
     public ClientListProxy(String serviceName, String name) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -34,6 +34,9 @@ import java.util.concurrent.locks.Condition;
 
 import static com.hazelcast.util.Preconditions.checkPositive;
 
+/**
+ * Proxy implementation of {@link ILock}.
+ */
 public class ClientLockProxy extends PartitionSpecificClientProxy implements ILock {
 
     public ClientLockProxy(String serviceName, String objectId) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -65,6 +65,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 
+/**
+ * Proxy implementation of {@link JobTracker} for a client initiated map reduce job.
+ */
 public class ClientMapReduceProxy
         extends ClientProxy
         implements JobTracker {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -52,6 +52,14 @@ import static com.hazelcast.topic.impl.reliable.ReliableTopicService.SERVICE_NAM
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+/**
+ * Reliable proxy implementation of {@link ITopic}.
+ * <p/>
+ * Unlike other topics, a reliable topic has its own {@link com.hazelcast.ringbuffer.Ringbuffer} to store events and
+ * has its own executor to process events.
+ *
+ * @param <E> message type
+ */
 public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E> {
 
     private static final int MAX_BACKOFF = 2000;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -51,6 +51,11 @@ import static com.hazelcast.util.Preconditions.checkNotNegative;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkTrue;
 
+/**
+ * Proxy implementation of {@link Ringbuffer}.
+ *
+ * @param <E> the type of elements in this ringbuffer
+ */
 public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<E> {
 
     private static final ClientMessageDecoder ADD_ASYNC_ASYNC_RESPONSE_DECODER = new ClientMessageDecoder() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
@@ -28,6 +28,9 @@ import com.hazelcast.core.ISemaphore;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Proxy implementation of {@link ISemaphore}.
+ */
 public class ClientSemaphoreProxy extends PartitionSpecificClientProxy implements ISemaphore {
 
     public ClientSemaphoreProxy(String serviceName, String objectId) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
@@ -50,6 +50,11 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+/**
+ * Proxy implementation of {@link ISet}.
+ *
+ * @param <E> the type of elements in this set
+ */
 public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements ISet<E> {
 
     public ClientSetProxy(String serviceName, String name) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
@@ -32,6 +32,11 @@ import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.topic.impl.DataAwareMessage;
 
+/**
+ * Proxy implementation of {@link ITopic}.
+ *
+ * @param <E> message type
+ */
 public class ClientTopicProxy<E> extends PartitionSpecificClientProxy implements ITopic<E> {
 
     public ClientTopicProxy(String serviceName, String objectId) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/AbstractClientTxnCollectionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/AbstractClientTxnCollectionProxy.java
@@ -19,7 +19,9 @@ package com.hazelcast.client.proxy.txn;
 import com.hazelcast.client.spi.ClientTransactionContext;
 
 /**
- * @ali 9/4/13
+ * Abstract proxy collection implementation of {@link com.hazelcast.transaction.TransactionalObject}.
+ *
+ * @param <E> the type of elements in this collection
  */
 public abstract class AbstractClientTxnCollectionProxy<E> extends ClientTxnProxy {
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnListProxy.java
@@ -27,6 +27,11 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.Preconditions;
 import com.hazelcast.util.ThreadUtil;
 
+/**
+ * Proxy implementation of {@link TransactionalList}.
+ *
+ * @param <E> the type of elements in this list
+ */
 public class ClientTxnListProxy<E> extends AbstractClientTxnCollectionProxy<E> implements TransactionalList<E> {
 
     public ClientTxnListProxy(String name, ClientTransactionContext transactionContext) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMapProxy.java
@@ -52,6 +52,9 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * Proxy implementation of {@link TransactionalMap} interface.
+ *
+ * @param <K> key
+ * @param <V> value
  */
 public class ClientTxnMapProxy<K, V> extends ClientTxnProxy implements TransactionalMap<K, V> {
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnMultiMapProxy.java
@@ -34,6 +34,11 @@ import com.hazelcast.util.ThreadUtil;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Proxy implementation of {@link TransactionalMultiMap}
+ * @param <K> key
+ * @param <V> value
+ */
 public class ClientTxnMultiMapProxy<K, V>
         extends ClientTxnProxy
         implements TransactionalMultiMap<K, V> {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
@@ -30,6 +30,11 @@ import com.hazelcast.util.ThreadUtil;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Proxy implementation of {@link TransactionalQueue}.
+ *
+ * @param <E> the type of elements in this queue
+ */
 public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements TransactionalQueue<E> {
 
     public ClientTxnQueueProxy(String name, ClientTransactionContext transactionContext) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnSetProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnSetProxy.java
@@ -27,6 +27,11 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.Preconditions;
 import com.hazelcast.util.ThreadUtil;
 
+/**
+ * Proxy implementation of {@link TransactionalSet}.
+ *
+ * @param <E> the type of elements in this set
+ */
 public class ClientTxnSetProxy<E> extends AbstractClientTxnCollectionProxy<E> implements TransactionalSet<E> {
 
     public ClientTxnSetProxy(String name, ClientTransactionContext transactionContext) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionContextProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/TransactionContextProxy.java
@@ -42,6 +42,12 @@ import javax.transaction.xa.XAResource;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Provides a context to perform transactional operations: beginning/committing transactions, but also retrieving
+ * transactional data-structures like the {@link com.hazelcast.core.TransactionalMap}.
+ * <p/>
+ * Provides client instance and client connection proxies that need to be accessed for sending invocations.
+ */
 public class TransactionContextProxy implements ClientTransactionContext {
 
     final ClientTransactionManagerServiceImpl transactionManager;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionContextProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XATransactionContextProxy.java
@@ -47,6 +47,14 @@ import javax.transaction.xa.Xid;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Provides a context to perform transactional operations: beginning/committing transactions, but also retrieving
+ * transactional data-structures like the {@link com.hazelcast.core.TransactionalMap}.
+ * <p/>
+ * Provides client instance and client connection proxies that need to be accessed for sending invocations.
+ * <p/>
+ * XA implementation of {@link com.hazelcast.client.spi.ClientTransactionContext}
+ */
 public class XATransactionContextProxy implements ClientTransactionContext {
 
     final ClientTransactionManagerServiceImpl transactionManager;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
@@ -23,6 +23,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.LoggingService;
 
+/**
+ * Context holding all the required services, managers and the configuration for a Hazelcast Client
+ */
 public final class ClientContext {
 
     private final SerializationService serializationService;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -30,6 +30,10 @@ import com.hazelcast.util.ExceptionUtil;
 
 import java.util.concurrent.Future;
 
+/**
+ * Base class for Client proxies.
+ * Allows the Client to proxy operations through Nodes
+ */
 public abstract class ClientProxy implements DistributedObject {
 
     protected final String name;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientTransactionManagerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientTransactionManagerService.java
@@ -22,6 +22,11 @@ import com.hazelcast.transaction.TransactionalTask;
 
 import javax.transaction.xa.Xid;
 
+/**
+ * Manages the execution of client transactions and provides {@link TransactionContext}s.
+ * <p/>
+ * Client equivalent of {@link com.hazelcast.transaction.TransactionManagerService}.
+ */
 public interface ClientTransactionManagerService {
 
     <T> T executeTransaction(TransactionalTask<T> task);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/EventHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/EventHandler.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.client.spi;
 
+/**
+ * Base interface for all client Event Handlers.
+ *
+ * @param <E> event type
+ */
 public interface EventHandler<E> {
 
     void handle(E event);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientAddressCancellableDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientAddressCancellableDelegatingFuture.java
@@ -29,6 +29,13 @@ import java.util.concurrent.CancellationException;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
+/**
+ * A DelegatingFuture that can cancel a Runnable/Callable that is executed by an
+ * {@link com.hazelcast.core.IExecutorService}.
+ * It does this by sending a Cancellation Request to the remote target Address and then cancelling the running task.
+ *
+ * @param <V> Type of returned object from the get method of this class.
+ */
 public class ClientAddressCancellableDelegatingFuture<V> extends ClientCancellableDelegatingFuture<V> {
 
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientPartitionCancellableDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientPartitionCancellableDelegatingFuture.java
@@ -28,6 +28,13 @@ import java.util.concurrent.CancellationException;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
+/**
+ * A DelegatingFuture that can cancel a Runnable/Callable that is executed by an
+ * {@link com.hazelcast.core.IExecutorService}.
+ * It does this by sending a Cancellation Request to the remote partition owner and then cancelling the running task.
+ *
+ * @param <T> Type of returned object from the get method of this class.
+ */
 public class ClientPartitionCancellableDelegatingFuture<T> extends ClientCancellableDelegatingFuture<T> {
 
     private final int partitionId;


### PR DESCRIPTION
Hello, I've removed the two javadoc suppresions for hazelcast-client and added the necessary javadoc comments to fix the resulting checkstyle errors. (as discussed in issue #7712 )

I tried to keep the comments in the same style as the rest of the javadoc comments in hazelcast-client. But it could be that they are not in-depth enough. Please tell me if this is the case, as then I will add some more info to them.

I was also a bit confused what to do about the "@ali" tag, for now I just removed it.

PS: Checkstyle seems to be giving some warning now about TransactionException. I don't know what causes this, in any case I haven't changed anything related to it.

