### PR TITLE
InvocationFuture method renaming to align with CompletableFuture

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -131,10 +131,10 @@ abstract class AbstractCacheProxyBase<K, V> {
         OperationService operationService = getNodeEngine().getOperationService();
         InternalCompletableFuture f = operationService.invokeOnPartition(CacheService.SERVICE_NAME, operation, partitionId);
         // TODO What happens in exception case? Cache doesn't get destroyed
-        f.getSafely();
+        f.join();
 
         cacheService.deleteCache(getDistributedObjectName(), true, null, true);
-        f.getSafely();
+        f.join();
     }
 
     public boolean isClosed() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -105,7 +105,7 @@ public class CacheProxy<K, V>
         OperationService operationService = getNodeEngine().getOperationService();
         int partitionId = getPartitionId(getNodeEngine(), k);
         InternalCompletableFuture<Boolean> f = operationService.invokeOnPartition(getServiceName(), operation, partitionId);
-        return f.getSafely();
+        return f.join();
     }
 
     @Override
@@ -236,7 +236,7 @@ public class CacheProxy<K, V>
             OperationService operationService = getNodeEngine().getOperationService();
             int partitionId = getPartitionId(getNodeEngine(), keyData);
             final InternalCompletableFuture<T> f = operationService.invokeOnPartition(getServiceName(), op, partitionId);
-            final T safely = f.getSafely();
+            final T safely = f.join();
             waitCompletionLatch(completionId);
             return safely;
         } catch (CacheException ce) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ClusterWideIterator.java
@@ -60,7 +60,7 @@ public class ClusterWideIterator<K, V>
         final OperationService operationService = cacheProxy.getNodeEngine().getOperationService();
         final InternalCompletableFuture<CacheKeyIteratorResult> f = operationService
                 .invokeOnPartition(CacheService.SERVICE_NAME, operation, partitionIndex);
-        return f.getSafely();
+        return f.join();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -112,7 +112,7 @@ public class HazelcastServerCacheManager
         InternalCompletableFuture<CacheConfig<K, V>> f =
                 operationService.invokeOnPartition(CacheService.SERVICE_NAME,
                                                    cacheCreateConfigOperation, partitionId);
-        return f.getSafely();
+        return f.join();
     }
 
     @Override
@@ -166,7 +166,7 @@ public class HazelcastServerCacheManager
         InternalCompletableFuture future =
                 operationService.invokeOnTarget(CacheService.SERVICE_NAME, op, nodeEngine.getThisAddress());
         if (syncCreate) {
-            return (CacheConfig<K, V>) future.getSafely();
+            return (CacheConfig<K, V>) future.join();
         } else {
             return currentCacheConfig;
         }
@@ -184,7 +184,7 @@ public class HazelcastServerCacheManager
         InternalCompletableFuture<CacheConfig> f =
                 nodeEngine.getOperationService()
                           .invokeOnPartition(CacheService.SERVICE_NAME, op, partitionId);
-        return f.getSafely();
+        return f.join();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvictionProcessor.java
@@ -52,7 +52,7 @@ public class QueueEvictionProcessor implements ScheduledEntryProcessor<String, V
             String name = entry.getKey();
             int partitionId = partitionService.getPartitionId(nodeEngine.toData(name));
             CheckAndEvictOperation op = new CheckAndEvictOperation(entry.getKey());
-            operationService.invokeOnPartition(QueueService.SERVICE_NAME, op, partitionId).getSafely();
+            operationService.invokeOnPartition(QueueService.SERVICE_NAME, op, partitionId).join();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
@@ -75,7 +75,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long addAndGet(long delta) {
-        return asyncAddAndGet(delta).getSafely();
+        return asyncAddAndGet(delta).join();
     }
 
     @Override
@@ -86,7 +86,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public boolean compareAndSet(long expect, long update) {
-        return asyncCompareAndSet(expect, update).getSafely();
+        return asyncCompareAndSet(expect, update).join();
     }
 
     @Override
@@ -97,7 +97,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public void set(long newValue) {
-        asyncSet(newValue).getSafely();
+        asyncSet(newValue).join();
     }
 
     @Override
@@ -108,7 +108,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long getAndSet(long newValue) {
-        return asyncGetAndSet(newValue).getSafely();
+        return asyncGetAndSet(newValue).join();
     }
 
     @Override
@@ -119,7 +119,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long getAndAdd(long delta) {
-        return asyncGetAndAdd(delta).getSafely();
+        return asyncGetAndAdd(delta).join();
     }
 
     @Override
@@ -130,7 +130,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long decrementAndGet() {
-        return asyncDecrementAndGet().getSafely();
+        return asyncDecrementAndGet().join();
     }
 
     @Override
@@ -140,7 +140,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long get() {
-        return asyncGet().getSafely();
+        return asyncGet().join();
     }
 
     @Override
@@ -151,7 +151,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long incrementAndGet() {
-        return asyncIncrementAndGet().getSafely();
+        return asyncIncrementAndGet().join();
     }
 
     @Override
@@ -161,7 +161,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long getAndIncrement() {
-        return asyncGetAndIncrement().getSafely();
+        return asyncGetAndIncrement().join();
     }
 
     @Override
@@ -171,7 +171,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public void alter(IFunction<Long, Long> function) {
-        asyncAlter(function).getSafely();
+        asyncAlter(function).join();
     }
 
     @Override
@@ -184,7 +184,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long alterAndGet(IFunction<Long, Long> function) {
-        return asyncAlterAndGet(function).getSafely();
+        return asyncAlterAndGet(function).join();
     }
 
     @Override
@@ -197,7 +197,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long getAndAlter(IFunction<Long, Long> function) {
-        return asyncGetAndAlter(function).getSafely();
+        return asyncGetAndAlter(function).join();
     }
 
     @Override
@@ -210,7 +210,7 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public <R> R apply(IFunction<Long, R> function) {
-        return asyncApply(function).getSafely();
+        return asyncApply(function).join();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
@@ -61,7 +61,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public void alter(IFunction<E, E> function) {
-        asyncAlter(function).getSafely();
+        asyncAlter(function).join();
     }
 
     @Override
@@ -75,7 +75,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public E alterAndGet(IFunction<E, E> function) {
-        return asyncAlterAndGet(function).getSafely();
+        return asyncAlterAndGet(function).join();
     }
 
     @Override
@@ -89,7 +89,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public E getAndAlter(IFunction<E, E> function) {
-        return asyncGetAndAlter(function).getSafely();
+        return asyncGetAndAlter(function).join();
     }
 
     @Override
@@ -103,7 +103,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public <R> R apply(IFunction<E, R> function) {
-        return asyncApply(function).getSafely();
+        return asyncApply(function).join();
     }
 
     @Override
@@ -117,7 +117,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public void clear() {
-        asyncClear().getSafely();
+        asyncClear().join();
     }
 
     @Override
@@ -127,7 +127,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public boolean compareAndSet(E expect, E update) {
-        return asyncCompareAndSet(expect, update).getSafely();
+        return asyncCompareAndSet(expect, update).join();
     }
 
     @Override
@@ -139,7 +139,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public E get() {
-        return asyncGet().getSafely();
+        return asyncGet().join();
     }
 
     @Override
@@ -150,7 +150,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public boolean contains(E expected) {
-        return asyncContains(expected).getSafely();
+        return asyncContains(expected).join();
     }
 
     @Override
@@ -162,7 +162,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public void set(E newValue) {
-        asyncSet(newValue).getSafely();
+        asyncSet(newValue).join();
     }
 
     @Override
@@ -174,7 +174,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public E getAndSet(E newValue) {
-        return asyncGetAndSet(newValue).getSafely();
+        return asyncGetAndSet(newValue).join();
     }
 
     @Override
@@ -186,7 +186,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public E setAndGet(E update) {
-        return asyncSetAndGet(update).getSafely();
+        return asyncSetAndGet(update).join();
     }
 
     @Override
@@ -198,7 +198,7 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public boolean isNull() {
-        return asyncIsNull().getSafely();
+        return asyncIsNull().join();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchProxy.java
@@ -70,14 +70,14 @@ public class CountDownLatchProxy extends AbstractDistributedObject<CountDownLatc
     public void countDown() {
         CountDownOperation op = new CountDownOperation(name);
         InternalCompletableFuture f = invoke(op);
-        f.getSafely();
+        f.join();
     }
 
     @Override
     public int getCount() {
         GetCountOperation op = new GetCountOperation(name);
         InternalCompletableFuture<Integer> f = invoke(op);
-        return f.getSafely();
+        return f.join();
     }
 
     @Override
@@ -86,7 +86,7 @@ public class CountDownLatchProxy extends AbstractDistributedObject<CountDownLatc
 
         SetCountOperation op = new SetCountOperation(name, count);
         InternalCompletableFuture<Boolean> f = invoke(op);
-        return f.getSafely();
+        return f.join();
     }
 
     private InternalCompletableFuture invoke(Operation op) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
@@ -96,7 +96,7 @@ final class ConditionImpl implements ICondition {
         Data key = lockProxy.getKeyData();
         BeforeAwaitOperation op = new BeforeAwaitOperation(namespace, key, threadId, conditionId);
         InternalCompletableFuture f = invoke(op);
-        f.getSafely();
+        f.join();
     }
 
     private InternalCompletableFuture invoke(Operation op) {
@@ -120,7 +120,7 @@ final class ConditionImpl implements ICondition {
         Data key = lockProxy.getKeyData();
         SignalOperation op = new SignalOperation(namespace, key, threadId, conditionId, all);
         InternalCompletableFuture f = invoke(op);
-        f.getSafely();
+        f.join();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
@@ -46,7 +46,7 @@ public final class LockProxySupport {
     public boolean isLocked(NodeEngine nodeEngine, Data key) {
         IsLockedOperation operation = new IsLockedOperation(namespace, key);
         InternalCompletableFuture<Boolean> f = invoke(nodeEngine, operation, key);
-        return f.getSafely();
+        return f.join();
     }
 
     private InternalCompletableFuture invoke(NodeEngine nodeEngine, Operation operation, Data key) {
@@ -57,19 +57,19 @@ public final class LockProxySupport {
     public boolean isLockedByCurrentThread(NodeEngine nodeEngine, Data key) {
         IsLockedOperation operation = new IsLockedOperation(namespace, key, getThreadId());
         InternalCompletableFuture<Boolean> f = invoke(nodeEngine, operation, key);
-        return f.getSafely();
+        return f.join();
     }
 
     public int getLockCount(NodeEngine nodeEngine, Data key) {
         Operation operation = new GetLockCountOperation(namespace, key);
         InternalCompletableFuture<Number> f = invoke(nodeEngine, operation, key);
-        return f.getSafely().intValue();
+        return f.join().intValue();
     }
 
     public long getRemainingLeaseTime(NodeEngine nodeEngine, Data key) {
         Operation operation = new GetRemainingLeaseTimeOperation(namespace, key);
         InternalCompletableFuture<Number> f = invoke(nodeEngine, operation, key);
-        return f.getSafely().longValue();
+        return f.join().longValue();
     }
 
     public void lock(NodeEngine nodeEngine, Data key) {
@@ -81,7 +81,7 @@ public final class LockProxySupport {
 
         LockOperation operation = new LockOperation(namespace, key, getThreadId(), leaseTime, -1);
         InternalCompletableFuture<Boolean> f = invoke(nodeEngine, operation, key);
-        if (!f.getSafely()) {
+        if (!f.join()) {
             throw new IllegalStateException();
         }
     }
@@ -146,13 +146,13 @@ public final class LockProxySupport {
     public void unlock(NodeEngine nodeEngine, Data key) {
         UnlockOperation operation = new UnlockOperation(namespace, key, getThreadId());
         InternalCompletableFuture<Number> f = invoke(nodeEngine, operation, key);
-        f.getSafely();
+        f.join();
     }
 
     public void forceUnlock(NodeEngine nodeEngine, Data key) {
         UnlockOperation operation = new UnlockOperation(namespace, key, -1, true);
         InternalCompletableFuture<Number> f = invoke(nodeEngine, operation, key);
-        f.getSafely();
+        f.join();
     }
 
     public ObjectNamespace getNamespace() {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
@@ -57,7 +57,7 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
 
         InitOperation operation = new InitOperation(name, permits);
         InternalCompletableFuture<Boolean> future = invoke(operation);
-        return future.getSafely();
+        return future.join();
     }
 
     @Override
@@ -82,14 +82,14 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
     public int availablePermits() {
         AvailableOperation operation = new AvailableOperation(name);
         InternalCompletableFuture<Integer> future = invoke(operation);
-        return future.getSafely();
+        return future.join();
     }
 
     @Override
     public int drainPermits() {
         DrainOperation operation = new DrainOperation(name);
         InternalCompletableFuture<Integer> future = invoke(operation);
-        return future.getSafely();
+        return future.join();
     }
 
     @Override
@@ -98,7 +98,7 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
 
         ReduceOperation operation = new ReduceOperation(name, reduction);
         InternalCompletableFuture<Object> future = invoke(operation);
-        future.getSafely();
+        future.join();
     }
 
     @Override
@@ -112,7 +112,7 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
 
         ReleaseOperation operation = new ReleaseOperation(name, permits);
         InternalCompletableFuture future = invoke(operation);
-        future.getSafely();
+        future.join();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
@@ -199,7 +199,7 @@ public final class MapReduceUtil {
 
         for (InternalCompletableFuture<V> future : futures) {
             try {
-                V response = future.getSafely();
+                V response = future.join();
                 if (response != null) {
                     results.add(response);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -216,7 +216,7 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject
         PutOperation putOperation = new PutOperation(getName(), dataKey, dataValue);
         InternalCompletableFuture<Object> future = getOperationService()
                 .invokeOnPartition(getServiceName(), putOperation, partitionId);
-        VersionResponsePair result = (VersionResponsePair) future.getSafely();
+        VersionResponsePair result = (VersionResponsePair) future.join();
         return nodeEngine.toObject(result.getResponse());
     }
 
@@ -235,7 +235,7 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject
         PutOperation putOperation = new PutOperation(getName(), dataKey, dataValue, ttlMillis);
         InternalCompletableFuture<Object> future = getOperationService()
                 .invokeOnPartition(getServiceName(), putOperation, partitionId);
-        VersionResponsePair result = (VersionResponsePair) future.getSafely();
+        VersionResponsePair result = (VersionResponsePair) future.join();
         return nodeEngine.toObject(result.getResponse());
     }
 
@@ -247,7 +247,7 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject
         RemoveOperation removeOperation = new RemoveOperation(getName(), dataKey);
         InternalCompletableFuture<Object> future = getOperationService()
                 .invokeOnPartition(getServiceName(), removeOperation, partitionId);
-        VersionResponsePair result = (VersionResponsePair) future.getSafely();
+        VersionResponsePair result = (VersionResponsePair) future.join();
         return nodeEngine.toObject(result.getResponse());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
@@ -92,21 +92,21 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
     public long size() {
         GenericOperation op = new GenericOperation(name, OPERATION_SIZE);
         InternalCompletableFuture f = invoke(op);
-        return (Long) f.getSafely();
+        return (Long) f.join();
     }
 
     @Override
     public long tailSequence() {
         GenericOperation op = new GenericOperation(name, OPERATION_TAIL);
         InternalCompletableFuture f = invoke(op);
-        return (Long) f.getSafely();
+        return (Long) f.join();
     }
 
     @Override
     public long headSequence() {
         GenericOperation op = new GenericOperation(name, OPERATION_HEAD);
         InternalCompletableFuture f = invoke(op);
-        return (Long) f.getSafely();
+        return (Long) f.join();
     }
 
     @Override
@@ -119,7 +119,7 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
 
         GenericOperation op = new GenericOperation(name, OPERATION_REMAINING_CAPACITY);
         InternalCompletableFuture f = invoke(op);
-        return (Long) f.getSafely();
+        return (Long) f.join();
     }
 
     @Override
@@ -128,7 +128,7 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
 
         AddOperation op = new AddOperation(name, toData(item), OVERWRITE);
         InternalCompletableFuture<Long> f = invoke(op);
-        return f.getSafely();
+        return f.join();
     }
 
     private Data toData(E item) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
@@ -26,5 +26,15 @@ import com.hazelcast.core.ICompletableFuture;
  */
 public interface InternalCompletableFuture<E> extends ICompletableFuture<E> {
 
+    /**
+     * Waits for this future to complete.
+     *
+     * @return the result.
+     */
+    E join();
+
+    /**
+     * @deprecated since 3.7. Use {@link #join()} instead.
+     */
     E getSafely();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -379,7 +379,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         }
 
         // there are no backups or the number of expected backups has returned; so signal the future that the result is ready.
-        future.set(response);
+        future.complete(response);
     }
 
     @Override
@@ -447,7 +447,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         // We are going to notify the future that a response is available. This can happen when:
         // - we had a regular operation (so no backups we need to wait for) that completed.
         // - we had a backup-aware operation that has completed, but also all its backups have completed.
-        future.set(value);
+        future.complete(value);
     }
 
     @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
@@ -494,7 +494,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
 
         // We are the lucky ones since we just managed to complete the last backup for this invocation and since the
         // pendingResponse is set, we can set it on the future.
-        future.set(pendingResponse);
+        future.complete(pendingResponse);
     }
 
     boolean checkInvocationTimeout() {
@@ -539,7 +539,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
     }
 
     private void handleContinueWait() {
-        future.set(WAIT_RESPONSE);
+        future.complete(WAIT_RESPONSE);
     }
 
     private void handleRetry(Object cause) {
@@ -554,11 +554,11 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         operationService.invocationRegistry.deregister(this);
 
         if (future.interrupted) {
-            future.set(INTERRUPTED_RESPONSE);
+            future.complete(INTERRUPTED_RESPONSE);
             return;
         }
 
-        if (!future.set(WAIT_RESPONSE)) {
+        if (!future.complete(WAIT_RESPONSE)) {
             logger.finest("Cannot retry " + toString() + ", because a different response is already set: "
                     + future.response);
             return;
@@ -605,7 +605,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         }
 
         // The backups have not yet completed, but we are going to release the future anyway if a pendingResponse has been set.
-        future.set(pendingResponse);
+        future.complete(pendingResponse);
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -148,7 +148,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
      * is set/applied, <tt>false</tt> otherwise. If <tt>false</tt> is returned, that means offered response is ignored
      * because a final response is already set to this future.
      */
-    public boolean set(Object offeredResponse) {
+    public boolean complete(Object offeredResponse) {
         assert !(offeredResponse instanceof Response) : "unexpected response found: " + offeredResponse;
 
         if (offeredResponse == null) {
@@ -207,7 +207,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
     }
 
     @Override
-    public E getSafely() {
+    public E join() {
         try {
             //this method is quite inefficient when there is unchecked exception, because it will be wrapped
             //in a ExecutionException, and then it is unwrapped again.
@@ -215,6 +215,11 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
         } catch (Throwable throwable) {
             throw ExceptionUtil.rethrow(throwable);
         }
+    }
+
+    @Override
+    public E getSafely() {
+        return join();
     }
 
     @Override
@@ -277,7 +282,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
                             continue;
                         }
                         // tries to set an OperationTimeoutException response if response is not set yet
-                        set(operationTimeoutException);
+                        complete(operationTimeoutException);
                     }
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -107,7 +107,7 @@ public class IsStillRunningService {
         if (isStillRunningOperation(invocation)) {
             // timeout the original invocation since IsStillExecutingOperation is timed out
             final InvocationFuture future = invocation.future;
-            future.set(false);
+            future.complete(false);
             return;
         }
 
@@ -238,7 +238,7 @@ public class IsStillRunningService {
 
         private void setOperationTimeout() {
             InvocationFuture future = invocation.future;
-            future.set(invocation.newOperationTimeoutException(future.getMaxCallTimeout()));
+            future.complete(invocation.newOperationTimeoutException(future.getMaxCallTimeout()));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
@@ -36,6 +36,6 @@ public class TotalOrderedTopicProxy extends TopicProxy {
         NodeEngine nodeEngine = getNodeEngine();
         PublishOperation operation = new PublishOperation(getName(), nodeEngine.toData(message));
         InternalCompletableFuture f = operationService.invokeOnPartition(TopicService.SERVICE_NAME, operation, partitionId);
-        f.getSafely();
+        f.join();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -247,7 +247,7 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
         HashSet<SerializableXID> xids = new HashSet<SerializableXID>();
         xids.addAll(xaService.getPreparedXids());
         for (InternalCompletableFuture<SerializableList> future : futureList) {
-            SerializableList xidSet = future.getSafely();
+            SerializableList xidSet = future.join();
             for (Data xidData : xidSet) {
                 SerializableXID xid = nodeEngine.toObject(xidData);
                 xids.add(xid);

--- a/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
@@ -298,7 +298,7 @@ public final class FutureUtil {
             throws ExecutionException, InterruptedException {
 
         if (future instanceof InternalCompletableFuture) {
-            return ((InternalCompletableFuture<V>) future).getSafely();
+            return ((InternalCompletableFuture<V>) future).join();
         }
 
         return future.get();

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
@@ -11,12 +11,10 @@ import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
-import com.hazelcast.test.AbstractHazelcastClassRunner;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runners.model.FrameworkMethod;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -764,7 +762,7 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
         });
 
         InternalCompletableFuture f = (InternalCompletableFuture) ringbuffer.readManyAsync(0, 1, 1, null);
-        f.getSafely();
+        f.join();
     }
     // ===================== misc ==========================
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
@@ -275,7 +275,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
             completedCall.incrementAndGet();
 
             try {
-                Long result = (Long) f.getSafely();
+                Long result = (Long) f.join();
 
                 if (!expectedResult.equals(result)) {
                     failedOperationCount.incrementAndGet();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
@@ -45,7 +45,7 @@ public class InvocationFuture_IsDoneTest extends HazelcastTestSupport {
         DummyOperation op = new GetLostPartitionOperation();
 
         InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null, op, getAddress(local));
-        future.set(InternalResponse.WAIT_RESPONSE);
+        future.complete(InternalResponse.WAIT_RESPONSE);
 
         assertFalse(future.isDone());
     }
@@ -55,7 +55,7 @@ public class InvocationFuture_IsDoneTest extends HazelcastTestSupport {
         DummyOperation op = new GetLostPartitionOperation();
 
         InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null, op, getAddress(local));
-        future.set(InternalResponse.INTERRUPTED_RESPONSE);
+        future.complete(InternalResponse.INTERRUPTED_RESPONSE);
 
         assertTrue(future.isDone());
     }
@@ -65,7 +65,7 @@ public class InvocationFuture_IsDoneTest extends HazelcastTestSupport {
         DummyOperation op = new GetLostPartitionOperation();
 
         InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null, op, getAddress(local));
-        future.set(InternalResponse.TIMEOUT_RESPONSE);
+        future.complete(InternalResponse.TIMEOUT_RESPONSE);
 
         assertTrue(future.isDone());
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -185,7 +185,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
 
         InvocationFuture f = invocation.future;
         try {
-            f.getSafely();
+            f.join();
             fail();
         } catch (HazelcastInstanceNotActiveException expected) {
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
@@ -67,7 +67,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
         Object value = "foo";
         invocationRegistry.notifyNormalResponse(callId, value, 0, null);
 
-        assertEquals(value, invocation.future.getSafely());
+        assertEquals(value, invocation.future.join());
         assertNull(invocationRegistry.get(callId));
     }
 
@@ -97,7 +97,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
         invocationRegistry.notifyNormalResponse(callId, value, 1, null);
         assertNull(invocationRegistry.get(callId));
 
-        assertEquals(value, invocation.future.getSafely());
+        assertEquals(value, invocation.future.join());
     }
 
     //todo: more permutations with different number of backups arriving in different orders.
@@ -136,7 +136,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
         invocationRegistry.notifyBackupComplete(callId);
         assertNull(invocationRegistry.get(callId));
 
-        assertEquals(value, invocation.future.getSafely());
+        assertEquals(value, invocation.future.join());
     }
 
     @Test
@@ -161,7 +161,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
         invocationRegistry.notifyErrorResponse(callId, new ExpectedRuntimeException(), null);
 
         try {
-            invocation.future.getSafely();
+            invocation.future.join();
             fail();
         } catch (ExpectedRuntimeException expected) {
         }
@@ -191,7 +191,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
         long callId = invocation.op.getCallId();
         invocationRegistry.notifyCallTimeout(callId, null);
 
-        assertNull(invocation.future.getSafely());
+        assertNull(invocation.future.join());
         assertNull(invocationRegistry.get(callId));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
@@ -49,7 +49,7 @@ public abstract class Invocation_NestedAbstractTest extends HazelcastTestSupport
                 f = operationService.invokeOnTarget(null, innerOperation, getNodeEngine().getThisAddress());
             }
 
-            result = f.getSafely();
+            result = f.join();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedLocalTest.java
@@ -46,7 +46,7 @@ public class Invocation_NestedLocalTest extends Invocation_NestedAbstractTest {
         OuterOperation outerOperation = new OuterOperation(innerOperation, getPartitionId(local));
         InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
 
-        assertEquals(RESPONSE, f.getSafely());
+        assertEquals(RESPONSE, f.join());
     }
 
     @Test
@@ -59,7 +59,7 @@ public class Invocation_NestedLocalTest extends Invocation_NestedAbstractTest {
         OuterOperation outerOperation = new OuterOperation(innerOperation, partitionId);
         InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
 
-        assertEquals(RESPONSE, f.getSafely());
+        assertEquals(RESPONSE, f.join());
     }
 
     @Test
@@ -75,7 +75,7 @@ public class Invocation_NestedLocalTest extends Invocation_NestedAbstractTest {
 
         expected.expect(IllegalThreadStateException.class);
         expected.expectMessage("cannot make remote call");
-        f.getSafely();
+        f.join();
     }
 
     @Test
@@ -94,7 +94,7 @@ public class Invocation_NestedLocalTest extends Invocation_NestedAbstractTest {
 
         expected.expect(IllegalThreadStateException.class);
         expected.expectMessage("cannot make remote call");
-        f.getSafely();
+        f.join();
     }
 
     @Test
@@ -106,7 +106,7 @@ public class Invocation_NestedLocalTest extends Invocation_NestedAbstractTest {
         OuterOperation outerOperation = new OuterOperation(innerOperation, GENERIC_OPERATION);
         InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(local));
 
-        assertEquals(RESPONSE, f.getSafely());
+        assertEquals(RESPONSE, f.join());
     }
 
     @Test
@@ -119,7 +119,7 @@ public class Invocation_NestedLocalTest extends Invocation_NestedAbstractTest {
         OuterOperation outerOperation = new OuterOperation(innerOperation, GENERIC_OPERATION);
         InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(local));
 
-        assertEquals(RESPONSE, f.getSafely());
+        assertEquals(RESPONSE, f.join());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedRemoteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedRemoteTest.java
@@ -48,7 +48,7 @@ public class Invocation_NestedRemoteTest extends Invocation_NestedAbstractTest {
         OuterOperation outerOperation = new OuterOperation(innerOperation, getPartitionId(remote));
         InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
 
-        assertEquals(RESPONSE, f.getSafely());
+        assertEquals(RESPONSE, f.join());
     }
 
     @Test
@@ -63,7 +63,7 @@ public class Invocation_NestedRemoteTest extends Invocation_NestedAbstractTest {
         OuterOperation outerOperation = new OuterOperation(innerOperation, partitionId);
         InternalCompletableFuture f = operationService.invokeOnPartition(null, outerOperation, outerOperation.getPartitionId());
 
-        assertEquals(RESPONSE, f.getSafely());
+        assertEquals(RESPONSE, f.join());
     }
 
     @Test
@@ -82,7 +82,7 @@ public class Invocation_NestedRemoteTest extends Invocation_NestedAbstractTest {
 
         expected.expect(IllegalThreadStateException.class);
         expected.expectMessage("cannot make remote call");
-        f.getSafely();
+        f.join();
     }
 
     @Test
@@ -101,7 +101,7 @@ public class Invocation_NestedRemoteTest extends Invocation_NestedAbstractTest {
 
         expected.expect(IllegalThreadStateException.class);
         expected.expectMessage("cannot make remote call");
-        f.getSafely();
+        f.join();
     }
 
     @Test
@@ -120,7 +120,7 @@ public class Invocation_NestedRemoteTest extends Invocation_NestedAbstractTest {
 
         expected.expect(IllegalThreadStateException.class);
         expected.expectMessage("cannot make remote call");
-        f.getSafely();
+        f.join();
     }
 
     @Test
@@ -134,7 +134,7 @@ public class Invocation_NestedRemoteTest extends Invocation_NestedAbstractTest {
         OuterOperation outerOperation = new OuterOperation(innerOperation, GENERIC_OPERATION);
         InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(remote));
 
-        assertEquals(RESPONSE, f.getSafely());
+        assertEquals(RESPONSE, f.join());
     }
 
     @Test
@@ -148,7 +148,7 @@ public class Invocation_NestedRemoteTest extends Invocation_NestedAbstractTest {
         OuterOperation outerOperation = new OuterOperation(innerOperation, GENERIC_OPERATION);
         InternalCompletableFuture f = operationService.invokeOnTarget(null, outerOperation, getAddress(remote));
 
-        assertEquals(RESPONSE, f.getSafely());
+        assertEquals(RESPONSE, f.join());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
@@ -257,7 +257,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
                 .setCallTimeout(callTimeout).invoke();
 
         try {
-            future.getSafely();
+            future.join();
             fail("Invocation should failed with timeout!");
         } catch (OperationTimeoutException ignored) {
         }
@@ -265,7 +265,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         IsLockedOperation isLockedOperation = new IsLockedOperation(new InternalLockNamespace(key),
                 nodeEngine.toData(key), 1);
         Boolean isLocked = (Boolean) operationService
-                .invokeOnPartition(null, isLockedOperation, partitionId).getSafely();
+                .invokeOnPartition(null, isLockedOperation, partitionId).join();
         assertFalse(isLocked);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -109,7 +109,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         });
 
         // we wait for completion.
-        f.getSafely();
+        f.join();
 
         // after the call is complete, the operation should not be running anymore eventually
         assertTrueEventually(new AssertTask() {
@@ -150,7 +150,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         });
 
         // we wait for completion
-        f.getSafely();
+        f.join();
 
         // after the call is complete, the operation should not be running anymore
         assertTrueEventually(new AssertTask() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionTest.java
@@ -58,7 +58,7 @@ public class OperationServiceImpl_invokeOnPartitionTest extends HazelcastTestSup
 
         InternalCompletableFuture<String> invocation = operationService.invokeOnPartition(
                 null, operation, getPartitionId(local));
-        assertEquals(expected, invocation.getSafely());
+        assertEquals(expected, invocation.join());
     }
 
     @Test
@@ -68,7 +68,7 @@ public class OperationServiceImpl_invokeOnPartitionTest extends HazelcastTestSup
 
         InternalCompletableFuture<String> invocation = operationService.invokeOnPartition(
                 null, operation, getPartitionId(remote));
-        assertEquals(expected, invocation.getSafely());
+        assertEquals(expected, invocation.join());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class OperationServiceImpl_invokeOnPartitionTest extends HazelcastTestSup
                 null, operation, getPartitionId(remote));
 
         try {
-            invocation.getSafely();
+            invocation.join();
             fail();
         } catch (ExpectedRuntimeException expected) {
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnTargetTest.java
@@ -46,7 +46,7 @@ public class OperationServiceImpl_invokeOnTargetTest extends HazelcastTestSuppor
         DummyOperation operation = new DummyOperation(expected);
         InternalCompletableFuture<String> invocation = operationService.invokeOnTarget(
                 null, operation, getAddress(local));
-        assertEquals(expected, invocation.getSafely());
+        assertEquals(expected, invocation.join());
 
         //todo: we need to verify that the call was run on the calling thread
     }
@@ -57,7 +57,7 @@ public class OperationServiceImpl_invokeOnTargetTest extends HazelcastTestSuppor
         DummyOperation operation = new DummyOperation(expected);
         InternalCompletableFuture<String> invocation = operationService.invokeOnTarget(
                 null, operation, getAddress(remote));
-        assertEquals(expected, invocation.getSafely());
+        assertEquals(expected, invocation.join());
     }
 
     //this test is very slow, so it is marked as a nightly test
@@ -73,7 +73,7 @@ public class OperationServiceImpl_invokeOnTargetTest extends HazelcastTestSuppor
                 null, operation, remoteAddress);
 
         try {
-            invocation.getSafely();
+            invocation.join();
             fail();
         } catch (TargetNotMemberException e) {
         }
@@ -86,7 +86,7 @@ public class OperationServiceImpl_invokeOnTargetTest extends HazelcastTestSuppor
                 null, operation, getAddress(remote));
 
         try {
-            invocation.getSafely();
+            invocation.join();
             fail();
         } catch (ExpectedRuntimeException expected) {
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
@@ -125,7 +125,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
             });
         } else {
             try {
-                future.getSafely();
+                future.join();
                 fail("Should throw OperationTimeoutException!");
             } catch (OperationTimeoutException ignored) {
                 latch.countDown();


### PR DESCRIPTION
Renamed InvocationFuture.set to complete
Renamed InternalCompletableFuture.getSafely to join. The getSafely has been deprecated. not removed, for compatibility reason.