### PR TITLE
Invocation receives OperationServiceImpl directly

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -17,9 +17,8 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.nio.Address;
 import com.hazelcast.internal.partition.InternalPartition;
-import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.nio.Address;
 
 /**
  * The InvocationBuilder is responsible for building an invocation of an operation and invoking it.
@@ -54,7 +53,6 @@ public abstract class InvocationBuilder {
      */
     public static final boolean DEFAULT_DESERIALIZE_RESULT = true;
 
-    protected final NodeEngineImpl nodeEngine;
     protected final String serviceName;
     protected final Operation op;
     protected final int partitionId;
@@ -70,22 +68,19 @@ public abstract class InvocationBuilder {
     /**
      * Creates an InvocationBuilder
      *
-     * @param nodeEngine  the nodeEngine
      * @param serviceName the name of the service
      * @param op          the operation to execute
      * @param partitionId the id of the partition upon which to execute the operation
      * @param target      the target machine. Either the partitionId or the target needs to be set.
      */
-    public InvocationBuilder(NodeEngineImpl nodeEngine, String serviceName, Operation op,
-                             int partitionId, Address target) {
-        this.nodeEngine = nodeEngine;
+    protected InvocationBuilder(String serviceName, Operation op, int partitionId, Address target) {
         this.serviceName = serviceName;
         this.op = op;
         this.partitionId = partitionId;
         this.target = target;
     }
 
-     /**
+    /**
      * Sets the replicaIndex.
      *
      * @param replicaIndex the replica index
@@ -164,6 +159,7 @@ public abstract class InvocationBuilder {
 
     /**
      * Gets the operation to execute.
+     *
      * @return the operation to execute
      */
     public Operation getOp() {
@@ -174,7 +170,7 @@ public abstract class InvocationBuilder {
      * Gets the replicaIndex.
      *
      * @return the replicaIndex
-      */
+     */
 
     public int getReplicaIndex() {
         return replicaIndex;
@@ -201,7 +197,7 @@ public abstract class InvocationBuilder {
     /**
      * Returns the target machine.
      *
-     * @return  the target machine.
+     * @return the target machine.
      */
     public Address getTarget() {
         return target;
@@ -210,7 +206,7 @@ public abstract class InvocationBuilder {
     /**
      * Returns the partition id.
      *
-     * @return  the partition id.
+     * @return the partition id.
      */
     public int getPartitionId() {
         return partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -103,31 +103,31 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
     // A flag to prevent multiple responses to be send tot he Invocation. Only needed for local operations.
     volatile Boolean responseReceived = FALSE;
 
-    final long callTimeout;
     final NodeEngineImpl nodeEngine;
+    final OperationServiceImpl operationService;
+    final InvocationFuture future;
+    final ILogger logger;
     final String serviceName;
     final int partitionId;
     final int replicaIndex;
     final int tryCount;
     final long tryPauseMillis;
-    final ILogger logger;
     final boolean deserialize;
+    final long callTimeout;
+
     boolean remote;
     Address invTarget;
     MemberImpl targetMember;
-    final InvocationFuture future;
-    final OperationServiceImpl operationService;
 
     // writes to that are normally handled through the INVOKE_COUNT to ensure atomic increments / decrements
     volatile int invokeCount;
 
-
-    Invocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
+    Invocation(OperationServiceImpl operationService, String serviceName, Operation op, int partitionId,
                int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout, ExecutionCallback callback,
                boolean deserialize) {
-        this.operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+        this.operationService = operationService;
         this.logger = operationService.invocationLogger;
-        this.nodeEngine = nodeEngine;
+        this.nodeEngine = operationService.nodeEngine;
         this.serviceName = serviceName;
         this.op = op;
         this.partitionId = partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -20,33 +20,35 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 
 /**
  * An {@link com.hazelcast.spi.InvocationBuilder} that is tied to the {@link OperationServiceImpl}.
  */
 public class InvocationBuilderImpl extends InvocationBuilder {
 
-    public InvocationBuilderImpl(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId) {
-        this(nodeEngine, serviceName, op, partitionId, null);
+    private final OperationServiceImpl operationService;
+
+    public InvocationBuilderImpl(OperationServiceImpl operationService, String serviceName, Operation op, int partitionId) {
+        this(operationService, serviceName, op, partitionId, null);
     }
 
-    public InvocationBuilderImpl(NodeEngineImpl nodeEngine, String serviceName, Operation op, Address target) {
-        this(nodeEngine, serviceName, op, Operation.GENERIC_PARTITION_ID, target);
+    public InvocationBuilderImpl(OperationServiceImpl operationService, String serviceName, Operation op, Address target) {
+        this(operationService, serviceName, op, Operation.GENERIC_PARTITION_ID, target);
     }
 
-    private InvocationBuilderImpl(NodeEngineImpl nodeEngine, String serviceName, Operation op,
+    private InvocationBuilderImpl(OperationServiceImpl operationService, String serviceName, Operation op,
                                   int partitionId, Address target) {
-        super(nodeEngine, serviceName, op, partitionId, target);
+        super(serviceName, op, partitionId, target);
+        this.operationService = operationService;
     }
 
     @Override
     public InternalCompletableFuture invoke() {
         if (target == null) {
-            return new PartitionInvocation(nodeEngine, serviceName, op, partitionId, replicaIndex,
+            return new PartitionInvocation(operationService, serviceName, op, partitionId, replicaIndex,
                     tryCount, tryPauseMillis, callTimeout, getTargetExecutionCallback(), resultDeserialized).invoke();
         } else {
-            return new TargetInvocation(nodeEngine, serviceName, op, target, tryCount, tryPauseMillis,
+            return new TargetInvocation(operationService, serviceName, op, target, tryCount, tryPauseMillis,
                     callTimeout, getTargetExecutionCallback(), resultDeserialized).invoke();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -78,7 +78,7 @@ public class IsStillRunningService {
             Operation isStillExecuting = createCheckOperation(invocation);
 
             Invocation inv = new TargetInvocation(
-                    invocation.nodeEngine, invocation.serviceName, isStillExecuting,
+                    invocation.operationService, invocation.serviceName, isStillExecuting,
                     invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, null, true);
             Future f = inv.invoke();
             invocation.logger.warning("Asking if operation execution has been started: " + invocation);
@@ -261,7 +261,7 @@ public class IsStillRunningService {
         @Override
         public void run() {
             Invocation inv = new TargetInvocation(
-                    invocation.nodeEngine, invocation.serviceName, isStillRunningOperation,
+                    invocation.operationService, invocation.serviceName, isStillRunningOperation,
                     invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, callback, true);
 
             invocation.logger.warning("Asking if operation execution has been started: " + invocation);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -278,7 +278,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         if (partitionId < 0) {
             throw new IllegalArgumentException("Partition id cannot be negative!");
         }
-        return new InvocationBuilderImpl(nodeEngine, serviceName, op, partitionId);
+        return new InvocationBuilderImpl(this, serviceName, op, partitionId);
     }
 
     @Override
@@ -286,7 +286,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         if (target == null) {
             throw new IllegalArgumentException("Target cannot be null!");
         }
-        return new InvocationBuilderImpl(nodeEngine, serviceName, op, target);
+        return new InvocationBuilderImpl(this, serviceName, op, target);
     }
 
     @Override
@@ -308,7 +308,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     @SuppressWarnings("unchecked")
     public <E> InternalCompletableFuture<E> invokeOnPartition(String serviceName, Operation op, int partitionId) {
         return new PartitionInvocation(
-                nodeEngine, serviceName, op, partitionId, DEFAULT_REPLICA_INDEX,
+                this, serviceName, op, partitionId, DEFAULT_REPLICA_INDEX,
                 DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
                 DEFAULT_CALL_TIMEOUT, null, DEFAULT_DESERIALIZE_RESULT).invoke();
     }
@@ -316,7 +316,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     @Override
     @SuppressWarnings("unchecked")
     public <E> InternalCompletableFuture<E> invokeOnTarget(String serviceName, Operation op, Address target) {
-        return new TargetInvocation(nodeEngine, serviceName, op, target, DEFAULT_TRY_COUNT,
+        return new TargetInvocation(this, serviceName, op, target, DEFAULT_TRY_COUNT,
                 DEFAULT_TRY_PAUSE_MILLIS,
                 DEFAULT_CALL_TIMEOUT, null, DEFAULT_DESERIALIZE_RESULT).invoke();
     }
@@ -324,7 +324,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     @Override
     @SuppressWarnings("unchecked")
     public <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback) {
-        new PartitionInvocation(nodeEngine, serviceName, op, partitionId, DEFAULT_REPLICA_INDEX,
+        new PartitionInvocation(this, serviceName, op, partitionId, DEFAULT_REPLICA_INDEX,
                 DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
                 DEFAULT_CALL_TIMEOUT, callback, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 
 /**
  * A {@link Invocation} evaluates a Operation Invocation for a particular partition running on top of the
@@ -28,10 +27,10 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
  */
 public final class PartitionInvocation extends Invocation {
 
-    public PartitionInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId,
+    public PartitionInvocation(OperationServiceImpl operationService, String serviceName, Operation op, int partitionId,
                                int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout,
                                ExecutionCallback callback, boolean resultDeserialized) {
-        super(nodeEngine, serviceName, op, partitionId, replicaIndex, tryCount, tryPauseMillis,
+        super(operationService, serviceName, op, partitionId, replicaIndex, tryCount, tryPauseMillis,
                 callTimeout, callback, resultDeserialized);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 
 /**
  * A {@link Invocation} evaluates a Operation Invocation for a particular target running on top of the
@@ -31,10 +30,10 @@ public final class TargetInvocation extends Invocation {
 
     private final Address target;
 
-    public TargetInvocation(NodeEngineImpl nodeEngine, String serviceName, Operation op,
+    public TargetInvocation(OperationServiceImpl operationService, String serviceName, Operation op,
                             Address target, int tryCount, long tryPauseMillis, long callTimeout,
                             ExecutionCallback callback, boolean resultDeserialized) {
-        super(nodeEngine, serviceName, op, op.getPartitionId(), op.getReplicaIndex(),
+        super(operationService, serviceName, op, op.getPartitionId(), op.getReplicaIndex(),
                 tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized);
         this.target = target;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/InvocationBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/InvocationBuilderTest.java
@@ -21,24 +21,24 @@ public class InvocationBuilderTest extends HazelcastTestSupport {
 
     @Test
     public void getTargetExecutionCallback_whenNull() {
-        InvocationBuilder builder = new MockInvocationBuilder(null, null, null, 0, null);
+        InvocationBuilder builder = new MockInvocationBuilder(null, null, 0, null);
 
         assertNull(builder.getTargetExecutionCallback());
     }
 
     @Test
     public void getTargetExecutionCallback_whenExecutionCallbackInstance() {
-        InvocationBuilder invocationBuilder = new MockInvocationBuilder(null, null, null, 0, null);
+        InvocationBuilder builder = new MockInvocationBuilder(null, null, 0, null);
 
-        ExecutionCallback executionCallback = mock(ExecutionCallback.class);
-        invocationBuilder.setExecutionCallback(executionCallback);
+        ExecutionCallback callback = mock(ExecutionCallback.class);
+        builder.setExecutionCallback(callback);
 
-        assertSame(executionCallback, invocationBuilder.getTargetExecutionCallback());
+        assertSame(callback, builder.getTargetExecutionCallback());
     }
 
     class MockInvocationBuilder extends InvocationBuilder {
-        public MockInvocationBuilder(NodeEngineImpl nodeEngine, String serviceName, Operation op, int partitionId, Address target) {
-            super(nodeEngine, serviceName, op, partitionId, target);
+        public MockInvocationBuilder(String serviceName, Operation op, int partitionId, Address target) {
+            super(serviceName, op, partitionId, target);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
@@ -234,6 +234,7 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(nodeEngine, null, op, 0, 0, 0, 0, 0, null, false);
+        OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+        return new PartitionInvocation(operationService, null, op, 0, 0, 0, 0, 0, null, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
@@ -29,11 +29,13 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
 
     private HazelcastInstance hz;
     private NodeEngineImpl nodeEngine;
+    private OperationServiceImpl operationService;
 
     @Before
     public void setup() {
         hz = createHazelcastInstance();
         nodeEngine = getNode(hz).nodeEngine;
+        operationService = getOperationServiceImpl(hz);
     }
 
     @Test
@@ -116,6 +118,6 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(nodeEngine, null, op, 0, 0, 0, 0, 0, null, false);
+        return new PartitionInvocation(operationService, null, op, 0, 0, 0, 0, 0, null, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -49,7 +49,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(nodeEngine, null, op, op.getPartitionId(), 0, 0, 0, 0, null, false);
+        return new PartitionInvocation(operationService, null, op, op.getPartitionId(), 0, 0, 0, 0, null, false);
     }
 
     // ====================== register ===============================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
@@ -42,7 +42,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
         warmUpPartitions(local);
         nodeEngine = getNodeEngineImpl(local);
 
-        operationService = (OperationServiceImpl) getOperationService(local);
+        operationService = getOperationServiceImpl(local);
         invocationRegistry = operationService.invocationRegistry;
     }
 
@@ -51,7 +51,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        Invocation invocation = new PartitionInvocation(nodeEngine, null, op, op.getPartitionId(), 0, 0, 0, 0, null, false);
+        Invocation invocation = new PartitionInvocation(operationService, null, op, op.getPartitionId(), 0, 0, 0, 0, null, false);
         invocation.invTarget = getAddress(local);
         return invocation;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
@@ -280,7 +280,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         // invoke on the "remote" member
         Address remoteAddress = getNode(remote).getThisAddress();
 
-        TargetInvocation orgInvocation = new TargetInvocation(getNodeEngineImpl(local), null,
+        TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local), null,
                 new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, null, true);
         InvocationFuture future = orgInvocation.invoke();
         final CountDownLatch timeoutLatch = new CountDownLatch(1);
@@ -302,7 +302,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
 
         long orgCallId = orgInvocation.op.getCallId();
 
-        TargetInvocation isStillExecutingInvocation = new TargetInvocation(getNodeEngineImpl(local), null,
+        TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local), null,
                 new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, null, true);
         InvocationFuture isStillExecutingFuture = isStillExecutingInvocation.invoke();
         isStillExecutingFuture.andThen(new IsStillRunningService.IsOperationStillRunningCallback(orgInvocation));
@@ -322,13 +322,13 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         // invoke on the "remote" member
         Address remoteAddress = getNode(remote).getThisAddress();
 
-        TargetInvocation orgInvocation = new TargetInvocation(getNodeEngineImpl(local), null,
+        TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local), null,
                 new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, null, true);
         InvocationFuture future = orgInvocation.invoke();
 
         long orgCallId = orgInvocation.op.getCallId();
 
-        TargetInvocation isStillExecutingInvocation = new TargetInvocation(getNodeEngineImpl(local), null,
+        TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local), null,
                 new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, null, true);
         InvocationFuture isStillExecutingFuture = isStillExecutingInvocation.invoke();
         isStillExecutingFuture.andThen(new IsStillRunningService.IsOperationStillRunningCallback(orgInvocation));

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -71,7 +71,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         started.countDown();
 
         PartitionInvocation invocation = new PartitionInvocation(
-                getNodeEngineImpl(hz), null, isStillExecutingOperation, partitionId, 0, 0, 0, 0, null, false);
+                getOperationServiceImpl(hz), null, isStillExecutingOperation, partitionId, 0, 0, 0, 0, null, false);
 
         boolean result = isStillRunningService.isOperationExecuting(invocation);
         assertFalse(result);
@@ -182,7 +182,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
 
         final IsStillRunningService isStillRunningService = operationService.getIsStillRunningService();
 
-        final TargetInvocation invocation = new TargetInvocation(getNodeEngineImpl(hz1), null,
+        final TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1), null,
                 new DummyOperation(callTimeoutMillis * 10), remoteAddress, 0, 0,
                 callTimeoutMillis, null, true);
         final InvocationFuture future = invocation.invoke();
@@ -221,7 +221,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         // invoke on the "remote" member
         Address remoteAddress = getNode(hz2).getThisAddress();
 
-        TargetInvocation invocation = new TargetInvocation(getNodeEngineImpl(hz1), null,
+        TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1), null,
                 new DummyOperation(1), remoteAddress, 0, 0,
                 callTimeoutMillis, null, true);
         final InvocationFuture future = invocation.invoke();

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -37,6 +37,7 @@ import com.hazelcast.internal.partition.impl.InternalPartitionServiceState;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import org.junit.After;
@@ -195,6 +196,11 @@ public abstract class HazelcastTestSupport {
     public static InternalOperationService getOperationService(HazelcastInstance hz) {
         Node node = getNode(hz);
         return node.nodeEngine.getOperationService();
+    }
+
+    public static OperationServiceImpl getOperationServiceImpl(HazelcastInstance hz) {
+        Node node = getNode(hz);
+        return (OperationServiceImpl) node.nodeEngine.getOperationService();
     }
 
     public static InternalPartitionService getPartitionService(HazelcastInstance hz) {


### PR DESCRIPTION
No need to go through indirection of NodeEngine to retrieve the
OperationServiceImpl