### PR TITLE
Invocation servicename/partitionid/replica-index removal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueEvictionProcessor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.collection.impl.queue;
 
 import com.hazelcast.collection.impl.queue.operations.CheckAndEvictOperation;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
@@ -32,11 +33,9 @@ import java.util.Collection;
 public class QueueEvictionProcessor implements ScheduledEntryProcessor<String, Void> {
 
     private final NodeEngine nodeEngine;
-    private final QueueService service;
 
-    public QueueEvictionProcessor(NodeEngine nodeEngine, QueueService service) {
+    public QueueEvictionProcessor(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
-        this.service = service;
     }
 
     @Override
@@ -51,8 +50,10 @@ public class QueueEvictionProcessor implements ScheduledEntryProcessor<String, V
         for (ScheduledEntry<String, Void> entry : entries) {
             String name = entry.getKey();
             int partitionId = partitionService.getPartitionId(nodeEngine.toData(name));
-            CheckAndEvictOperation op = new CheckAndEvictOperation(entry.getKey());
-            operationService.invokeOnPartition(QueueService.SERVICE_NAME, op, partitionId).join();
+            Operation op = new CheckAndEvictOperation(entry.getKey())
+                    .setPartitionId(partitionId);
+
+            operationService.invokeOnPartition(op).join();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -94,7 +94,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
     public QueueService(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
         TaskScheduler globalScheduler = nodeEngine.getExecutionService().getGlobalTaskScheduler();
-        QueueEvictionProcessor entryProcessor = new QueueEvictionProcessor(nodeEngine, this);
+        QueueEvictionProcessor entryProcessor = new QueueEvictionProcessor(nodeEngine);
         this.queueEvictionScheduler = EntryTaskSchedulerFactory.newScheduler(
                 globalScheduler, entryProcessor, ScheduleType.POSTPONE);
         this.logger = nodeEngine.getLogger(QueueService.class);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
@@ -32,8 +32,6 @@ import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationService;
-import com.hazelcast.util.ExceptionUtil;
 
 import static com.hazelcast.util.Preconditions.isNotNull;
 
@@ -46,17 +44,6 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
         super(nodeEngine, service);
         this.name = name;
         this.partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
-    }
-
-    private <E> InternalCompletableFuture<E> asyncInvoke(Operation operation) {
-        try {
-            OperationService operationService = getNodeEngine().getOperationService();
-            //noinspection unchecked
-            return (InternalCompletableFuture<E>) operationService.invokeOnPartition(
-                    AtomicLongService.SERVICE_NAME, operation, partitionId);
-        } catch (Throwable throwable) {
-            throw ExceptionUtil.rethrow(throwable);
-        }
     }
 
     @Override
@@ -80,8 +67,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public InternalCompletableFuture<Long> asyncAddAndGet(long delta) {
-        Operation operation = new AddAndGetOperation(name, delta);
-        return asyncInvoke(operation);
+        Operation operation = new AddAndGetOperation(name, delta)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -91,8 +79,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public InternalCompletableFuture<Boolean> asyncCompareAndSet(long expect, long update) {
-        Operation operation = new CompareAndSetOperation(name, expect, update);
-        return asyncInvoke(operation);
+        Operation operation = new CompareAndSetOperation(name, expect, update)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -102,8 +91,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public InternalCompletableFuture<Void> asyncSet(long newValue) {
-        Operation operation = new SetOperation(name, newValue);
-        return asyncInvoke(operation);
+        Operation operation = new SetOperation(name, newValue)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -113,8 +103,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public InternalCompletableFuture<Long> asyncGetAndSet(long newValue) {
-        Operation operation = new GetAndSetOperation(name, newValue);
-        return asyncInvoke(operation);
+        Operation operation = new GetAndSetOperation(name, newValue)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -124,8 +115,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public InternalCompletableFuture<Long> asyncGetAndAdd(long delta) {
-        Operation operation = new GetAndAddOperation(name, delta);
-        return asyncInvoke(operation);
+        Operation operation = new GetAndAddOperation(name, delta)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -145,8 +137,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public InternalCompletableFuture<Long> asyncGet() {
-        GetOperation operation = new GetOperation(name);
-        return asyncInvoke(operation);
+        Operation operation = new GetOperation(name)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -178,8 +171,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
     public InternalCompletableFuture<Void> asyncAlter(IFunction<Long, Long> function) {
         isNotNull(function, "function");
 
-        Operation operation = new AlterOperation(name, function);
-        return asyncInvoke(operation);
+        Operation operation = new AlterOperation(name, function)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -191,8 +185,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
     public InternalCompletableFuture<Long> asyncAlterAndGet(IFunction<Long, Long> function) {
         isNotNull(function, "function");
 
-        Operation operation = new AlterAndGetOperation(name, function);
-        return asyncInvoke(operation);
+        Operation operation = new AlterAndGetOperation(name, function)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -204,8 +199,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
     public InternalCompletableFuture<Long> asyncGetAndAlter(IFunction<Long, Long> function) {
         isNotNull(function, "function");
 
-        Operation operation = new GetAndAlterOperation(name, function);
-        return asyncInvoke(operation);
+        Operation operation = new GetAndAlterOperation(name, function)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -217,8 +213,9 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
     public <R> InternalCompletableFuture<R> asyncApply(IFunction<Long, R> function) {
         isNotNull(function, "function");
 
-        Operation operation = new ApplyOperation<R>(name, function);
-        return asyncInvoke(operation);
+        Operation operation = new ApplyOperation<R>(name, function)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
@@ -27,7 +27,6 @@ import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationService;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -55,8 +54,9 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
     public boolean init(int permits) {
         checkNotNegative(permits, "permits can't be negative");
 
-        InitOperation operation = new InitOperation(name, permits);
-        InternalCompletableFuture<Boolean> future = invoke(operation);
+        Operation operation = new InitOperation(name, permits)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Boolean> future = invokeOnPartition(operation);
         return future.join();
     }
 
@@ -70,8 +70,9 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
         checkNotNegative(permits, "permits can't be negative");
 
         try {
-            AcquireOperation operation = new AcquireOperation(name, permits, -1);
-            InternalCompletableFuture<Object> future = invoke(operation);
+            Operation operation = new AcquireOperation(name, permits, -1)
+                    .setPartitionId(partitionId);
+            InternalCompletableFuture<Object> future = invokeOnPartition(operation);
             future.get();
         } catch (Throwable t) {
             throw rethrowAllowInterrupted(t);
@@ -80,15 +81,17 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
 
     @Override
     public int availablePermits() {
-        AvailableOperation operation = new AvailableOperation(name);
-        InternalCompletableFuture<Integer> future = invoke(operation);
+        Operation operation = new AvailableOperation(name)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Integer> future = invokeOnPartition(operation);
         return future.join();
     }
 
     @Override
     public int drainPermits() {
-        DrainOperation operation = new DrainOperation(name);
-        InternalCompletableFuture<Integer> future = invoke(operation);
+        Operation operation = new DrainOperation(name)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Integer> future = invokeOnPartition(operation);
         return future.join();
     }
 
@@ -96,8 +99,9 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
     public void reducePermits(int reduction) {
         checkNotNegative(reduction, "reduction can't be negative");
 
-        ReduceOperation operation = new ReduceOperation(name, reduction);
-        InternalCompletableFuture<Object> future = invoke(operation);
+        Operation operation = new ReduceOperation(name, reduction)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Object> future = invokeOnPartition(operation);
         future.join();
     }
 
@@ -110,8 +114,9 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
     public void release(int permits) {
         checkNotNegative(permits, "permits can't be negative");
 
-        ReleaseOperation operation = new ReleaseOperation(name, permits);
-        InternalCompletableFuture future = invoke(operation);
+        Operation operation = new ReleaseOperation(name, permits)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture future = invokeOnPartition(operation);
         future.join();
     }
 
@@ -143,20 +148,13 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
         checkNotNegative(permits, "permits can't be negative");
 
         try {
-            AcquireOperation operation = new AcquireOperation(name, permits, unit.toMillis(timeout));
-            Future<Boolean> future = invoke(operation);
+            Operation operation = new AcquireOperation(name, permits, unit.toMillis(timeout))
+                    .setPartitionId(partitionId);
+            Future<Boolean> future = invokeOnPartition(operation);
             return future.get();
         } catch (Throwable t) {
             throw rethrowAllowInterrupted(t);
         }
-    }
-
-    private <T> InternalCompletableFuture<T> invoke(Operation operation) {
-        NodeEngine nodeEngine = getNodeEngine();
-        OperationService operationService = nodeEngine.getOperationService();
-        //noinspection unchecked
-        return (InternalCompletableFuture) operationService.invokeOnPartition(
-                SemaphoreService.SERVICE_NAME, operation, partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -972,10 +972,6 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         return serializationService.toObject(obj);
     }
 
-    protected Data toData(Object obj) {
-        return serializationService.toData(obj);
-    }
-
     protected Data toData(Object o, PartitioningStrategy partitioningStrategy) {
         return serializationService.toData(o, partitioningStrategy);
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
@@ -90,23 +90,26 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
 
     @Override
     public long size() {
-        GenericOperation op = new GenericOperation(name, OPERATION_SIZE);
-        InternalCompletableFuture f = invoke(op);
-        return (Long) f.join();
+        Operation op = new GenericOperation(name, OPERATION_SIZE)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Long> f = invokeOnPartition(op);
+        return f.join();
     }
 
     @Override
     public long tailSequence() {
-        GenericOperation op = new GenericOperation(name, OPERATION_TAIL);
-        InternalCompletableFuture f = invoke(op);
-        return (Long) f.join();
+        Operation op = new GenericOperation(name, OPERATION_TAIL)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Long> f = invokeOnPartition(op);
+        return f.join();
     }
 
     @Override
     public long headSequence() {
-        GenericOperation op = new GenericOperation(name, OPERATION_HEAD);
-        InternalCompletableFuture f = invoke(op);
-        return (Long) f.join();
+        Operation op = new GenericOperation(name, OPERATION_HEAD)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Long> f = invokeOnPartition(op);
+        return f.join();
     }
 
     @Override
@@ -117,22 +120,20 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
             return config.getCapacity();
         }
 
-        GenericOperation op = new GenericOperation(name, OPERATION_REMAINING_CAPACITY);
-        InternalCompletableFuture f = invoke(op);
-        return (Long) f.join();
+        Operation op = new GenericOperation(name, OPERATION_REMAINING_CAPACITY)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Long> f = invokeOnPartition(op);
+        return f.join();
     }
 
     @Override
     public long add(E item) {
         checkNotNull(item, "item can't be null");
 
-        AddOperation op = new AddOperation(name, toData(item), OVERWRITE);
-        InternalCompletableFuture<Long> f = invoke(op);
+        Operation op = new AddOperation(name, toData(item), OVERWRITE)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Long> f = invokeOnPartition(op);
         return f.join();
-    }
-
-    private Data toData(E item) {
-        return getNodeEngine().getSerializationService().toData(item);
     }
 
     @Override
@@ -140,16 +141,18 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
         checkNotNull(item, "item can't be null");
         checkNotNull(overflowPolicy, "overflowPolicy can't be null");
 
-        AddOperation op = new AddOperation(name, toData(item), overflowPolicy);
-        return invoke(op);
+        Operation op = new AddOperation(name, toData(item), overflowPolicy)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(op);
     }
 
     @Override
     public E readOne(long sequence) throws InterruptedException {
         checkSequence(sequence);
 
-        ReadOneOperation op = new ReadOneOperation(name, sequence);
-        InternalCompletableFuture<E> f = invoke(op);
+        Operation op = new ReadOneOperation(name, sequence)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<E> f = invokeOnPartition(op);
         try {
             return f.get();
         } catch (Throwable t) {
@@ -164,7 +167,8 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
         checkFalse(collection.isEmpty(), "collection can't be empty");
         checkTrue(collection.size() <= MAX_BATCH_SIZE, "collection can't be larger than " + MAX_BATCH_SIZE);
 
-        AddAllOperation op = new AddAllOperation(name, toDataArray(collection), overflowPolicy);
+        Operation op = new AddAllOperation(name, toDataArray(collection), overflowPolicy)
+                .setPartitionId(partitionId);
         OperationService operationService = getOperationService();
         return operationService.createInvocationBuilder(null, op, partitionId)
                 .setCallTimeout(Long.MAX_VALUE)
@@ -191,16 +195,12 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
         checkTrue(minCount <= config.getCapacity(), "the minCount should be smaller than or equal to the capacity");
         checkTrue(maxCount <= MAX_BATCH_SIZE, "maxCount can't be larger than " + MAX_BATCH_SIZE);
 
-        ReadManyOperation op = new ReadManyOperation(name, startSequence, minCount, maxCount, filter);
+        Operation op = new ReadManyOperation(name, startSequence, minCount, maxCount, filter)
+                .setPartitionId(partitionId);
         OperationService operationService = getOperationService();
         return operationService.createInvocationBuilder(null, op, partitionId)
                 .setCallTimeout(Long.MAX_VALUE)
                 .invoke();
-    }
-
-    private <T> InternalCompletableFuture<T> invoke(Operation op) {
-        OperationService operationService = getOperationService();
-        return operationService.invokeOnPartition(null, op, partitionId);
     }
 
     private static void checkSequence(long sequence) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
@@ -24,6 +24,7 @@ import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 
 /**
  * Abstract DistributedObject implementation. Useful to provide basic functionality.
+ *
  * @param <S>
  */
 public abstract class AbstractDistributedObject<S extends RemoteService> implements DistributedObject {
@@ -56,7 +57,15 @@ public abstract class AbstractDistributedObject<S extends RemoteService> impleme
         postDestroy();
     }
 
-    protected int getPartitionId(Data key) {
+    protected final Data toData(Object object) {
+        return getNodeEngine().toData(object);
+    }
+
+    protected final <E> InternalCompletableFuture<E> invokeOnPartition(Operation operation) {
+        return getNodeEngine().getOperationService().invokeOnPartition(operation);
+    }
+
+    protected final int getPartitionId(Data key) {
         return getNodeEngine().getPartitionService().getPartitionId(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -539,8 +539,8 @@ public abstract class Operation implements DataSerializable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(getClass().getName()).append('{');
-        sb.append("identityHash=").append(System.identityHashCode(this));
-        sb.append(", serviceName='").append(getServiceName()).append('\'');
+        sb.append("serviceName='").append(getServiceName()).append('\'');
+        sb.append(", identityHash=").append(System.identityHashCode(this));
         sb.append(", partitionId=").append(partitionId);
         sb.append(", replicaIndex=").append(replicaIndex);
         sb.append(", callId=").append(callId);

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -117,6 +117,15 @@ public interface OperationService {
 
     <E> InternalCompletableFuture<E> invokeOnPartition(String serviceName, Operation op, int partitionId);
 
+    /**
+     * Executes an operation on a partition.
+     *
+     * @param op the operation
+     * @param <E> the return type of the operation response
+     * @return the future.
+     */
+    <E> InternalCompletableFuture<E> invokeOnPartition(Operation op);
+
     <E> InternalCompletableFuture<E> invokeOnTarget(String serviceName, Operation op, Address target);
 
     InvocationBuilder createInvocationBuilder(String serviceName, Operation op, int partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -44,12 +44,15 @@ public class InvocationBuilderImpl extends InvocationBuilder {
 
     @Override
     public InternalCompletableFuture invoke() {
+        op.setServiceName(serviceName);
+
         if (target == null) {
-            return new PartitionInvocation(operationService, serviceName, op, partitionId, replicaIndex,
-                    tryCount, tryPauseMillis, callTimeout, getTargetExecutionCallback(), resultDeserialized).invoke();
+            op.setPartitionId(partitionId).setReplicaIndex(replicaIndex);
+            return new PartitionInvocation(operationService, op, tryCount, tryPauseMillis, callTimeout,
+                    getTargetExecutionCallback(), resultDeserialized).invoke();
         } else {
-            return new TargetInvocation(operationService, serviceName, op, target, tryCount, tryPauseMillis,
-                    callTimeout, getTargetExecutionCallback(), resultDeserialized).invoke();
+            return new TargetInvocation(operationService, op, target, tryCount, tryPauseMillis, callTimeout,
+                    getTargetExecutionCallback(), resultDeserialized).invoke();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -78,7 +78,7 @@ public class IsStillRunningService {
             Operation isStillExecuting = createCheckOperation(invocation);
 
             Invocation inv = new TargetInvocation(
-                    invocation.operationService, invocation.serviceName, isStillExecuting,
+                    invocation.operationService, isStillExecuting,
                     invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, null, true);
             Future f = inv.invoke();
             invocation.logger.warning("Asking if operation execution has been started: " + invocation);
@@ -126,7 +126,7 @@ public class IsStillRunningService {
         Operation op = invocation.op;
         if (op instanceof TraceableOperation) {
             TraceableOperation traceable = (TraceableOperation) op;
-            return new TraceableIsStillExecutingOperation(invocation.serviceName, traceable.getTraceIdentifier());
+            return new TraceableIsStillExecutingOperation(op.getServiceName(), traceable.getTraceIdentifier());
         } else {
             return new IsStillExecutingOperation(op.getCallId(), op.getPartitionId());
         }
@@ -261,7 +261,7 @@ public class IsStillRunningService {
         @Override
         public void run() {
             Invocation inv = new TargetInvocation(
-                    invocation.operationService, invocation.serviceName, isStillRunningOperation,
+                    invocation.operationService, isStillRunningOperation,
                     invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, callback, true);
 
             invocation.logger.warning("Asking if operation execution has been started: " + invocation);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -27,16 +27,15 @@ import com.hazelcast.spi.Operation;
  */
 public final class PartitionInvocation extends Invocation {
 
-    public PartitionInvocation(OperationServiceImpl operationService, String serviceName, Operation op, int partitionId,
-                               int replicaIndex, int tryCount, long tryPauseMillis, long callTimeout,
-                               ExecutionCallback callback, boolean resultDeserialized) {
-        super(operationService, serviceName, op, partitionId, replicaIndex, tryCount, tryPauseMillis,
+    public PartitionInvocation(OperationServiceImpl operationService, Operation op, int tryCount, long tryPauseMillis,
+                               long callTimeout, ExecutionCallback callback, boolean resultDeserialized) {
+        super(operationService, op, tryCount, tryPauseMillis,
                 callTimeout, callback, resultDeserialized);
     }
 
     @Override
     public Address getTarget() {
-        return getPartition().getReplicaAddress(replicaIndex);
+        return getPartition().getReplicaAddress(op.getReplicaIndex());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -30,11 +30,10 @@ public final class TargetInvocation extends Invocation {
 
     private final Address target;
 
-    public TargetInvocation(OperationServiceImpl operationService, String serviceName, Operation op,
+    public TargetInvocation(OperationServiceImpl operationService, Operation op,
                             Address target, int tryCount, long tryPauseMillis, long callTimeout,
                             ExecutionCallback callback, boolean resultDeserialized) {
-        super(operationService, serviceName, op, op.getPartitionId(), op.getReplicaIndex(),
-                tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized);
+        super(operationService, op, tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized);
         this.target = target;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TotalOrderedTopicProxy.java
@@ -18,24 +18,22 @@ package com.hazelcast.topic.impl;
 
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.Operation;
 
 public class TotalOrderedTopicProxy extends TopicProxy {
 
     private final int partitionId;
-    private final OperationService operationService;
 
     public TotalOrderedTopicProxy(String name, NodeEngine nodeEngine, TopicService service) {
         super(name, nodeEngine, service);
         this.partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
-        this.operationService = nodeEngine.getOperationService();
     }
 
     @Override
     public void publish(Object message) {
-        NodeEngine nodeEngine = getNodeEngine();
-        PublishOperation operation = new PublishOperation(getName(), nodeEngine.toData(message));
-        InternalCompletableFuture f = operationService.invokeOnPartition(TopicService.SERVICE_NAME, operation, partitionId);
+        Operation operation = new PublishOperation(getName(), toData(message))
+                .setPartitionId(partitionId);
+        InternalCompletableFuture f = invokeOnPartition(operation);
         f.join();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
@@ -235,6 +235,6 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
 
     private Invocation newInvocation(Operation op) {
         OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
-        return new PartitionInvocation(operationService, null, op, 0, 0, 0, 0, 0, null, false);
+        return new PartitionInvocation(operationService, op, 0, 0, 0, null, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
@@ -118,6 +118,6 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(operationService, null, op, 0, 0, 0, 0, 0, null, false);
+        return new PartitionInvocation(operationService, op, 0, 0, 0, null, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -49,7 +49,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(operationService, null, op, op.getPartitionId(), 0, 0, 0, 0, null, false);
+        return new PartitionInvocation(operationService, op, 0, 0, 0, null, false);
     }
 
     // ====================== register ===============================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
@@ -51,7 +51,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        Invocation invocation = new PartitionInvocation(operationService, null, op, op.getPartitionId(), 0, 0, 0, 0, null, false);
+        Invocation invocation = new PartitionInvocation(operationService, op , 0, 0, 0, null, false);
         invocation.invTarget = getAddress(local);
         return invocation;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
@@ -280,7 +280,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         // invoke on the "remote" member
         Address remoteAddress = getNode(remote).getThisAddress();
 
-        TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local), null,
+        TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local),
                 new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, null, true);
         InvocationFuture future = orgInvocation.invoke();
         final CountDownLatch timeoutLatch = new CountDownLatch(1);
@@ -302,7 +302,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
 
         long orgCallId = orgInvocation.op.getCallId();
 
-        TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local), null,
+        TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local),
                 new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, null, true);
         InvocationFuture isStillExecutingFuture = isStillExecutingInvocation.invoke();
         isStillExecutingFuture.andThen(new IsStillRunningService.IsOperationStillRunningCallback(orgInvocation));
@@ -322,13 +322,13 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         // invoke on the "remote" member
         Address remoteAddress = getNode(remote).getThisAddress();
 
-        TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local), null,
+        TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local),
                 new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, null, true);
         InvocationFuture future = orgInvocation.invoke();
 
         long orgCallId = orgInvocation.op.getCallId();
 
-        TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local), null,
+        TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local),
                 new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, null, true);
         InvocationFuture isStillExecutingFuture = isStillExecutingInvocation.invoke();
         isStillExecutingFuture.andThen(new IsStillRunningService.IsOperationStillRunningCallback(orgInvocation));

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -71,7 +71,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         started.countDown();
 
         PartitionInvocation invocation = new PartitionInvocation(
-                getOperationServiceImpl(hz), null, isStillExecutingOperation, partitionId, 0, 0, 0, 0, null, false);
+               operationService, isStillExecutingOperation, 0, 0, 0, null, false);
 
         boolean result = isStillRunningService.isOperationExecuting(invocation);
         assertFalse(result);
@@ -182,7 +182,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
 
         final IsStillRunningService isStillRunningService = operationService.getIsStillRunningService();
 
-        final TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1), null,
+        final TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1),
                 new DummyOperation(callTimeoutMillis * 10), remoteAddress, 0, 0,
                 callTimeoutMillis, null, true);
         final InvocationFuture future = invocation.invoke();
@@ -221,7 +221,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         // invoke on the "remote" member
         Address remoteAddress = getNode(hz2).getThisAddress();
 
-        TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1), null,
+        TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1),
                 new DummyOperation(1), remoteAddress, 0, 0,
                 callTimeoutMillis, null, true);
         final InvocationFuture future = invocation.invoke();


### PR DESCRIPTION
All this information is already available on the operation itself. So the operation is used as leading source of this information instead of copied. 