### PR TITLE
Removing Wildcard Supression for ClientQueueProxy

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -92,6 +92,7 @@
 
     <!-- Client -->
     <!-- TODO: we need to get these wildcard suppressions fixed -->
+    <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientQueueProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientListProxy"/>
     <suppress checks="" files="com/hazelcast/client/proxy/ClientMultiMapProxy"/>
     <suppress checks="" files="com/hazelcast/client/proxy/ClientMapProxy"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -92,7 +92,6 @@
 
     <!-- Client -->
     <!-- TODO: we need to get these wildcard suppressions fixed -->
-    <suppress checks="" files="com/hazelcast/client/proxy/ClientQueueProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientListProxy"/>
     <suppress checks="" files="com/hazelcast/client/proxy/ClientMultiMapProxy"/>
     <suppress checks="" files="com/hazelcast/client/proxy/ClientMapProxy"/>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
@@ -62,6 +62,11 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
+/**
+ * Proxy implementation of {@link IQueue}.
+ *
+ * @param <E> the type of elements in this queue
+ */
 public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy implements IQueue<E> {
 
     public ClientQueueProxy(String serviceName, String name) {
@@ -350,7 +355,8 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         Collection<Data> dataCollection = CollectionUtil.objectToDataCollection(c, getSerializationService());
         ClientMessage request = QueueCompareAndRemoveAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
-        QueueCompareAndRemoveAllCodec.ResponseParameters resultParameters = QueueCompareAndRemoveAllCodec.decodeResponse(response);
+        QueueCompareAndRemoveAllCodec.ResponseParameters resultParameters =
+                QueueCompareAndRemoveAllCodec.decodeResponse(response);
         return resultParameters.response;
     }
 
@@ -359,7 +365,8 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         Collection<Data> dataCollection = CollectionUtil.objectToDataCollection(c, getSerializationService());
         ClientMessage request = QueueCompareAndRetainAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
-        QueueCompareAndRetainAllCodec.ResponseParameters resultParameters = QueueCompareAndRetainAllCodec.decodeResponse(response);
+        QueueCompareAndRetainAllCodec.ResponseParameters resultParameters =
+                QueueCompareAndRetainAllCodec.decodeResponse(response);
         return resultParameters.response;
     }
 


### PR DESCRIPTION
In my quest to remove most checkstyle supressions from hazelcast-client I've removed the wildcard suppression for ClientQueueProxy and replaced it with a methodcount suppression.

I've also added a small javadoc comment and fixed the line length errors.

(See Issue #7712 )