### PR TITLE
Make MemArrayQuickSorter's base address mutable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/IntMemArrayQuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/IntMemArrayQuickSorter.java
@@ -25,16 +25,12 @@ import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
  * {@link QuickSorter} implementation for a memory block which stores an array of {@code int}s.
  * Memory is accessed using the provided {@link MemoryAccessor}.
  */
-public class IntMemArrayQuickSorter extends QuickSorter {
-
-    private final MemoryAccessor mem;
-    private final long baseAddress;
+public class IntMemArrayQuickSorter extends MemArrayQuickSorter {
 
     private int pivot;
 
     public IntMemArrayQuickSorter(MemoryAccessor mem, long baseAddress) {
-        this.mem = mem;
-        this.baseAddress = baseAddress;
+        super(mem, baseAddress);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/LongMemArrayQuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/LongMemArrayQuickSorter.java
@@ -25,16 +25,12 @@ import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
  * {@link QuickSorter} implementation for a memory block which stores an array of {@code int}s.
  * Memory is accessed using the provided {@link MemoryAccessor}.
  */
-public class LongMemArrayQuickSorter extends QuickSorter {
-
-    private final MemoryAccessor mem;
-    private final long baseAddress;
+public class LongMemArrayQuickSorter extends MemArrayQuickSorter {
 
     private long pivot;
 
     public LongMemArrayQuickSorter(MemoryAccessor mem, long baseAddress) {
-        this.mem = mem;
-        this.baseAddress = baseAddress;
+        super(mem, baseAddress);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/MemArrayQuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/MemArrayQuickSorter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.memory.impl;
+
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.internal.memory.QuickSorter;
+
+/**
+ * Base class for {@link QuickSorter} implementations on a memory block accessed by a
+ * {@link MemoryAccessor}.
+ */
+public abstract class MemArrayQuickSorter extends QuickSorter {
+
+    protected final MemoryAccessor mem;
+    protected long baseAddress;
+
+    /**
+     * @param mem the {@link MemoryAccessor} to use
+     * @param baseAddress the initial base address of the block to sort
+     */
+    protected MemArrayQuickSorter(MemoryAccessor mem, long baseAddress) {
+        this.mem = mem;
+        this.baseAddress = baseAddress;
+    }
+
+    /**
+     * Sets the base address to the supplied address.
+     */
+    public void setBaseAddress(long baseAddress) {
+        this.baseAddress = baseAddress;
+    }
+}


### PR DESCRIPTION
Mutable base address reduces object litter by allowing the same instance to be reused.