### PR TITLE
Removing wildcard checkstyle suppression for ClientMultiMapProxy

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -94,6 +94,7 @@
     <!-- TODO: we need to get these wildcard suppressions fixed -->
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientQueueProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientListProxy"/>
+    <suppress checks="MethodCount|ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientMultiMapProxy"/>
     <suppress checks="" files="com/hazelcast/client/proxy/ClientMapProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
     <suppress checks="ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -94,7 +94,6 @@
     <!-- TODO: we need to get these wildcard suppressions fixed -->
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientQueueProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientListProxy"/>
-    <suppress checks="" files="com/hazelcast/client/proxy/ClientMultiMapProxy"/>
     <suppress checks="" files="com/hazelcast/client/proxy/ClientMapProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
     <suppress checks="ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -83,6 +83,11 @@ import static com.hazelcast.util.Preconditions.checkPositive;
 import static com.hazelcast.util.Preconditions.isNotNull;
 
 /**
+ * Proxy implementation of {@link MultiMap}.
+ *
+ * @param <K> key
+ * @param <V> value
+ *
  * @author ali 5/19/13
  */
 public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K, V> {


### PR DESCRIPTION
Hello again, I've refined the suppression for ClientMultiMapProxy and added the param tags to it's javadoc comment.

As asked of us in issue #7712 these PRs are kept small on purpose. But I can imagine this is a bit too small, so if you'd prefer I can tackle all the wildcards under the Client comment in one go. Of course, if you prefer these small PRs I can continue like this.