### PR TITLE
Reorganization of collections code

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Long2LongMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Long2LongMap.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+/**
+ * A map that uses primitive {@code long}s for both key and value.
+ */
+public interface Long2LongMap {
+
+    long get(long key);
+
+    long put(long key, long value);
+
+    long putIfAbsent(long key, long value);
+
+    void putAll(Long2LongMap entries);
+
+    boolean replace(long key, long oldValue, long newValue);
+
+    long replace(long key, long value);
+
+    long remove(long key);
+
+    boolean remove(long key, long value);
+
+    boolean containsKey(long key);
+
+    long size();
+
+    boolean isEmpty();
+
+    void clear();
+
+    void dispose();
+
+    LongLongCursor cursor();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Long2LongMapHsa.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Long2LongMapHsa.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import com.hazelcast.internal.util.hashslot.HashSlotArray8byteKey;
+import com.hazelcast.internal.util.hashslot.impl.HashSlotArray8byteKeyImpl;
+import com.hazelcast.internal.util.hashslot.HashSlotCursor8byteKey;
+import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.internal.memory.MemoryManager;
+
+import static com.hazelcast.internal.memory.MemoryAllocator.NULL_ADDRESS;
+import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
+
+/**
+ * a {@link Long2LongMap} implemented in terms of a {@link HashSlotArray8byteKey}.
+ */
+public class Long2LongMapHsa implements Long2LongMap {
+
+    private final HashSlotArray8byteKey hsa;
+    private final long nullValue;
+    private MemoryAccessor mem;
+
+    /**
+     * @param nullValue the value that represents "null" or missing value
+     * @param memMgr memory manager to use. It is safe for its {@link MemoryManager#getAccessor} method
+     *               to return an accessor that only supports aligned memory access.
+     */
+    public Long2LongMapHsa(long nullValue, MemoryManager memMgr) {
+        this.hsa = new HashSlotArray8byteKeyImpl(nullValue, memMgr, LONG_SIZE_IN_BYTES);
+        hsa.gotoNew();
+        this.mem = memMgr.getAccessor();
+        this.nullValue = nullValue;
+    }
+
+    @Override public long get(long key) {
+        final long valueAddr = hsa.get(key);
+        return valueAddr != NULL_ADDRESS ? mem.getLong(valueAddr) : nullValue;
+    }
+
+    @Override public long put(long key, long value) {
+        assert value != nullValue : "put() called with null-sentinel value " + nullValue;
+        long valueAddr = hsa.ensure(key);
+        long result;
+        if (valueAddr < 0) {
+            valueAddr = -valueAddr;
+            result = mem.getLong(valueAddr);
+        } else {
+            result = nullValue;
+        }
+        mem.putLong(valueAddr, value);
+        return result;
+    }
+
+    @Override public long putIfAbsent(long key, long value) {
+        assert value != nullValue : "putIfAbsent() called with null-sentinel value " + nullValue;
+        long valueAddr = hsa.ensure(key);
+        if (valueAddr > 0) {
+            mem.putLong(valueAddr, value);
+            return nullValue;
+        } else {
+            valueAddr = -valueAddr;
+            return mem.getLong(valueAddr);
+        }
+    }
+
+    @Override public void putAll(Long2LongMap from) {
+        for (LongLongCursor cursor = from.cursor(); cursor.advance();) {
+            put(cursor.key(), cursor.value());
+        }
+    }
+
+    @Override public boolean replace(long key, long oldValue, long newValue) {
+        assert oldValue != nullValue : "replace() called with null-sentinel oldValue " + nullValue;
+        assert newValue != nullValue : "replace() called with null-sentinel newValue " + nullValue;
+        final long valueAddr = hsa.get(key);
+        if (valueAddr == NULL_ADDRESS) {
+            return false;
+        }
+        final long actualValue = mem.getLong(valueAddr);
+        if (actualValue != oldValue) {
+            return false;
+        }
+        mem.putLong(valueAddr, newValue);
+        return true;
+    }
+
+    @Override public long replace(long key, long value) {
+        assert value != nullValue : "replace() called with null-sentinel value " + nullValue;
+        final long valueAddr = hsa.get(key);
+        if (valueAddr == NULL_ADDRESS) {
+            return nullValue;
+        }
+        final long oldValue = mem.getLong(valueAddr);
+        mem.putLong(valueAddr, value);
+        return oldValue;
+    }
+
+    @Override public long remove(long key) {
+        final long valueAddr = hsa.get(key);
+        if (valueAddr == NULL_ADDRESS) {
+            return nullValue;
+        }
+        final long oldValue = mem.getLong(valueAddr);
+        hsa.remove(key);
+        return oldValue;
+    }
+
+    @Override public boolean remove(long key, long value) {
+        assert value != nullValue : "remove() called with null-sentinel value " + nullValue;
+        final long valueAddr = hsa.get(key);
+        if (valueAddr == NULL_ADDRESS) {
+            return false;
+        }
+        final long actualValue = mem.getLong(valueAddr);
+        if (actualValue == value) {
+            hsa.remove(key);
+            return true;
+        }
+        return false;
+    }
+
+    @Override public boolean containsKey(long key) {
+        return hsa.get(key) != NULL_ADDRESS;
+    }
+
+    @Override public long size() {
+        return hsa.size();
+    }
+
+    @Override public boolean isEmpty() {
+        return hsa.size() == 0;
+    }
+
+    @Override public void clear() {
+        hsa.clear();
+    }
+
+    @Override public void dispose() {
+        hsa.dispose();
+    }
+
+    @Override public LongLongCursor cursor() {
+        return new Cursor(hsa);
+    }
+
+    private final class Cursor implements LongLongCursor {
+
+        private final HashSlotCursor8byteKey cursor;
+
+        Cursor(HashSlotArray8byteKey hsa) {
+            this.cursor = hsa.cursor();
+        }
+
+        @Override public boolean advance() {
+            return cursor.advance();
+        }
+
+        @Override public long key() {
+            return cursor.key();
+        }
+
+        @Override public long value() {
+            return mem.getLong(cursor.valueAddress());
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongCursor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+/**
+ * Cursor over a collection of {@code long} values. Initially the cursor's location is
+ * before the first element and the cursor is invalid. The cursor becomes invalid again after a
+ * call to {@link #advance()} returns {@code false}. After {@link advance} returns {@code false},
+ * it is illegal to call any methods except {@link #reset}.
+ */
+public interface LongCursor {
+
+    /**
+     * Advances to the next {@code long} element. It is illegal to call this method after a previous
+     * call returned {@code false}. An {@code AssertionError} may be thrown.
+     *
+     * @return {@code true} if the cursor advanced. If {@code false} is returned, the cursor is now invalid.
+     */
+    boolean advance();
+
+    /**
+     * @return the {@code long} value at the cursor's current position
+     */
+    long value();
+
+    /**
+     * Resets the cursor to the inital state.
+     */
+    void reset();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongLongCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongLongCursor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+/**
+ * Cursor over the entries of a primitive {@code long}-to-{@code long} map.
+ */
+public interface LongLongCursor {
+
+    /**
+     * Advances to the next map entry. It is illegal to call this method after a previous
+     * call returned {@code false}. An {@code AssertionError} may be thrown.
+     *
+     * @return {@code true} if the cursor advanced. If {@code false} is returned, the cursor is now invalid.
+     */
+    boolean advance();
+
+    /**
+     * @return the key of the current entry.
+     */
+    long key();
+
+    /**
+     * @return the value of the current entry.
+     */
+    long value();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongSet.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import com.hazelcast.nio.Disposable;
+
+/** Set of primitive {@code long}s. */
+public interface LongSet extends Disposable {
+
+    boolean add(long value);
+
+    boolean remove(long value);
+
+    boolean contains(long value);
+
+    long size();
+
+    boolean isEmpty();
+
+    void clear();
+
+    LongCursor cursor();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongSetHsa.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/LongSetHsa.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import com.hazelcast.internal.memory.MemoryManager;
+import com.hazelcast.internal.util.hashslot.HashSlotArray8byteKey;
+import com.hazelcast.internal.util.hashslot.HashSlotCursor8byteKey;
+import com.hazelcast.internal.util.hashslot.impl.HashSlotArray8byteKeyNoValue;
+
+import static com.hazelcast.internal.memory.MemoryAllocator.NULL_ADDRESS;
+import static com.hazelcast.internal.util.hashslot.impl.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.internal.util.hashslot.impl.CapacityUtil.DEFAULT_LOAD_FACTOR;
+
+/**
+ * {@link LongSet} implementation based on {@link HashSlotArray8byteKey}.
+ */
+public class LongSetHsa implements LongSet {
+
+    private final long nullValue;
+    private final HashSlotArray8byteKey hsa;
+
+    public LongSetHsa(long nullValue, MemoryManager memMgr) {
+        this(nullValue, memMgr, DEFAULT_CAPACITY, DEFAULT_LOAD_FACTOR);
+    }
+
+    public LongSetHsa(long nullValue, MemoryManager memMgr, int initialCapacity, float loadFactor) {
+        this.nullValue = nullValue;
+        this.hsa = new HashSlotArray8byteKeyNoValue(nullValue, memMgr, initialCapacity, loadFactor);
+        hsa.gotoNew();
+    }
+
+    @Override
+    public boolean add(long value) {
+        assert value != nullValue : "add() called with null-sentinel value " + nullValue;
+        return hsa.ensure(value) > 0;
+    }
+
+    @Override
+    public boolean remove(long value) {
+        assert value != nullValue : "remove() called with null-sentinel value " + nullValue;
+        return hsa.remove(value);
+    }
+
+    @Override
+    public boolean contains(long value) {
+        assert value != nullValue : "contains() called with null-sentinel value " + nullValue;
+        return hsa.get(value) != NULL_ADDRESS;
+    }
+
+    @Override
+    public long size() {
+        return hsa.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public void clear() {
+        hsa.clear();
+    }
+
+    @Override
+    public LongCursor cursor() {
+        assert hsa.address() >= 0 : "cursor() called on a disposed map";
+        return new Cursor();
+    }
+
+    @Override
+    public void dispose() {
+        hsa.dispose();
+    }
+
+    private final class Cursor implements LongCursor {
+
+        private final HashSlotCursor8byteKey hsaCursor = hsa.cursor();
+
+        @Override
+        public boolean advance() {
+            return hsaCursor.advance();
+        }
+
+        @Override
+        public long value() {
+            return hsaCursor.key();
+        }
+
+        @Override
+        public void reset() {
+            hsaCursor.reset();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Primitive-typed collections.
+ */
+package com.hazelcast.internal.util.collection;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray8byteKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray8byteKey.java
@@ -41,7 +41,7 @@ public interface HashSlotArray8byteKey extends HashSlotArray {
      * @param key the key
      * @return address of the value block or
      * {@link MemoryAllocator#NULL_ADDRESS MemoryAllocator.NULL_ADDRESS}
-     * if no mapping for {@code (key1, key2)} exists.
+     * if no mapping for {@code key} exists.
      */
     long get(long key);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotCursor.java
@@ -18,7 +18,9 @@ package com.hazelcast.internal.util.hashslot;
 
 /**
  * Cursor over assigned slots in a {@link HashSlotArray}. Initially the cursor's location is
- * before the first slot and the cursor is invalid.
+ * before the first slot and the cursor is invalid. The cursor becomes invalid again after a
+ * call to {@link #advance()} return {@code false}. It is illegal to call any methods except
+ * {@link #reset} on an invalid cursor.
  */
 public interface HashSlotCursor {
 
@@ -28,15 +30,15 @@ public interface HashSlotCursor {
     void reset();
 
     /**
-     * Advances to the next assigned slot.
-     * @return true if the cursor advanced. If false is returned, the cursor is now invalid.
-     * @throws IllegalStateException if a previous call to advance() already returned false.
+     * Advances to the next assigned slot. It is illegal to call this method after a previous
+     * call returned {@code false}. An {@code AssertionError} may be thrown.
+     *
+     * @return {@code true} if the cursor advanced. If {@code false} is returned, the cursor is now invalid.
      */
     boolean advance();
 
     /**
      * @return Address of the current slot's value block.
-     * @throws IllegalStateException if the cursor is invalid.
      */
     long valueAddress();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyNoValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyNoValue.java
@@ -18,6 +18,9 @@ package com.hazelcast.internal.util.hashslot.impl;
 
 import com.hazelcast.internal.memory.MemoryManager;
 
+import static com.hazelcast.internal.util.hashslot.impl.CapacityUtil.DEFAULT_CAPACITY;
+import static com.hazelcast.internal.util.hashslot.impl.CapacityUtil.DEFAULT_LOAD_FACTOR;
+
 /**
  * Specialization of {@link HashSlotArray8byteKeyImpl} to the case of zero-length value. Suitable for a {@code long} set
  * implementation. Unassigned sentinel is kept at the start of the slot, i.e., in the key part.
@@ -25,12 +28,12 @@ import com.hazelcast.internal.memory.MemoryManager;
  */
 public class HashSlotArray8byteKeyNoValue extends HashSlotArray8byteKeyImpl {
 
-    public HashSlotArray8byteKeyNoValue(long unassignedSentinel, MemoryManager mm, int valueLength,
+    public HashSlotArray8byteKeyNoValue(long unassignedSentinel, MemoryManager mm,
                                         int initialCapacity, float loadFactor) {
-        super(unassignedSentinel, 0L, mm, valueLength, initialCapacity, loadFactor);
+        super(unassignedSentinel, 0L, mm, 0, initialCapacity, loadFactor);
     }
 
-    public HashSlotArray8byteKeyNoValue(long unassignedSentinel, MemoryManager mm, int valueLength) {
-        super(unassignedSentinel, 0L, mm, valueLength, CapacityUtil.DEFAULT_CAPACITY, CapacityUtil.DEFAULT_LOAD_FACTOR);
+    public HashSlotArray8byteKeyNoValue(long unassignedSentinel, MemoryManager mm) {
+        super(unassignedSentinel, 0L, mm, 0, DEFAULT_CAPACITY, DEFAULT_LOAD_FACTOR);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/IntMemArrayQuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/IntMemArrayQuickSorter.java
@@ -14,59 +14,57 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.memory.impl;
+package com.hazelcast.internal.util.sort;
 
 import com.hazelcast.internal.memory.MemoryAccessor;
-import com.hazelcast.internal.util.sort.QuickSorter;
 
-import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
+import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 
 /**
  * {@link QuickSorter} implementation for a memory block which stores an array of {@code int}s.
  * Memory is accessed using the provided {@link MemoryAccessor}.
  */
-public class LongMemArrayQuickSorter extends MemArrayQuickSorter {
+public class IntMemArrayQuickSorter extends MemArrayQuickSorter {
 
-    private long pivot;
+    private int pivot;
 
-    public LongMemArrayQuickSorter(MemoryAccessor mem, long baseAddress) {
+    public IntMemArrayQuickSorter(MemoryAccessor mem, long baseAddress) {
         super(mem, baseAddress);
     }
 
     @Override
     protected void loadPivot(long index) {
-        pivot = longAtIndex(index);
+        pivot = intAtIndex(index);
     }
 
     @Override
     protected boolean isLessThanPivot(long index) {
-        return longAtIndex(index) < pivot;
+        return intAtIndex(index) < pivot;
     }
 
     @Override
     protected boolean isGreaterThanPivot(long index) {
-        return longAtIndex(index) > pivot;
+        return intAtIndex(index) > pivot;
     }
 
     @Override
     protected void swap(long index1, long index2) {
         final long addrOfIndex1 = addrOfIndex(index1);
         final long addrOfIndex2 = addrOfIndex(index2);
-        final long tmp = longAtAddress(addrOfIndex1);
-        mem.putLong(addrOfIndex1, longAtAddress(addrOfIndex2));
-        mem.putLong(addrOfIndex2, tmp);
+        final int tmp = intAtAddress(addrOfIndex1);
+        mem.putInt(addrOfIndex1, intAtAddress(addrOfIndex2));
+        mem.putInt(addrOfIndex2, tmp);
     }
 
     private long addrOfIndex(long index) {
-        return baseAddress + LONG_SIZE_IN_BYTES * index;
+        return baseAddress + INT_SIZE_IN_BYTES * index;
     }
 
-    private long longAtIndex(long index) {
-        return longAtAddress(addrOfIndex(index));
+    private int intAtIndex(long index) {
+        return intAtAddress(addrOfIndex(index));
     }
 
-    private long longAtAddress(long address) {
-        return mem.getLong(address);
+    private int intAtAddress(long address) {
+        return mem.getInt(address);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/LongMemArrayQuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/LongMemArrayQuickSorter.java
@@ -14,58 +14,58 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.memory.impl;
+package com.hazelcast.internal.util.sort;
 
 import com.hazelcast.internal.memory.MemoryAccessor;
-import com.hazelcast.internal.memory.QuickSorter;
 
-import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
+import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 
 /**
  * {@link QuickSorter} implementation for a memory block which stores an array of {@code int}s.
  * Memory is accessed using the provided {@link MemoryAccessor}.
  */
-public class IntMemArrayQuickSorter extends MemArrayQuickSorter {
+public class LongMemArrayQuickSorter extends MemArrayQuickSorter {
 
-    private int pivot;
+    private long pivot;
 
-    public IntMemArrayQuickSorter(MemoryAccessor mem, long baseAddress) {
+    public LongMemArrayQuickSorter(MemoryAccessor mem, long baseAddress) {
         super(mem, baseAddress);
     }
 
     @Override
     protected void loadPivot(long index) {
-        pivot = intAtIndex(index);
+        pivot = longAtIndex(index);
     }
 
     @Override
     protected boolean isLessThanPivot(long index) {
-        return intAtIndex(index) < pivot;
+        return longAtIndex(index) < pivot;
     }
 
     @Override
     protected boolean isGreaterThanPivot(long index) {
-        return intAtIndex(index) > pivot;
+        return longAtIndex(index) > pivot;
     }
 
     @Override
     protected void swap(long index1, long index2) {
         final long addrOfIndex1 = addrOfIndex(index1);
         final long addrOfIndex2 = addrOfIndex(index2);
-        final int tmp = intAtAddress(addrOfIndex1);
-        mem.putInt(addrOfIndex1, intAtAddress(addrOfIndex2));
-        mem.putInt(addrOfIndex2, tmp);
+        final long tmp = longAtAddress(addrOfIndex1);
+        mem.putLong(addrOfIndex1, longAtAddress(addrOfIndex2));
+        mem.putLong(addrOfIndex2, tmp);
     }
 
     private long addrOfIndex(long index) {
-        return baseAddress + INT_SIZE_IN_BYTES * index;
+        return baseAddress + LONG_SIZE_IN_BYTES * index;
     }
 
-    private int intAtIndex(long index) {
-        return intAtAddress(addrOfIndex(index));
+    private long longAtIndex(long index) {
+        return longAtAddress(addrOfIndex(index));
     }
 
-    private int intAtAddress(long address) {
-        return mem.getInt(address);
+    private long longAtAddress(long address) {
+        return mem.getLong(address);
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/MemArrayQuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/MemArrayQuickSorter.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.memory.impl;
+package com.hazelcast.internal.util.sort;
 
 import com.hazelcast.internal.memory.MemoryAccessor;
-import com.hazelcast.internal.util.sort.QuickSorter;
 
 /**
  * Base class for {@link QuickSorter} implementations on a memory block accessed by a
@@ -39,8 +38,10 @@ public abstract class MemArrayQuickSorter extends QuickSorter {
 
     /**
      * Sets the base address to the supplied address.
+     * @return {@code this}
      */
-    public void setBaseAddress(long baseAddress) {
+    public MemArrayQuickSorter gotoAddress(long baseAddress) {
         this.baseAddress = baseAddress;
+        return this;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/QuickSorter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/QuickSorter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.memory;
+package com.hazelcast.internal.util.sort;
 
 /** <p>
  * Base class for QuickSort implementations. Works with an abstract notion of a mutable array of

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/sort/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/sort/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * General API for sorting.
+ */
+package com.hazelcast.internal.util.sort;

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/Long2LongMapHsaTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/Long2LongMapHsaTest.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import com.hazelcast.internal.memory.impl.HeapMemoryManager;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.RequireAssertEnabled;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class Long2LongMapHsaTest {
+
+    private static final long MISSING_VALUE = -1L;
+
+    private final Random random = new Random();
+    private HeapMemoryManager memMgr;
+    private Long2LongMapHsa map;
+
+    @Before
+    public void setUp() throws Exception {
+        memMgr = new HeapMemoryManager(32 * 1000 * 1000);
+        map = new Long2LongMapHsa(MISSING_VALUE, memMgr);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        map.dispose();
+        memMgr.dispose();
+    }
+
+    @Test
+    public void testPut() {
+        long key = newKey();
+        long value = newValue();
+        assertEqualsKV(MISSING_VALUE, map.put(key, value), key, value);
+
+        long newValue = newValue();
+        long oldValue = map.put(key, newValue);
+        assertEqualsKV(value, oldValue, key, value);
+    }
+
+    @Test
+    public void testGet() {
+        long key = newKey();
+        long value = newValue();
+        map.put(key, value);
+
+        long currentValue = map.get(key);
+        assertEqualsKV(value, currentValue, key, value);
+    }
+
+    @Test
+    public void testPutIfAbsent_success() {
+        long key = newKey();
+        long value = newValue();
+        assertEqualsKV(MISSING_VALUE, map.putIfAbsent(key, value), key, value);
+    }
+
+    @Test
+    public void testPutIfAbsent_fail() {
+        long key = newKey();
+        long value = newValue();
+        map.put(key, value);
+
+        long newValue = newValue();
+        assertEqualsKV(value, map.putIfAbsent(key, newValue), key, value);
+    }
+
+    @Test
+    public void testPutAll() throws Exception {
+        int count = 100;
+        Long2LongMap entries = new Long2LongMapHsa(count, memMgr);
+
+        for (int i = 0; i < count; i++) {
+            long key = newKey();
+            long value = newValue();
+            entries.put(key, value);
+        }
+
+        map.putAll(entries);
+        assertEquals(count, map.size());
+
+        for (LongLongCursor cursor = map.cursor(); cursor.advance();) {
+            assertEquals(map.get(cursor.key()), cursor.value());
+        }
+    }
+
+    @Test
+    public void testReplace() throws Exception {
+        long key = newKey();
+        long value = newValue();
+
+        assertEqualsKV(MISSING_VALUE, map.replace(key, value), key, value);
+
+        map.put(key, value);
+
+        long newValue = newValue();
+        assertEqualsKV(value, map.replace(key, newValue), key, value);
+    }
+
+    @Test
+    public void testReplace_if_same_success() {
+        long key = newKey();
+        long value = newValue();
+        map.put(key, value);
+
+        long newValue = value + 1;
+        assertTrueKV(map.replace(key, value, newValue), key, value);
+    }
+
+    @Test
+    public void testReplace_if_same_not_exist() {
+        long key = newKey();
+        long value = newValue();
+        long newValue = value + 1;
+        assertFalseKV(map.replace(key, value, newValue), key, value);
+    }
+
+    @Test
+    public void testReplace_if_same_fail() {
+        long key = newKey();
+        long value = newValue();
+        map.put(key, value);
+
+        long wrongValue = value + 1;
+        long newValue = value + 2;
+        assertFalseKV(map.replace(key, wrongValue, newValue), key, newValue);
+    }
+
+    @Test
+    public void testRemove() {
+        long key = newKey();
+        assertEqualsKV(MISSING_VALUE, map.remove(key), key, 0);
+
+        long value = newValue();
+        map.put(key, value);
+
+        long oldValue = map.remove(key);
+        assertEqualsKV(value, oldValue, key, value);
+    }
+
+    @Test
+    public void testRemove_if_same_success() {
+        long key = newKey();
+        long value = newValue();
+        map.put(key, value);
+
+        assertTrueKV(map.remove(key, value), key, value);
+    }
+
+    @Test
+    public void testRemove_if_same_not_exist() {
+        long key = newKey();
+        long value = newValue();
+        assertFalseKV(map.remove(key, value), key, value);
+    }
+
+    @Test
+    public void testRemove_if_same_fail() {
+        long key = newKey();
+        long value = newValue();
+        map.put(key, value);
+
+        long wrongValue = value + 1;
+        assertFalseKV(map.remove(key, wrongValue), key, value);
+    }
+
+    @Test
+    public void testContainsKey_fail() throws Exception {
+        long key = newKey();
+        assertFalseKV(map.containsKey(key), key, 0);
+    }
+
+    @Test
+    public void testContainsKey_success() {
+        long key = newKey();
+        long value = newValue();
+        map.put(key, value);
+
+        assertTrueKV(map.containsKey(key), key, value);
+    }
+
+    @Test
+    public void testPut_withTheSameValue() {
+        long key = newKey();
+        long value = newValue();
+        map.put(key, value);
+
+        long oldValue = map.put(key, value);
+        assertEqualsKV(value, oldValue, key, value);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void test_put_invalidValue() {
+        map.put(newKey(), MISSING_VALUE);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void test_putIfAbsent_invalidValue() {
+        map.putIfAbsent(newKey(), MISSING_VALUE);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void test_set_invalidValue() {
+        map.put(newKey(), MISSING_VALUE);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void test_replace_invalidValue() {
+        map.replace(newKey(), MISSING_VALUE);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void test_replaceIfEquals_invalidOldValue() {
+        map.replace(newKey(), MISSING_VALUE, newValue());
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void test_replaceIfEquals_invalidNewValue() {
+        map.replace(newKey(), newValue(), MISSING_VALUE);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void test_removeIfEquals_Value() {
+        map.remove(newKey(), MISSING_VALUE);
+    }
+
+    @Test
+    public void testSize() {
+        assertEquals(0, map.size());
+
+        int expected = 100;
+        for (long i = 0; i < expected; i++) {
+            long value = newValue();
+            map.put(i, value);
+        }
+
+        assertEquals(map.toString(), expected, map.size());
+    }
+
+    @Test
+    public void testClear() {
+        for (long i = 0; i < 100; i++) {
+            long value = newValue();
+            map.put(i, value);
+        }
+
+        map.clear();
+        assertEquals(0, map.size());
+        assertTrue(map.toString(), map.isEmpty());
+    }
+
+    @Test
+    public void testIsEmpty() {
+        assertTrue(map.isEmpty());
+
+        long key = newKey();
+        long value = newValue();
+        map.put(key, value);
+
+        assertFalseKV(map.isEmpty(), key, value);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testGet_after_dispose() {
+        map.dispose();
+        map.get(newKey());
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testPut_after_dispose() {
+        map.dispose();
+        map.put(newKey(), newValue());
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testRemove_after_dispose() {
+        map.dispose();
+        map.remove(newKey());
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testReplace_after_dispose() {
+        map.dispose();
+        map.replace(newKey(), newValue());
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testContainsKey_after_dispose() {
+        map.dispose();
+        map.containsKey(newKey());
+    }
+
+    @Test
+    public void testMemoryLeak() {
+        int keyRange = 100;
+
+        for (int i = 0; i < 100000; i++) {
+            int k = random.nextInt(7);
+            switch (k) {
+                case 0:
+                    _put_(keyRange);
+                    break;
+
+                case 1:
+                    _set_(keyRange);
+                    break;
+
+                case 2:
+                    _putIfAbsent_(keyRange);
+                    break;
+
+                case 3:
+                    _replace_(keyRange);
+                    break;
+
+                case 4:
+                    _replaceIfSame_(keyRange);
+                    break;
+
+                case 5:
+                    _remove_(keyRange);
+                    break;
+
+                case 6:
+                    _removeIfPresent_(keyRange);
+                    break;
+            }
+        }
+
+        map.clear();
+        map.dispose();
+        assertEquals(0, memMgr.getUsedMemory());
+    }
+
+    private void _put_(int keyRange) {
+        map.put(newKey(keyRange), newValue());
+    }
+
+    private void _set_(int keyRange) {
+        map.put(newKey(keyRange), newValue());
+    }
+
+    private void _putIfAbsent_(int keyRange) {
+        map.putIfAbsent(newKey(keyRange), newValue());
+    }
+
+    private void _replace_(int keyRange) {
+        map.replace(newKey(keyRange), newValue());
+    }
+
+    private void _replaceIfSame_(int keyRange) {
+        long key = newKey(keyRange);
+        long value = newValue();
+        long old = map.get(key);
+        if (old != MISSING_VALUE) {
+            map.replace(key, old, value);
+        }
+    }
+
+    private void _remove_(int keyRange) {
+        map.remove(newKey(keyRange));
+    }
+
+    private void _removeIfPresent_(int keyRange) {
+        long key = newKey(keyRange);
+        long old = map.get(key);
+        if (old != MISSING_VALUE) {
+            map.remove(key, old);
+        }
+    }
+
+    @Test
+    public void testDestroyMemoryLeak() {
+        for (int i = 0; i < 100; i++) {
+            map.put(newKey(), newValue());
+        }
+
+        map.clear();
+        map.dispose();
+        assertEquals(0, memMgr.getUsedMemory());
+    }
+
+    @Test
+    public void testMemoryLeak_whenCapacityExpandFails() {
+        while (true) {
+            long key = newKey();
+            long value = newValue();
+            try {
+                map.put(key, value);
+            } catch (OutOfMemoryError e) {
+                break;
+            }
+        }
+
+        map.clear();
+        map.dispose();
+        assertEquals(0, memMgr.getUsedMemory());
+    }
+
+    private long newKey() {
+        return random.nextLong();
+    }
+
+    private long newKey(int keyRange) {
+        return (long) random.nextInt(keyRange);
+    }
+
+    private long newValue() {
+        return random.nextInt(Integer.MAX_VALUE) + 1L;
+    }
+
+    private static void assertEqualsKV(long expected, long actual, long key, long value) {
+        Assert.assertEquals(String.format("key %d value %d", key, value), expected, actual);
+    }
+
+    private static void assertTrueKV(boolean actual, long key, long value) {
+        Assert.assertTrue(String.format("key %d value %d", key, value), actual);
+    }
+
+    private static void assertFalseKV(boolean actual, long key, long value) {
+        Assert.assertFalse(String.format("key %d value %d", key, value), actual);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/LongSetHsaTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/LongSetHsaTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import com.hazelcast.internal.memory.MemoryManager;
+import com.hazelcast.internal.memory.impl.HeapMemoryManager;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.RequireAssertEnabled;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class LongSetHsaTest {
+
+    private final Random random = new Random();
+    private MemoryManager memMgr;
+    private LongSet set;
+
+    @Before
+    public void setUp() {
+        memMgr = new HeapMemoryManager(32 * 1000 * 1000);
+        set = new LongSetHsa(0L, memMgr);
+    }
+
+    @After
+    public void tearDown()  {
+        set.dispose();
+        memMgr.dispose();
+    }
+
+    @Test
+    public void testAdd() {
+        long key = random.nextLong();
+        assertTrue(set.add(key));
+        assertFalse(set.add(key));
+    }
+
+    @Test
+    public void testAddMany() {
+        for (int i = 1; i <= 1000; i++) {
+            assertTrue(set.add(i));
+        }
+    }
+
+    @Test
+    public void testRemove() {
+        long key = random.nextLong();
+        assertFalse(set.remove(key));
+        set.add(key);
+        assertTrue(set.remove(key));
+    }
+
+    @Test
+    public void testContains() {
+        long key = random.nextLong();
+        assertFalse(set.contains(key));
+        set.add(key);
+        assertTrue(set.contains(key));
+    }
+
+    @Test
+    public void testCursor() {
+        assertFalse(set.cursor().advance());
+
+        Set<Long> expected = new HashSet<Long>();
+        for (int i = 1; i <= 1000; i++) {
+            set.add(i);
+            expected.add((long) i);
+        }
+
+        LongCursor cursor = set.cursor();
+        while (cursor.advance()) {
+            long key = cursor.value();
+            assertTrue("Key: " + key, expected.remove(key));
+        }
+    }
+
+    @Test
+    public void testClear() {
+        for (int i = 1; i <= 1000; i++) {
+            set.add(i);
+        }
+
+        set.clear();
+        assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
+    public void testSize() {
+        assertEquals(0, set.size());
+
+        int expected = 1000;
+        for (int i = 1; i <= expected; i++) {
+            set.add(i);
+        }
+
+        assertEquals(expected, set.size());
+    }
+
+    @Test
+    public void testIsEmpty() {
+        assertTrue(set.isEmpty());
+
+        set.add(random.nextLong());
+
+        assertFalse(set.isEmpty());
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testAdd_after_destroy() {
+        set.dispose();
+        set.add(1);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testRemove_after_destroy() {
+        set.dispose();
+        set.remove(1);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testContains_after_destroy() {
+        set.dispose();
+        set.contains(1);
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testCursor_after_destroy() {
+        set.dispose();
+        set.cursor();
+    }
+
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testCursor_after_destroy2() {
+        set.add(1);
+        LongCursor cursor = set.cursor();
+        set.dispose();
+        cursor.advance();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/sort/QuickSorterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/sort/QuickSorterTest.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.memory.impl;
+package com.hazelcast.internal.util.sort;
 
 import com.hazelcast.internal.memory.MemoryManager;
 import com.hazelcast.internal.memory.MemoryAccessor;
+import com.hazelcast.internal.memory.impl.HeapMemoryManager;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;


### PR DESCRIPTION
1. Fixed constructor signatures and Javadoc in HashSlotArray8byteKey.
2. Moved QuickSort classes to a fitting package (from `...memory` to `...internal.util.sort`)
3. Changes in  `Long2LongX` API: 
    1. Reimplement classes in terms of `HashSlotArray`
    2. Replace `Iterator` with `Cursor`
    3. Remove "elastic" word from name
    4. Move from EE to OSS