### PR TITLE
CompletableFuture cleanup

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -143,7 +143,7 @@ public class ClientMapReduceProxy
                                 response = collator.collate(((Map) response).entrySet());
                             }
                         } finally {
-                            completableFuture.setResult(response);
+                            completableFuture.complete(response);
                             trackableJobs.remove(jobId);
                         }
                     }
@@ -155,7 +155,7 @@ public class ClientMapReduceProxy
                             if (t instanceof ExecutionException && t.getCause() instanceof CancellationException) {
                                 t = t.getCause();
                             }
-                            completableFuture.setResult(t);
+                            completableFuture.complete(t);
                         } finally {
                             trackableJobs.remove(jobId);
                         }
@@ -259,8 +259,8 @@ public class ClientMapReduceProxy
         }
 
         @Override
-        protected void setResult(Object result) {
-            super.setResult(result);
+        protected void complete(Object result) {
+            super.complete(result);
         }
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/VeryAbstractCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/VeryAbstractCompletableFuture.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.concurrent.Executor;
+
+public abstract class VeryAbstractCompletableFuture<V> implements ICompletableFuture<V> {
+
+    protected final ILogger logger;
+    protected final Executor defaultExecutor;
+
+    public VeryAbstractCompletableFuture(Executor defaultExecutor, ILogger logger) {
+        this.logger = logger;
+        this.defaultExecutor = defaultExecutor;
+    }
+
+    @Override
+    public void andThen(ExecutionCallback<V> callback) {
+        andThen(callback, defaultExecutor);
+    }
+
+    public V join() {
+        try {
+            //this method is quite inefficient when there is unchecked exception, because it will be wrapped
+            //in a ExecutionException, and then it is unwrapped again.
+            return get();
+        } catch (Throwable throwable) {
+            throw ExceptionUtil.rethrow(throwable);
+        }
+    }
+
+    public V getSafely() {
+        return join();
+    }
+
+    protected void runAsynchronous(ExecutionCallbackNode head, Object result) {
+        while (head != null) {
+            runAsynchronous(head.callback, head.executor, result);
+            head = head.next;
+        }
+    }
+
+    protected void runAsynchronous(ExecutionCallback<V> callback, Executor executor, Object result) {
+        if (callback != null) {
+            executor.execute(new ExecutionCallbackRunnable<V>(getClass(), result, callback));
+        }
+    }
+
+    protected Object resolve(Object result) {
+        return result;
+    }
+
+    protected static final class ExecutionCallbackNode<E> {
+        protected final ExecutionCallback<E> callback;
+        protected final Executor executor;
+        protected final ExecutionCallbackNode<E> next;
+
+        public ExecutionCallbackNode(ExecutionCallback<E> callback, Executor executor, ExecutionCallbackNode<E> next) {
+            this.callback = callback;
+            this.executor = executor;
+            this.next = next;
+        }
+    }
+
+    protected final class ExecutionCallbackRunnable<V> implements Runnable {
+        private final Class<?> caller;
+        private final Object result;
+        private final ExecutionCallback<V> callback;
+
+        protected ExecutionCallbackRunnable(Class<?> caller, Object result, ExecutionCallback<V> callback) {
+            this.caller = caller;
+            this.result = result;
+            this.callback = callback;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Object response = resolve(result);
+
+                if (response instanceof Throwable) {
+                    callback.onFailure((Throwable) response);
+                } else {
+                    callback.onResponse((V) response);
+                }
+            } catch (Throwable cause) {
+                logger.severe("Failed asynchronous execution of execution callback: " + callback + " for call " + caller, cause);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -230,9 +230,9 @@ public class MapKeyLoader {
         if (lastBatch) {
             state.nextOrStay(State.LOADED);
             if (exception != null) {
-                loadFinished.setResult(exception);
+                loadFinished.complete(exception);
             } else {
-                loadFinished.setResult(true);
+                loadFinished.complete(true);
             }
         } else if (state.is(State.LOADED)) {
             state.next(State.LOADING);
@@ -266,7 +266,7 @@ public class MapKeyLoader {
             if (state.is(State.LOADING)) {
                 // previous loading was in progress. cancel and start from scratch
                 state.next(State.NOT_LOADED);
-                loadFinished.setResult(false);
+                loadFinished.complete(false);
             }
         }
 
@@ -392,7 +392,7 @@ public class MapKeyLoader {
 
         private LoadFinishedFuture(Boolean result) {
             this();
-            setResult(result);
+            complete(result);
         }
 
         private LoadFinishedFuture() {
@@ -410,14 +410,14 @@ public class MapKeyLoader {
         @Override
         public void onResponse(Boolean loaded) {
             if (loaded) {
-                setResult(loaded);
+                complete(loaded);
             }
             // if not loaded yet we wait for the last batch to arrive
         }
 
         @Override
         public void onFailure(Throwable t) {
-            setResult(t);
+            complete(t);
         }
 
         @Override
@@ -426,8 +426,8 @@ public class MapKeyLoader {
         }
 
         @Override
-        protected void setResult(Object result) {
-            super.setResult(result);
+        protected void complete(Object result) {
+            super.complete(result);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeyValueJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/KeyValueJobOperation.java
@@ -121,7 +121,7 @@ public class KeyValueJobOperation<K, V>
             TrackableJobFuture future = jobTracker.unregisterTrackableJob(jobId);
             if (future != null) {
                 Exception exception = new CancellationException("Operation was cancelled by the user");
-                future.setResult(exception);
+                future.complete(exception);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/StartProcessingJobOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/operation/StartProcessingJobOperation.java
@@ -77,7 +77,7 @@ public class StartProcessingJobOperation<K>
             TrackableJobFuture future = jobTracker.unregisterTrackableJob(jobId);
             if (future != null) {
                 Exception exception = new CancellationException("Operation was cancelled by the user");
-                future.setResult(exception);
+                future.complete(exception);
             }
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
@@ -153,7 +153,7 @@ public class JobSupervisor {
             // Might be already cancelled by another members exception
             ExceptionUtil.fixRemoteStackTrace(throwable, Thread.currentThread().getStackTrace(),
                     "Operation failed on node: " + remoteAddress);
-            future.setResult(throwable);
+            future.complete(throwable);
         }
     }
 
@@ -172,7 +172,7 @@ public class JobSupervisor {
 
         if (future != null) {
             // Might be already cancelled by another members exception
-            future.setResult(exception);
+            future.complete(exception);
         }
 
         return true;
@@ -511,7 +511,7 @@ public class JobSupervisor {
                 jobTracker.unregisterMapCombineTask(jobId);
                 jobTracker.unregisterReducerTask(jobId);
                 mapReduceService.destroyJobSupervisor(jobSupervisor);
-                future.setResult(finalResult);
+                future.complete(finalResult);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/TrackableJobFuture.java
@@ -62,10 +62,10 @@ public class TrackableJobFuture<V>
     }
 
     @Override
-    public void setResult(Object result) {
+    public void complete(Object result) {
         Object finalResult = result;
         if (finalResult instanceof Throwable && !(finalResult instanceof CancellationException)) {
-            super.setResult(new ExecutionException((Throwable) finalResult));
+            super.complete(new ExecutionException((Throwable) finalResult));
             return;
         }
         // If collator is available we need to execute it now
@@ -80,7 +80,7 @@ public class TrackableJobFuture<V>
         if (finalResult instanceof Throwable && !(finalResult instanceof CancellationException)) {
             finalResult = new ExecutionException((Throwable) finalResult);
         }
-        super.setResult(finalResult);
+        super.complete(finalResult);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFuture.java
@@ -61,15 +61,15 @@ class BasicCompletableFuture<V> extends AbstractCompletableFuture<V> {
         } catch (InterruptedException ex) {
             sneakyThrow(ex);
         } catch (ExecutionException ex) {
-            setResult(ex);
+            complete(ex);
             throw ex;
         } catch (CancellationException ex) {
-            setResult(ex);
+            complete(ex);
             throw ex;
         } catch (Throwable t) {
             result = t;
         }
-        setResult(result);
+        complete(result);
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CompletableFutureTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CompletableFutureTask.java
@@ -68,11 +68,11 @@ public class CompletableFutureTask<V> extends AbstractCompletableFuture<V> imple
                 } catch (Throwable ex) {
                     result = new ExecutionException(ex);
                 } finally {
-                    setResult(result);
+                    complete(result);
                 }
             }
         } finally {
-            // runner must be non-null until state is settled in setResult() to
+            // runner must be non-null until state is settled in complete() to
             // prevent concurrent calls to run()
             runner = null;
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractCompletableFutureTest.java
@@ -91,7 +91,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
 
     private void future_resultSet_doneNotCancelled(Object result) {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
-        future.setResult(result);
+        future.complete(result);
 
         assertTrue("Future with result should be done", future.isDone());
         assertFalse("Done future should not be cancelled", future.isCancelled());
@@ -110,7 +110,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     @Test
     public void future_resultSetAndCancelled() throws Exception {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
-        future.setResult(RESULT);
+        future.complete(RESULT);
         boolean cancelled = future.cancel(false);
 
         assertFalse(cancelled);
@@ -122,7 +122,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     public void future_cancelledAndResultSet() throws Exception {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         boolean cancelled = future.cancel(false);
-        future.setResult(RESULT);
+        future.complete(RESULT);
 
         assertTrue(cancelled);
         assertTrue("Cancelled future should be done", future.isDone());
@@ -151,7 +151,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     @Test
     public void get_ordinaryResultSet_returnsResult() throws Exception {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
-        future.setResult(RESULT);
+        future.complete(RESULT);
 
         Object result = future.get();
 
@@ -161,7 +161,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     @Test
     public void getWithTimeout_ordinaryResultSet_returnsResult() throws Exception {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
-        future.setResult(RESULT);
+        future.complete(RESULT);
 
         Object result = future.get(10, TimeUnit.MILLISECONDS);
 
@@ -171,7 +171,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     @Test
     public void get_exceptionResultSet_exceptionThrown() throws Exception {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
-        future.setResult(EXCEPTION);
+        future.complete(EXCEPTION);
 
         expected.expect(EXCEPTION.getClass());
         expected.expectMessage(EXCEPTION_MESSAGE);
@@ -182,7 +182,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     @Test
     public void getWithTimeout_exceptionResultSet_exceptionThrown_noTimeout() throws Exception {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
-        future.setResult(EXCEPTION);
+        future.complete(EXCEPTION);
 
         expected.expect(EXCEPTION.getClass());
         expected.expectMessage(EXCEPTION_MESSAGE);
@@ -193,7 +193,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     @Test
     public void get_nullResultSet_returnsResult() throws Exception {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
-        future.setResult(null);
+        future.complete(null);
 
         Object result = future.get();
 
@@ -203,7 +203,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     @Test
     public void getWithTimeout_nullResultSet_returnsResult() throws Exception {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
-        future.setResult(null);
+        future.complete(null);
 
         Object result = future.get(10, TimeUnit.MILLISECONDS);
 
@@ -286,7 +286,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     private void setResult_resultSet_futureDone(Object result) {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
 
-        future.setResult(result);
+        future.complete(result);
 
         assertTrue("Future should be done after result has been set", future.isDone());
     }
@@ -296,8 +296,8 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
         Object initialResult = "firstresult", secondResult = "secondresult";
 
-        future.setResult(initialResult);
-        future.setResult(secondResult);
+        future.complete(initialResult);
+        future.complete(secondResult);
 
         assertSame(initialResult, future.get());
     }
@@ -324,7 +324,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
         future.andThen(callback1);
         future.andThen(callback2);
 
-        future.setResult(result);
+        future.complete(result);
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -370,7 +370,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
     @Test
     public void getResult_whenNullResult() throws Exception {
         TestFutureImpl future = new TestFutureImpl(nodeEngine, logger);
-        future.setResult(null);
+        future.complete(null);
 
         Object result = future.getResult();
 
@@ -444,7 +444,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
         final Object result = "result";
         final ExecutionCallback callback = mock(ExecutionCallback.class);
 
-        future.setResult(result);
+        future.complete(result);
         future.andThen(callback, executor);
 
         assertSame(result, future.get());
@@ -476,7 +476,7 @@ public class AbstractCompletableFutureTest extends HazelcastTestSupport {
                 try {
                     sleepMillis(timeInMillis);
                 } finally {
-                    future.setResult(result);
+                    future.complete(result);
                 }
             }
         });


### PR DESCRIPTION
The AbstractCompletableFuture and InvocationFuture shared quite a lot of logic. So
this has been pulled into the VeryAbstractCompletableFuture. Mostly the async
execution and registration of callbacks.

More cleanup will follow