### PR TITLE
Removing wildcard checkstyle suppression for ClientMapProxy

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -95,6 +95,7 @@
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientQueueProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientListProxy"/>
     <suppress checks="MethodCount|ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientMultiMapProxy"/>
+    <suppress checks="FileLengthCheck|MethodCount|ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientMapProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
     <suppress checks="ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
     <suppress checks="" files="com/hazelcast/client/impl/HazelcastClientInstance"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -95,7 +95,6 @@
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientQueueProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientListProxy"/>
     <suppress checks="MethodCount|ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientMultiMapProxy"/>
-    <suppress checks="" files="com/hazelcast/client/proxy/ClientMapProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
     <suppress checks="ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
     <suppress checks="" files="com/hazelcast/client/impl/HazelcastClientInstance"/>


### PR DESCRIPTION
I've removed the wildcard suppression for ClientMapProxy and replaced it with some more precise suppressions.

I've also added a javadoc comment, renamed some of its constants and spread some statements over multiple lines.