### PR TITLE
InvocationFuture stacktrace fixes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -33,6 +33,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static com.hazelcast.util.ExceptionUtil.fixAsyncStackTrace;
+
 public class ClientInvocationFuture implements ICompletableFuture<ClientMessage> {
 
     protected final ILogger logger;
@@ -125,7 +127,7 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
 
     private ClientMessage resolveResponse() throws ExecutionException, TimeoutException, InterruptedException {
         if (response instanceof Throwable) {
-            ExceptionUtil.fixRemoteStackTrace((Throwable) response, Thread.currentThread().getStackTrace());
+            fixAsyncStackTrace((Throwable) response, Thread.currentThread().getStackTrace());
             if (response instanceof ExecutionException) {
                 throw (ExecutionException) response;
             }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
@@ -59,6 +59,7 @@ import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_S
 import static com.hazelcast.mapreduce.JobPartitionState.State.REDUCING;
 import static com.hazelcast.mapreduce.impl.MapReduceUtil.createJobProcessInformation;
 import static com.hazelcast.mapreduce.impl.operation.RequestPartitionResult.ResultState.SUCCESSFUL;
+import static com.hazelcast.util.ExceptionUtil.fixAsyncStackTrace;
 
 /**
  * The JobSupervisor is the overall control instance of a map reduce job. There is one JobSupervisor per
@@ -151,7 +152,7 @@ public class JobSupervisor {
 
         if (future != null) {
             // Might be already cancelled by another members exception
-            ExceptionUtil.fixRemoteStackTrace(throwable, Thread.currentThread().getStackTrace(),
+            fixAsyncStackTrace(throwable, Thread.currentThread().getStackTrace(),
                     "Operation failed on node: " + remoteAddress);
             future.setResult(throwable);
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -37,7 +37,7 @@ import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.INTE
 import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.NULL_RESPONSE;
 import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.TIMEOUT_RESPONSE;
 import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.WAIT_RESPONSE;
-import static com.hazelcast.util.ExceptionUtil.fixRemoteStackTrace;
+import static com.hazelcast.util.ExceptionUtil.fixAsyncStackTrace;
 import static com.hazelcast.util.Preconditions.isNotNull;
 import static java.lang.Math.min;
 
@@ -370,9 +370,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
 
         if (response instanceof Throwable) {
             Throwable throwable = ((Throwable) response);
-            if (invocation.remote) {
-                fixRemoteStackTrace((Throwable) response, Thread.currentThread().getStackTrace());
-            }
+            fixAsyncStackTrace((Throwable) response, Thread.currentThread().getStackTrace());
             return throwable;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutionException;
  */
 public final class ExceptionUtil {
 
-    private static final String EXCEPTION_SEPARATOR = "------ End remote and begin local stack-trace ------";
+    private static final String EXCEPTION_SEPARATOR = "------ submitted from ------";
     private static final String EXCEPTION_MESSAGE_SEPARATOR = "------ %MSG% ------";
 
     //we don't want instances
@@ -129,17 +129,17 @@ public final class ExceptionUtil {
     }
 
     /**
-     * This method changes the given remote cause, and it adds the also given local stacktrace.<br/>
+     * This method changes the given async cause, and it adds the also given local stacktrace.<br/>
      * If the remoteCause is an {@link java.util.concurrent.ExecutionException} and it has a non-null inner
      * cause, this inner cause is unwrapped and the local stacktrace and exception message are added to the
-     * that instead of the given remoteCause itself.
+     * that instead of the given asyncCause itself.
      *
-     * @param remoteCause         the remotely generated exception
+     * @param asyncCause         the async exception
      * @param localSideStackTrace the local stacktrace to add to the exception stacktrace
      */
-    public static void fixRemoteStackTrace(Throwable remoteCause, StackTraceElement[] localSideStackTrace) {
-        Throwable throwable = remoteCause;
-        if (remoteCause instanceof ExecutionException && throwable.getCause() != null) {
+    public static void fixAsyncStackTrace(Throwable asyncCause, StackTraceElement[] localSideStackTrace) {
+        Throwable throwable = asyncCause;
+        if (asyncCause instanceof ExecutionException && throwable.getCause() != null) {
             throwable = throwable.getCause();
         }
 
@@ -152,21 +152,21 @@ public final class ExceptionUtil {
     }
 
     /**
-     * This method changes the given remote cause, and it adds the also given local stacktrace separated by the
+     * This method changes the given async cause, and it adds the also given local stacktrace separated by the
      * supplied exception message.<br/>
      * If the remoteCause is an {@link java.util.concurrent.ExecutionException} and it has a non-null inner
      * cause, this inner cause is unwrapped and the local stacktrace and exception message are added to the
      * that instead of the given remoteCause itself.
      *
-     * @param remoteCause           the remotely generated exception
+     * @param asyncCause           the async exception
      * @param localSideStackTrace   the local stacktrace to add to the exceptions stacktrace
      * @param localExceptionMessage a special exception message which is added to the stacktrace
      */
-    public static void fixRemoteStackTrace(Throwable remoteCause, StackTraceElement[] localSideStackTrace,
-                                           String localExceptionMessage) {
+    public static void fixAsyncStackTrace(Throwable asyncCause, StackTraceElement[] localSideStackTrace,
+                                          String localExceptionMessage) {
 
-        Throwable throwable = remoteCause;
-        if (remoteCause instanceof ExecutionException && throwable.getCause() != null) {
+        Throwable throwable = asyncCause;
+        if (asyncCause instanceof ExecutionException && throwable.getCause() != null) {
             throwable = throwable.getCause();
         }
 


### PR DESCRIPTION
InvocationFuture always fixes stacktrace no matter if remote or local call. The bug is that in case of a local call, e..g iatomiclong.alter; you don't see the local stacktrace; only the stacktrace of the partition thread. 

Renamed the fixstacktrace method to fixasyncstacktrace instead of fixremote

Minor change in the separator message between stiched stacktraces. Remote
and local is removed since it isn't about remote and local