### PR TITLE
Removes unused 'initialLoad' parameter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
@@ -47,7 +47,7 @@ public class MapPutAllMessageTask
         }
 
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
-        return operationProvider.createPutAllOperation(parameters.name, mapEntries, false);
+        return operationProvider.createPutAllOperation(parameters.name, mapEntries);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -220,8 +220,8 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createPutAllOperation(String name, MapEntries mapEntries, boolean initialLoad) {
-        return new PutAllOperation(name, mapEntries, initialLoad);
+    public MapOperation createPutAllOperation(String name, MapEntries mapEntries) {
+        return new PutAllOperation(name, mapEntries);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -71,7 +71,7 @@ public interface MapOperationProvider {
 
     MapOperation createLoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues);
 
-    MapOperation createPutAllOperation(String name, MapEntries mapEntries, boolean initialLoad);
+    MapOperation createPutAllOperation(String name, MapEntries mapEntries);
 
     MapOperation createPutFromLoadAllOperation(String name, List<Data> keyValueSequence);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -133,8 +133,8 @@ public abstract class MapOperationProviderDelegator implements MapOperationProvi
     }
 
     @Override
-    public MapOperation createPutAllOperation(String name, MapEntries mapEntries, boolean initialLoad) {
-        return getDelegate().createPutAllOperation(name, mapEntries, initialLoad);
+    public MapOperation createPutAllOperation(String name, MapEntries mapEntries) {
+        return getDelegate().createPutAllOperation(name, mapEntries);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
@@ -119,9 +119,9 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
     }
 
     @Override
-    public MapOperation createPutAllOperation(String name, MapEntries mapEntries, boolean initialLoad) {
+    public MapOperation createPutAllOperation(String name, MapEntries mapEntries) {
         checkWanReplicationQueues(name);
-        return getDelegate().createPutAllOperation(name, mapEntries, initialLoad);
+        return getDelegate().createPutAllOperation(name, mapEntries);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -67,9 +67,6 @@ import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.spi.partition.IPartition;
-import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.DefaultObjectNamespace;
@@ -81,6 +78,9 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.BinaryOperationFactory;
+import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.partition.IPartitionService;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.FutureUtil;
 import com.hazelcast.util.IterableUtil;
@@ -730,7 +730,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     }
 
     protected Future createPutAllOperationFuture(final String name, MapEntries entries, int partitionId) {
-        MapOperation op = operationProvider.createPutAllOperation(name, entries, false);
+        MapOperation op = operationProvider.createPutAllOperation(name, entries);
         op.setPartitionId(partitionId);
         final long size = entries.size();
         final long time = System.currentTimeMillis();


### PR DESCRIPTION
Removes unused 'initialLoad' parameter from PutAllOperation, it is a left-over.