### PR TITLE
Uses recordStore.set instead of recordStore.put in PutAllOperation if…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -56,4 +56,6 @@ public interface MapEventPublisher {
      * some conditions internally.
      */
     void hintMapEvent(Address caller, String mapName, EntryEventType eventType, int numberOfEntriesAffected, int partitionId);
+
+    boolean hasEventListener(String mapName);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -36,8 +36,8 @@ import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.wan.ReplicationEventObject;
 import com.hazelcast.wan.WanReplicationPublisher;
 
@@ -263,6 +263,11 @@ public class MapEventPublisherImpl implements MapEventPublisher {
     public void hintMapEvent(Address caller, String mapName, EntryEventType eventType,
                              int numberOfEntriesAffected, int partitionId) {
         // NOP
+    }
+
+    @Override
+    public boolean hasEventListener(String mapName) {
+        return eventService.hasEventRegistration(SERVICE_NAME, mapName);
     }
 
     protected Collection<EventRegistration> getRegistrations(String mapName) {


### PR DESCRIPTION
… there is no map-listener to prevent unnneeded old-value loading of map-loader.

By using `recordStore.set`, we get-rid-of one extra map-loader access.Because `recordStore.put` tries to find previous value by using map-loader, in order to pass it `EntryEvent`. If loading from map-store is expensive, this can lead serious performance degradation. To prevent this potential problem, when there is no map-listener exists, don't use `recordStore.put`

