### PR TITLE
Removed ExecutionCallback from Invocation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.MemberImpl;
@@ -119,7 +118,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
     volatile int invokeCount;
 
     Invocation(OperationServiceImpl operationService, Operation op, int tryCount, long tryPauseMillis, long callTimeout,
-               ExecutionCallback callback, boolean deserialize) {
+               boolean deserialize) {
         this.operationService = operationService;
         this.logger = operationService.invocationLogger;
         this.nodeEngine = operationService.nodeEngine;
@@ -127,8 +126,8 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         this.tryCount = tryCount;
         this.tryPauseMillis = tryPauseMillis;
         this.callTimeout = getCallTimeout(callTimeout);
-        this.future = new InvocationFuture(operationService, this, callback);
         this.deserialize = deserialize;
+        this.future = new InvocationFuture(operationService, this);
     }
 
     abstract ExceptionAction onException(Throwable t);
@@ -167,8 +166,9 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         return future;
     }
 
-    public final void invokeAsync() {
+    public final InvocationFuture invokeAsync() {
         invoke0(true);
+        return future;
     }
 
     private void invoke0(boolean isAsync) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -46,13 +46,21 @@ public class InvocationBuilderImpl extends InvocationBuilder {
     public InternalCompletableFuture invoke() {
         op.setServiceName(serviceName);
 
+        Invocation invocation;
         if (target == null) {
             op.setPartitionId(partitionId).setReplicaIndex(replicaIndex);
-            return new PartitionInvocation(operationService, op, tryCount, tryPauseMillis, callTimeout,
-                    getTargetExecutionCallback(), resultDeserialized).invoke();
+            invocation = new PartitionInvocation(
+                    operationService, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
         } else {
-            return new TargetInvocation(operationService, op, target, tryCount, tryPauseMillis, callTimeout,
-                    getTargetExecutionCallback(), resultDeserialized).invoke();
+            invocation = new TargetInvocation(
+                    operationService, op, target, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
         }
+
+        InternalCompletableFuture future = invocation.invoke();
+        if (executionCallback != null) {
+            future.andThen(executionCallback);
+        }
+
+        return future;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -66,13 +66,9 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
     private final OperationServiceImpl operationService;
     private volatile ExecutionCallbackNode<E> callbackHead;
 
-    InvocationFuture(OperationServiceImpl operationService, Invocation invocation, ExecutionCallback callback) {
+    InvocationFuture(OperationServiceImpl operationService, Invocation invocation) {
         this.invocation = invocation;
         this.operationService = operationService;
-
-        if (callback != null) {
-            callbackHead = new ExecutionCallbackNode<E>(callback, operationService.asyncExecutor, null);
-        }
     }
 
     static long decrementTimeout(long timeout, long diff) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -63,6 +63,7 @@ public class IsStillRunningService {
 
     /**
      * Checks if an operation is still running.
+     *
      * @param invocation The invocation for this operation.
      * @return true if the operation is running, false otherwise.
      */
@@ -79,7 +80,7 @@ public class IsStillRunningService {
 
             Invocation inv = new TargetInvocation(
                     invocation.operationService, isStillExecuting,
-                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, null, true);
+                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, true);
             Future f = inv.invoke();
             invocation.logger.warning("Asking if operation execution has been started: " + invocation);
             executing = (Boolean) invocation.nodeEngine.toObject(f.get(IS_EXECUTING_CALL_TIMEOUT, TimeUnit.MILLISECONDS));
@@ -134,10 +135,11 @@ public class IsStillRunningService {
 
     /**
      * Checks if an operation is still running.
+     *
      * @param callerAddress The caller address for this operation.
-     * @param callerUuid The caller Uuid for this operation.
-     * @param serviceName The service name for this operation.
-     * @param identifier The object identifier for this operation.
+     * @param callerUuid    The caller Uuid for this operation.
+     * @param serviceName   The service name for this operation.
+     * @param identifier    The object identifier for this operation.
      * @return true if the operation is running, false otherwise.
      */
     public boolean isOperationExecuting(Address callerAddress, String callerUuid, String serviceName, Object identifier) {
@@ -158,8 +160,9 @@ public class IsStillRunningService {
      * If the partition id isn't set, then we iterate over all generic-operationthread and check if one of them is running
      * the given operation. So this is more expensive, but in most cases this should not be an issue since most of the data
      * is hot in cache.
-     * @param callerAddress The caller address for this operation.
-     * @param partitionId The id of the partition where this operation resides.
+     *
+     * @param callerAddress   The caller address for this operation.
+     * @param partitionId     The id of the partition where this operation resides.
      * @param operationCallId The call id for this operation.
      * @return true if the operation is running, false otherwise.
      */
@@ -262,10 +265,14 @@ public class IsStillRunningService {
         public void run() {
             Invocation inv = new TargetInvocation(
                     invocation.operationService, isStillRunningOperation,
-                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, callback, true);
+                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, true);
 
             invocation.logger.warning("Asking if operation execution has been started: " + invocation);
             inv.invoke();
+
+            if (callback != null) {
+                inv.future.andThen(callback);
+            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -313,7 +313,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
 
         return new PartitionInvocation(
                 this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, null, DEFAULT_DESERIALIZE_RESULT).invoke();
+                DEFAULT_CALL_TIMEOUT, DEFAULT_DESERIALIZE_RESULT).invoke();
     }
 
     @Override
@@ -321,7 +321,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     public <E> InternalCompletableFuture<E> invokeOnPartition(Operation op) {
         return new PartitionInvocation(
                 this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, null, DEFAULT_DESERIALIZE_RESULT).invoke();
+                DEFAULT_CALL_TIMEOUT, DEFAULT_DESERIALIZE_RESULT).invoke();
     }
 
     @Override
@@ -330,8 +330,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         op.setServiceName(serviceName);
 
         return new TargetInvocation(this, op, target, DEFAULT_TRY_COUNT,
-                DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, null, DEFAULT_DESERIALIZE_RESULT).invoke();
+                DEFAULT_TRY_PAUSE_MILLIS, DEFAULT_CALL_TIMEOUT, DEFAULT_DESERIALIZE_RESULT).invoke();
     }
 
     @Override
@@ -339,8 +338,12 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     public <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback) {
         op.setServiceName(serviceName).setPartitionId(partitionId).setReplicaIndex(DEFAULT_REPLICA_INDEX);
 
-        new PartitionInvocation(this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, callback, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
+        InvocationFuture future = new PartitionInvocation(this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
+                DEFAULT_CALL_TIMEOUT, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
+
+        if (callback != null) {
+            future.andThen(callback);
+        }
     }
 
     // =============================== processing operation  ===============================

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
@@ -29,9 +28,8 @@ import com.hazelcast.spi.partition.IPartition;
 public final class PartitionInvocation extends Invocation {
 
     public PartitionInvocation(OperationServiceImpl operationService, Operation op, int tryCount, long tryPauseMillis,
-                               long callTimeout, ExecutionCallback callback, boolean resultDeserialized) {
-        super(operationService, op, tryCount, tryPauseMillis,
-                callTimeout, callback, resultDeserialized);
+                               long callTimeout, boolean resultDeserialized) {
+        super(operationService, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
@@ -32,8 +31,8 @@ public final class TargetInvocation extends Invocation {
 
     public TargetInvocation(OperationServiceImpl operationService, Operation op,
                             Address target, int tryCount, long tryPauseMillis, long callTimeout,
-                            ExecutionCallback callback, boolean resultDeserialized) {
-        super(operationService, op, tryCount, tryPauseMillis, callTimeout, callback, resultDeserialized);
+                            boolean resultDeserialized) {
+        super(operationService, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
         this.target = target;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
@@ -235,6 +235,6 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
 
     private Invocation newInvocation(Operation op) {
         OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
-        return new PartitionInvocation(operationService, op, 0, 0, 0, null, false);
+        return new PartitionInvocation(operationService, op, 0, 0, 0, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
@@ -118,6 +118,6 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(operationService, op, 0, 0, 0, null, false);
+        return new PartitionInvocation(operationService, op, 0, 0, 0, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -49,7 +49,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(operationService, op, 0, 0, 0, null, false);
+        return new PartitionInvocation(operationService, op, 0, 0, 0, false);
     }
 
     // ====================== register ===============================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
@@ -51,7 +51,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        Invocation invocation = new PartitionInvocation(operationService, op , 0, 0, 0, null, false);
+        Invocation invocation = new PartitionInvocation(operationService, op , 0, 0, 0, false);
         invocation.invTarget = getAddress(local);
         return invocation;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
@@ -281,7 +281,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         Address remoteAddress = getNode(remote).getThisAddress();
 
         TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local),
-                new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, null, true);
+                new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, true);
         InvocationFuture future = orgInvocation.invoke();
         final CountDownLatch timeoutLatch = new CountDownLatch(1);
         future.andThen(new ExecutionCallback() {
@@ -303,7 +303,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         long orgCallId = orgInvocation.op.getCallId();
 
         TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local),
-                new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, null, true);
+                new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, true);
         InvocationFuture isStillExecutingFuture = isStillExecutingInvocation.invoke();
         isStillExecutingFuture.andThen(new IsStillRunningService.IsOperationStillRunningCallback(orgInvocation));
 
@@ -323,13 +323,13 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         Address remoteAddress = getNode(remote).getThisAddress();
 
         TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local),
-                new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, null, true);
+                new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, true);
         InvocationFuture future = orgInvocation.invoke();
 
         long orgCallId = orgInvocation.op.getCallId();
 
         TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local),
-                new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, null, true);
+                new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, true);
         InvocationFuture isStillExecutingFuture = isStillExecutingInvocation.invoke();
         isStillExecutingFuture.andThen(new IsStillRunningService.IsOperationStillRunningCallback(orgInvocation));
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -70,8 +70,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
 
         started.countDown();
 
-        PartitionInvocation invocation = new PartitionInvocation(
-               operationService, isStillExecutingOperation, 0, 0, 0, null, false);
+        PartitionInvocation invocation = new PartitionInvocation(operationService, isStillExecutingOperation, 0, 0, 0, false);
 
         boolean result = isStillRunningService.isOperationExecuting(invocation);
         assertFalse(result);
@@ -183,8 +182,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         final IsStillRunningService isStillRunningService = operationService.getIsStillRunningService();
 
         final TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1),
-                new DummyOperation(callTimeoutMillis * 10), remoteAddress, 0, 0,
-                callTimeoutMillis, null, true);
+                new DummyOperation(callTimeoutMillis * 10), remoteAddress, 0, 0, callTimeoutMillis, true);
         final InvocationFuture future = invocation.invoke();
 
         assertTrueEventually(new AssertTask() {
@@ -222,8 +220,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         Address remoteAddress = getNode(hz2).getThisAddress();
 
         TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1),
-                new DummyOperation(1), remoteAddress, 0, 0,
-                callTimeoutMillis, null, true);
+                new DummyOperation(1), remoteAddress, 0, 0, callTimeoutMillis, true);
         final InvocationFuture future = invocation.invoke();
         assertEquals(Boolean.TRUE, future.get());
 


### PR DESCRIPTION
The ExecutonCallback is part of the InvocationFuture; not of the Invocation. This change pushes
the ExecutionCallback registration into the future using an andThen; just as any normal call.