### PR TITLE
Fixes inconsistency in naming of performance monitor property

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -104,6 +104,15 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.health.monitoring.threshold.cpu.percentage", 70);
 
     /**
+     * The minimum level for probes is MANDATORY, but it can be changed to INFO or DEBUG. A lower level will increase
+     * memory usage (probably just a few 100KB) and provides much greater detail on what is going on inside a HazelcastInstance.
+     * <p/>
+     * By default only mandatory probes are being tracked
+     */
+    public static final HazelcastProperty PERFORMANCE_METRICS_LEVEL
+            = new HazelcastProperty("hazelcast.performance.metric.level", ProbeLevel.MANDATORY.name());
+
+    /**
      * Use the performance monitor to see internal performance metrics. Currently this is quite
      * limited since it will only show read/write events per selector and operations executed per operation-thread. But in
      * the future, all kinds of new metrics will be added.
@@ -115,18 +124,9 @@ public final class GroupProperty {
      * The default is false.
      */
     public static final HazelcastProperty PERFORMANCE_MONITOR_ENABLED
-            = new HazelcastProperty("hazelcast.performance.monitoring.enabled", false);
+            = new HazelcastProperty("hazelcast.performance.monitor.enabled", false);
 
-    /**
-     * The minimum level for probes is MANDATORY, but it can be changed to INFO or DEBUG. A lower level will increase
-     * memory usage (probably just a few 100KB) and provides much greater detail on what is going on inside a HazelcastInstance.
-     * <p/>
-     * By default only mandatory probes are being tracked
-     */
-    public static final HazelcastProperty PERFORMANCE_METRICS_LEVEL
-            = new HazelcastProperty("hazelcast.performance.metric.level", ProbeLevel.MANDATORY.name());
-
-    /**
+     /**
      * The PerformanceMonitor uses a rolling file approach to prevent eating too much disk space.
      * <p/>
      * This property sets the maximum size in MB for a single file.

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceMonitor.java
@@ -60,10 +60,28 @@ public class PerformanceMonitor {
         this.hzThreadGroup = hzThreadGroup;
         this.logger = logger;
         this.properties = properties;
-        this.enabled = properties.getBoolean(PERFORMANCE_MONITOR_ENABLED);
+        this.enabled = isEnabled(properties);
+        if (enabled) {
+            logger.info("PerformanceMonitor is enabled");
+        }
         this.singleLine = !properties.getBoolean(PERFORMANCE_MONITOR_HUMAN_FRIENDLY_FORMAT);
     }
 
+    private boolean isEnabled(HazelcastProperties properties) {
+        String s = properties.getString(PERFORMANCE_MONITOR_ENABLED);
+        if (s != null) {
+            return properties.getBoolean(PERFORMANCE_MONITOR_ENABLED);
+        }
+
+        // check for the old property name.
+        s = properties.get("hazelcast.performance.monitoring.enabled");
+        if (s != null) {
+            logger.warning("Don't use deprecated 'hazelcast.performance.monitoring.enabled' "
+                    + "but use '" + PERFORMANCE_MONITOR_ENABLED.getName() + "' instead. "
+                    + "The former name will be removed in Hazelcast 3.8.");
+        }
+        return Boolean.parseBoolean(s);
+    }
 
     /**
      * Registers a MonitorTask to it will be scheduled.


### PR DESCRIPTION
All performance monitor properties are called 'hazelcast.performance.monitor.something'
but the enabled property is called 'hazelcast.performance.monitoring.enabled' so it is
inconsistent.

This PR fixes that; but still allows the old property to function but shows a warning
when it is detected.