### PR TITLE
Removed OperationService.send(response) from interface

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -17,7 +17,6 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
 
 import java.util.Collection;
 import java.util.Map;
@@ -109,7 +108,6 @@ public interface OperationService {
      *
      * @param op the operation to check.
      * @return true if the operation is allowed to run on the calling thread, false otherwise.
-     *
      * @deprecated since 3.5 since not needed anymore.
      */
     @Deprecated
@@ -120,7 +118,7 @@ public interface OperationService {
     /**
      * Executes an operation on a partition.
      *
-     * @param op the operation
+     * @param op  the operation
      * @param <E> the return type of the operation response
      * @return the future.
      */
@@ -169,17 +167,4 @@ public interface OperationService {
      * @return true if send is successful, false otherwise.
      */
     boolean send(Operation op, Address target);
-
-    /**
-     * Sends a response to a remote machine.
-     * <p/>
-     * This methods is deprecated since 3.5. It is an implementation detail, so it is moved to the
-     * {@link com.hazelcast.spi.impl.operationservice.InternalOperationService}.
-     *
-     * @param response the response to send.
-     * @param target   the address of the target machine
-     * @return true if send is successful, false otherwise.
-     */
-    @Deprecated
-    boolean send(Response response, Address target);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -423,7 +423,6 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         return connectionManager.transmit(packet, connection);
     }
 
-    @Override
     public boolean send(Response response, Address target) {
         if (target == null) {
             throw new IllegalArgumentException("Target is required!");

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RemoteInvocationResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RemoteInvocationResponseHandler.java
@@ -20,7 +20,6 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.exception.ResponseNotSentException;
-import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
@@ -31,9 +30,9 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
  * to that operation.
  */
 public final class RemoteInvocationResponseHandler implements OperationResponseHandler {
-    private final InternalOperationService operationService;
+    private final OperationServiceImpl operationService;
 
-    public RemoteInvocationResponseHandler(InternalOperationService operationService) {
+    public RemoteInvocationResponseHandler(OperationServiceImpl operationService) {
         this.operationService = operationService;
     }
 
@@ -52,7 +51,7 @@ public final class RemoteInvocationResponseHandler implements OperationResponseH
 
         if (!operationService.send(response, operation.getCallerAddress())) {
             throw new ResponseNotSentException("Cannot send response: " + obj + " to " + conn.getEndPoint()
-                + ". Op: " + operation);
+                    + ". Op: " + operation);
         }
     }
 


### PR DESCRIPTION
This method is removed from OperationService since it exposes internal implementation details. The method was deprecated; so safe to remove.

No enterprise change is needed.