### PR TITLE
Slow Invocations Plugin

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/GroupProperty.java
@@ -19,6 +19,7 @@ package com.hazelcast.instance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.monitors.HealthMonitorLevel;
+import com.hazelcast.internal.monitors.InvocationPlugin;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.query.QueryResultSizeLimiter;
 import com.hazelcast.query.TruePredicate;
@@ -188,6 +189,20 @@ public final class GroupProperty {
     public static final HazelcastProperty PERFORMANCE_MONITOR_PENDING_INVOCATIONS_THRESHOLD
             = new HazelcastProperty("hazelcast.performance.monitor.pending.invocations.threshold", 1);
 
+
+    /**
+     * The sample period in seconds for the {@link InvocationPlugin}.
+     *
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS
+            = new HazelcastProperty("hazelcast.performance.monitor.invocation.sample.period.seconds", 0, SECONDS);
+
+    /**
+     * The threshold in seconds for the {@link InvocationPlugin} to consider an invocation to be slow.
+     */
+    public static final HazelcastProperty PERFORMANCE_MONITOR_INVOCATION_SLOW_THRESHOLD_SECONDS
+            = new HazelcastProperty("hazelcast.performance.monitor.invocation.slow.threshold.seconds", 5, SECONDS);
 
     /**
      * The period in seconds the PerformanceMonitor OverloadedConnectionPlugin runs.
@@ -512,13 +527,9 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.slow.operation.detector.stacktrace.logging.enabled", false);
 
     /**
-     * Defines a threshold above which a running invocation in {@link com.hazelcast.spi.OperationService} is considered
-     * to be slow. Any slow invocation will be logged.
-     * <p/>
-     * This is an experimental feature and we do not provide any backwards compatibility guarantees on it.
-     * <p/>
-     * The default is -1 indicating there is no detection.
-     */
+     * Property isn't used anymore, use {@link #PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS}.
+      */
+    @Deprecated
     public static final HazelcastProperty SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS
             = new HazelcastProperty("hazelcast.slow.invocation.detector.threshold.millis", -1, MILLISECONDS);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/InvocationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/InvocationPlugin.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.monitors;
+
+import com.hazelcast.instance.GroupProperties;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.impl.operationservice.impl.Invocation;
+import com.hazelcast.spi.impl.operationservice.impl.InvocationRegistry;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.util.Clock;
+import com.hazelcast.util.ItemCounter;
+
+import static com.hazelcast.instance.GroupProperty.PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS;
+import static com.hazelcast.instance.GroupProperty.PERFORMANCE_MONITOR_INVOCATION_SLOW_THRESHOLD_SECONDS;
+
+/**
+ * A {@link PerformanceMonitorPlugin} that displays all invocations that have been executing for some time.
+ *
+ * It will display the current invocations.
+ *
+ * But it will also display the history. E.g. if a entry processor has been running for 5 minutes and
+ * the {@link com.hazelcast.instance.GroupProperty#PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS} is set to
+ * 1 minute, then there will be 5 samples for that given invocation. This is useful to track which operations have
+ * been slow over a longer period of time.
+ */
+public class InvocationPlugin extends PerformanceMonitorPlugin {
+    private final InvocationRegistry invocationRegistry;
+    private final long samplePeriodMillis;
+    private final long thresholdMillis;
+    private final ILogger logger;
+    private final ItemCounter<String> slowOccurrences = new ItemCounter<String>();
+    private final ItemCounter<String> occurrences = new ItemCounter<String>();
+
+    public InvocationPlugin(NodeEngineImpl nodeEngine) {
+        InternalOperationService operationService = nodeEngine.getOperationService();
+        this.invocationRegistry = ((OperationServiceImpl) operationService).getInvocationRegistry();
+        this.logger = nodeEngine.getLogger(PendingInvocationsPlugin.class);
+        GroupProperties props = nodeEngine.getGroupProperties();
+        this.samplePeriodMillis = props.getMillis(PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS);
+        this.thresholdMillis = props.getMillis(PERFORMANCE_MONITOR_INVOCATION_SLOW_THRESHOLD_SECONDS);
+    }
+
+    @Override
+    public long getPeriodMillis() {
+        return samplePeriodMillis;
+    }
+
+    @Override
+    public void onStart() {
+        logger.info("Plugin:active: period-millis:" + samplePeriodMillis + " threshold-millis:" + thresholdMillis);
+    }
+
+    @Override
+    public void run(PerformanceLogWriter writer) {
+        long now = Clock.currentTimeMillis();
+
+        writer.startSection("Invocations");
+
+        runCurrent(writer, now);
+
+        renderHistory(writer);
+
+        renderSlowHistory(writer);
+
+        writer.endSection();
+    }
+
+    private void runCurrent(PerformanceLogWriter writer, long now) {
+        writer.startSection("Pending");
+        for (Invocation invocation : invocationRegistry) {
+            long durationMs = now - invocation.firstInvocationTimeMillis;
+            if (durationMs >= thresholdMillis) {
+                writer.writeEntry(invocation.toString() + " duration=" + durationMs + " ms");
+                slowOccurrences.add(invocation.op.getClass().getName(), 1);
+            }
+
+            occurrences.add(invocation.op.getClass().getName(), 1);
+        }
+        writer.endSection();
+    }
+
+    private void renderHistory(PerformanceLogWriter writer) {
+        writer.startSection("History");
+        for (String item : occurrences.descendingKeys()) {
+            writer.writeEntry(item + " samples=" + occurrences.get(item));
+        }
+        writer.endSection();
+    }
+
+    private void renderSlowHistory(PerformanceLogWriter writer) {
+        writer.startSection("SlowHistory");
+        for (String item : slowOccurrences.descendingKeys()) {
+            writer.writeEntry(item + " samples=" + slowOccurrences.get(item));
+        }
+        writer.endSection();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -33,6 +33,7 @@ import com.hazelcast.internal.monitors.MetricsPlugin;
 import com.hazelcast.internal.monitors.OverloadedConnectionsPlugin;
 import com.hazelcast.internal.monitors.PendingInvocationsPlugin;
 import com.hazelcast.internal.monitors.PerformanceMonitor;
+import com.hazelcast.internal.monitors.InvocationPlugin;
 import com.hazelcast.internal.monitors.SlowOperationPlugin;
 import com.hazelcast.internal.monitors.SystemPropertiesPlugin;
 import com.hazelcast.internal.partition.InternalPartitionService;
@@ -164,6 +165,7 @@ public class NodeEngineImpl implements NodeEngine {
         performanceMonitor.register(new PendingInvocationsPlugin(this));
         performanceMonitor.register(new MetricsPlugin(this));
         performanceMonitor.register(new SlowOperationPlugin(this));
+        performanceMonitor.register(new InvocationPlugin(this));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -90,6 +90,11 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
     @SuppressWarnings("checkstyle:visibilitymodifier")
     public final Operation op;
 
+    // The first time this invocation got executed. This field is used to determine how long an invocation has actually
+    // been running.
+    @SuppressWarnings("checkstyle:visibilitymodifier")
+    public final long firstInvocationTimeMillis = Clock.currentTimeMillis();
+
     // The time in millis when the response of the primary has been received.
     volatile long pendingResponseReceivedMillis = -1;
     // contains the pending response from the primary. It is pending because it could be that backups need to complete.

--- a/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
@@ -16,9 +16,14 @@
 
 package com.hazelcast.util;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static java.util.Collections.sort;
 
 /**
  * Non Thread-Safe Counter of things. It allows to count items without worrying about nulls.
@@ -35,6 +40,31 @@ public final class ItemCounter<T> {
      */
     public Set<T> keySet() {
         return map.keySet();
+    }
+
+
+    /**
+     * Returns a List of keys in descending value order.
+     *
+     * @return the list of keys
+     */
+    public List<T> descendingKeys() {
+        List<T> list = new ArrayList<T>(map.keySet());
+
+        sort(list, new Comparator<T>() {
+            @Override
+            public int compare(T o1, T o2) {
+                MutableLong l1 = map.get(o1);
+                MutableLong l2 = map.get(o2);
+                return compare(l2.value, l1.value);
+            }
+
+            private int compare(long x, long y) {
+                return (x < y) ? -1 : ((x == y) ? 0 : 1);
+            }
+        });
+
+        return list;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/InvocationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/InvocationPluginTest.java
@@ -1,0 +1,79 @@
+package com.hazelcast.internal.monitors;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.impl.operation.EntryOperation;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static com.hazelcast.instance.GroupProperty.PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS;
+import static com.hazelcast.instance.GroupProperty.PERFORMANCE_MONITOR_INVOCATION_SLOW_THRESHOLD_SECONDS;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class InvocationPluginTest extends AbstractPerformanceMonitorPluginTest {
+
+    private InvocationPlugin plugin;
+    private HazelcastInstance hz;
+
+    @Before
+    public void setup() {
+        Config config = new Config();
+        config.setProperty(PERFORMANCE_MONITOR_INVOCATION_SAMPLE_PERIOD_SECONDS, "1");
+        config.setProperty(PERFORMANCE_MONITOR_INVOCATION_SLOW_THRESHOLD_SECONDS, "5");
+
+        hz = createHazelcastInstance(config);
+
+        plugin = new InvocationPlugin(getNodeEngineImpl(hz));
+        plugin.onStart();
+    }
+
+    @Test
+    public void testGetPeriodMillis() {
+        assertEquals(1000, plugin.getPeriodMillis());
+    }
+
+    @Test
+    public void testRun() {
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                hz.getMap("foo").executeOnKey(randomString(), new SlowEntryProcessor());
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                logWriter.write(plugin);
+                assertContains(EntryOperation.class.getName());
+            }
+        });
+    }
+
+    static class SlowEntryProcessor implements EntryProcessor {
+        @Override
+        public Object process(Map.Entry entry) {
+            try {
+                Thread.sleep(100000);
+            } catch (InterruptedException e) {
+            }
+            return null;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/ItemCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ItemCounterTest.java
@@ -52,6 +52,15 @@ public class ItemCounterTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testDescendingKeys() {
+        counter.add("key1", 2);
+        counter.add("key2", 3);
+        counter.add("key3", 1);
+
+        assertEquals(asList("key2", "key1", "key3"), counter.descendingKeys());
+    }
+
+    @Test
     public void testGet_returnsZeroWhenEmpty() throws Exception {
         long count = counter.get(new Object());
         assertEquals(0, count);


### PR DESCRIPTION
A new plugin for the performance monitor that shows the invocations that are slow. This was integrated in the InvocationMonitor; but now is moved into its own plugin.