### PR TITLE
[DONT MERGE] Added a public API to retrieve a configured Hazelcast Property

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -326,6 +326,12 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return getDistributedObject(XAService.SERVICE_NAME, XAService.SERVICE_NAME);
     }
 
+    @Override
+    public String getProperty(String name) {
+        return clientProperties.get(name);
+    }
+
+    @Override
     public Config getConfig() {
         throw new UnsupportedOperationException("Client cannot access cluster config!");
     }
@@ -601,5 +607,4 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             discoveryService.destroy();
         }
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -256,6 +256,11 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     }
 
     @Override
+    public String getProperty(String name) {
+        return getClient().getProperty(name);
+    }
+
+    @Override
     public void shutdown() {
         getLifecycleService().shutdown();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/internal/properties/ClientPropertyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/internal/properties/ClientPropertyTest.java
@@ -1,12 +1,38 @@
 package com.hazelcast.client.internal.properties;
 
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class ClientPropertyTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
 
     @Test
     public void testConstructor() throws Exception {
         assertUtilityConstructor(ClientProperty.class);
+    }
+
+    @Test
+    public void testGetPropertyFromHazelcastClientInstance() {
+        String propertyKey = ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName();
+
+        hazelcastFactory.newHazelcastInstance();
+
+        ClientConfig config = new ClientConfig();
+        config.setProperty(propertyKey, "notDefaultValue");
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
+
+        assertEquals("notDefaultValue", client.getProperty(propertyKey));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -176,10 +176,9 @@ public interface HazelcastInstance {
      * Returned endpoint will be a {@link Member} instance for cluster nodes
      * and a {@link Client} instance for clients.
      *
+     * @return the local {@link Endpoint} which this HazelcastInstance belongs to
      * @see Member
      * @see Client
-     *
-     * @return the local {@link Endpoint} which this HazelcastInstance belongs to
      */
     Endpoint getLocalEndpoint();
 
@@ -202,9 +201,8 @@ public interface HazelcastInstance {
      * and returns the result of the task.
      *
      * @param task the transactional task to be executed
-     * @param <T> return type of task
+     * @param <T>  return type of task
      * @return result of the transactional task
-     *
      * @throws TransactionException if an error occurs during transaction.
      */
     <T> T executeTransaction(TransactionalTask<T> task) throws TransactionException;
@@ -214,10 +212,9 @@ public interface HazelcastInstance {
      * and returns the result of the task.
      *
      * @param options options for this transactional task
-     * @param task task to be executed
-     * @param <T> return type of task
+     * @param task    task to be executed
+     * @param <T>     return type of task
      * @return result of the transactional task
-     *
      * @throws TransactionException if an error occurs during transaction.
      */
     <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task) throws TransactionException;
@@ -363,10 +360,9 @@ public interface HazelcastInstance {
     LifecycleService getLifecycleService();
 
     /**
-     *
      * @param serviceName name of the service
-     * @param name name of the object
-     * @param <T> type of the DistributedObject
+     * @param name        name of the object
+     * @param <T>         type of the DistributedObject
      * @return DistributedObject created by the service
      */
     <T extends DistributedObject> T getDistributedObject(String serviceName, String name);
@@ -390,6 +386,14 @@ public interface HazelcastInstance {
      * @return the xaResource.
      */
     HazelcastXAResource getXAResource();
+
+    /**
+     * Gets the effective value of a named property if it has been configured or its default value otherwise.
+     *
+     * @param name property name
+     * @return effective value of the property
+     */
+    String getProperty(String name);
 
     /**
      * Shuts down this HazelcastInstance. For more information see {@link com.hazelcast.core.LifecycleService#shutdown()}.

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -382,6 +382,11 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
     }
 
     @Override
+    public String getProperty(String name) {
+        return node.getGroupProperties().get(name);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -260,6 +260,11 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
     }
 
     @Override
+    public String getProperty(String name) {
+        return getOriginal().getProperty(name);
+    }
+
+    @Override
     public void shutdown() {
         getLifecycleService().shutdown();
     }
@@ -303,5 +308,3 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
         return !(name != null ? !name.equals(that.getName()) : that.getName() != null);
     }
 }
-
-

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -253,6 +253,11 @@ class HazelcastOSGiInstanceImpl
     }
 
     @Override
+    public String getProperty(String name) {
+        return delegatedInstance.getProperty(name);
+    }
+
+    @Override
     public void shutdown() {
         delegatedInstance.shutdown();
     }
@@ -309,5 +314,4 @@ class HazelcastOSGiInstanceImpl
         sb.append('}');
         return sb.toString();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/properties/GroupPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/properties/GroupPropertyTest.java
@@ -1,12 +1,27 @@
 package com.hazelcast.internal.properties;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class GroupPropertyTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor() throws Exception {
         assertUtilityConstructor(GroupProperty.class);
+    }
+
+    @Test
+    public void testGetPropertyFromHazelcastInstance() {
+        String propertyKey = GroupProperty.ENTERPRISE_LICENSE_KEY.getName();
+
+        Config config = new Config();
+        config.setProperty(propertyKey, "notDefaultValue");
+        HazelcastInstance instance = createHazelcastInstance(config);
+
+        assertEquals("notDefaultValue", instance.getProperty(propertyKey));
     }
 }


### PR DESCRIPTION
Added a public API to retrieve a configured property from `HazelcastInstance`. This will not expose any of the internal classes and nevertheless enable users to retrieve the effective value of a Hazelcast property (no matter how it was defined).

The goal of this PR is to give users a simple API to retrieve the effective value of a Hazelcast property. The source can be `Config`, `ClientConfig`, the XML files or `-DpropertyName`. The value is retrieved from our internal `GroupProperties` or `ClientProperties`, without exposing those classes. It also takes the plain String name as parameter, which can be found in the reference manual.