### PR TITLE
fix to a regression caused by #7635.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -169,7 +169,9 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     public void shutdown() {
         isShutdown = true;
         responseThread.interrupt();
-        callIdMap.clear();
+        CleanResourcesTask cleanResourcesTask = new CleanResourcesTask();
+        cleanResourcesTask.run();
+        assert callIdMap.isEmpty();
     }
 
     private class CleanResourcesTask implements Runnable {


### PR DESCRIPTION
Invocations of dead connections were handling as soon as connection
is closed before #7635. With the change in #7635, the invocations
are started to handled by a separate thread periodically.
Since that thread is closed when client itself closes, there can
be some invocations left unhandled. This pr makes sure they are
handled in ClienInvocationService shutdown.

fixes #7527