### PR TITLE
Changing the exception when client sends request before authentication

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -30,6 +30,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.SecurityContext;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -124,7 +125,7 @@ public abstract class AbstractMessageTask<P>
         if (nodeEngine.isRunning()) {
             String message = "Client " + endpoint + " must authenticate before any operation.";
             logger.severe(message);
-            exception = new AuthenticationException(message);
+            exception = new RetryableHazelcastException(new AuthenticationException(message));
         } else {
             exception = new HazelcastInstanceNotActiveException();
         }


### PR DESCRIPTION
related to fix done here #5422.
The AuthenticationException send when client sends wrong credentials
should before authentication, it should be retried.
Changing the later case exception to be able to remove
AuthenticationException from exceptions that needs to be retried to
reduce complexity.