### PR TITLE
Removing wildcard checkstyle suppressions for HazelcastClientInstanceImpl

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -98,7 +98,6 @@
     <suppress checks="FileLengthCheck|MethodCount|ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientMapProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
     <suppress checks="ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
-    <suppress checks="" files="com/hazelcast/client/impl/HazelcastClientInstance"/>
     <suppress checks="" files="com/hazelcast/client/impl/HazelcastClientProxy"/>
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/client/proxy/ClientExecutorServiceProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientExecutorServiceProxy"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -98,6 +98,7 @@
     <suppress checks="FileLengthCheck|MethodCount|ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientMapProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
     <suppress checks="ClassFanOutComplexity" files="com/hazelcast/client/proxy/ClientReplicatedMapProxy"/>
+    <suppress checks="MethodCount|ClassDataAbstractionCoupling|ClassFanOutComplexity|ExecutableStatementCount" files="com/hazelcast/client/impl/HazelcastClientInstance"/>
     <suppress checks="" files="com/hazelcast/client/impl/HazelcastClientProxy"/>
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/client/proxy/ClientExecutorServiceProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientExecutorServiceProxy"/>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.client.impl;
 
 import com.hazelcast.cache.impl.nearcache.NearCacheManager;
@@ -119,7 +135,7 @@ import java.util.logging.Level;
 public class HazelcastClientInstanceImpl implements HazelcastInstance, SerializationServiceSupport {
 
     private static final AtomicInteger CLIENT_ID = new AtomicInteger();
-    private static final short protocolVersion = 1;
+    private static final short PROTOCOL_VERSION = 1;
 
     private final ClientProperties clientProperties;
     private final int id = CLIENT_ID.getAndIncrement();
@@ -578,7 +594,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     public short getProtocolVersion() {
-        return protocolVersion;
+        return PROTOCOL_VERSION;
     }
 
     @Override


### PR DESCRIPTION
I've removed the wildcard suppression for HazelcastClientInstance(Impl) and added some finer suppressions.

I've also added the licence and renamed `protocolVersion` to `PROTOCOL_VERSION`.

See issue #7712 