### PR TITLE
Tentative fix for https://github.com/hazelcast/hazelcast/issues/3395

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
@@ -314,11 +314,13 @@ public class WaitNotifyServiceImpl implements WaitNotifyService {
                         return true;
                     }
                     if (waitingOp.isValid() && waitingOp.needsInvalidation()) {
-                        invalidate(waitingOp);
-                        if (!localNodeIsValidTarget(waitingOp)) {
+                        if (localNodeIsValidTarget(waitingOp)) {
+                            invalidate(waitingOp);
+                        } else {
                             logger.warning("Removing waiting operation " + waitingOp +
                                     " from queue since local node is not the target");
                             q.remove(waitingOp);
+                            waitingOp.getOperation().getResponseHandler().sendResponse(new IllegalStateException("Wrong target"));
                         }
                     }
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
@@ -314,9 +314,8 @@ public class WaitNotifyServiceImpl implements WaitNotifyService {
                         return true;
                     }
                     if (waitingOp.isValid() && waitingOp.needsInvalidation()) {
-                        if (localNodeIsValidTarget(waitingOp)) {
-                            invalidate(waitingOp);
-                        } else {
+                        invalidate(waitingOp);
+                        if (!localNodeIsValidTarget(waitingOp)) {
                             logger.warning("Removing waiting operation " + waitingOp +
                                     " from queue since local node is not the target");
                             q.remove(waitingOp);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
@@ -310,6 +310,7 @@ public class WaitNotifyServiceImpl implements WaitNotifyService {
             }
 
             for (Queue<WaitingOperation> q : mapWaitingOps.values()) {
+                Iterator<WaitingOperation> it = q.iterator();
                 while (it.hasNext()) {
                     if (Thread.interrupted()) {
                         return true;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
@@ -310,10 +310,11 @@ public class WaitNotifyServiceImpl implements WaitNotifyService {
             }
 
             for (Queue<WaitingOperation> q : mapWaitingOps.values()) {
-                for (WaitingOperation waitingOp : q) {
+                while (it.hasNext()) {
                     if (Thread.interrupted()) {
                         return true;
                     }
+                    WaitingOperation waitingOp = it.next();
                     if (waitingOp.isValid() && waitingOp.needsInvalidation()) {
                         Address targetAddress = getTargetAddress(waitingOp);
                         if (!waitingOp.validatesTarget() || nodeEngine.getThisAddress().equals(targetAddress)) {
@@ -326,6 +327,7 @@ public class WaitNotifyServiceImpl implements WaitNotifyService {
                                 waitingOp.getClass().getName(), waitingOp.getServiceName());
                             OperationResponseHandler responseHandler = waitingOp.getOperation().getOperationResponseHandler();
                             responseHandler.sendResponse(waitingOp.getOperation(), wte);
+                            it.remove();
                         }
                     }
                 }


### PR DESCRIPTION
It looks like the continuous WrongTargetException's are caused by WaitNotifyServiceImpl's ExpirationTask calling invalidate() about once a second on the same WaitingOp. Due to the exception, the WaitingOp never removes itself from the mapWaitingOps queue.

To fix the issue, before calling invalidate(), ExpirationTask  now checks if the target is the local node. If not, it returns a WrongTargetException to the invoker (similar to what we do for partition migration), then remove the WaitingOp from the mapWaitingOps queue.