### PR TITLE
Client package privateapi

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.client.ClientPrincipal;
 import com.hazelcast.core.Client;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.Credentials;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.transaction.TransactionContext;
 
 import javax.security.auth.Subject;
@@ -29,6 +30,7 @@ import java.util.concurrent.Callable;
 /**
  * Represents an endpoint to a client. So for each client connected to a member, a ClientEndpoint object is available.
  */
+@PrivateApi
 public interface ClientEndpoint extends Client {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client;
 
 import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.util.Collection;
 import java.util.Set;
@@ -26,6 +27,7 @@ import java.util.Set;
  *
  * All the methods are thread-safe.
  */
+@PrivateApi
 public interface ClientEndpointManager {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEngine.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.ProxyService;
+import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.serialization.SerializationService;
 
@@ -35,6 +36,7 @@ import java.util.Map;
  *
  * todo: what is the purpose of the client engine.
  */
+@PrivateApi
 public interface ClientEngine {
 
     int getClientEndpointCount();

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEvent.java
@@ -18,12 +18,14 @@ package com.hazelcast.client;
 
 import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientType;
+import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.net.InetSocketAddress;
 
 /**
  * Event used for notification of client connection and disconnection
  */
+@PrivateApi
 public class ClientEvent implements Client {
 
     private final String uuid;

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEventType.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.client;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * Event type used for client connection and disconnect events
  */
+@PrivateApi
 public enum ClientEventType {
     /**
      * Client Connected Event

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientTypes.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.client;
 
+import com.hazelcast.spi.annotation.PrivateApi;
+
 /**
  * Constants class that contains the different types of clients.
  */
+@PrivateApi
 public final class ClientTypes {
 
     /**


### PR DESCRIPTION
Many classes of the com.hazelcast.client module have been marked as PrivateAPI to prepare them for moving in 3.8.