### PR TITLE
PerformanceMonitor scheduler task catches exception

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceMonitor.java
@@ -95,7 +95,6 @@ public class PerformanceMonitor {
     private ScheduledExecutorService scheduler;
     private final HazelcastThreadGroup hzThreadGroup;
 
-
     public PerformanceMonitor(
             String fileName,
             ILogger logger,
@@ -211,7 +210,12 @@ public class PerformanceMonitor {
 
         @Override
         public void run() {
-            performanceLog.render(plugin);
+            try {
+                performanceLog.render(plugin);
+            } catch (Throwable t) {
+                // we need to catch any exception; otherwise the task is going to be removed by the scheduler.
+                logger.severe(t);
+            }
         }
     }
 


### PR DESCRIPTION
If exception isn't caught and logged; the task will be removed from
execution.