### PR TITLE
Fixes client shutdown problem

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -294,6 +294,10 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     private AuthenticationFuture triggerConnect(Address target, boolean asOwner) {
+        if (!alive) {
+            throw new HazelcastException("ConnectionManager is not active!!!");
+        }
+
         AuthenticationFuture callback = new AuthenticationFuture();
         AuthenticationFuture firstCallback = connectionsInProgress.putIfAbsent(target, callback);
         if (firstCallback == null) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -627,11 +627,11 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public void doShutdown() {
         proxyManager.destroy();
+        connectionManager.shutdown();
         clusterService.shutdown();
         executionService.shutdown();
         partitionService.stop();
         transactionManager.shutdown();
-        connectionManager.shutdown();
         invocationService.shutdown();
         listenerService.shutdown();
         ((InternalSerializationService) serializationService).dispose();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -134,32 +134,19 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
 
     }
 
-    void listenMembershipEvents(Address ownerConnectionAddress) {
+    void listenMembershipEvents(Address ownerConnectionAddress) throws Exception {
         initialListFetchedLatch = new CountDownLatch(1);
-        try {
-            ClientMessage clientMessage = ClientAddMembershipListenerCodec.encodeRequest(false);
-
-            Connection connection = connectionManager.getConnection(ownerConnectionAddress);
-            if (connection == null) {
-                throw new IllegalStateException(
-                        "Can not load initial members list because owner connection is null. Address "
-                                + ownerConnectionAddress);
-            }
-            ClientInvocation invocation = new ClientInvocation(client, clientMessage, connection);
-            invocation.setEventHandler(this);
-            invocation.invokeUrgent().get();
-            waitInitialMemberListFetched();
-
-        } catch (Exception e) {
-            if (client.getLifecycleService().isRunning()) {
-                if (logger.isFinestEnabled()) {
-                    logger.warning("Error while registering to cluster events! -> " + ownerConnectionAddress, e);
-                } else {
-                    logger.warning("Error while registering to cluster events! -> " + ownerConnectionAddress + ", Error: " + e
-                            .toString());
-                }
-            }
+        ClientMessage clientMessage = ClientAddMembershipListenerCodec.encodeRequest(false);
+        Connection connection = connectionManager.getConnection(ownerConnectionAddress);
+        if (connection == null) {
+            throw new IllegalStateException(
+                    "Can not load initial members list because owner connection is null. Address "
+                            + ownerConnectionAddress);
         }
+        ClientInvocation invocation = new ClientInvocation(client, clientMessage, connection);
+        invocation.setEventHandler(this);
+        invocation.invokeUrgent().get();
+        waitInitialMemberListFetched();
     }
 
     private void waitInitialMemberListFetched() throws InterruptedException {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -44,12 +44,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import static com.hazelcast.client.internal.properties.ClientProperty.SHUFFLE_MEMBER_LIST;
 
 public abstract class ClusterListenerSupport implements ConnectionListener, ConnectionHeartbeatListener, ClientClusterService {
 
+    private static final long TERMINATE_TIMEOUT_SECONDS = 30;
     protected final HazelcastClientInstanceImpl client;
 
     private final Collection<AddressProvider> addressProviders;
@@ -91,11 +93,15 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
 
     public void shutdown() {
         clusterExecutor.shutdown();
-    }
-
-    protected void connectToCluster() throws Exception {
-        connectToOne();
-        clientMembershipListener.listenMembershipEvents(ownerConnectionAddress);
+        try {
+            boolean success = clusterExecutor.awaitTermination(TERMINATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!success) {
+                logger.warning("cluster executor awaitTermination could not completed in "
+                        + TERMINATE_TIMEOUT_SECONDS + " seconds");
+            }
+        } catch (InterruptedException e) {
+            logger.warning("cluster executor await termination is interrupted", e);
+        }
     }
 
     private Collection<InetSocketAddress> getSocketAddresses() {
@@ -125,7 +131,7 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
         this.principal = principal;
     }
 
-    private void connectToOne() throws Exception {
+    public void connectToCluster() throws Exception {
         ownerConnectionAddress = null;
 
         final ClientNetworkConfig networkConfig = client.getClientConfig().getNetworkConfig();
@@ -172,6 +178,12 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     private boolean connect(Set<InetSocketAddress> triedAddresses) throws Exception {
         final Collection<InetSocketAddress> socketAddresses = getSocketAddresses();
         for (InetSocketAddress inetSocketAddress : socketAddresses) {
+            if (!client.getLifecycleService().isRunning()) {
+                if (logger.isFinestEnabled()) {
+                    logger.finest("Giving up on retrying to connect to cluster since client is shutdown");
+                }
+                break;
+            }
             try {
                 triedAddresses.add(inetSocketAddress);
                 Address address = new Address(inetSocketAddress);
@@ -179,8 +191,9 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
                     logger.finest("Trying to connect to " + address);
                 }
                 Connection connection = connectionManager.getOrConnect(address, true);
-                fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
                 ownerConnectionAddress = connection.getEndPoint();
+                clientMembershipListener.listenMembershipEvents(ownerConnectionAddress);
+                fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
                 return true;
             } catch (Exception e) {
                 Level level = e instanceof AuthenticationException ? Level.WARNING : Level.FINEST;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
@@ -32,7 +32,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -109,7 +108,6 @@ public class ClientInvocationTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore
     public void executionCallback_FailOnShutdown() {
         HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
@@ -140,7 +138,7 @@ public class ClientInvocationTest extends HazelcastTestSupport {
 
                 @Override
                 public void onFailure(Throwable t) {
-                    if (t instanceof HazelcastClientNotActiveException) {
+                    if (t.getCause() instanceof HazelcastClientNotActiveException) {
                         shutdownLatch.countDown();
                     }
                     errorLatch.countDown();


### PR DESCRIPTION
Main issue we are trying to fix is to make sure there are
no invocations left after client has shutdown.

The assert(in ClientInvocationServiceSupport) that checks
all invocations are cleared was failing.

One of the reason that an invocation is left there was
clusterService thread. In ClusterService shutdown we will
wait for executor to shutdown completely to make sure, there
is no invocation left triggered by cluster thread.

It turns out that CleanResources Task logic is indeed not suitable
for using when client is shutting down. Because it was postponing
clearing some invocation for 1 seconds if connection is closed
in last 5 seconds. Much simpler version of clearing invocations
is implemented in place of it.