### PR TITLE
Fixes client shutdown problem

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -288,6 +288,10 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     private AuthenticationFuture triggerConnect(Address target, boolean asOwner) {
+        if (!alive) {
+            throw new HazelcastException("ConnectionManager is not active!!!");
+        }
+
         AuthenticationFuture callback = new AuthenticationFuture();
         AuthenticationFuture firstCallback = connectionsInProgress.putIfAbsent(target, callback);
         if (firstCallback == null) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -582,11 +582,11 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public void doShutdown() {
         proxyManager.destroy();
+        connectionManager.shutdown();
         clusterService.shutdown();
         executionService.shutdown();
         partitionService.stop();
         transactionManager.shutdown();
-        connectionManager.shutdown();
         invocationService.shutdown();
         listenerService.shutdown();
         serializationService.destroy();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -168,8 +168,12 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     public void shutdown() {
         isShutdown = true;
         responseThread.interrupt();
-        CleanResourcesTask cleanResourcesTask = new CleanResourcesTask();
-        cleanResourcesTask.run();
+        Iterator<ClientInvocation> iterator = callIdMap.values().iterator();
+        while (iterator.hasNext()) {
+            ClientInvocation invocation = iterator.next();
+            iterator.remove();
+            invocation.notifyException(new HazelcastClientNotActiveException("Client is shutting down"));
+        }
         assert callIdMap.isEmpty();
     }
 
@@ -191,8 +195,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
                     continue;
                 }
 
-                int pendingPacketCount = connection.getPendingPacketCount();
-                if (pendingPacketCount != 0) {
+                if (connection.getPendingPacketCount() != 0) {
                     long closedTime = connection.getClosedTime();
                     long elapsed = System.currentTimeMillis() - closedTime;
                     if (elapsed < WAIT_TIME_FOR_PACKETS_TO_BE_CONSUMED_THRESHOLD) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -134,32 +134,19 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
 
     }
 
-    void listenMembershipEvents(Address ownerConnectionAddress) {
+    void listenMembershipEvents(Address ownerConnectionAddress) throws Exception {
         initialListFetchedLatch = new CountDownLatch(1);
-        try {
-            ClientMessage clientMessage = ClientAddMembershipListenerCodec.encodeRequest(false);
-
-            Connection connection = connectionManager.getConnection(ownerConnectionAddress);
-            if (connection == null) {
-                throw new IllegalStateException(
-                        "Can not load initial members list because owner connection is null. Address "
-                                + ownerConnectionAddress);
-            }
-            ClientInvocation invocation = new ClientInvocation(client, clientMessage, connection);
-            invocation.setEventHandler(this);
-            invocation.invokeUrgent().get();
-            waitInitialMemberListFetched();
-
-        } catch (Exception e) {
-            if (client.getLifecycleService().isRunning()) {
-                if (LOGGER.isFinestEnabled()) {
-                    LOGGER.warning("Error while registering to cluster events! -> " + ownerConnectionAddress, e);
-                } else {
-                    LOGGER.warning("Error while registering to cluster events! -> " + ownerConnectionAddress + ", Error: " + e
-                            .toString());
-                }
-            }
+        ClientMessage clientMessage = ClientAddMembershipListenerCodec.encodeRequest(false);
+        Connection connection = connectionManager.getConnection(ownerConnectionAddress);
+        if (connection == null) {
+            throw new IllegalStateException(
+                    "Can not load initial members list because owner connection is null. Address "
+                            + ownerConnectionAddress);
         }
+        ClientInvocation invocation = new ClientInvocation(client, clientMessage, connection);
+        invocation.setEventHandler(this);
+        invocation.invokeUrgent().get();
+        waitInitialMemberListFetched();
     }
 
     private void waitInitialMemberListFetched() throws InterruptedException {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
@@ -138,7 +138,7 @@ public class ClientInvocationTest extends HazelcastTestSupport {
 
                 @Override
                 public void onFailure(Throwable t) {
-                    if (t instanceof HazelcastClientNotActiveException) {
+                    if (t.getCause() instanceof HazelcastClientNotActiveException) {
                         shutdownLatch.countDown();
                     }
                     errorLatch.countDown();


### PR DESCRIPTION
Main issue we are trying to fix is to make sure there are
no invocations left after client has shutdown.

The assert(in ClientInvocationServiceSupport) that checks
all invocations are cleared was failing.

One of the reason that an invocation is left there was
clusterService thread. In ClusterService shutdown we will
wait for executor to shutdown completely to make sure, there
is no invocation left triggered by cluster thread.

ConnectionManager close will be done before clusterService
close to make sure, cluster thread can not trigger a new
authentication while trying to shutting down.

It turns out that CleanResources Task logic is indeed not suitable
for using when client is shutting down. Because it was postponing
clearing some invocation for 1 seconds if connection is closed
in last 5 seconds. Much simpler version of clearing invocations
is implemented in place of it.