### PR TITLE
Fixes index creation in wrong map-container problem. 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -23,10 +23,7 @@ import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
 
-import java.util.Map;
-
 import static com.hazelcast.map.impl.MapConfigValidator.checkInMemoryFormat;
-import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 /**
  * Defines remote service behavior of map service.
@@ -60,14 +57,6 @@ class MapRemoteService implements RemoteService {
     @Override
     public void destroyDistributedObject(String name) {
         mapServiceContext.destroyMap(name);
-        nodeEngine.getEventService().deregisterAllListeners(SERVICE_NAME, name);
-        Map<String, MapContainer> mapContainers = mapServiceContext.getMapContainers();
-        MapContainer mapContainer = mapContainers.get(name);
-        if (mapContainer != null) {
-            mapServiceContext.getNearCacheProvider().destroyNearCache(name);
-            mapContainer.getMapStoreContext().stop();
-            mapContainers.remove(name);
-        }
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -124,4 +124,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     Extractors getExtractors(String mapName);
 
     void incrementOperationStats(long startTime, LocalMapStatsImpl localMapStats, String mapName, Operation operation);
+
+    void removeMapContainer(MapContainer mapContainer);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -226,18 +226,29 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
-    public void destroyMap(final String mapName) {
-        localMapStatsProvider.destroyLocalMapStatsImpl(mapName);
-        final PartitionContainer[] containers = partitionContainers;
-        final Semaphore semaphore = new Semaphore(0);
+    public void destroyMap(String mapName) {
+        MapContainer mapContainer = mapContainers.get(mapName);
+        if (mapContainer == null) {
+            return;
+        }
+        mapContainer.getMapStoreContext().stop();
+        nearCacheProvider.destroyNearCache(mapName);
+        nodeEngine.getEventService().deregisterAllListeners(SERVICE_NAME, mapName);
+        localMapStatsProvider.destroyLocalMapStatsImpl(mapContainer.getName());
+
+        destroyPartitionsAndMapContainer(mapContainer);
+    }
+
+    private void destroyPartitionsAndMapContainer(MapContainer mapContainer) {
+        Semaphore semaphore = new Semaphore(0);
         InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
-        for (final PartitionContainer container : containers) {
-            MapPartitionDestroyTask partitionDestroyTask = new MapPartitionDestroyTask(container, mapName, semaphore);
+        for (PartitionContainer container : partitionContainers) {
+            MapPartitionDestroyTask partitionDestroyTask = new MapPartitionDestroyTask(container, mapContainer, semaphore);
             operationService.execute(partitionDestroyTask);
         }
 
         try {
-            semaphore.tryAcquire(containers.length, DESTROY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            semaphore.tryAcquire(partitionContainers.length, DESTROY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (Throwable t) {
             throw ExceptionUtil.rethrow(t);
         }
@@ -540,5 +551,10 @@ class MapServiceContextImpl implements MapServiceContext {
     public RecordStore createRecordStore(MapContainer mapContainer, int partitionId, MapKeyLoader keyLoader) {
         ILogger logger = nodeEngine.getLogger(DefaultRecordStore.class);
         return new DefaultRecordStore(mapContainer, partitionId, keyLoader, logger);
+    }
+
+    @Override
+    public void removeMapContainer(MapContainer mapContainer) {
+        mapContainers.remove(mapContainer.getName(), mapContainer);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -124,7 +124,8 @@ public class PartitionContainer {
         return maps.get(mapName);
     }
 
-    public void destroyMap(String name) {
+    public void destroyMap(MapContainer mapContainer) {
+        String name = mapContainer.getName();
         RecordStore recordStore = maps.remove(name);
         if (recordStore != null) {
             recordStore.destroy();
@@ -135,6 +136,9 @@ public class PartitionContainer {
             // this IMap partition.
             clearLockStore(name);
         }
+
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        mapServiceContext.removeMapContainer(mapContainer);
     }
 
     private void clearLockStore(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapPartitionDestroyTask.java
@@ -17,24 +17,25 @@
 package com.hazelcast.map.impl.operation;
 
 
+import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import java.util.concurrent.Semaphore;
 
 public class MapPartitionDestroyTask implements PartitionSpecificRunnable {
     private final PartitionContainer partitionContainer;
-    private final String mapName;
+    private final MapContainer mapContainer;
     private Semaphore semaphore;
 
-    public MapPartitionDestroyTask(PartitionContainer partitionContainer, String mapName, Semaphore semaphore) {
-        this.partitionContainer = partitionContainer;
-        this.mapName = mapName;
+    public MapPartitionDestroyTask(PartitionContainer container, MapContainer mapContainer, Semaphore semaphore) {
+        this.partitionContainer = container;
+        this.mapContainer = mapContainer;
         this.semaphore = semaphore;
     }
 
     @Override
     public void run() {
-        partitionContainer.destroyMap(mapName);
+        partitionContainer.destroyMap(mapContainer);
         semaphore.release();
     }
 


### PR DESCRIPTION
__Bug:__
Upon subsequent destroy and creation of imap, there is a possibility that there can be more than one map-container referenced by different record-stores at the same time. Due to that, indexes can be created in an unexpected map-container and this can lead to return less than expected number of results when we query imap.

__Fix:__
Moved the removal of mapContainer to partition-thread, by making this, i want to be sure that after map#destroy, there is always a new mapContainer instance referenced from a newly created recordstore and that mapContainer instance is different from the removed one.

__Test:__
Testing this defect is so hard. I was able to reproduce it with adding some sleeps. But still trying to find a simple test also. 