### PR TITLE
Implement #1686 - Make IndexAwarePredicate generic

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
@@ -23,9 +23,9 @@ import java.util.Set;
 /**
  * This interface is used for create filterable Predicates.
  */
-public interface IndexAwarePredicate extends Predicate {
+public interface IndexAwarePredicate<K, V> extends Predicate<K, V> {
 
-    Set<QueryableEntry> filter(QueryContext queryContext);
+    Set<QueryableEntry<K, V>> filter(QueryContext queryContext);
 
     boolean isIndexed(QueryContext queryContext);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
@@ -35,14 +35,14 @@ import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICAT
  * when FalsePredicate is going to implement IdentifiedDataSerializable, make sure no new instance
  * is created, but the INSTANCE is returned. No need to create new objects.
  */
-public class FalsePredicate implements IdentifiedDataSerializable, Predicate, IndexAwarePredicate {
+public class FalsePredicate<K, V> implements IdentifiedDataSerializable, Predicate<K, V>, IndexAwarePredicate<K, V> {
     /**
      * An instance of the FalsePredicate.
      */
     public static final FalsePredicate INSTANCE = new FalsePredicate();
 
      @Override
-    public boolean apply(Map.Entry mapEntry) {
+    public boolean apply(Map.Entry<K, V> mapEntry) {
         return false;
     }
 
@@ -52,7 +52,7 @@ public class FalsePredicate implements IdentifiedDataSerializable, Predicate, In
     }
 
     @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
+    public Set<QueryableEntry<K, V>> filter(QueryContext queryContext) {
         return Collections.emptySet();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
@@ -20,7 +20,7 @@ import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 
-public abstract class AbstractIndexAwarePredicate extends AbstractPredicate implements IndexAwarePredicate {
+public abstract class AbstractIndexAwarePredicate<K, V> extends AbstractPredicate<K, V> implements IndexAwarePredicate<K, V> {
 
     protected AbstractIndexAwarePredicate() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -37,8 +37,8 @@ import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICAT
  * Provides base features for predicates, such as extraction and convertion of the attribute's value.
  * It also handles apply() on MultiResult.
  */
-public abstract class AbstractPredicate
-        implements Predicate, IdentifiedDataSerializable {
+public abstract class AbstractPredicate<K, V>
+        implements Predicate<K, V>, IdentifiedDataSerializable {
 
     String attributeName;
     private transient volatile AttributeType attributeType;
@@ -51,7 +51,7 @@ public abstract class AbstractPredicate
     }
 
     @Override
-    public boolean apply(Map.Entry mapEntry) {
+    public boolean apply(Map.Entry<K, V> mapEntry) {
         Object attributeValue = readAttributeValue(mapEntry);
         if (attributeValue instanceof MultiResult) {
             return applyForMultiResult(mapEntry, (MultiResult) attributeValue);

--- a/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
@@ -23,7 +23,7 @@ import com.hazelcast.query.impl.QueryableEntry;
 import java.util.Map;
 import java.util.Set;
 
-public class TestPredicate implements IndexAwarePredicate {
+public class TestPredicate implements IndexAwarePredicate<String, TempData> {
 
     private String value;
     private boolean didApply;
@@ -32,14 +32,14 @@ public class TestPredicate implements IndexAwarePredicate {
         this.value = value;
     }
 
-    public boolean apply(Map.Entry mapEntry) {
+    public boolean apply(Map.Entry<String, TempData> mapEntry) {
         didApply = true;
         TempData data = (TempData) mapEntry.getValue();
         return data.getAttr1().equals(value);
     }
 
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        return queryContext.getIndex("attr1").getRecords(value);
+    public Set<QueryableEntry<String, TempData>> filter(QueryContext queryContext) {
+        return (Set) queryContext.getIndex("attr1").getRecords(value);
     }
 
     public boolean isIndexed(QueryContext queryContext) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -91,18 +91,18 @@ public class PredicatesTest extends HazelcastTestSupport {
         String name = randomString();
         map.put("key", new Value(name));
 
-        final ShouldExecuteOncePredicate indexAwareNotIndexedPredicate = new ShouldExecuteOncePredicate();
+        final ShouldExecuteOncePredicate<?, ?> indexAwareNotIndexedPredicate = new ShouldExecuteOncePredicate<Object, Object>();
         final EqualPredicate equalPredicate = new EqualPredicate("name", name);
         final AndPredicate andPredicate = new AndPredicate(indexAwareNotIndexedPredicate, equalPredicate);
         map.values(andPredicate);
     }
 
-    static class ShouldExecuteOncePredicate implements IndexAwarePredicate {
+    static class ShouldExecuteOncePredicate<K, V> implements IndexAwarePredicate<K, V> {
 
         boolean executed = false;
 
         @Override
-        public boolean apply(Map.Entry mapEntry) {
+        public boolean apply(Map.Entry<K, V> mapEntry) {
             if (!executed) {
                 executed = true;
                 return true;
@@ -111,7 +111,7 @@ public class PredicatesTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Set<QueryableEntry> filter(final QueryContext queryContext) {
+        public Set<QueryableEntry<K, V>> filter(final QueryContext queryContext) {
             return null;
         }
 


### PR DESCRIPTION
Add <K, V> generic parameters to IndexAwarePredicate, and propagate to a
minimal number of subclasses. These include:
* All index-aware predicates used for testing;
* FalsePredicate, which implements both IndexAwarePredicate and
Predicate and so needs to supply parameters to both for consistency
(note that TruePredicate does not implement IAP), and;
* AbstractIndexAwarePredicate and by extension, AbstractPredicate.

A previous commit that affected Indexes.query and its sole caller, MapQueryEngineImpl.tryQueryUsingIndexes has been reverted.

Implements #1686