### PR TITLE
Removed InvocationBuilder litter for client call

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
@@ -33,8 +33,8 @@ public abstract class AbstractInvocationMessageTask<P> extends AbstractMessageTa
     @Override
     protected void processMessage() {
         final ClientEndpoint endpoint = getEndpoint();
-        Operation op = prepareOperation();
-        op.setCallerUuid(endpoint.getUuid());
+        Operation op = prepareOperation()
+                .setCallerUuid(endpoint.getUuid());
 
         InvocationBuilder builder = getInvocationBuilder(op)
                 .setExecutionCallback(this)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 
 /**
@@ -55,14 +54,14 @@ public abstract class AbstractPartitionMessageTask<P>
     @Override
     public final void processMessage() {
         beforeProcess();
-        Operation op = prepareOperation();
-        op.setCallerUuid(endpoint.getUuid());
-        InvocationBuilder builder = nodeEngine.getOperationService()
-                .createInvocationBuilder(getServiceName(), op, getPartitionId())
-                .setExecutionCallback(this)
-                .setResultDeserialized(false);
+        Operation op = prepareOperation()
+                .setPartitionId(getPartitionId())
+                .setCallerUuid(endpoint.getUuid())
+                .setService(getServiceName());
 
-        builder.invoke();
+        nodeEngine.getOperationService().invokeOnPartition(op)
+                .setDeserialize(false)
+                .andThen(this);
     }
 
     protected abstract Operation prepareOperation();
@@ -80,5 +79,4 @@ public abstract class AbstractPartitionMessageTask<P>
         handleProcessingFailure(t);
         afterResponse();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
@@ -27,6 +27,18 @@ import com.hazelcast.core.ICompletableFuture;
 public interface InternalCompletableFuture<E> extends ICompletableFuture<E> {
 
     /**
+     * Sets of the result needs to be deserialized.
+     *
+     * This call is thread-safe; but it needs to be made before any get/join/andThen calls are made.
+     *
+     * This method should be called before a call to join.
+     *
+     * @param deserialize true if deserialized, false otherwise.
+     * @return the instance
+     */
+    InternalCompletableFuture setDeserialize(boolean deserialize);
+
+    /**
      * Waits for this future to complete.
      *
      * @return the result.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -110,7 +110,6 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
     final ILogger logger;
     final int tryCount;
     final long tryPauseMillis;
-    final boolean deserialize;
     final long callTimeout;
 
     boolean remote;
@@ -120,8 +119,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
     // writes to that are normally handled through the INVOKE_COUNT to ensure atomic increments / decrements
     volatile int invokeCount;
 
-    Invocation(OperationServiceImpl operationService, Operation op, int tryCount, long tryPauseMillis, long callTimeout,
-               boolean deserialize) {
+    Invocation(OperationServiceImpl operationService, Operation op, int tryCount, long tryPauseMillis, long callTimeout) {
         this.operationService = operationService;
         this.logger = operationService.invocationLogger;
         this.nodeEngine = operationService.nodeEngine;
@@ -129,7 +127,6 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         this.tryCount = tryCount;
         this.tryPauseMillis = tryPauseMillis;
         this.callTimeout = getCallTimeout(callTimeout);
-        this.deserialize = deserialize;
         this.future = new InvocationFuture(operationService, this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -49,12 +49,12 @@ public class InvocationBuilderImpl extends InvocationBuilder {
         Invocation invocation;
         if (target == null) {
             op.setPartitionId(partitionId).setReplicaIndex(replicaIndex);
-            invocation = new PartitionInvocation(
-                    operationService, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+            invocation = new PartitionInvocation(operationService, op, tryCount, tryPauseMillis, callTimeout);
         } else {
-            invocation = new TargetInvocation(
-                    operationService, op, target, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+            invocation = new TargetInvocation(operationService, op, target, tryCount, tryPauseMillis, callTimeout);
         }
+
+        invocation.future.setDeserialize(resultDeserialized);
 
         InternalCompletableFuture future = invocation.invoke();
         if (executionCallback != null) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningService.java
@@ -80,7 +80,7 @@ public class IsStillRunningService {
 
             Invocation inv = new TargetInvocation(
                     invocation.operationService, isStillExecuting,
-                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, true);
+                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT);
             Future f = inv.invoke();
             invocation.logger.warning("Asking if operation execution has been started: " + invocation);
             executing = (Boolean) invocation.nodeEngine.toObject(f.get(IS_EXECUTING_CALL_TIMEOUT, TimeUnit.MILLISECONDS));
@@ -265,7 +265,7 @@ public class IsStillRunningService {
         public void run() {
             Invocation inv = new TargetInvocation(
                     invocation.operationService, isStillRunningOperation,
-                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT, true);
+                    invocation.getTarget(), 0, 0, IS_EXECUTING_CALL_TIMEOUT);
 
             invocation.logger.warning("Asking if operation execution has been started: " + invocation);
             inv.invoke();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -62,7 +62,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_CALL_TIMEOUT;
-import static com.hazelcast.spi.InvocationBuilder.DEFAULT_DESERIALIZE_RESULT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_REPLICA_INDEX;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_COUNT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS;
@@ -311,26 +310,20 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
                 .setPartitionId(partitionId)
                 .setReplicaIndex(DEFAULT_REPLICA_INDEX);
 
-        return new PartitionInvocation(
-                this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, DEFAULT_DESERIALIZE_RESULT).invoke();
+        return new PartitionInvocation(this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS, DEFAULT_CALL_TIMEOUT).invoke();
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <E> InternalCompletableFuture<E> invokeOnPartition(Operation op) {
-        return new PartitionInvocation(
-                this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, DEFAULT_DESERIALIZE_RESULT).invoke();
+        return new PartitionInvocation(this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS, DEFAULT_CALL_TIMEOUT).invoke();
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <E> InternalCompletableFuture<E> invokeOnTarget(String serviceName, Operation op, Address target) {
         op.setServiceName(serviceName);
-
-        return new TargetInvocation(this, op, target, DEFAULT_TRY_COUNT,
-                DEFAULT_TRY_PAUSE_MILLIS, DEFAULT_CALL_TIMEOUT, DEFAULT_DESERIALIZE_RESULT).invoke();
+        return new TargetInvocation(this, op, target, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS, DEFAULT_CALL_TIMEOUT).invoke();
     }
 
     @Override
@@ -338,8 +331,8 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     public <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback) {
         op.setServiceName(serviceName).setPartitionId(partitionId).setReplicaIndex(DEFAULT_REPLICA_INDEX);
 
-        InvocationFuture future = new PartitionInvocation(this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS,
-                DEFAULT_CALL_TIMEOUT, DEFAULT_DESERIALIZE_RESULT).invokeAsync();
+        InvocationFuture future = new PartitionInvocation(
+                this, op, DEFAULT_TRY_COUNT, DEFAULT_TRY_PAUSE_MILLIS, DEFAULT_CALL_TIMEOUT).invokeAsync();
 
         if (callback != null) {
             future.andThen(callback);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -28,8 +28,8 @@ import com.hazelcast.spi.partition.IPartition;
 public final class PartitionInvocation extends Invocation {
 
     public PartitionInvocation(OperationServiceImpl operationService, Operation op, int tryCount, long tryPauseMillis,
-                               long callTimeout, boolean resultDeserialized) {
-        super(operationService, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+                               long callTimeout) {
+        super(operationService, op, tryCount, tryPauseMillis, callTimeout);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -30,9 +30,8 @@ public final class TargetInvocation extends Invocation {
     private final Address target;
 
     public TargetInvocation(OperationServiceImpl operationService, Operation op,
-                            Address target, int tryCount, long tryPauseMillis, long callTimeout,
-                            boolean resultDeserialized) {
-        super(operationService, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+                            Address target, int tryCount, long tryPauseMillis, long callTimeout) {
+        super(operationService, op, tryCount, tryPauseMillis, callTimeout);
         this.target = target;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
@@ -235,6 +235,6 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
 
     private Invocation newInvocation(Operation op) {
         OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
-        return new PartitionInvocation(operationService, op, 0, 0, 0, false);
+        return new PartitionInvocation(operationService, op, 0, 0, 0);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
@@ -118,6 +118,6 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(operationService, op, 0, 0, 0, false);
+        return new PartitionInvocation(operationService, op, 0, 0, 0);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -49,7 +49,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(operationService, op, 0, 0, 0, false);
+        return new PartitionInvocation(operationService, op, 0, 0, 0);
     }
 
     // ====================== register ===============================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry_NotifyTest.java
@@ -51,7 +51,7 @@ public class InvocationRegistry_NotifyTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        Invocation invocation = new PartitionInvocation(operationService, op , 0, 0, 0, false);
+        Invocation invocation = new PartitionInvocation(operationService, op , 0, 0, 0);
         invocation.invTarget = getAddress(local);
         return invocation;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
@@ -281,7 +281,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         Address remoteAddress = getNode(remote).getThisAddress();
 
         TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local),
-                new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, true);
+                new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1);
         InvocationFuture future = orgInvocation.invoke();
         final CountDownLatch timeoutLatch = new CountDownLatch(1);
         future.andThen(new ExecutionCallback() {
@@ -303,7 +303,7 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         long orgCallId = orgInvocation.op.getCallId();
 
         TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local),
-                new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, true);
+                new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1);
         InvocationFuture isStillExecutingFuture = isStillExecutingInvocation.invoke();
         isStillExecutingFuture.andThen(new IsStillRunningService.IsOperationStillRunningCallback(orgInvocation));
 
@@ -323,13 +323,13 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         Address remoteAddress = getNode(remote).getThisAddress();
 
         TargetInvocation orgInvocation = new TargetInvocation(getOperationServiceImpl(local),
-                new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1, true);
+                new IsStillRunningServiceTest.DummyOperation(60000), remoteAddress, 0, 0, -1);
         InvocationFuture future = orgInvocation.invoke();
 
         long orgCallId = orgInvocation.op.getCallId();
 
         TargetInvocation isStillExecutingInvocation = new TargetInvocation(getOperationServiceImpl(local),
-                new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1, true);
+                new SleepingIsStillExecutingOperation(orgCallId, 60000), remoteAddress, 0, 0, -1);
         InvocationFuture isStillExecutingFuture = isStillExecutingInvocation.invoke();
         isStillExecutingFuture.andThen(new IsStillRunningService.IsOperationStillRunningCallback(orgInvocation));
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/IsStillRunningServiceTest.java
@@ -70,7 +70,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
 
         started.countDown();
 
-        PartitionInvocation invocation = new PartitionInvocation(operationService, isStillExecutingOperation, 0, 0, 0, false);
+        PartitionInvocation invocation = new PartitionInvocation(operationService, isStillExecutingOperation, 0, 0, 0);
 
         boolean result = isStillRunningService.isOperationExecuting(invocation);
         assertFalse(result);
@@ -182,7 +182,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         final IsStillRunningService isStillRunningService = operationService.getIsStillRunningService();
 
         final TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1),
-                new DummyOperation(callTimeoutMillis * 10), remoteAddress, 0, 0, callTimeoutMillis, true);
+                new DummyOperation(callTimeoutMillis * 10), remoteAddress, 0, 0, callTimeoutMillis);
         final InvocationFuture future = invocation.invoke();
 
         assertTrueEventually(new AssertTask() {
@@ -220,7 +220,7 @@ public class IsStillRunningServiceTest extends HazelcastTestSupport {
         Address remoteAddress = getNode(hz2).getThisAddress();
 
         TargetInvocation invocation = new TargetInvocation(getOperationServiceImpl(hz1),
-                new DummyOperation(1), remoteAddress, 0, 0, callTimeoutMillis, true);
+                new DummyOperation(1), remoteAddress, 0, 0, callTimeoutMillis);
         final InvocationFuture future = invocation.invoke();
         assertEquals(Boolean.TRUE, future.get());
 


### PR DESCRIPTION
The InvocationBuilder is needed to configure deserialize; this has not been
made available as option on the InternalCompletableFuture.