### PR TITLE
Renamed ClientRead/WriteHandler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientReadHandler.java
@@ -30,18 +30,18 @@ import java.nio.ByteBuffer;
  * to the {@link IOService#handleClientMessage(ClientMessage, Connection)}.
  *
  * Probably the design can be simplified if the IOService would expose a method getMessageHandler; so we
- * don't need to let the NewClientReadHandler act like the MessageHandler, but directly send to the right
+ * don't need to let the ClientReadHandler act like the MessageHandler, but directly send to the right
  * data-structure.
  *
- * @see NewClientWriteHandler
+ * @see ClientWriteHandler
  */
-public class NewClientReadHandler implements ReadHandler, ClientMessageBuilder.MessageHandler {
+public class ClientReadHandler implements ReadHandler, ClientMessageBuilder.MessageHandler {
 
     private final ClientMessageBuilder builder;
     private final Connection connection;
     private final IOService ioService;
 
-    public NewClientReadHandler(Connection connection, IOService ioService) throws IOException {
+    public ClientReadHandler(Connection connection, IOService ioService) throws IOException {
         this.connection = connection;
         this.ioService = ioService;
         this.builder = new ClientMessageBuilder(this);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientWriteHandler.java
@@ -23,12 +23,12 @@ import java.nio.ByteBuffer;
 /**
  * A {@link WriteHandler} for the new-client. It writes ClientMessages to the ByteBuffer.
  *
- * @see NewClientReadHandler
+ * @see ClientReadHandler
  */
-public class NewClientWriteHandler implements WriteHandler<ClientMessage> {
+public class ClientWriteHandler implements WriteHandler<ClientMessage> {
 
     @Override
-    public boolean onWrite(ClientMessage frame, ByteBuffer dst) throws Exception {
-        return frame.writeTo(dst);
+    public boolean onWrite(ClientMessage message, ByteBuffer dst) throws Exception {
+        return message.writeTo(dst);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -23,7 +23,7 @@ import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.ascii.TextReadHandler;
-import com.hazelcast.nio.tcp.NewClientReadHandler;
+import com.hazelcast.nio.tcp.ClientReadHandler;
 import com.hazelcast.nio.tcp.ReadHandler;
 import com.hazelcast.nio.tcp.SocketReader;
 import com.hazelcast.nio.tcp.SocketWriter;
@@ -197,7 +197,7 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
             } else if (CLIENT_BINARY_NEW.equals(protocol)) {
                 configureBuffers(ioService.getSocketClientReceiveBufferSize() * KILO_BYTE);
                 socketWriter.setProtocol(CLIENT_BINARY_NEW);
-                readHandler = new NewClientReadHandler(connection, ioService);
+                readHandler = new ClientReadHandler(connection, ioService);
             } else {
                 configureBuffers(ioService.getSocketReceiveBufferSize() * KILO_BYTE);
                 socketWriter.setProtocol(Protocols.TEXT);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.OutboundFrame;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.ascii.TextWriteHandler;
-import com.hazelcast.nio.tcp.NewClientWriteHandler;
+import com.hazelcast.nio.tcp.ClientWriteHandler;
 import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.WriteHandler;
@@ -169,7 +169,7 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
                 registerOp(SelectionKey.OP_WRITE);
             } else if (CLIENT_BINARY_NEW.equals(protocol)) {
                 configureBuffers(ioService.getSocketClientReceiveBufferSize() * KILO_BYTE);
-                writeHandler = new NewClientWriteHandler();
+                writeHandler = new ClientWriteHandler();
             } else {
                 configureBuffers(ioService.getSocketClientSendBufferSize() * KILO_BYTE);
                 writeHandler = new TextWriteHandler(connection);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
@@ -24,7 +24,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.ascii.TextReadHandler;
-import com.hazelcast.nio.tcp.NewClientReadHandler;
+import com.hazelcast.nio.tcp.ClientReadHandler;
 import com.hazelcast.nio.tcp.ReadHandler;
 import com.hazelcast.nio.tcp.SocketChannelWrapper;
 import com.hazelcast.nio.tcp.SocketReader;
@@ -160,7 +160,7 @@ public class SpinningSocketReader extends AbstractHandler implements SocketReade
         } else if (CLIENT_BINARY_NEW.equals(protocol)) {
             configureBuffers(ioService.getSocketClientReceiveBufferSize() * KILO_BYTE);
             socketWriter.setProtocol(CLIENT_BINARY_NEW);
-            readHandler = new NewClientReadHandler(connection, ioService);
+            readHandler = new ClientReadHandler(connection, ioService);
         } else {
             configureBuffers(ioService.getSocketReceiveBufferSize() * KILO_BYTE);
             socketWriter.setProtocol(Protocols.TEXT);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
@@ -24,7 +24,7 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.OutboundFrame;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.ascii.TextWriteHandler;
-import com.hazelcast.nio.tcp.NewClientWriteHandler;
+import com.hazelcast.nio.tcp.ClientWriteHandler;
 import com.hazelcast.nio.tcp.SocketChannelWrapper;
 import com.hazelcast.nio.tcp.SocketWriter;
 import com.hazelcast.nio.tcp.TcpIpConnection;
@@ -164,7 +164,7 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
             outputBuffer.put(stringToBytes(CLUSTER));
         } else if (CLIENT_BINARY_NEW.equals(protocol)) {
             configureBuffers(ioService.getSocketClientReceiveBufferSize() * KILO_BYTE);
-            writeHandler = new NewClientWriteHandler();
+            writeHandler = new ClientWriteHandler();
         } else {
             configureBuffers(ioService.getSocketClientSendBufferSize() * KILO_BYTE);
             writeHandler = new TextWriteHandler(connection);

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientReadHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientReadHandlerTest.java
@@ -21,9 +21,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class NewClientReadHandlerTest {
+public class ClientReadHandlerTest {
 
-    private NewClientReadHandler readHandler;
+    private ClientReadHandler readHandler;
     private IOService ioService;
     private Connection connection;
 
@@ -31,7 +31,7 @@ public class NewClientReadHandlerTest {
     public void setup() throws IOException {
         ioService = mock(IOService.class);
         connection = mock(Connection.class);
-        readHandler = new NewClientReadHandler(connection, ioService);
+        readHandler = new ClientReadHandler(connection, ioService);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientWriteHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientWriteHandlerTest.java
@@ -18,13 +18,13 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class NewClientWriteHandlerTest extends HazelcastTestSupport {
+public class ClientWriteHandlerTest extends HazelcastTestSupport {
 
-    private NewClientWriteHandler writeHandler;
+    private ClientWriteHandler writeHandler;
 
     @Before
     public void setup() {
-        writeHandler = new NewClientWriteHandler();
+        writeHandler = new ClientWriteHandler();
     }
 
     @Test


### PR DESCRIPTION
Since the old client has been removed; there is no point in calling these classes
NewClientReadHandler and NewClientWriteHandler. So they have been renamed to
ClientReadHandler and ClientWriteHandler