### PR TITLE
Minor invocation cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -305,7 +305,7 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
     }
 
     long getMaxCallTimeout() {
-        long callTimeout = invocation.callTimeout;
+        long callTimeout = invocation.callTimeoutMillis;
         long maxCallTimeout = callTimeout + getCallTimeoutExtension(callTimeout);
         return maxCallTimeout > 0 ? maxCallTimeout : Long.MAX_VALUE;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -21,6 +21,8 @@ import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.partition.IPartition;
 
+import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
+
 /**
  * A {@link Invocation} evaluates a Operation Invocation for a particular partition running on top of the
  * {@link OperationServiceImpl}.
@@ -28,8 +30,8 @@ import com.hazelcast.spi.partition.IPartition;
 public final class PartitionInvocation extends Invocation {
 
     public PartitionInvocation(OperationServiceImpl operationService, Operation op, int tryCount, long tryPauseMillis,
-                               long callTimeout, boolean resultDeserialized) {
-        super(operationService, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+                               long callTimeoutMillis, boolean deserialize) {
+        super(operationService, op, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
     }
 
     @Override
@@ -41,6 +43,6 @@ public final class PartitionInvocation extends Invocation {
     @Override
     ExceptionAction onException(Throwable t) {
         ExceptionAction action = op.onInvocationException(t);
-        return action != null ? action : ExceptionAction.THROW_EXCEPTION;
+        return action != null ? action : THROW_EXCEPTION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -21,6 +21,8 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
 
+import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
+
 /**
  * A {@link Invocation} evaluates a Operation Invocation for a particular target running on top of the
  * {@link OperationServiceImpl}.
@@ -29,10 +31,9 @@ public final class TargetInvocation extends Invocation {
 
     private final Address target;
 
-    public TargetInvocation(OperationServiceImpl operationService, Operation op,
-                            Address target, int tryCount, long tryPauseMillis, long callTimeout,
-                            boolean resultDeserialized) {
-        super(operationService, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+    public TargetInvocation(OperationServiceImpl operationService, Operation op, Address target,
+                            int tryCount, long tryPauseMillis, long callTimeoutMillis, boolean deserialize) {
+        super(operationService, op, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
         this.target = target;
     }
 
@@ -43,6 +44,6 @@ public final class TargetInvocation extends Invocation {
 
     @Override
     ExceptionAction onException(Throwable t) {
-        return t instanceof MemberLeftException ? ExceptionAction.THROW_EXCEPTION : op.onInvocationException(t);
+        return t instanceof MemberLeftException ? THROW_EXCEPTION : op.onInvocationException(t);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_CallTimeoutTestMillis.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_CallTimeoutTestMillis.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class Invocation_CallTimeoutTest extends HazelcastTestSupport {
+public class Invocation_CallTimeoutTestMillis extends HazelcastTestSupport {
 
     private final static long callTimeout = 12345;
 
@@ -45,7 +45,7 @@ public class Invocation_CallTimeoutTest extends HazelcastTestSupport {
         Operation op = new DummyOperation();
         InvocationFuture f = (InvocationFuture) opService.invokeOnTarget(null, op, thisAddress);
 
-        assertEquals(callTimeout, f.invocation.callTimeout);
+        assertEquals(callTimeout, f.invocation.callTimeoutMillis);
         assertEquals(callTimeout, f.invocation.op.getCallTimeout());
     }
 
@@ -59,7 +59,7 @@ public class Invocation_CallTimeoutTest extends HazelcastTestSupport {
 
         InvocationFuture f = (InvocationFuture) opService.invokeOnTarget(null, op, thisAddress);
 
-        assertEquals(explicitCallTimeout, f.invocation.callTimeout);
+        assertEquals(explicitCallTimeout, f.invocation.callTimeoutMillis);
         assertEquals(explicitCallTimeout, f.invocation.op.getCallTimeout());
     }
 
@@ -72,7 +72,7 @@ public class Invocation_CallTimeoutTest extends HazelcastTestSupport {
                 .setCallTimeout(explicitCallTimeout)
                 .invoke();
 
-        assertEquals(explicitCallTimeout, f.invocation.callTimeout);
+        assertEquals(explicitCallTimeout, f.invocation.callTimeoutMillis);
         assertEquals(explicitCallTimeout, f.invocation.op.getCallTimeout());
     }
 }


### PR DESCRIPTION
Rename of deserializeResult variable
Included the firstInvocationTime in the toString
renamed method/variables for calltimeout to include timeunit