### PR TITLE
Moved InvocationRegistry.notifyLogic into ResponseHandler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicateUpdateToCallerOperation.java
@@ -27,7 +27,6 @@ import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
-import com.hazelcast.spi.impl.operationservice.impl.InvocationRegistry;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 
 import java.io.IOException;
@@ -104,8 +103,7 @@ public class ReplicateUpdateToCallerOperation extends AbstractOperation implemen
 
     private void notifyCaller() {
         OperationServiceImpl operationService = (OperationServiceImpl) getNodeEngine().getOperationService();
-        InvocationRegistry registry = operationService.getInvocationRegistry();
-        registry.notifyBackupComplete(callId);
+        operationService.getResponseHandler().notifyBackupComplete(callId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -127,6 +127,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     private final AsyncResponsePacketHandler responsePacketExecutor;
     private final InternalSerializationService serializationService;
     private final InvocationMonitor invocationMonitor;
+    private final ResponsePacketHandlerImpl responseHandler;
 
     public OperationServiceImpl(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
@@ -156,13 +157,15 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
 
         this.operationBackupHandler = new OperationBackupHandler(this);
 
+        this.responseHandler = new ResponsePacketHandlerImpl(
+                logger,
+                node.getSerializationService(),
+                invocationRegistry,
+                nodeEngine);
         this.responsePacketExecutor = new AsyncResponsePacketHandler(
                 node.getHazelcastThreadGroup(),
                 logger,
-                new ResponsePacketHandlerImpl(
-                        logger,
-                        node.getSerializationService(),
-                        invocationRegistry));
+                responseHandler);
 
         this.operationExecutor = new ClassicOperationExecutor(
                 groupProperties,
@@ -202,6 +205,10 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
 
     public InvocationRegistry getInvocationRegistry() {
         return invocationRegistry;
+    }
+
+    public ResponsePacketHandlerImpl getResponseHandler() {
+        return responseHandler;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -155,7 +155,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
 
         if (nodeEngine.getThisAddress().equals(originalCaller)) {
-            operationService.getInvocationRegistry().notifyBackupComplete(callId);
+            operationService.getResponseHandler().notifyBackupComplete(callId);
         } else {
             BackupResponse backupResponse = new BackupResponse(callId, backupOp.isUrgent());
             operationService.send(backupResponse, originalCaller);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponseHandlerTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class AsyncResponsePacketHandlerTest extends HazelcastTestSupport {
+public class AsyncResponseHandlerTest extends HazelcastTestSupport {
 
     private PacketHandler responsePacketHandler;
     private AsyncResponsePacketHandler asyncHandler;


### PR DESCRIPTION
Notifyin the invocations is a concern of the response handler; not of the invocation registry. So
the logic has been moved into the ResponseHandler.