### PR TITLE
Class cache introduced

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
@@ -31,14 +31,17 @@ import java.util.concurrent.ConcurrentMap;
  * Utility class to deal with classloaders.
  */
 public final class ClassLoaderUtil {
-
     public static final String HAZELCAST_BASE_PACKAGE = "com.hazelcast.";
     public static final String HAZELCAST_ARRAY = "[L" + HAZELCAST_BASE_PACKAGE;
+
+    private static final boolean CLASS_CACHE_DISABLED = Boolean.getBoolean("hazelcast.compat.classloading.cache.disabled");
 
     private static final Map<String, Class> PRIMITIVE_CLASSES;
     private static final int MAX_PRIM_CLASSNAME_LENGTH = 7;
 
-    private static final ConstructorCache CONSTRUCTOR_CACHE = new ConstructorCache();
+    private static final ClassLoaderWeakCache<Constructor> CONSTRUCTOR_CACHE = new ClassLoaderWeakCache<Constructor>();
+    private static final ClassLoaderWeakCache<Class> CLASS_CACHE = new ClassLoaderWeakCache<Class>();
+
 
     static {
         final Map<String, Class> primitives = new HashMap<String, Class>(10, 1.0f);
@@ -118,11 +121,26 @@ public final class ClassLoaderUtil {
     private static Class<?> tryLoadClass(String className, ClassLoader classLoader)
             throws ClassNotFoundException {
 
-        if (className.startsWith("[")) {
-            return Class.forName(className, false, classLoader);
-        } else {
-            return classLoader.loadClass(className);
+        Class<?> clazz;
+
+        if (!CLASS_CACHE_DISABLED) {
+            clazz = CLASS_CACHE.get(classLoader, className);
+            if (clazz != null) {
+                return clazz;
+            }
         }
+
+        if (className.startsWith("[")) {
+            clazz = Class.forName(className, false, classLoader);
+        } else {
+            clazz = classLoader.loadClass(className);
+        }
+
+        if (!CLASS_CACHE_DISABLED) {
+            CLASS_CACHE.put(classLoader, className, clazz);
+        }
+
+        return clazz;
     }
 
     public static boolean isInternalType(Class type) {
@@ -131,41 +149,41 @@ public final class ClassLoaderUtil {
         return type.getClassLoader() == classLoader && name.startsWith(HAZELCAST_BASE_PACKAGE);
     }
 
-    private static final class ConstructorCache {
-        private final ConcurrentMap<ClassLoader, ConcurrentMap<String, WeakReference<Constructor>>> cache;
+    private static final class ClassLoaderWeakCache<V> {
+        private final ConcurrentMap<ClassLoader, ConcurrentMap<String, WeakReference<V>>> cache;
 
-        private ConstructorCache() {
+        private ClassLoaderWeakCache() {
             // Guess 16 classloaders to not waste to much memory (16 is default concurrency level)
-            cache = new ConcurrentReferenceHashMap<ClassLoader, ConcurrentMap<String, WeakReference<Constructor>>>(16);
+            cache = new ConcurrentReferenceHashMap<ClassLoader, ConcurrentMap<String, WeakReference<V>>>(16);
         }
 
-        private <T> Constructor put(ClassLoader classLoader, String className, Constructor<T> constructor) {
+        private V put(ClassLoader classLoader, String className, V value) {
             ClassLoader cl = classLoader == null ? ClassLoaderUtil.class.getClassLoader() : classLoader;
-            ConcurrentMap<String, WeakReference<Constructor>> innerCache = cache.get(cl);
+            ConcurrentMap<String, WeakReference<V>> innerCache = cache.get(cl);
             if (innerCache == null) {
                 // Let's guess a start of 100 classes per classloader
-                innerCache = new ConcurrentHashMap<String, WeakReference<Constructor>>(100);
-                ConcurrentMap<String, WeakReference<Constructor>> old = cache.putIfAbsent(cl, innerCache);
+                innerCache = new ConcurrentHashMap<String, WeakReference<V>>(100);
+                ConcurrentMap<String, WeakReference<V>> old = cache.putIfAbsent(cl, innerCache);
                 if (old != null) {
                     innerCache = old;
                 }
             }
-            innerCache.put(className, new WeakReference<Constructor>(constructor));
-            return constructor;
+            innerCache.put(className, new WeakReference<V>(value));
+            return value;
         }
 
-        public <T> Constructor<T> get(ClassLoader classLoader, String className) {
+        public V get(ClassLoader classloader, String className) {
             ValidationUtil.isNotNull(className, "className");
-            ConcurrentMap<String, WeakReference<Constructor>> innerCache = cache.get(classLoader);
+            ConcurrentMap<String, WeakReference<V>> innerCache = cache.get(classloader);
             if (innerCache == null) {
                 return null;
             }
-            WeakReference<Constructor> reference = innerCache.get(className);
-            Constructor constructor = reference == null ? null : reference.get();
-            if (reference != null && constructor == null) {
+            WeakReference<V> reference = innerCache.get(className);
+            V value = reference == null ? null : reference.get();
+            if (reference != null && value == null) {
                 innerCache.remove(className);
             }
-            return (Constructor<T>) constructor;
+            return value;
         }
     }
 }


### PR DESCRIPTION
We already have a constructor cache in place. However the constructor cache is not
used in the case of Java serialization. Many classloaders out there have coarse grained
locking and it's causing a contention.

This change generalizes the same map to be used as both constructor cache and class cache.
There is a compatibility switch to disable the new cache should it caused any issues.

This is a backport into 3.4 branch. Master branch should also change the logic how classes are loaded,
but I'm intentionally keeping this changeset as small as possible to minimize a risk of  a regression