### PR TITLE
Dedicated priority generic thread(s)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/properties/GroupProperty.java
@@ -79,6 +79,15 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.operation.generic.thread.count", -1);
 
     /**
+     * The number of priority generic operation handler threads per Member.
+     * <p/>
+     * The default is 1.
+     */
+    public static final HazelcastProperty PRIORITY_GENERIC_OPERATION_THREAD_COUNT
+            = new HazelcastProperty("hazelcast.operation.priority.generic.thread.count", 1);
+
+
+    /**
      * The number of threads that the client engine has available for processing requests that are not partition specific.
      * Most of the requests, such as map.put and map.get, are partition specific and will use a partition-operation-thread, but
      * there are also requests that can't be executed on a partition-specific operation-thread, such as multimap.contain(value);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/classic/OperationThread.java
@@ -116,17 +116,21 @@ public abstract class OperationThread extends HazelcastManagedThread {
 
             processedTotal.inc();
 
-            if (task.getClass() == Packet.class) {
-                processPacket((Packet) task);
-            } else if (task instanceof Operation) {
-                processOperation((Operation) task);
-            } else if (task instanceof PartitionSpecificRunnable) {
-                processPartitionSpecificRunnable((PartitionSpecificRunnable) task);
-            } else if (task instanceof Runnable) {
-                processRunnable((Runnable) task);
-            } else {
-                throw new IllegalStateException("Unhandled task type for task:" + task);
-            }
+            process(task);
+        }
+    }
+
+    void process(Object task) {
+        if (task.getClass() == Packet.class) {
+            processPacket((Packet) task);
+        } else if (task instanceof Operation) {
+            processOperation((Operation) task);
+        } else if (task instanceof PartitionSpecificRunnable) {
+            processPartitionSpecificRunnable((PartitionSpecificRunnable) task);
+        } else if (task instanceof Runnable) {
+            processRunnable((Runnable) task);
+        } else {
+            throw new IllegalStateException("Unhandled task type for task:" + task);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/AbstractClassicOperationExecutorTest.java
@@ -19,6 +19,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
@@ -166,6 +167,13 @@ public abstract class AbstractClassicOperationExecutorTest extends HazelcastTest
         protected void readInternal(ObjectDataInput in) throws IOException {
             super.readInternal(in);
             durationMs = in.readInt();
+        }
+    }
+
+    protected static class UrgentDummyOperation extends DummyOperation implements UrgentSystemOperation {
+
+        public UrgentDummyOperation(int partitionId) {
+            super(partitionId);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/RunOnCallingThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/classic/RunOnCallingThreadTest.java
@@ -1,6 +1,5 @@
 package com.hazelcast.spi.impl.operationexecutor.classic;
 
-import com.hazelcast.internal.properties.GroupProperty;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -12,6 +11,8 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
+import static com.hazelcast.internal.properties.GroupProperty.GENERIC_OPERATION_THREAD_COUNT;
+import static com.hazelcast.internal.properties.GroupProperty.PRIORITY_GENERIC_OPERATION_THREAD_COUNT;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -39,7 +40,8 @@ public class RunOnCallingThreadTest extends AbstractClassicOperationExecutorTest
 
     @Test
     public void test_whenGenericOperation_andCallingFromGenericThread() {
-        config.setProperty(GroupProperty.GENERIC_OPERATION_THREAD_COUNT.getName(), "1");
+        config.setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "1");
+        config.setProperty(PRIORITY_GENERIC_OPERATION_THREAD_COUNT.getName(), "0");
         initExecutor();
 
         final DummyOperationRunner genericOperationHandler = ((DummyOperationRunnerFactory) handlerFactory).genericOperationHandlers.get(0);


### PR DESCRIPTION
The OperationExecutor is now by default configured with 1 extra priority generic thread. This thread will only process generic priority operations; which still can be picked up by another regular generic thread if the priority thread for whatever reason is busy. But it can't happen that if only regular generic tasks are running that a priority generic task is not going to be picked up.

This should increase reliability since generic threads are used for all kinds of purposes, e.g. launching and syncing on queries. And stuff like heartbeats, cluster operations etc should be processed asap.