### PR TITLE
Semaphore additions and changes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreAcquireCodec;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreAvailablePermitsCodec;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreDrainPermitsCodec;
+import com.hazelcast.client.impl.protocol.codec.SemaphoreIncreasePermitsCodec;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreInitCodec;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreReducePermitsCodec;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreReleaseCodec;
@@ -83,6 +84,13 @@ public class ClientSemaphoreProxy extends PartitionSpecificClientProxy implement
     public void reducePermits(int reduction) {
         checkNegative(reduction);
         ClientMessage request = SemaphoreReducePermitsCodec.encodeRequest(name, reduction);
+        invokeOnPartition(request);
+    }
+
+    @Override
+    public void increasePermits(int increase) {
+        checkNegative(increase);
+        ClientMessage request = SemaphoreIncreasePermitsCodec.encodeRequest(name, increase);
         invokeOnPartition(request);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreTest.java
@@ -124,6 +124,23 @@ public class ClientSemaphoreTest {
     }
 
     @Test
+    public void testAvailableIncreasePermits() throws Exception {
+        final ISemaphore semaphore = client.getSemaphore(randomString());
+        semaphore.init(10);
+        semaphore.drainPermits();
+        semaphore.increasePermits(5);
+        assertEquals(5, semaphore.availablePermits());
+    }
+
+    @Test
+    public void testAvailableIncreasePermits_WhenIncreasedFromZero() throws Exception {
+        final ISemaphore semaphore = client.getSemaphore(randomString());
+        semaphore.init(0);
+        semaphore.increasePermits(1);
+        assertEquals(1, semaphore.availablePermits());
+    }
+
+    @Test
     public void testTryAcquire_whenAvailable() throws Exception {
         final ISemaphore semaphore = client.getSemaphore(randomString());
         semaphore.init(1);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -32,12 +32,12 @@ import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddCardinalityEstim
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddDurableExecutorConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddEventJournalConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddExecutorConfigMessageTask;
+import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddFlakeIdGeneratorConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddListConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddLockConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddMultiMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddQueueConfigMessageTask;
-import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddFlakeIdGeneratorConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReliableTopicConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddReplicatedMapConfigMessageTask;
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.AddRingbufferConfigMessageTask;
@@ -73,9 +73,9 @@ import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecut
 import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecutorTaskIsCancelledFromPartitionMessageTask;
 import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecutorTaskIsDoneFromAddressMessageTask;
 import com.hazelcast.client.impl.protocol.task.scheduledexecutor.ScheduledExecutorTaskIsDoneFromPartitionMessageTask;
+import com.hazelcast.flakeidgen.impl.client.NewIdBatchMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.flakeidgen.impl.client.NewIdBatchMessageTask;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -646,6 +646,11 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         factories[com.hazelcast.client.impl.protocol.codec.SemaphoreReducePermitsCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new com.hazelcast.client.impl.protocol.task.semaphore.SemaphoreReducePermitsMessageTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.SemaphoreIncreasePermitsCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new com.hazelcast.client.impl.protocol.task.semaphore.SemaphoreIncreasePermitsMessageTask(clientMessage,node, connection);
             }
         };
         factories[com.hazelcast.client.impl.protocol.codec.SemaphoreTryAcquireCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreIncreasePermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/semaphore/SemaphoreIncreasePermitsMessageTask.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.semaphore;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.SemaphoreIncreasePermitsCodec;
+import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
+import com.hazelcast.concurrent.semaphore.SemaphoreService;
+import com.hazelcast.concurrent.semaphore.operations.IncreaseOperation;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.SemaphorePermission;
+import com.hazelcast.spi.Operation;
+
+import java.security.Permission;
+
+public class SemaphoreIncreasePermitsMessageTask
+        extends AbstractPartitionMessageTask<SemaphoreIncreasePermitsCodec.RequestParameters> {
+
+    public SemaphoreIncreasePermitsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        return new IncreaseOperation(parameters.name, parameters.increase);
+    }
+
+    @Override
+    protected SemaphoreIncreasePermitsCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return SemaphoreIncreasePermitsCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    public String getServiceName() {
+        return SemaphoreService.SERVICE_NAME;
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return SemaphoreIncreasePermitsCodec.encodeResponse();
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return new SemaphorePermission(parameters.name, ActionConstants.ACTION_ACQUIRE);
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "increasePermits";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{parameters.increase};
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
@@ -92,11 +92,11 @@ public class SemaphoreContainer implements IdentifiedDataSerializable {
     }
 
     public int getAvailable() {
-        return available;
+        return available < 0 ? 0 : available;
     }
 
     public boolean isAvailable(int permitCount) {
-        return available - permitCount >= 0;
+        return available > 0 && available - permitCount >= 0;
     }
 
     public boolean acquire(String owner, int permitCount) {
@@ -119,14 +119,27 @@ public class SemaphoreContainer implements IdentifiedDataSerializable {
         return drain;
     }
 
-    public boolean reduce(int permitCount) {
-        if (available == 0 || permitCount == 0) {
+    public boolean increase(int permitCount) {
+        if (permitCount == 0) {
             return false;
         }
-        available -= permitCount;
-        if (available < 0) {
-            available = 0;
+        int newAvailable = available + permitCount;
+        if (newAvailable < available) {
+            return false;
         }
+        available = newAvailable;
+        return true;
+    }
+
+    public boolean reduce(int permitCount) {
+        if (permitCount == 0) {
+            return false;
+        }
+        int newAvailable = available - permitCount;
+        if (newAvailable > available) {
+            return false;
+        }
+        available = newAvailable;
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
@@ -21,6 +21,8 @@ import com.hazelcast.concurrent.semaphore.operations.AcquireOperation;
 import com.hazelcast.concurrent.semaphore.operations.AvailableOperation;
 import com.hazelcast.concurrent.semaphore.operations.DrainBackupOperation;
 import com.hazelcast.concurrent.semaphore.operations.DrainOperation;
+import com.hazelcast.concurrent.semaphore.operations.IncreaseBackupOperation;
+import com.hazelcast.concurrent.semaphore.operations.IncreaseOperation;
 import com.hazelcast.concurrent.semaphore.operations.InitBackupOperation;
 import com.hazelcast.concurrent.semaphore.operations.InitOperation;
 import com.hazelcast.concurrent.semaphore.operations.ReduceBackupOperation;
@@ -57,6 +59,8 @@ public class SemaphoreDataSerializerHook implements DataSerializerHook {
     public static final int RELEASE_OPERATION = 12;
     public static final int DETACH_MEMBER_OPERATION = 13;
     public static final int SEMAPHORE_REPLICATION_OPERATION = 14;
+    public static final int INCREASE_OPERATION = 15;
+    public static final int INCREASE_BACKUP_OPERATION = 16;
 
     @Override
     public int getFactoryId() {
@@ -99,6 +103,10 @@ public class SemaphoreDataSerializerHook implements DataSerializerHook {
                         return new SemaphoreDetachMemberOperation();
                     case SEMAPHORE_REPLICATION_OPERATION:
                         return new SemaphoreReplicationOperation();
+                    case INCREASE_OPERATION:
+                        return new IncreaseOperation();
+                    case INCREASE_BACKUP_OPERATION:
+                        return new IncreaseBackupOperation();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
@@ -20,9 +20,11 @@ import com.hazelcast.concurrent.semaphore.operations.AcquireOperation;
 import com.hazelcast.concurrent.semaphore.operations.AvailableOperation;
 import com.hazelcast.concurrent.semaphore.operations.DrainOperation;
 import com.hazelcast.concurrent.semaphore.operations.InitOperation;
+import com.hazelcast.concurrent.semaphore.operations.IncreaseOperation;
 import com.hazelcast.concurrent.semaphore.operations.ReduceOperation;
 import com.hazelcast.concurrent.semaphore.operations.ReleaseOperation;
 import com.hazelcast.core.ISemaphore;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
@@ -100,6 +102,20 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
         checkNotNegative(reduction, "reduction can't be negative");
 
         Operation operation = new ReduceOperation(name, reduction)
+                .setPartitionId(partitionId);
+        InternalCompletableFuture<Object> future = invokeOnPartition(operation);
+        future.join();
+    }
+
+    @Override
+    public void increasePermits(int increase) {
+        if (getNodeEngine().getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
+            throw new UnsupportedOperationException("Increasing permits is available when cluster version is 3.10 or higher");
+        }
+
+        checkNotNegative(increase, "increase can't be negative");
+
+        Operation operation = new IncreaseOperation(name, increase)
                 .setPartitionId(partitionId);
         InternalCompletableFuture<Object> future = invokeOnPartition(operation);
         future.join();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/IncreaseBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/IncreaseBackupOperation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.concurrent.semaphore.operations;
+
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
+import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
+
+public class IncreaseBackupOperation extends SemaphoreBackupOperation {
+
+    public IncreaseBackupOperation() {
+    }
+
+    public IncreaseBackupOperation(String name, int permitCount) {
+        super(name, permitCount, null);
+    }
+
+    @Override
+    public void run() throws Exception {
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        semaphoreContainer.increase(permitCount);
+        response = true;
+    }
+
+    @Override
+    public int getId() {
+        return SemaphoreDataSerializerHook.INCREASE_BACKUP_OPERATION;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/IncreaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/IncreaseOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.concurrent.semaphore.operations;
+
+import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
+import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.MutatingOperation;
+
+public class IncreaseOperation extends SemaphoreBackupAwareOperation implements MutatingOperation {
+
+    public IncreaseOperation() {
+    }
+
+    public IncreaseOperation(String name, int permitCount) {
+        super(name, permitCount);
+    }
+
+    @Override
+    public void run() throws Exception {
+        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
+        response = semaphoreContainer.increase(permitCount);
+    }
+
+    @Override
+    public boolean shouldBackup() {
+        return Boolean.TRUE.equals(response);
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new IncreaseBackupOperation(name, permitCount);
+    }
+
+    @Override
+    public int getId() {
+        return SemaphoreDataSerializerHook.INCREASE_OPERATION;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/core/ISemaphore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ISemaphore.java
@@ -152,6 +152,16 @@ public interface ISemaphore extends DistributedObject {
     void reducePermits(int reduction);
 
     /**
+     * Increases the number of available permits by the indicated
+     * amount. This method differs from {@code release} in that it does not
+     * effect the amount of permits this caller has attached.
+     *
+     * @param increase the number of permits to add
+     * @throws IllegalArgumentException if {@code increase} is negative
+     */
+    void increasePermits(int increase);
+
+    /**
      * Releases a permit, increasing the number of available permits by
      * one. If any threads in the cluster are trying to acquire a permit,
      * then one is selected and given the permit that was just released.

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/SemaphoreMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/SemaphoreMBean.java
@@ -51,6 +51,12 @@ public class SemaphoreMBean extends HazelcastMBean<ISemaphore> {
         managedObject.reducePermits(reduction);
     }
 
+    @ManagedAnnotation(value = "increase", operation = true)
+    @ManagedDescription("Increases the number of available permits by the indicated increase. Does not block")
+    public void increase(int increases) {
+        managedObject.increasePermits(increases);
+    }
+
     @ManagedAnnotation(value = "release", operation = true)
     @ManagedDescription("Releases the given number of permits, increasing the number of available permits by that amount")
     public void release(int permits) {

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicTest.java
@@ -103,7 +103,32 @@ public abstract class SemaphoreBasicTest extends HazelcastTestSupport {
 
         assertEquals(semaphore.availablePermits(), numberOfPermits);
     }
-
+    
+    @Test(timeout = 30000)
+    public void testAllowNegativePermits() {
+        assertTrue(semaphore.init(10));
+        
+        semaphore.reducePermits(15);
+        
+        assertEquals(0, semaphore.availablePermits());
+        
+        semaphore.release(10);
+        
+        assertEquals(5, semaphore.availablePermits());
+    }    
+    
+    
+    @Test(timeout = 30000)
+    public void testIncreasePermits() {
+        assertTrue(semaphore.init(10));
+                
+        assertEquals(10, semaphore.availablePermits());
+        
+        semaphore.increasePermits(100);
+        
+        assertEquals(110, semaphore.availablePermits());
+    }
+    
     @Test(timeout = 30000)
     public void testRelease_whenArgumentNegative() {
         try {
@@ -270,6 +295,16 @@ public abstract class SemaphoreBasicTest extends HazelcastTestSupport {
         assertEquals(0, semaphore.availablePermits());
     }
 
+    @Test(timeout = 30000)
+    public void testIncrease_whenArgumentNegative() {
+        try {
+            semaphore.increasePermits(-5);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
+        assertEquals(0, semaphore.availablePermits());
+    }
+    
 
     @Test(timeout = 30000)
     public void testTryAcquire() {

--- a/hazelcast/src/test/java/com/hazelcast/quorum/QuorumOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/QuorumOperationTest.java
@@ -84,7 +84,8 @@ public class QuorumOperationTest {
             "lock", "signal",
             "prepare", "commit",
             "load", "flush",
-            "clear", "destroy"
+            "clear", "destroy",
+            "increase"
     );
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/semaphore/SemaphoreQuorumWriteTest.java
@@ -121,6 +121,17 @@ public class SemaphoreQuorumWriteTest extends AbstractQuorumTest {
     }
 
     @Test
+    public void increase() {
+        semaphore(0).drainPermits();
+        semaphore(0).increasePermits(1);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void increasePermits_successful_whenQuorumSize_notMet() {
+        semaphore(3).increasePermits(1);
+    }
+
+    @Test
     public void release_successful_whenQuorumSize_met() {
         semaphore(0).release();
     }


### PR DESCRIPTION
Hi

For our use of Hazelcast, we needed the ability to change the number of permits available in a semaphore at runtime. This PR adds a few new functions to the ISemaphore class, including increasePermits and reducePermits. In addition, it allows the amount of available permits to become negative, meaning 1 or more releases are required before another acquire will be successful.

Regards
Stephen
