### PR TITLE
Fixes hanging authentication future

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -69,6 +69,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.client.config.ClientProperty.HEARTBEAT_INTERVAL;
@@ -216,7 +217,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                     return connection;
                 }
                 AuthenticationFuture firstCallback = triggerConnect(address, asOwner);
-                connection = firstCallback.get();
+                connection = firstCallback.get(connectionTimeout);
                 if (!asOwner) {
                     return connection;
                 }
@@ -248,12 +249,15 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             countDownLatch.countDown();
         }
 
-        Connection get() throws Throwable {
-            countDownLatch.await();
+        Connection get(int timeout) throws Throwable {
+            countDownLatch.await(timeout, TimeUnit.MILLISECONDS);
             if (connection != null) {
                 return connection;
             }
-            throw throwable;
+            if (throwable != null) {
+                throw throwable;
+            }
+            throw new TimeoutException("Authentication response did not come back in " + timeout + " millis");
         }
     }
 
@@ -363,6 +367,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             for (ConnectionListener connectionListener : connectionListeners) {
                 connectionListener.connectionRemoved(conn);
             }
+        } else {
+            ((ClientConnection) connection).close(e);
         }
     }
 


### PR DESCRIPTION
When connection gets exception from socket and destroyConnection
is called before connection is authenticated, client does not
have an endpoint and it is not in connections map. Because of
that closing that connection was missing. I have added close
for that.

Secondly, authentication future was waiting infinite. Since it is
not in connections map, heartbeat does not works on that connection
yet. And we should not have infinite wait on something we can not
detect if heart is beating.

Fixes testMapReduceJobSubmissionWithNoDataNode test which was
failing spuriously.