### PR TITLE
Exist key operation.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -207,6 +207,11 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         return containsKeyInternal(keyData);
     }
 
+    @Override
+    public boolean existKey(Object key) {
+        throw new UnsupportedOperationException("Locality is ambiguous for client!!!");
+    }
+
     protected boolean containsKeyInternal(Data keyData) {
         ClientMessage message = MapContainsKeyCodec.encodeRequest(name, keyData, ThreadUtil.getThreadId());
         ClientMessage result = invoke(message, keyData);

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -98,6 +98,20 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
 
     /**
      * {@inheritDoc}
+     * <p/>
+     * <p><b>Warning:</b></p>
+     * <p>                                                                                      ˆ
+     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
+     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
+     * defined in the <tt>key</tt>'s class.  The <tt>key</tt> will be searched for in memory.
+     * </p>
+     *
+     * @throws NullPointerException if the specified key is null.
+     */
+    boolean existKey(Object key);
+
+    /**
+     * {@inheritDoc}
      *
      * @throws NullPointerException if the specified value is null.
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -45,6 +45,10 @@ public class ContainsKeyOperation extends KeyBasedMapOperation implements Readon
         return containsKey;
     }
 
+    public void setResponse(final boolean response){
+        containsKey = response;
+    }
+
     @Override
     public WaitNotifyKey getWaitKey() {
         DefaultObjectNamespace namespace = new DefaultObjectNamespace(MapService.SERVICE_NAME, name);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -124,6 +124,11 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
+    public MapOperation createExistKeyOperation(String name, Data dataKey) {
+        return new ExistKeyOperation(name, dataKey);
+    }
+
+    @Override
     public OperationFactory createContainsValueOperationFactory(String name, Data testValue) {
         return new ContainsValueOperationFactory(name, testValue);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ExistKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ExistKeyOperation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.nio.serialization.Data;
+
+public class ExistKeyOperation extends ContainsKeyOperation {
+
+    public ExistKeyOperation() {
+        super();
+    }
+
+    public ExistKeyOperation(String name, Data dataKey) {
+        super(name, dataKey);
+    }
+
+    public void run() {
+        setResponse(recordStore.existKey(dataKey));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -65,6 +65,8 @@ public interface MapOperationProvider {
 
     MapOperation createContainsKeyOperation(String name, Data dataKey);
 
+    MapOperation createExistKeyOperation(String name, Data dataKey);
+
     MapOperation createGetEntryViewOperation(String name, Data dataKey);
 
     MapOperation createGetOperation(String name, Data dataKey);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -118,6 +118,11 @@ public abstract class MapOperationProviderDelegator implements MapOperationProvi
     }
 
     @Override
+    public MapOperation createExistKeyOperation(String name, Data dataKey) {
+        return getDelegate().createExistKeyOperation(name, dataKey);
+    }
+
+    @Override
     public MapOperation createGetEntryViewOperation(String name, Data dataKey) {
         return getDelegate().createGetEntryViewOperation(name, dataKey);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -216,6 +216,14 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
+    public boolean existKey(Object k) {
+        checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
+
+        Data key = toData(k, partitionStrategy);
+        return existKeyInternal(key);
+    }
+
+    @Override
     public boolean containsValue(Object v) {
         checkNotNull(v, NULL_VALUE_IS_NOT_ALLOWED);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -511,6 +511,19 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         }
     }
 
+    protected boolean existKeyInternal(Data key) {
+        int partitionId = partitionService.getPartitionId(key);
+        MapOperation containsKeyOperation = operationProvider.createExistKeyOperation(name, key);
+        containsKeyOperation.setThreadId(ThreadUtil.getThreadId());
+        containsKeyOperation.setServiceName(SERVICE_NAME);
+        try {
+            Future f = operationService.invokeOnPartition(SERVICE_NAME, containsKeyOperation, partitionId);
+            return (Boolean) toObject(f.get());
+        } catch (Throwable t) {
+            throw ExceptionUtil.rethrow(t);
+        }
+    }
+
     public void waitUntilLoaded() {
         try {
             int mapNamePartition = partitionService.getPartitionId(name);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -650,11 +650,15 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     @Override
     public boolean containsKey(Data key) {
+        return containsOrExistKey(key, true);
+    }
+
+    private boolean containsOrExistKey(final Data key, final boolean load) {
         checkIfLoaded();
         final long now = getNow();
 
         Record record = getRecordOrNull(key, now, false);
-        if (record == null) {
+        if (load && record == null) {
             record = loadRecordOrNull(key, false);
         }
         boolean contains = record != null;
@@ -663,6 +667,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
 
         return contains;
+    }
+
+    @Override
+    public boolean existKey(Data key) {
+        return containsOrExistKey(key, false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -105,6 +105,8 @@ public interface RecordStore<R extends Record> {
 
     boolean containsKey(Data dataKey);
 
+    boolean existKey(Data dataKey);
+
     Object replace(Data dataKey, Object update);
 
 


### PR DESCRIPTION
This operation is equal than containsKey but this doesn't trigger the mapLoader.
Useful when you know you are on the owner node and need to fast-query if the value is loaded into the local map instead of iterate over all localKeySet.