### PR TITLE
Renamed ClassicOperationExecutor to OperationExecutorImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/InterceptorRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/InterceptorRegistry.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.map.MapInterceptor;
-import com.hazelcast.spi.impl.operationexecutor.classic.PartitionOperationThread;
+import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -67,7 +67,7 @@ public class InterceptorRegistry {
      * If there is no registration associated with the `id`, registers interceptor,
      * otherwise silently ignores registration.
      *
-     * This method is called by {@link com.hazelcast.spi.impl.operationexecutor.classic.GenericOperationThread}
+     * This method is called by {@link com.hazelcast.spi.impl.operationexecutor.impl.GenericOperationThread}
      * when registering via {@link com.hazelcast.map.impl.operation.AddInterceptorOperation}
      *
      * @param id          id of the interceptor
@@ -94,7 +94,7 @@ public class InterceptorRegistry {
     /**
      * De-registers {@link MapInterceptor} for the supplied `id`, if there is any.
      *
-     * This method is called by {@link com.hazelcast.spi.impl.operationexecutor.classic.GenericOperationThread}
+     * This method is called by {@link com.hazelcast.spi.impl.operationexecutor.impl.GenericOperationThread}
      * when de-registering via {@link com.hazelcast.map.impl.operation.RemoveInterceptorOperation}
      *
      * @param id id of the interceptor

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.operationexecutor;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
 
 /**
  * The OperationExecutor is responsible for scheduling work (packets/operations) to be executed. It can be compared
@@ -26,7 +27,7 @@ import com.hazelcast.spi.impl.PartitionSpecificRunnable;
  * operations and PartitionSpecificRunnable to a thread instead of only runnables.
  *
  * It depends on the implementation if an operation is executed on the calling thread or not. For example the
- * {@link com.hazelcast.spi.impl.operationexecutor.classic.ClassicOperationExecutor} will always offload a partition specific
+ * {@link OperationExecutorImpl} will always offload a partition specific
  * Operation to the correct partition-operation-thread.
  *
  * The actual processing of a operation-packet, Operation, or a PartitionSpecificRunnable is forwarded to the

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.impl.operationexecutor;
 
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
 
 /**
  * The OperationRunner is responsible for the actual running of operations.
@@ -80,7 +81,7 @@ public abstract class OperationRunner {
      * This value only has meaning when an Operation is running. It depends on the implementation if the field is unset
      * after an operation is executed or not. So it could be that a value is returned while no operation is running.
      * <p/>
-     * For example, the {@link com.hazelcast.spi.impl.operationexecutor.classic.ClassicOperationExecutor} will never unset
+     * For example, the {@link OperationExecutorImpl} will never unset
      * this field since each OperationRunner is bound to a single OperationThread; so this field is initialized when the
      * OperationRunner is created.
      * <p/>

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueue.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentLinkedQueue;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.NodeExtension;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.NodeExtension;
@@ -60,10 +60,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * generic operation threads: these threads are responsible for executing operations that are not
  * specific to a partition. E.g. a heart beat.
  * </li>
+ *
  * </ol>
  */
 @SuppressWarnings("checkstyle:methodcount")
-public final class ClassicOperationExecutor implements OperationExecutor {
+public final class OperationExecutorImpl implements OperationExecutor {
 
     public static final int TERMINATION_TIMEOUT_SECONDS = 3;
 
@@ -82,15 +83,15 @@ public final class ClassicOperationExecutor implements OperationExecutor {
     private final Address thisAddress;
     private final OperationRunner adHocOperationRunner;
 
-    public ClassicOperationExecutor(GroupProperties properties,
-                                    LoggingService loggerService,
-                                    Address thisAddress,
-                                    OperationRunnerFactory operationRunnerFactory,
-                                    HazelcastThreadGroup threadGroup,
-                                    NodeExtension nodeExtension,
-                                    MetricsRegistry metricsRegistry) {
+    public OperationExecutorImpl(GroupProperties properties,
+                                 LoggingService loggerService,
+                                 Address thisAddress,
+                                 OperationRunnerFactory operationRunnerFactory,
+                                 HazelcastThreadGroup threadGroup,
+                                 NodeExtension nodeExtension,
+                                 MetricsRegistry metricsRegistry) {
         this.thisAddress = thisAddress;
-        this.logger = loggerService.getLogger(ClassicOperationExecutor.class);
+        this.logger = loggerService.getLogger(OperationExecutorImpl.class);
 
         this.adHocOperationRunner = operationRunnerFactory.createAdHocRunner();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueue.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 /**
  * The OperationQueue is the queue used to schedule operations/tasks on an OperationThread.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.NodeExtension;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionOperationThread.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.NodeExtension;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Contains the {@link com.hazelcast.spi.impl.operationexecutor.classic.ClassicOperationExecutor} code.
+ * Contains the {@link com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl} code.
  */
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -43,7 +43,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
-import com.hazelcast.spi.impl.operationexecutor.classic.ClassicOperationExecutor;
+import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
 import com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationDetector;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
@@ -166,7 +166,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
                 logger,
                 responseHandler);
 
-        this.operationExecutor = new ClassicOperationExecutor(
+        this.operationExecutor = new OperationExecutorImpl(
                 groupProperties,
                 node.loggingService,
                 node.getThisAddress(),

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueStressTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.instance.BuildInfo;
@@ -40,13 +40,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Abstract test support to test the {@link ClassicOperationExecutor}.
+ * Abstract test support to test the {@link OperationExecutorImpl}.
  * <p/>
  * The idea is the following; all dependencies for the executor are available as fields in this object and by calling the
  * {@link #initExecutor()} method, the actual ClassicOperationExecutor instance is created. But if you need to replace
  * the dependencies by mocks, just replace them before calling the {@link #initExecutor()} method.
  */
-public abstract class ClassicOperationExecutor_AbstractTest extends HazelcastTestSupport {
+public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSupport {
 
     protected LoggingServiceImpl loggingService;
     protected GroupProperties groupProperties;
@@ -56,7 +56,7 @@ public abstract class ClassicOperationExecutor_AbstractTest extends HazelcastTes
     protected OperationRunnerFactory handlerFactory;
     protected InternalSerializationService serializationService;
     protected PacketHandler responsePacketHandler;
-    protected ClassicOperationExecutor executor;
+    protected OperationExecutorImpl executor;
     protected Config config;
     protected MetricsRegistry metricsRegistry;
 
@@ -81,9 +81,9 @@ public abstract class ClassicOperationExecutor_AbstractTest extends HazelcastTes
         responsePacketHandler = new DummyResponsePacketHandler();
     }
 
-    protected ClassicOperationExecutor initExecutor() {
+    protected OperationExecutorImpl initExecutor() {
         groupProperties = new GroupProperties(config);
-        executor = new ClassicOperationExecutor(
+        executor = new OperationExecutorImpl(
                 groupProperties, loggingService, thisAddress, handlerFactory,
                 threadGroup, nodeExtension, metricsRegistry);
         executor.start();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.internal.properties.GroupProperty;
 import com.hazelcast.spi.Operation;
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_BasicTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_BasicTest extends OperationExecutorImpl_AbstractTest {
 
     @Test
     public void testConstruction() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecuteOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecuteOperationTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_ExecuteOperationTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_ExecuteOperationTest extends OperationExecutorImpl_AbstractTest {
 
     @Test(expected = NullPointerException.class)
     public void whenNull() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecutePacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecutePacketTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
@@ -14,11 +14,11 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests {@link ClassicOperationExecutor#execute(com.hazelcast.nio.Packet)}
+ * Tests {@link OperationExecutorImpl#execute(com.hazelcast.nio.Packet)}
  */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_ExecutePacketTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_ExecutePacketTest extends OperationExecutorImpl_AbstractTest {
 
     @Test(expected = NullPointerException.class)
     public void test_whenNullPacket() {
@@ -40,7 +40,7 @@ public class ClassicOperationExecutor_ExecutePacketTest extends ClassicOperation
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                DummyResponsePacketHandler responsePacketHandler = (DummyResponsePacketHandler) ClassicOperationExecutor_ExecutePacketTest.this.responsePacketHandler;
+                DummyResponsePacketHandler responsePacketHandler = (DummyResponsePacketHandler) OperationExecutorImpl_ExecutePacketTest.this.responsePacketHandler;
                 responsePacketHandler.packets.contains(packet);
                 responsePacketHandler.responses.contains(normalResponse);
             }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecutePartitionSpecificRunnableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecutePartitionSpecificRunnableTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.test.AssertTask;
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_ExecutePartitionSpecificRunnableTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_ExecutePartitionSpecificRunnableTest extends OperationExecutorImpl_AbstractTest {
 
     @Test(expected = NullPointerException.class)
     public void whenNull() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_GetOperationRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_GetOperationRunnerTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_GetOperationRunnerTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_GetOperationRunnerTest extends OperationExecutorImpl_AbstractTest {
 
     @Test(expected = NullPointerException.class)
     public void test_whenNull() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsInvocationAllowedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsInvocationAllowedTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.spi.Operation;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_IsInvocationAllowedTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_IsInvocationAllowedTest extends OperationExecutorImpl_AbstractTest {
 
     @Test(expected = NullPointerException.class)
     public void test_whenNullOperation() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsOperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsOperationThreadTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.spi.Operation;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_IsOperationThreadTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_IsOperationThreadTest extends OperationExecutorImpl_AbstractTest {
 
     @Test
     public void test_whenCallingFromNonOperationThread() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsRunAllowedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_IsRunAllowedTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.spi.Operation;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_IsRunAllowedTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_IsRunAllowedTest extends OperationExecutorImpl_AbstractTest {
 
     @Test(expected = NullPointerException.class)
     public void test_whenNullOperation() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunOrExecuteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunOrExecuteTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_RunOrExecuteTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_RunOrExecuteTest extends OperationExecutorImpl_AbstractTest {
 
 
     @Test(expected = NullPointerException.class)

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.internal.properties.GroupProperty;
 import com.hazelcast.spi.Operation;
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ClassicOperationExecutor_RunTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationExecutorImpl_RunTest extends OperationExecutorImpl_AbstractTest {
 
     @Test(expected = NullPointerException.class)
     public void test_whenNull() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.logging.ILogger;
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class OperationThreadTest extends ClassicOperationExecutor_AbstractTest {
+public class OperationThreadTest extends OperationExecutorImpl_AbstractTest {
 
     @Test
     public void testOOME_whenDeserializing() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionSpecificCallable.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionSpecificCallable.java
@@ -1,4 +1,4 @@
-package com.hazelcast.spi.impl.operationexecutor.classic;
+package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
@@ -7,7 +7,7 @@ import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.impl.operationexecutor.classic.ClassicOperationExecutor;
+import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
 import com.hazelcast.test.HazelcastTestSupport;
 
 import java.io.IOException;
@@ -18,7 +18,7 @@ public abstract class Invocation_NestedAbstractTest extends HazelcastTestSupport
 
     public static boolean mappedToSameThread(OperationService operationService, int partitionId1, int partitionId2) {
         OperationServiceImpl operationServiceImpl = (OperationServiceImpl) operationService;
-        ClassicOperationExecutor executor = (ClassicOperationExecutor) operationServiceImpl.getOperationExecutor();
+        OperationExecutorImpl executor = (OperationExecutorImpl) operationServiceImpl.getOperationExecutor();
         int thread1 = executor.toPartitionThreadIndex(partitionId1);
         int thread2 = executor.toPartitionThreadIndex(partitionId2);
         return thread1 == thread2;


### PR DESCRIPTION
It was named classic since a year ago I had another implementation that allows for caller runs optimization. However due to threading limitations in HZ enterprise; this is not a practical model