### PR TITLE
OperationService cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/OperationServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/OperationServiceMBean.java
@@ -76,6 +76,6 @@ public class OperationServiceMBean extends HazelcastMBean<InternalOperationServi
     @ManagedAnnotation("operationThreadCount")
     @ManagedDescription("Number of threads executing operations")
     public long getOperationThreadCount() {
-        return managedObject.getPartitionOperationThreadCount();
+        return managedObject.getPartitionThreadCount();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/OperationServiceDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/OperationServiceDTO.java
@@ -44,7 +44,7 @@ public class OperationServiceDTO implements JsonSerializable {
         runningOperationsCount = os.getRunningOperationsCount();
         remoteOperationCount = os.getRemoteOperationsCount();
         executedOperationCount = os.getExecutedOperationCount();
-        operationThreadCount = os.getPartitionOperationThreadCount();
+        operationThreadCount = os.getPartitionThreadCount();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
@@ -162,7 +162,7 @@ public class ExpirationManager {
             final int times = 3;
             InternalOperationService opService
                     = (InternalOperationService) ExpirationManager.this.nodeEngine.getOperationService();
-            return times * opService.getPartitionOperationThreadCount();
+            return times * opService.getPartitionThreadCount();
         }
 
         private boolean isContainerEmpty(PartitionContainer container) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -45,18 +45,6 @@ public interface OperationService {
      */
     void executeOperation(Operation op);
 
-    /**
-     * Returns true if the given operation is allowed to run on the calling thread, false otherwise.
-     * If this method returns true, then the operation can be executed using {@link #runOperationOnCallingThread(Operation)}
-     * method, otherwise {@link #executeOperation(Operation)} should be used.
-     *
-     * @param op the operation to check.
-     * @return true if the operation is allowed to run on the calling thread, false otherwise.
-     * @deprecated since 3.5 since not needed anymore.
-     */
-    @Deprecated
-    boolean isAllowedToRunOnCallingThread(Operation op);
-
     <E> InternalCompletableFuture<E> invokeOnPartition(String serviceName, Operation op, int partitionId);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -138,7 +138,6 @@ public interface OperationExecutor {
      * @return true if it is allowed, false otherwise.
      * @throws java.lang.NullPointerException if op is null.
      */
-    @Deprecated
     boolean isRunAllowed(Operation op);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -35,6 +35,11 @@ import java.util.List;
  */
 public interface InternalOperationService extends OperationService, PacketHandler {
 
+    /**
+     * Returns the size of the response queue.
+     *
+     * @return the size of the response queue.
+     */
     int getResponseQueueSize();
 
     int getOperationExecutorQueueSize();
@@ -45,11 +50,26 @@ public interface InternalOperationService extends OperationService, PacketHandle
 
     int getRemoteOperationsCount();
 
-    int getPartitionOperationThreadCount();
-
-    int getGenericOperationThreadCount();
-
+    /**
+     * Returns the number of executed operations.
+     *
+     * @return the number of executed operations.
+     */
     long getExecutedOperationCount();
+
+    /**
+     * Returns the number of partition threads.
+     *
+     * @return the number of partition threads.
+     */
+    int getPartitionThreadCount();
+
+    /**
+     * Returns the number of generic threads.
+     *
+     * @return number of generic threads.
+     */
+    int getGenericThreadCount();
 
     /**
      * Checks if this call is timed out. A timed out call is not going to be executed.
@@ -58,6 +78,16 @@ public interface InternalOperationService extends OperationService, PacketHandle
      * @return true if it is timed out, false otherwise.
      */
     boolean isCallTimedOut(Operation op);
+
+    /**
+     * Returns true if the given operation is allowed to run on the calling thread, false otherwise.
+     * If this method returns true, then the operation can be executed using {@link #runOperationOnCallingThread(Operation)}
+     * method, otherwise {@link #executeOperation(Operation)} should be used.
+     *
+     * @param op the operation to check.
+     * @return true if the operation is allowed to run on the calling thread, false otherwise.
+     */
+    boolean isRunAllowed(Operation op);
 
     /**
      * Executes a PartitionSpecificRunnable.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -60,6 +60,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.nio.Packet.FLAG_OP;
+import static com.hazelcast.nio.Packet.FLAG_RESPONSE;
+import static com.hazelcast.nio.Packet.FLAG_URGENT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_CALL_TIMEOUT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_DESERIALIZE_RESULT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_REPLICA_INDEX;
@@ -123,7 +126,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
 
     private final SlowOperationDetector slowOperationDetector;
     private final IsStillRunningService isStillRunningService;
-    private final AsyncResponsePacketHandler responsePacketExecutor;
+    private final AsyncResponseHandler responsePacketExecutor;
     private final InternalSerializationService serializationService;
     private final InvocationMonitor invocationMonitor;
     private final ResponseHandler responseHandler;
@@ -161,10 +164,11 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
                 node.getSerializationService(),
                 invocationRegistry,
                 nodeEngine);
-        this.responsePacketExecutor = new AsyncResponsePacketHandler(
+        this.responsePacketExecutor = new AsyncResponseHandler(
                 node.getHazelcastThreadGroup(),
                 logger,
-                responseHandler);
+                responseHandler,
+                metricsRegistry);
 
         this.operationExecutor = new OperationExecutorImpl(
                 groupProperties,
@@ -211,12 +215,12 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     }
 
     @Override
-    public int getPartitionOperationThreadCount() {
+    public int getPartitionThreadCount() {
         return operationExecutor.getPartitionThreadCount();
     }
 
     @Override
-    public int getGenericOperationThreadCount() {
+    public int getGenericThreadCount() {
         return operationExecutor.getGenericThreadCount();
     }
 
@@ -249,7 +253,6 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         return operationExecutor;
     }
 
-    @Probe(name = "response-queue.size", level = MANDATORY)
     @Override
     public int getResponseQueueSize() {
         return responsePacketExecutor.getQueueSize();
@@ -258,9 +261,9 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     @Override
     public void handle(Packet packet) throws Exception {
         checkNotNull(packet, "packet can't be null");
-        checkTrue(packet.isFlagSet(Packet.FLAG_OP), "Packet.FLAG_OP should be set!");
+        checkTrue(packet.isFlagSet(FLAG_OP), "Packet.FLAG_OP should be set!");
 
-        if (packet.isFlagSet(Packet.FLAG_RESPONSE)) {
+        if (packet.isFlagSet(FLAG_RESPONSE)) {
             responsePacketExecutor.handle(packet);
         } else {
             operationExecutor.execute(packet);
@@ -299,7 +302,7 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
     }
 
     @Override
-    public boolean isAllowedToRunOnCallingThread(Operation op) {
+    public boolean isRunAllowed(Operation op) {
         return operationExecutor.isRunAllowed(op);
     }
 
@@ -410,11 +413,11 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
 
         byte[] bytes = serializationService.toBytes(op);
         int partitionId = op.getPartitionId();
-        Packet packet = new Packet(bytes, partitionId);
-        packet.setFlag(Packet.FLAG_OP);
+        Packet packet = new Packet(bytes, partitionId)
+                .setFlag(FLAG_OP);
 
         if (op.isUrgent()) {
-            packet.setFlag(Packet.FLAG_URGENT);
+            packet.setFlag(FLAG_URGENT);
         }
 
         ConnectionManager connectionManager = node.getConnectionManager();
@@ -432,12 +435,11 @@ public final class OperationServiceImpl implements InternalOperationService, Pac
         }
 
         byte[] bytes = serializationService.toBytes(response);
-        Packet packet = new Packet(bytes, -1);
-        packet.setFlag(Packet.FLAG_OP);
-        packet.setFlag(Packet.FLAG_RESPONSE);
+        Packet packet = new Packet(bytes, -1)
+                .setAllFlags(FLAG_OP | FLAG_RESPONSE);
 
         if (response.isUrgent()) {
-            packet.setFlag(Packet.FLAG_URGENT);
+            packet.setFlag(FLAG_URGENT);
         }
 
         ConnectionManager connectionManager = node.getConnectionManager();

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/MetricsPluginTest.java
@@ -69,6 +69,6 @@ public class MetricsPluginTest extends AbstractPerformanceMonitorPluginTest {
 
         // we just test a few to make sure the metrics are written.
         assertContains("client.endpoint.count=0");
-        assertContains("operation.response-queue.size=0");
+        assertContains("operation.responseQueueSize=0");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_BasicTest.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.properties.GroupProperty;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -43,11 +45,33 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.concurrent.ExecutionException;
 
+import static com.hazelcast.internal.properties.GroupProperty.GENERIC_OPERATION_THREAD_COUNT;
+import static com.hazelcast.internal.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class OperationServiceImplTest extends HazelcastTestSupport {
+public class OperationServiceImpl_BasicTest extends HazelcastTestSupport {
+
+    @Test
+    public void testGetPartitionThreadCount(){
+        Config config = new Config();
+        config.setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "5");
+        HazelcastInstance hz = createHazelcastInstance(config);
+        OperationServiceImpl operationService = getOperationServiceImpl(hz);
+
+        assertEquals(5, operationService.getPartitionThreadCount());
+    }
+
+    @Test
+    public void testGetGenericThreadCount(){
+        Config config = new Config();
+        config.setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "5");
+        HazelcastInstance hz = createHazelcastInstance(config);
+        OperationServiceImpl operationService = getOperationServiceImpl(hz);
+
+        assertEquals(5, operationService.getGenericThreadCount());
+    }
 
     // there was a memory leak caused by the invocation not releasing the backup registration
     // when Future.get() is not called.

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
@@ -51,7 +51,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
             assertNull(response);
         }
 
-        OperationServiceImplTest.assertNoLitterInOpService(hz);
+        OperationServiceImpl_BasicTest.assertNoLitterInOpService(hz);
     }
 
     //there was a memory leak caused by the invocation not releasing the backup registration when there is a timeout.
@@ -67,8 +67,8 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
             assertNull(response);
         }
 
-        OperationServiceImplTest.assertNoLitterInOpService(hz1);
-        OperationServiceImplTest.assertNoLitterInOpService(hz2);
+        OperationServiceImpl_BasicTest.assertNoLitterInOpService(hz1);
+        OperationServiceImpl_BasicTest.assertNoLitterInOpService(hz2);
     }
 
     @Test
@@ -135,7 +135,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
         assertOpenEventually("Should throw OperationTimeoutException", latch);
 
         for (HazelcastInstance instance : instances) {
-            OperationServiceImplTest.assertNoLitterInOpService(instance);
+            OperationServiceImpl_BasicTest.assertNoLitterInOpService(instance);
         }
     }
 


### PR DESCRIPTION
- renamed InternalOpServe.getPartitionOperatonThreadCount to getPartitionThreadCount
- renamed InternalOpServe.getGenericOperationThreadCount to getGenericOperationThreadCount
- added tests for the above methods
- removed Opservice.isAllowedToRunOnCallingThread since it is deprecated
- introduced InOpService.isRunAllowed since it is needed by enterprise
- removed deprecation annotation of OperationExecutor.isRunAllowed since method is still used
- added documentation to some methods on InternalOpService
- renamed AsyncResponsePacketHandler to AsyncResponseHandler to be in line with ResponseHandler
- moved the probe for AsyncResponseHandler from OpService into AsyncResponseHandler
- renamed the probe for asyncresponsepacket handler from response-queue.size to responseQueueSize
- minor testing cleanup
