### PR TITLE
MetricsRegistry init cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+/**
+ * To be implemented by an object that can provide metrics (so has a bunch of probes).
+ */
+public interface MetricsProvider {
+
+    void provideMetrics(MetricsRegistry metricsRegistry);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -163,4 +163,12 @@ public interface MetricsRegistry {
      * @throws NullPointerException if renderer is null.
      */
     void render(ProbeRenderer renderer);
+
+    /**
+     * For each object that implements {@link MetricsProvider} the {@link MetricsProvider#provideMetrics(MetricsRegistry)}
+     * is called.
+     *
+     * @param objects the array of objects to initialize.
+     */
+    void collectMetrics(Object... objects);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.metrics.impl;
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeFunction;
 import com.hazelcast.internal.metrics.ProbeLevel;
@@ -236,6 +237,15 @@ public class MetricsRegistryImpl implements MetricsRegistry {
 
         for (ProbeInstance probeInstance : getSortedProbeInstances()) {
             render(renderer, probeInstance);
+        }
+    }
+
+    @Override
+    public void collectMetrics(Object... objects) {
+        for (Object object : objects) {
+            if (object instanceof MetricsProvider) {
+                ((MetricsProvider) object).provideMetrics(this);
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -164,6 +164,10 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     public void start() {
+        metricsRegistry.collectMetrics(operationService);
+        metricsRegistry.collectMetrics(proxyService);
+        metricsRegistry.collectMetrics(eventService);
+
         serviceManager.start();
         proxyService.init();
         operationService.start();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -19,6 +19,8 @@ package com.hazelcast.spi.impl.eventservice.impl;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.metrics.MetricsProvider;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.properties.GroupProperties;
 import com.hazelcast.internal.properties.GroupProperty;
@@ -61,7 +63,7 @@ import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 
-public class EventServiceImpl implements InternalEventService {
+public class EventServiceImpl implements InternalEventService, MetricsProvider {
 
     public static final String EVENT_SYNC_FREQUENCY_PROP = "hazelcast.event.sync.frequency";
 
@@ -125,8 +127,11 @@ public class EventServiceImpl implements InternalEventService {
         this.deregistrationExceptionHandler
                 = new FutureUtilExceptionHandler(logger, "Member left while de-registering listener...");
         this.segments = new ConcurrentHashMap<String, EventServiceSegment>();
+    }
 
-        nodeEngine.getMetricsRegistry().scanAndRegister(this, "event");
+    @Override
+    public void provideMetrics(MetricsRegistry metricsRegistry) {
+        metricsRegistry.scanAndRegister(this, "event");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
@@ -30,7 +30,7 @@ public final class GenericOperationThread extends OperationThread {
 
     public GenericOperationThread(String name, int threadId, OperationQueue queue,
                                   ILogger logger, HazelcastThreadGroup threadGroup,
-                                  NodeExtension nodeExtension,  OperationRunner operationRunner) {
+                                  NodeExtension nodeExtension, OperationRunner operationRunner) {
         super(name, threadId, queue, logger, threadGroup, nodeExtension);
         this.operationRunner = operationRunner;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -18,6 +18,8 @@ package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.NodeExtension;
+import com.hazelcast.internal.metrics.MetricsProvider;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
@@ -41,7 +43,7 @@ import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
  * <p/>
  * The actual processing of an operation is forwarded to the {@link com.hazelcast.spi.impl.operationexecutor.OperationRunner}.
  */
-public abstract class OperationThread extends HazelcastManagedThread {
+public abstract class OperationThread extends HazelcastManagedThread implements MetricsProvider {
 
     final int threadId;
     final OperationQueue queue;
@@ -137,6 +139,11 @@ public abstract class OperationThread extends HazelcastManagedThread {
         } finally {
             currentRunner = null;
         }
+    }
+
+    @Override
+    public void provideMetrics(MetricsRegistry metricsRegistry) {
+        metricsRegistry.scanAndRegister(this, "operation." + getName());
     }
 
     public final void shutdown() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.properties.GroupProperties;
@@ -49,7 +50,7 @@ import static java.util.logging.Level.INFO;
  * An experimental feature to support debugging is the slow invocation detector. So it can log any invocation that takes
  * more than x seconds. See {@link GroupProperty#SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS} for more information.
  */
-public class InvocationMonitor {
+public class InvocationMonitor implements MetricsProvider {
 
     private static final long ON_MEMBER_LEFT_DELAY_MS = 1111;
     private static final int SCAN_DELAY_MILLIS = 1000;
@@ -65,14 +66,16 @@ public class InvocationMonitor {
     private final SwCounter normalTimeoutsCount = newSwCounter();
 
     public InvocationMonitor(InvocationRegistry invocationRegistry, ILogger logger, GroupProperties props,
-                             HazelcastThreadGroup hzThreadGroup, ExecutionService executionService,
-                             MetricsRegistry metricsRegistry) {
+                             HazelcastThreadGroup hzThreadGroup, ExecutionService executionService) {
         this.invocationRegistry = invocationRegistry;
         this.logger = logger;
         this.executionService = executionService;
         this.backupTimeoutMillis = props.getMillis(GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS);
         this.monitorThread = new InvocationMonitorThread(hzThreadGroup);
+    }
 
+    @Override
+    public void provideMetrics(MetricsRegistry metricsRegistry) {
         metricsRegistry.scanAndRegister(this, "operation.invocations");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
@@ -47,7 +48,7 @@ import static com.hazelcast.spi.OperationAccessor.setCallId;
  * - pre-allocate all invocations. Because the ringbuffer has a fixed capacity, pre-allocation should be easy. Also
  * the PartitionInvocation and TargetInvocation can be folded into Invocation.
  */
-public class InvocationRegistry implements Iterable<Invocation> {
+public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider {
 
     private static final int INITIAL_CAPACITY = 1000;
     private static final float LOAD_FACTOR = 0.75f;
@@ -58,12 +59,14 @@ public class InvocationRegistry implements Iterable<Invocation> {
     private final ILogger logger;
     private final CallIdSequence callIdSequence;
 
-    public InvocationRegistry(ILogger logger, CallIdSequence callIdSequence,
-                              int concurrencyLevel, MetricsRegistry metricsRegistry) {
+    public InvocationRegistry(ILogger logger, CallIdSequence callIdSequence, int concurrencyLevel) {
         this.logger = logger;
         this.callIdSequence = callIdSequence;
         this.invocations = new ConcurrentHashMap<Long, Invocation>(INITIAL_CAPACITY, LOAD_FACTOR, concurrencyLevel);
+    }
 
+    @Override
+    public void provideMetrics(MetricsRegistry metricsRegistry) {
         metricsRegistry.scanAndRegister(this, "operation");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -24,6 +24,8 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
+import com.hazelcast.internal.metrics.MetricsProvider;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.util.counters.Counter;
@@ -73,7 +75,7 @@ import static java.util.logging.Level.WARNING;
 /**
  * Responsible for processing an Operation.
  */
-class OperationRunnerImpl extends OperationRunner {
+class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
 
     static final int AD_HOC_PARTITION_ID = -2;
 
@@ -108,9 +110,15 @@ class OperationRunnerImpl extends OperationRunner {
 
         if (partitionId >= 0) {
             this.count = newSwCounter();
-            nodeEngine.getMetricsRegistry().scanAndRegister(this, "operation.partition[" + partitionId + "]");
         } else {
             this.count = null;
+        }
+    }
+
+    @Override
+    public void provideMetrics(MetricsRegistry metricsRegistry) {
+        if (partitionId >= 0) {
+            metricsRegistry.scanAndRegister(this, "operation.partition[" + partitionId + "]");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponseHandler.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.internal.metrics.MetricsProvider;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.partition.ReplicaErrorLogger;
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -40,7 +42,7 @@ import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
  * Responsible for handling responses for invocations. Based on the content of the response packet, it will lookup the
  * Invocation from the InvocationRegistry and notify the Invocation.
  */
-public final class ResponseHandler implements PacketHandler {
+public final class ResponseHandler implements PacketHandler, MetricsProvider {
 
     private final ILogger logger;
     private final InternalSerializationService serializationService;
@@ -65,7 +67,11 @@ public final class ResponseHandler implements PacketHandler {
         this.serializationService = serializationService;
         this.invocationRegistry = invocationRegistry;
         this.nodeEngine = nodeEngine;
-        nodeEngine.getMetricsRegistry().scanAndRegister(this, "operation.invocations");
+    }
+
+    @Override
+    public void provideMetrics(MetricsRegistry metricsRegistry) {
+        metricsRegistry.scanAndRegister(this, "operation.invocations");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -20,6 +20,8 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.Member;
+import com.hazelcast.internal.metrics.MetricsProvider;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.logging.ILogger;
@@ -58,7 +60,8 @@ import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class ProxyServiceImpl
-        implements InternalProxyService, PostJoinAwareService, EventPublishingService<DistributedObjectEventPacket, Object> {
+        implements InternalProxyService, PostJoinAwareService,
+        EventPublishingService<DistributedObjectEventPacket, Object>, MetricsProvider {
 
     public static final String SERVICE_NAME = "hz:core:proxyService";
 
@@ -90,7 +93,11 @@ public class ProxyServiceImpl
     public ProxyServiceImpl(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
         this.logger = nodeEngine.getLogger(ProxyService.class.getName());
-        nodeEngine.getMetricsRegistry().scanAndRegister(this, "proxy");
+    }
+
+    @Override
+    public void provideMetrics(MetricsRegistry metricsRegistry) {
+        metricsRegistry.scanAndRegister(this, "proxy");
     }
 
     public void init() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -35,6 +35,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static com.hazelcast.internal.properties.GroupProperty.GENERIC_OPERATION_THREAD_COUNT;
+import static com.hazelcast.internal.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.internal.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
 import static java.util.Collections.synchronizedList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -58,7 +61,6 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
     protected PacketHandler responsePacketHandler;
     protected OperationExecutorImpl executor;
     protected Config config;
-    protected MetricsRegistry metricsRegistry;
 
     @Before
     public void setup() throws Exception {
@@ -66,9 +68,9 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
 
         serializationService = new DefaultSerializationServiceBuilder().build();
         config = new Config();
-        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "10");
-        config.setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "10");
-        config.setProperty(GroupProperty.GENERIC_OPERATION_THREAD_COUNT.getName(), "10");
+        config.setProperty(PARTITION_COUNT.getName(), "10");
+        config.setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "10");
+        config.setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "10");
         thisAddress = new Address("localhost", 5701);
         threadGroup = new HazelcastThreadGroup(
                 "foo",
@@ -77,7 +79,6 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
         nodeExtension = new DefaultNodeExtension(Mockito.mock(Node.class));
         handlerFactory = new DummyOperationRunnerFactory();
 
-        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistry.class), INFO);
         responsePacketHandler = new DummyResponsePacketHandler();
     }
 
@@ -85,7 +86,7 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
         groupProperties = new GroupProperties(config);
         executor = new OperationExecutorImpl(
                 groupProperties, loggingService, thisAddress, handlerFactory,
-                threadGroup, nodeExtension, metricsRegistry);
+                threadGroup, nodeExtension);
         executor.start();
         return executor;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponseHandlerTest.java
@@ -42,7 +42,7 @@ public class AsyncResponseHandlerTest extends HazelcastTestSupport {
         ILogger logger = Logger.getLogger(getClass());
         HazelcastThreadGroup threadGroup = new HazelcastThreadGroup("test", logger, getClass().getClassLoader());
         responsePacketHandler = mock(PacketHandler.class);
-        asyncHandler = new AsyncResponseHandler(threadGroup, logger, responsePacketHandler, mock(MetricsRegistry.class));
+        asyncHandler = new AsyncResponseHandler(threadGroup, logger, responsePacketHandler);
         asyncHandler.start();
         serializationService = new DefaultSerializationServiceBuilder().build();
     }


### PR DESCRIPTION
No more need to pass the MetricsRegistry to the constructors and add the registration logic into the constructors of the objects using metrics. 