### PR TITLE
Cleanup of PartitionIteratingOperation and ResponseQueueFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -79,7 +79,7 @@ final class InvokeOnPartitions {
         for (Map.Entry<Address, List<Integer>> mp : memberPartitions.entrySet()) {
             Address address = mp.getKey();
             List<Integer> partitions = mp.getValue();
-            PartitionIteratingOperation pi = new PartitionIteratingOperation(partitions, operationFactory);
+            PartitionIteratingOperation pi = new PartitionIteratingOperation(operationFactory, partitions);
             Future future = operationService.createInvocationBuilder(serviceName, pi, address)
                     .setTryCount(TRY_COUNT)
                     .setTryPauseMillis(TRY_PAUSE_MILLIS)
@@ -95,7 +95,7 @@ final class InvokeOnPartitions {
                 Future future = response.getValue();
                 PartitionIteratingOperation.PartitionResponse result = (PartitionIteratingOperation.PartitionResponse)
                         nodeEngine.toObject(future.get());
-                partitionResults.putAll(result.asMap());
+                result.addResults(partitionResults);
             } catch (Throwable t) {
                 if (operationService.logger.isFinestEnabled()) {
                     operationService.logger.finest(t);

--- a/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
@@ -25,6 +25,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 /**
  * Various collection utility methods, mainly targeted to use internally.
  */
@@ -34,52 +36,54 @@ public final class CollectionUtil {
     }
 
     /**
-     * Returns {@code true} if the given collection is null or empty, otherwise returns {@code false}.
+     * Returns {@code true} if the given collection is {@code null} or empty, otherwise returns {@code false}.
      *
-     * @param collection the given collection.
-     * @return {@code true} if collection is empty.
+     * @param collection the given collection
+     * @return {@code true} if collection is empty
      */
     public static boolean isEmpty(Collection collection) {
         return collection == null || collection.isEmpty();
     }
 
     /**
-     * Returns {@code true} if the given collection is not null and not empty, otherwise returns {@code false}.
+     * Returns {@code true} if the given collection is not {@code null} and not empty, otherwise returns {@code false}.
      *
-     * @param collection the given collection.
-     * @return {@code true} if collection is not empty.
+     * @param collection the given collection
+     * @return {@code true} if collection is not empty
      */
     public static boolean isNotEmpty(Collection collection) {
         return !isEmpty(collection);
     }
 
     /**
-     * Add value to list of values in the map. Creates a new list if it doesn't exist for the key
+     * Adds a value to a list of values in the map.
      *
-     * @param map
-     * @param key
-     * @param value
-     * @return the updated list of values.
+     * Creates a new list if no list is found for the key.
+     *
+     * @param map   the given map of lists
+     * @param key   the key of the target list
+     * @param value the value to add to the target list
+     * @return the updated list of values
      */
     public static <K, V> List<V> addToValueList(Map<K, List<V>> map, K key, V value) {
-
-        List<V> values = map.get(key);
-        if (values == null) {
-            values = new ArrayList<V>();
-            map.put(key, values);
+        List<V> valueList = map.get(key);
+        if (valueList == null) {
+            valueList = new ArrayList<V>();
+            map.put(key, valueList);
         }
-        values.add(value);
+        valueList.add(value);
 
-        return values;
+        return valueList;
     }
 
     /**
-     * Return n-th item or null if collection is smaller
+     * Returns the n-th item or {@code null} if collection is smaller.
      *
-     * @param collection
-     * @param position
-     * @param <T>
-     * @return
+     * @param collection the given collection
+     * @param position   position of the wanted item
+     * @return the item on position or {@code null} if the given collection is too small
+     *
+     * @throws NullPointerException if collection is {@code null}
      */
     public static <T> T getItemAtPositionOrNull(Collection<T> collection, int position) {
         if (position >= collection.size()) {
@@ -97,19 +101,55 @@ public final class CollectionUtil {
     }
 
     /**
-     * @param collection           collection of objects to be converted to collection of data
-     * @param serializationService will be used for converting object to data
+     * Converts a collection of any type to a collection of {@link Data}.
+     *
+     * @param collection           the given collection
+     * @param serializationService will be used for converting object to {@link Data}
      * @return collection of data
-     * @throws java.lang.NullPointerException if collection is null, or contains a null element
+     *
+     * @throws NullPointerException if collection is {@code null} or contains a {@code null} item
      */
-    public static <C> Collection<Data> objectToDataCollection(Collection<C> collection
-            , SerializationService serializationService) {
+    public static <C> Collection<Data> objectToDataCollection(Collection<C> collection,
+                                                              SerializationService serializationService) {
         List<Data> dataKeys = new ArrayList<Data>(collection.size());
-        for (C c : collection) {
-            Preconditions.checkNotNull(c);
-            dataKeys.add(serializationService.toData(c));
+        for (C item : collection) {
+            checkNotNull(item);
+            dataKeys.add(serializationService.toData(item));
         }
         return dataKeys;
     }
 
+    /**
+     * Converts a {@link Collection<Integer>} to a primitive {@code int[]} array.
+     *
+     * @param collection the given collection
+     * @return a primitive int[] array
+     *
+     * @throws NullPointerException if collection is {@code null}
+     */
+    public static int[] toIntArray(Collection<Integer> collection) {
+        int[] collectionArray = new int[collection.size()];
+        int index = 0;
+        for (Integer item : collection) {
+            collectionArray[index++] = item;
+        }
+        return collectionArray;
+    }
+
+    /**
+     * Converts a {@link Collection<Long>} to a primitive {@code long[]} array.
+     *
+     * @param collection the given collection
+     * @return a primitive long[] array
+     *
+     * @throws NullPointerException if collection is {@code null}
+     */
+    public static long[] toLongArray(Collection<Long> collection) {
+        long[] collectionArray = new long[collection.size()];
+        int index = 0;
+        for (Long item : collection) {
+            collectionArray[index++] = item;
+        }
+        return collectionArray;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/ResponseQueueFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ResponseQueueFactory.java
@@ -27,7 +27,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Factory for creating response queues.
- * <p/>
+ *
  * See LockBasedResponseQueue.
  */
 public final class ResponseQueueFactory {
@@ -37,19 +37,23 @@ public final class ResponseQueueFactory {
 
     /**
      * Creates new response queue
+     *
      * @return LockBasedResponseQueue new created response queue
      */
-    public static BlockingQueue newResponseQueue() {
+    public static BlockingQueue<Object> newResponseQueue() {
         return new LockBasedResponseQueue();
     }
 
-    private static final class LockBasedResponseQueue extends AbstractQueue implements BlockingQueue {
+    private static final class LockBasedResponseQueue extends AbstractQueue<Object> implements BlockingQueue<Object> {
+
         private static final Object NULL = new Object();
-        private Object response;
+
         private final Lock lock = new ReentrantLock();
         private final Condition noValue = lock.newCondition();
 
+        private Object response;
 
+        @Override
         public Object take() throws InterruptedException {
             lock.lock();
             try {
@@ -63,10 +67,12 @@ public final class ResponseQueueFactory {
             }
         }
 
-        public boolean offer(Object o, long timeout, TimeUnit unit) throws InterruptedException {
-            return offer(o);
+        @Override
+        public boolean offer(Object object, long timeout, TimeUnit unit) throws InterruptedException {
+            return offer(object);
         }
 
+        @Override
         public Object poll(long timeout, TimeUnit unit) throws InterruptedException {
             if (timeout < 0) {
                 throw new IllegalArgumentException();
@@ -86,12 +92,14 @@ public final class ResponseQueueFactory {
             }
         }
 
-        public void put(Object o) throws InterruptedException {
-            offer(o);
+        @Override
+        public void put(Object object) throws InterruptedException {
+            offer(object);
         }
 
-        public boolean offer(Object obj) {
-            Object item = obj;
+        @Override
+        public boolean offer(Object object) {
+            Object item = object;
             if (item == null) {
                 item = NULL;
             }
@@ -109,6 +117,7 @@ public final class ResponseQueueFactory {
             }
         }
 
+        @Override
         public Object poll() {
             lock.lock();
             try {
@@ -118,29 +127,22 @@ public final class ResponseQueueFactory {
             }
         }
 
-        /**
-         * Internal method, should be called under lock.
-         *
-         * @return response
-         */
-        private Object getAndRemoveResponse() {
-            final Object value = response;
-            response = null;
-            return (value == NULL) ? null : value;
-        }
-
+        @Override
         public int remainingCapacity() {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public int drainTo(Collection c) {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public int drainTo(Collection c, int maxElements) {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public void clear() {
             lock.lock();
             try {
@@ -151,7 +153,7 @@ public final class ResponseQueueFactory {
         }
 
         @Override
-        public Iterator iterator() {
+        public Iterator<Object> iterator() {
             throw new UnsupportedOperationException();
         }
 
@@ -165,6 +167,7 @@ public final class ResponseQueueFactory {
             }
         }
 
+        @Override
         public Object peek() {
             lock.lock();
             try {
@@ -172,6 +175,15 @@ public final class ResponseQueueFactory {
             } finally {
                 lock.unlock();
             }
+        }
+
+        /**
+         * Internal method, should be called under lock.
+         */
+        private Object getAndRemoveResponse() {
+            Object value = response;
+            response = null;
+            return (value == NULL ? null : value);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/CollectionUtilTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -28,13 +29,27 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 
+import static com.hazelcast.util.CollectionUtil.addToValueList;
+import static com.hazelcast.util.CollectionUtil.getItemAtPositionOrNull;
+import static com.hazelcast.util.CollectionUtil.isEmpty;
+import static com.hazelcast.util.CollectionUtil.isNotEmpty;
+import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
+import static com.hazelcast.util.CollectionUtil.toIntArray;
+import static com.hazelcast.util.CollectionUtil.toLongArray;
+import static java.util.Collections.EMPTY_LIST;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -42,86 +57,135 @@ import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class CollectionUtilTest {
+public class CollectionUtilTest extends HazelcastTestSupport {
 
     @Test
-    public void getItemAtPositionOrNull_whenEmptyArray_thenReturnNull() {
+    public void testConstructor() {
+        assertUtilityConstructor(CollectionUtil.class);
+    }
+
+    @Test
+    public void testIsEmpty() {
+        assertTrue(isEmpty(EMPTY_LIST));
+        assertFalse(isEmpty(singletonList(23)));
+    }
+
+    @Test
+    public void testIsNotEmpty() {
+        assertFalse(isNotEmpty(EMPTY_LIST));
+        assertTrue(isNotEmpty(singletonList(23)));
+    }
+
+    @Test
+    public void testAddToValueList() {
+        List<Integer> list = new ArrayList<Integer>();
+        list.add(23);
+
+        Map<String, List<Integer>> map = new HashMap<String, List<Integer>>();
+        map.put("existingKey", list);
+
+        addToValueList(map, "existingKey", 42);
+
+        assertEquals(1, map.size());
+        assertEquals(2, list.size());
+        assertTrue(list.contains(42));
+    }
+
+    @Test
+    public void testAddToValueList_whenKeyDoesNotExist_thenNewListIsCreated() {
+        Map<String, List<Integer>> map = new HashMap<String, List<Integer>>();
+
+        addToValueList(map, "nonExistingKey", 42);
+
+        assertEquals(1, map.size());
+
+        List<Integer> list = map.get("nonExistingKey");
+        assertEquals(1, list.size());
+        assertTrue(list.contains(42));
+    }
+
+    @Test
+    public void testGetItemAtPositionOrNull_whenEmptyArray_thenReturnNull() {
         Collection<Object> src = new LinkedHashSet<Object>();
-        Object result = CollectionUtil.getItemAtPositionOrNull(src, 0);
+        Object result = getItemAtPositionOrNull(src, 0);
 
         assertNull(result);
     }
 
     @Test
-    public void getItemAtPositionOrNull_whenPositionExist_thenReturnTheItem() {
+    public void testGetItemAtPositionOrNull_whenPositionExist_thenReturnTheItem() {
         Object obj = new Object();
         Collection<Object> src = new LinkedHashSet<Object>();
         src.add(obj);
 
-        Object result = CollectionUtil.getItemAtPositionOrNull(src, 0);
+        Object result = getItemAtPositionOrNull(src, 0);
 
         assertSame(obj, result);
     }
 
     @Test
-    public void getItemAtPositionOrNull_whenSmallerArray_thenReturnNull() {
+    public void testGetItemAtPositionOrNull_whenSmallerArray_thenReturnNull() {
         Object obj = new Object();
         Collection<Object> src = new LinkedHashSet<Object>();
         src.add(obj);
 
-        Object result = CollectionUtil.getItemAtPositionOrNull(src, 1);
+        Object result = getItemAtPositionOrNull(src, 1);
 
         assertNull(result);
     }
 
     @Test
-    public void getItemAsPositionOrNull_whenInputImplementsList_thenDoNotUserIterator() {
+    @SuppressWarnings("unchecked")
+    public void testGetItemAsPositionOrNull_whenInputImplementsList_thenDoNotUserIterator() {
         Object obj = new Object();
 
         List<Object> src = mock(List.class);
         when(src.size()).thenReturn(1);
         when(src.get(0)).thenReturn(obj);
 
-        Object result = CollectionUtil.getItemAtPositionOrNull(src, 0);
+        Object result = getItemAtPositionOrNull(src, 0);
 
         assertSame(obj, result);
         verify(src, never()).iterator();
     }
 
     @Test
-    public void objectToDataCollection_size() {
+    public void testObjectToDataCollection_size() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        Collection list = new ArrayList();
+        Collection<Object> list = new ArrayList<Object>();
         list.add(1);
         list.add("foo");
-        Collection<Data> dataCollection = CollectionUtil.objectToDataCollection(list, serializationService);
+
+        Collection<Data> dataCollection = objectToDataCollection(list, serializationService);
+
         assertEquals(list.size(), dataCollection.size());
-
     }
 
     @Test(expected = NullPointerException.class)
-    public void objectToDataCollection_withNullItem() {
+    public void testObjectToDataCollection_withNullItem() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        Collection list = new ArrayList();
+        Collection<Object> list = new ArrayList<Object>();
         list.add(null);
-        CollectionUtil.objectToDataCollection(list, serializationService);
+
+        objectToDataCollection(list, serializationService);
     }
 
     @Test(expected = NullPointerException.class)
-    public void objectToDataCollection_withNullCollection() {
+    public void testObjectToDataCollection_withNullCollection() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        CollectionUtil.objectToDataCollection(null, serializationService);
-    }
 
+        objectToDataCollection(null, serializationService);
+    }
 
     @Test
-    public void objectToDataCollection_deserializeBack() {
+    public void testObjectToDataCollection_deserializeBack() {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        Collection list = new ArrayList();
+        Collection<Object> list = new ArrayList<Object>();
         list.add(1);
         list.add("foo");
 
-        Collection<Data> dataCollection = CollectionUtil.objectToDataCollection(list, serializationService);
+        Collection<Data> dataCollection = objectToDataCollection(list, serializationService);
+
         Iterator<Data> it1 = dataCollection.iterator();
         Iterator it2 = list.iterator();
         while (it1.hasNext() && it2.hasNext()) {
@@ -129,5 +193,45 @@ public class CollectionUtilTest {
         }
     }
 
+    @Test
+    public void testToIntArray() {
+        List<Integer> list = new ArrayList<Integer>();
+        list.add(42);
+        list.add(23);
+        list.add(Integer.MAX_VALUE);
 
+        int[] intArray = toIntArray(list);
+
+        assertNotNull(intArray);
+        assertEquals(list.size(), intArray.length);
+        assertEquals(list.get(0).intValue(), intArray[0]);
+        assertEquals(list.get(1).intValue(), intArray[1]);
+        assertEquals(list.get(2).intValue(), intArray[2]);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testToIntArray_whenNull_thenThrowNPE() {
+        toIntArray(null);
+    }
+
+    @Test
+    public void testToLongArray() {
+        List<Long> list = new ArrayList<Long>();
+        list.add(42L);
+        list.add(23L);
+        list.add(Long.MAX_VALUE);
+
+        long[] longArray = toLongArray(list);
+
+        assertNotNull(longArray);
+        assertEquals(list.size(), longArray.length);
+        assertEquals(list.get(0).longValue(), longArray[0]);
+        assertEquals(list.get(1).longValue(), longArray[1]);
+        assertEquals(list.get(2).longValue(), longArray[2]);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testToLongArray_whenNull_thenThrowNPE() {
+        toLongArray(null);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/ResponseQueueFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ResponseQueueFactoryTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
+
+public class ResponseQueueFactoryTest extends HazelcastTestSupport {
+
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(ResponseQueueFactory.class);
+    }
+}


### PR DESCRIPTION
* Cleanup of `PartitionIteratingOperation` and `ResponseQueueFactory`.
* Switched from `HashMaps` to `int[]` and `Object[]` to reduce litter and lookup costs.
* Reused an internal array to reduce litter.
* Pulled out new utility methods to `CollectionUtil`.
* Increased code coverage of `CollectionUtil` and `ResponseQueueFactory`.

I verified the cleanup with JFR and a simple benchmark.

Test code: [PartitionIteratingOperationBenchmark.java](https://gist.github.com/Donnerbart/33e8258d432701c68aea528395a4f5ac#file-partitioniteratingoperationbenchmark-java)
JFR settings: [hz-profiling.zip](https://github.com/hazelcast/hazelcast/files/204521/hz-profiling.zip)

```
Cluster size: 10
Partition count: 2571
Map size: 25710
Iterations: 500000
```
```
500000 operations done in 604276 ms (1208 µs per op) (master)...
vs.
500000 operations done in 587978 ms (1175 µs per op) (cleanup)...
```

| Name | Master | Cleanup |
| --- | ---: | ---: |
| Duration per operation | ~1208 µs | ~1175 µs |
| GC Count | 2206 | 1786 |
| Total GC Time | 5s 30ms | 4s 231ms |
| TLAB count | 13,023,904 | 10,575,857 |
| Allocation Rate for TLAB | 1.16 GB/s | 980.52 MB/s |

**Allocation pressure by class (master vs. cleanup)**
![pio-alloc-pressure-by-class-master](https://cloud.githubusercontent.com/assets/4196298/14282307/14253822-fb3e-11e5-87a3-f4c9a424f7ad.png)
![pio-alloc-pressure-by-class-cleanup](https://cloud.githubusercontent.com/assets/4196298/14282310/17f05b12-fb3e-11e5-88ea-9c3b14e61946.png)

`HashMap$Node` and `Integer` allocation pressure is down by 14.01%. The added allocation pressure by `int[]` and `Object[]` is 6.37%. But this might be hard to compare, since the whole pressure profile shifted a bit. Nevertheless we saved 96.2% of the `HashMap$Node` and 32.6% of `Integer` allocations, mostly in the `com.hazelcast.spi.impl.operationservice.impl.AsyncResponseHandler$ResponseThread`.

**Garbage collections (master vs. cleanup)**
![pio-gc-master](https://cloud.githubusercontent.com/assets/4196298/14309799/e282a24a-fbde-11e5-8091-0051232a6c71.png)
![pio-gc-cleanup](https://cloud.githubusercontent.com/assets/4196298/14309803/ea220c3e-fbde-11e5-9d89-686c507e0ee4.png)

This should have a positive effect on all usages of this operation, which should be `IMap.size()`, `IMap.isEmpty()`, `IMap.clear()`, `IMap.contains...()`, `IMap.keySet()`, `IMap.entrySet()`, `IMap.values()`, `IMap.getAll()`, `IMap.executeOnKeys()`,  etc.