### PR TITLE
Fixed NearCacheTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
@@ -830,7 +830,7 @@ public class NearCacheTest extends HazelcastTestSupport {
         NearCacheConfig nearCacheConfig = newNearCacheConfig();
         nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
         String name = randomName();
-        Config config = new Config();
+        Config config = getConfig();
         config.addMapConfig(new MapConfig(name).setNearCacheConfig(nearCacheConfig));
         HazelcastInstance instance = createHazelcastInstance(config);
         IMap<Integer, Integer> map = instance.getMap(name);


### PR DESCRIPTION
Fixed `NearCacheTest` to use `getConfig()` instead of `new Config()`, so the EE test can override the method with its specific setup.

At the moment the EE which extends this class is constantly failing, since EE specific configuration can't be set in the local config.