### PR TITLE
Cleanup of partition.impl package

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -195,12 +195,7 @@
     <suppress checks="JavadocMethod" files="com/hazelcast/partition/"/>
     <suppress checks="JavadocType" files="com/hazelcast/partition/"/>
     <suppress checks="JavadocVariable" files="com/hazelcast/partition/"/>
-    <suppress checks="MethodCount|ExecutableStatementCount|FileLengthCheck|MagicNumber"
-              files="com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl"/>
-    <suppress checks="ClassFanOutComplexity|ClassDataAbstractionCoupling"
-              files="com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl"/>
-    <suppress checks="CyclomaticComplexity|NPathComplexity"
-              files="com/hazelcast/internal/partition/impl/PartitionStateGeneratorImpl"/>
+    <suppress checks="FileLengthCheck" files="com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl"/>
 
     <!-- Topic -->
     <suppress checks="VisibilityModifier" files="com/hazelcast/topic/impl/TopicEvent"/>

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
@@ -26,20 +26,29 @@ import java.util.Arrays;
 
 public class InternalPartitionImpl implements InternalPartition {
 
+    private final int partitionId;
+    private final PartitionListener partitionListener;
+    private final Address thisAddress;
+
     @SuppressFBWarnings(value = "VO_VOLATILE_REFERENCE_TO_ARRAY", justification =
             "The contents of this array will never be updated, so it can be safely read using a volatile read."
                     + " Writing to `addresses` is done under InternalPartitionServiceImpl.lock,"
                     + " so there's no need to guard `addresses` field or to use a CAS.")
     private volatile Address[] addresses = new Address[MAX_REPLICA_COUNT];
-    private final int partitionId;
-    private final PartitionListener partitionListener;
-    private final Address thisAddress;
     private volatile boolean isMigrating;
 
     InternalPartitionImpl(int partitionId, PartitionListener partitionListener, Address thisAddress) {
         this.partitionId = partitionId;
         this.partitionListener = partitionListener;
         this.thisAddress = thisAddress;
+    }
+
+    static InternalPartitionImpl[] createArray(int partitionCount, PartitionListener partitionListener, Address thisAddress) {
+        InternalPartitionImpl[] partitions = new InternalPartitionImpl[partitionCount];
+        for (int i = 0; i < partitionCount; i++) {
+            partitions[i] = new InternalPartitionImpl(i, partitionListener, thisAddress);
+        }
+        return partitions;
     }
 
     @Override
@@ -112,11 +121,9 @@ public class InternalPartitionImpl implements InternalPartition {
         Address[] oldAddresses = addresses;
         addresses = newAddresses;
         callPartitionListener(newAddresses, oldAddresses, PartitionReplicaChangeReason.ASSIGNMENT);
-
     }
 
-    private void callPartitionListener(Address[] newAddresses, Address[] oldAddresses,
-                                       PartitionReplicaChangeReason reason) {
+    private void callPartitionListener(Address[] newAddresses, Address[] oldAddresses, PartitionReplicaChangeReason reason) {
         if (partitionListener != null) {
             for (int replicaIndex = 0; replicaIndex < MAX_REPLICA_COUNT; replicaIndex++) {
                 Address oldAddress = oldAddresses[replicaIndex];

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceState.java
@@ -16,31 +16,31 @@
 
 package com.hazelcast.internal.partition.impl;
 
-/*
-    This enum represents internal state of the InternalPartitionServiceImpl over all partitions
-    @see InternalPartitionServiceImpl#getMemberState
+/**
+ * This enum represents the internal state of the {@link InternalPartitionServiceImpl} over all partitions.
+ *
+ * @see InternalPartitionServiceImpl#getMemberState
  */
 public enum InternalPartitionServiceState {
 
     /**
-     *  Indicates that there is no migration operation on the system and all first backups are sync for partitions
-     *  owned by this node
+     * Indicates that there is no migration operation on the system and all first backups are sync for partitions
+     * owned by this node
      */
     SAFE,
 
     /**
-     *  Indicates that there is a migration operation ongoing on this node
+     * Indicates that there is a migration operation ongoing on this node
      */
     MIGRATION_LOCAL,
 
     /**
-     *  Indicates that master node manages a migration operation between 2 other nodes
+     * Indicates that master node manages a migration operation between 2 other nodes
      */
     MIGRATION_ON_MASTER,
 
     /**
-     *  Indicates that there is an not-sync first replica on other nodes for owned partitions of the this node
+     * Indicates that there is an not-sync first replica on other nodes for owned partitions of the this node
      */
     REPLICA_NOT_SYNC
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationListenerAdapter.java
@@ -22,7 +22,7 @@ import com.hazelcast.core.MigrationListener;
 import com.hazelcast.partition.PartitionEventListener;
 
 /**
- * Wraps a migration listener and dispatches a migration event to matching method
+ * Wraps a migration listener and dispatches a migration event to matching method.
  */
 class MigrationListenerAdapter implements PartitionEventListener<MigrationEvent> {
 
@@ -34,8 +34,7 @@ class MigrationListenerAdapter implements PartitionEventListener<MigrationEvent>
 
     @Override
     public void onEvent(MigrationEvent migrationEvent) {
-
-        final MigrationStatus status = migrationEvent.getStatus();
+        MigrationStatus status = migrationEvent.getStatus();
         switch (status) {
             case STARTED:
                 migrationListener.migrationStarted(migrationEvent);
@@ -49,7 +48,5 @@ class MigrationListenerAdapter implements PartitionEventListener<MigrationEvent>
             default:
                 throw new IllegalArgumentException("Not a known MigrationStatus: " + status);
         }
-
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationQueue.java
@@ -82,5 +82,4 @@ class MigrationQueue {
     public int size() {
         return queue.size();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionLostListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionLostListenerAdapter.java
@@ -34,5 +34,4 @@ class PartitionLostListenerAdapter implements PartitionEventListener<PartitionLo
     public void onEvent(PartitionLostEvent event) {
         listener.partitionLost(event);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaChangeEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaChangeEvent.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.partition.PartitionReplicaChangeReason;
 import com.hazelcast.nio.Address;
 
 public class PartitionReplicaChangeEvent {
+
     private final int partitionId;
     private final int replicaIndex;
     private final Address oldAddress;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
@@ -23,12 +23,21 @@ import java.util.Arrays;
 import static java.lang.System.arraycopy;
 
 final class PartitionReplicaVersions {
-    final int partitionId;
-    // read and updated only by operation/partition threads
-    final long[] versions = new long[InternalPartition.MAX_BACKUP_COUNT];
 
-    PartitionReplicaVersions(int partitionId) {
+    private final int partitionId;
+    // read and updated only by operation/partition threads
+    private final long[] versions = new long[InternalPartition.MAX_BACKUP_COUNT];
+
+    private PartitionReplicaVersions(int partitionId) {
         this.partitionId = partitionId;
+    }
+
+    static PartitionReplicaVersions[] createArray(int partitionCount) {
+        PartitionReplicaVersions[] replicaVersions = new PartitionReplicaVersions[partitionCount];
+        for (int i = 0; i < partitionCount; i++) {
+            replicaVersions[i] = new PartitionReplicaVersions(i);
+        }
+        return replicaVersions;
     }
 
     long[] incrementAndGet(int backupCount) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/ReplicaSyncInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/ReplicaSyncInfo.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.partition.impl;
 import com.hazelcast.nio.Address;
 
 public final class ReplicaSyncInfo {
+
     final int partitionId;
     final int replicaIndex;
     final Address target;


### PR DESCRIPTION
* Cleanup of CheckStyle suppressions.
* Re-ordered fields to have `final` before `volatile` fields.
* Aligned order of field definition and assignment in `InternalPartitionServiceImpl`.
* Pulled out methods from constructor of `InternalPartitionServiceImpl`.
* Used `CollectionUtil.addToValueList()` in `InternalPartitionServiceImpl`.
* Removed unused method `PartitionTable.contains()` (internal private static class).

No logic has been changed.