### PR TITLE
[BACKPORT] JCache detection improvement

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.spi.impl;
 
+import com.hazelcast.cache.impl.JCacheDetector;
 import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnection;
@@ -30,7 +31,6 @@ import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
@@ -92,8 +92,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
 
 
     private ClientExceptionFactory initClientExceptionFactory() {
-        ClassLoader classLoader = client.getClientConfig().getClassLoader();
-        boolean jcacheAvailable = ClassLoaderUtil.isClassAvailable(classLoader, "javax.cache.Caching");
+        boolean jcacheAvailable = JCacheDetector.isJcacheAvailable(client.getClientConfig().getClassLoader());
         return new ClientExceptionFactory(jcacheAvailable);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.ClassLoaderUtil;
+
+/**
+ * Utility class to detect existence of JCache 1.0.0 in the classpath.
+ * Earlier versions (1.0.0-PFD, 0.9, 0.5) do not provide the complete JCache API. If a stale version
+ * is detected, a warning will be logged and JCache is considered missing from the classpath.
+ * <p>Related issues:
+ * <ul>
+ * <li>https://github.com/hazelcast/hazelcast/issues/7810</li>
+ * <li>https://github.com/hazelcast/hazelcast/issues/7854</li>
+ * </ul>
+ * </p>
+ */
+public final class JCacheDetector {
+
+    private static final String JCACHE_CACHING_CLASSNAME =  "javax.cache.Caching";
+    private static final String[] JCACHE_ADDITIONAL_REQUIRED_CLASSES = new String[]{
+            "javax.cache.integration.CacheLoaderException",
+            "javax.cache.integration.CacheWriterException",
+            "javax.cache.processor.EntryProcessorException",
+            "javax.cache.configuration.CompleteConfiguration",
+            };
+
+    // do not allow construction of instances
+    private JCacheDetector() {
+
+    }
+
+    public static boolean isJcacheAvailable(ClassLoader classLoader) {
+        return isJcacheAvailable(classLoader, null);
+    }
+
+    /**
+     * @param classLoader   the class loader to use, when attempting to load JCache API classes.
+     * @param logger        if not null and a pre-v1.0.0 JCache JAR is detected on the classpath,
+     *                      logs a warning against using this version.
+     * @return {@code true} if JCache 1.0.0 is located in the classpath, otherwise {@code false}.
+     */
+    public static boolean isJcacheAvailable(ClassLoader classLoader, ILogger logger) {
+        if (!ClassLoaderUtil.isClassAvailable(classLoader, JCACHE_CACHING_CLASSNAME)) {
+            // no cache-api jar in the classpath
+            return false;
+        }
+        for (String className : JCACHE_ADDITIONAL_REQUIRED_CLASSES) {
+            if (!ClassLoaderUtil.isClassAvailable(classLoader, className)) {
+                logger.warning("An outdated version of JCache API was located in the classpath, please use newer versions of "
+                        + "JCache API rather than 1.0.0-PFD or 0.x versions.");
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl;
 
+import com.hazelcast.cache.impl.JCacheDetector;
 import com.hazelcast.client.AuthenticationException;
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.ClientEndpointManager;
@@ -45,7 +46,6 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.nio.Packet;
@@ -139,8 +139,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     }
 
     private ClientExceptionFactory initClientExceptionFactory() {
-        ClassLoader classLoader = nodeEngine.getConfigClassLoader();
-        boolean jcacheAvailable = ClassLoaderUtil.isClassAvailable(classLoader, "javax.cache.Caching");
+        boolean jcacheAvailable = JCacheDetector.isJcacheAvailable(nodeEngine.getConfigClassLoader());
         return new ClientExceptionFactory(jcacheAvailable);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.servicemanager.impl;
 
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.JCacheDetector;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.collection.impl.list.ListService;
@@ -159,16 +160,11 @@ public final class ServiceManagerImpl implements ServiceManager {
 
     private void registerCacheServiceIfAvailable() {
         //CacheService Optional initialization
-        try {
-            //search for jcache api jar on classpath
-            final String localClassName = "javax.cache.Caching";
-            ClassLoader classLoader = nodeEngine.getConfigClassLoader();
-            Class theClass = ClassLoaderUtil.loadClass(classLoader, localClassName);
-            if (theClass != null) {
-                ICacheService service = createService(ICacheService.class);
-                registerService(ICacheService.SERVICE_NAME, service);
-            }
-        } catch (ClassNotFoundException e) {
+        //search for jcache api jar on classpath
+        if (JCacheDetector.isJcacheAvailable(nodeEngine.getConfigClassLoader(), logger)) {
+            ICacheService service = createService(ICacheService.class);
+            registerService(ICacheService.SERVICE_NAME, service);
+        } else {
             logger.finest("javax.cache api is not detected on classpath. Skipping CacheService...");
         }
     }


### PR DESCRIPTION
This PR fixes #7854 by introducing a separate utility class com.hazelcast.cache.impl.JCacheDetector which handles JCache detection; specifically we make sure we locate a number of classes which are available since JCache 1.0.0-PFD but not in previous versions which caused NoClassDefFound exception as shown in #7810 (therefore when JCache 0.9 or 0.5 is in the classpath, Hazelcast will consider JCache is not available).