### PR TITLE
InvocationContext introduced

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -26,20 +26,20 @@ import com.hazelcast.spi.Operation;
  */
 public class InvocationBuilderImpl extends InvocationBuilder {
 
-    private final OperationServiceImpl operationService;
+    private final InvocationContext context;
 
-    public InvocationBuilderImpl(OperationServiceImpl operationService, String serviceName, Operation op, int partitionId) {
-        this(operationService, serviceName, op, partitionId, null);
+    public InvocationBuilderImpl(InvocationContext context, String serviceName, Operation op, int partitionId) {
+        this(context, serviceName, op, partitionId, null);
     }
 
-    public InvocationBuilderImpl(OperationServiceImpl operationService, String serviceName, Operation op, Address target) {
-        this(operationService, serviceName, op, Operation.GENERIC_PARTITION_ID, target);
+    public InvocationBuilderImpl(InvocationContext context, String serviceName, Operation op, Address target) {
+        this(context, serviceName, op, Operation.GENERIC_PARTITION_ID, target);
     }
 
-    private InvocationBuilderImpl(OperationServiceImpl operationService, String serviceName, Operation op,
+    private InvocationBuilderImpl(InvocationContext context, String serviceName, Operation op,
                                   int partitionId, Address target) {
         super(serviceName, op, partitionId, target);
-        this.operationService = operationService;
+        this.context = context;
     }
 
     @Override
@@ -50,10 +50,10 @@ public class InvocationBuilderImpl extends InvocationBuilder {
         if (target == null) {
             op.setPartitionId(partitionId).setReplicaIndex(replicaIndex);
             invocation = new PartitionInvocation(
-                    operationService, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+                    context, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
         } else {
             invocation = new TargetInvocation(
-                    operationService, op, target, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+                    context, op, target, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
         }
 
         InternalCompletableFuture future = invocation.invoke();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.ClusterClock;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.util.counters.MwCounter;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
+import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
+import com.hazelcast.util.executor.ManagedExecutorService;
+
+/**
+ * The InvocationContext contains all 'static' dependencies for an Invocation; dependencies that don't change between
+ * invocations. All invocation specific dependencies/settings are passed in through the constructor of the invocation.
+ *
+ * This object should have no functionality apart from providing dependencies. So no methods should be added to this class.
+ *
+ * The goals of the InvocationContext are:
+ * <ol>
+ * <li>prevent a.b.c.d call in the invocation by pulling all dependencies in the InvocationContext</li>
+ * <li>reduce the need on having a cluster running when testing Invocations.</li>
+ * <lI>removed dependence on NodeEngineImpl. Only NodeEnigne is needed to set on Operation</lI>
+ * <li>reduce coupling to Node. Most calls point now direct to the right dependency, instead of needing
+ * to go through node/NodeEngine. This makes it easier in the future to get rid of Node</li>
+ * </ol>
+ */
+class InvocationContext {
+    ManagedExecutorService asyncExecutor;
+    ClusterClock clusterClock;
+    ClusterService clusterService;
+    ConnectionManager connectionManager;
+    InternalExecutionService executionService;
+    long defaultCallTimeoutMillis;
+    InvocationRegistry invocationRegistry;
+    InvocationMonitor invocationMonitor;
+    String localMemberUuid;
+    ILogger logger;
+    Node node;
+    NodeEngine nodeEngine;
+    InternalPartitionService partitionService;
+    OperationServiceImpl operationService;
+    OperationExecutor operationExecutor;
+    MwCounter retryCount;
+    InternalSerializationService serializationService;
+    Address thisAddress;
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -47,8 +47,8 @@ final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
     final Invocation invocation;
     private final boolean deserialize;
 
-    InvocationFuture(OperationServiceImpl operationService, Invocation invocation, boolean deserialize) {
-        super(operationService.asyncExecutor, invocation.logger);
+    InvocationFuture(Invocation invocation, boolean deserialize) {
+        super(invocation.context.asyncExecutor, invocation.context.logger);
         this.invocation = invocation;
         this.deserialize = deserialize;
     }
@@ -100,7 +100,7 @@ final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
 
         Object value = unresolved;
         if (deserialize && value instanceof Data) {
-            value = invocation.nodeEngine.toObject(value);
+            value = invocation.context.serializationService.toObject(value);
             if (value == null) {
                 return null;
             }
@@ -130,7 +130,7 @@ final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
             sb.append("Last heartbeat: ");
             appendHeartbeat(sb, lastHeartbeatMillis);
 
-            long lastHeartbeatFromMemberMillis = invocation.operationService.invocationMonitor
+            long lastHeartbeatFromMemberMillis = invocation.context.invocationMonitor
                     .getLastMemberHeartbeatMillis(invocation.invTarget);
             sb.append("Last member heartbeat: ");
             appendHeartbeat(sb, lastHeartbeatFromMemberMillis);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -29,14 +29,14 @@ import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
  */
 public final class PartitionInvocation extends Invocation {
 
-    public PartitionInvocation(OperationServiceImpl operationService, Operation op, int tryCount, long tryPauseMillis,
+    public PartitionInvocation(InvocationContext context, Operation op, int tryCount, long tryPauseMillis,
                                long callTimeoutMillis, boolean deserialize) {
-        super(operationService, op, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
+        super(context, op, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
     }
 
     @Override
     public Address getTarget() {
-        IPartition partition = nodeEngine.getPartitionService().getPartition(op.getPartitionId());
+        IPartition partition = context.partitionService.getPartition(op.getPartitionId());
         return partition.getReplicaAddress(op.getReplicaIndex());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -31,9 +31,9 @@ public final class TargetInvocation extends Invocation {
 
     private final Address target;
 
-    public TargetInvocation(OperationServiceImpl operationService, Operation op, Address target,
+    public TargetInvocation(InvocationContext context, Operation op, Address target,
                             int tryCount, long tryPauseMillis, long callTimeoutMillis, boolean deserialize) {
-        super(operationService, op, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
+        super(context, op, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
         this.target = target;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
@@ -234,7 +234,7 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
-        return new PartitionInvocation(operationService, op, 0, 0, 0, false);
+        InvocationContext context = new InvocationContext();
+        return new PartitionInvocation(context, op, 0, 0, 0, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
@@ -118,6 +118,7 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(operationService, op, 0, 0, 0, false);
+        InvocationContext context = new InvocationContext();
+        return new PartitionInvocation(context, op, 0, 0, 0, false);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor_GetLastMemberHeartbeatMillisTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor_GetLastMemberHeartbeatMillisTest.java
@@ -38,7 +38,7 @@ public class InvocationMonitor_GetLastMemberHeartbeatMillisTest extends Hazelcas
         localAddress = getAddress(local);
         remote = cluster[1];
         remoteAddress = getAddress(remote);
-        invocationMonitor = getOperationServiceImpl(local).invocationMonitor;
+        invocationMonitor = getOperationServiceImpl(local).getInvocationMonitor();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.fail;
 public class InvocationRegistryTest extends HazelcastTestSupport {
 
     private InvocationRegistry invocationRegistry;
-    private NodeEngineImpl nodeEngine;
     private OperationServiceImpl operationService;
     private HazelcastInstance local;
 
@@ -38,7 +37,6 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
         config.setProperty(BACKPRESSURE_ENABLED.getName(), "false");
         local = createHazelcastInstance(config);
         warmUpPartitions(local);
-        nodeEngine = getNodeEngineImpl(local);
 
         operationService = (OperationServiceImpl) getOperationService(local);
         invocationRegistry = operationService.invocationRegistry;
@@ -49,7 +47,8 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        return new PartitionInvocation(operationService, op, 0, 0, 0, false);
+        InvocationContext context = operationService.invocationContext;
+        return new PartitionInvocation(context, op, 0, 0, 0, false);
     }
 
     // ====================== register ===============================

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/ResponseHandler_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/ResponseHandler_NotifyTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.fail;
 public class ResponseHandler_NotifyTest extends HazelcastTestSupport {
 
     private InvocationRegistry invocationRegistry;
-    private NodeEngineImpl nodeEngine;
     private OperationServiceImpl operationService;
     private HazelcastInstance local;
     private ResponseHandler responseHandler;
@@ -42,7 +41,6 @@ public class ResponseHandler_NotifyTest extends HazelcastTestSupport {
         config.setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "20000");
         local = createHazelcastInstance(config);
         warmUpPartitions(local);
-        nodeEngine = getNodeEngineImpl(local);
 
         operationService = getOperationServiceImpl(local);
         invocationRegistry = operationService.invocationRegistry;
@@ -54,7 +52,8 @@ public class ResponseHandler_NotifyTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        Invocation invocation = new PartitionInvocation(operationService, op , 0, 0, 0, false);
+        InvocationContext context = operationService.invocationContext;
+        Invocation invocation = new PartitionInvocation(context, op , 0, 0, 0, false);
         invocation.invTarget = getAddress(local);
         return invocation;
     }


### PR DESCRIPTION
The goal of the InvocationContext is make the invocaiton a bit less dependant on the OperationService. Currently the OperationService is used as 'context' to get dependencies from and if you want an Invocation, you need an OperationServiceImpl -> NodeEngineImpl -> Node. So you can't use Invocations without having a cluster up and running.

The InvocationContext is the object with all dependencies for the invocations. Apart from reducing the need for anOperationService, a lot of trainwrecks have been removed by adding the dependency directly on the InvocationContext. This used to be a problem because not all dependencies exist when the OperationService is constructed, but the InvocationContext is created after these dependencies are created, so the InvocationContext can get these dependencies.