### PR TITLE
Fix semaphore dead member handling mechanism

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
@@ -19,7 +19,7 @@ package com.hazelcast.concurrent.semaphore;
 import com.hazelcast.concurrent.semaphore.operations.AcquireBackupOperation;
 import com.hazelcast.concurrent.semaphore.operations.AcquireOperation;
 import com.hazelcast.concurrent.semaphore.operations.AvailableOperation;
-import com.hazelcast.concurrent.semaphore.operations.DeadMemberBackupOperation;
+import com.hazelcast.concurrent.semaphore.operations.SemaphoreDeadMemberBackupOperation;
 import com.hazelcast.concurrent.semaphore.operations.DrainBackupOperation;
 import com.hazelcast.concurrent.semaphore.operations.DrainOperation;
 import com.hazelcast.concurrent.semaphore.operations.InitBackupOperation;
@@ -54,7 +54,7 @@ public class SemaphoreDataSerializerHook implements DataSerializerHook {
     public static final int REDUCE_OPERATION = 9;
     public static final int RELEASE_BACKUP_OPERATION = 10;
     public static final int RELEASE_OPERATION = 11;
-    public static final int SEMAPHORE_DEAD_MEMBER_OPERATION = 12;
+    public static final int DEAD_MEMBER_OPERATION = 12;
     public static final int SEMAPHORE_REPLICATION_OPERATION = 13;
 
     @Override
@@ -75,7 +75,7 @@ public class SemaphoreDataSerializerHook implements DataSerializerHook {
                     case AVAILABLE_OPERATION:
                         return new AvailableOperation();
                     case DEAD_MEMBER_BACKUP_OPERATION:
-                        return new DeadMemberBackupOperation();
+                        return new SemaphoreDeadMemberBackupOperation();
                     case DRAIN_BACKUP_OPERATION:
                         return new DrainBackupOperation();
                     case DRAIN_OPERATION:
@@ -92,7 +92,7 @@ public class SemaphoreDataSerializerHook implements DataSerializerHook {
                         return new ReleaseBackupOperation();
                     case RELEASE_OPERATION:
                         return new ReleaseOperation();
-                    case SEMAPHORE_DEAD_MEMBER_OPERATION:
+                    case DEAD_MEMBER_OPERATION:
                         return new SemaphoreDeadMemberOperation();
                     case SEMAPHORE_REPLICATION_OPERATION:
                         return new SemaphoreReplicationOperation();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
@@ -19,7 +19,6 @@ package com.hazelcast.concurrent.semaphore;
 import com.hazelcast.concurrent.semaphore.operations.SemaphoreDeadMemberOperation;
 import com.hazelcast.concurrent.semaphore.operations.SemaphoreReplicationOperation;
 import com.hazelcast.config.SemaphoreConfig;
-import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.spi.ClientAwareService;
@@ -74,7 +73,6 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
         return getOrPutIfAbsent(containers, name, containerConstructor);
     }
 
-    // just for testing
     public boolean containsSemaphore(String name) {
         return containers.containsKey(name);
     }
@@ -113,16 +111,14 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
 
         for (String name : containers.keySet()) {
             int partitionId = partitionService.getPartitionId(getPartitionKey(name));
-            IPartition partition = partitionService.getPartition(partitionId);
-            if (partition.isLocal()) {
-                Operation op = new SemaphoreDeadMemberOperation(name, caller)
-                        .setPartitionId(partitionId)
-                        .setOperationResponseHandler(createEmptyResponseHandler())
-                        .setService(this)
-                        .setNodeEngine(nodeEngine)
-                        .setServiceName(SERVICE_NAME);
-                operationService.executeOperation(op);
-            }
+            Operation op = new SemaphoreDeadMemberOperation(name, caller)
+                    .setPartitionId(partitionId)
+                    .setValidateTarget(false)
+                    .setOperationResponseHandler(createEmptyResponseHandler())
+                    .setService(this)
+                    .setNodeEngine(nodeEngine)
+                    .setServiceName(SERVICE_NAME);
+            operationService.executeOperation(op);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberBackupOperation.java
@@ -18,23 +18,26 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
+import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class DeadMemberBackupOperation extends SemaphoreBackupOperation
+public class SemaphoreDeadMemberBackupOperation extends SemaphoreBackupOperation
         implements IdentifiedDataSerializable {
 
-    public DeadMemberBackupOperation() {
+    public SemaphoreDeadMemberBackupOperation() {
     }
 
-    public DeadMemberBackupOperation(String name, String firstCaller) {
+    public SemaphoreDeadMemberBackupOperation(String name, String firstCaller) {
         super(name, -1, firstCaller);
     }
 
     @Override
     public void run() throws Exception {
-        SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
-        semaphoreContainer.memberRemoved(firstCaller);
-        response = true;
+        SemaphoreService service = getService();
+        if (service.containsSemaphore(name)) {
+            SemaphoreContainer semaphoreContainer = service.getSemaphoreContainer(name);
+            response = semaphoreContainer.memberRemoved(firstCaller);
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
@@ -34,7 +34,7 @@ public class SemaphoreSplitBrainTest extends HazelcastTestSupport {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceManager.shutdownAll();
+        HazelcastInstanceManager.terminateAll();
     }
 
     @Test
@@ -97,7 +97,7 @@ public class SemaphoreSplitBrainTest extends HazelcastTestSupport {
         return config;
     }
 
-    private class TestLifeCycleListener implements LifecycleListener {
+    private static class TestLifeCycleListener implements LifecycleListener {
 
         CountDownLatch latch;
 
@@ -113,7 +113,7 @@ public class SemaphoreSplitBrainTest extends HazelcastTestSupport {
         }
     }
 
-    private class TestMemberShipListener implements MembershipListener {
+    private static class TestMemberShipListener implements MembershipListener {
 
         final CountDownLatch latch;
 


### PR DESCRIPTION
- Semaphore cleanup should run on partition thread regardless of
current member being owner or backup of partition.
- If it's owner of partition, it should send backup too.
- This is required to guarantee to execute cleanup even for the cases
where no one owns the partition.