### PR TITLE
Dedicated priority generic operation threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/properties/GroupProperty.java
@@ -77,6 +77,18 @@ public final class GroupProperty {
      */
     public static final HazelcastProperty GENERIC_OPERATION_THREAD_COUNT
             = new HazelcastProperty("hazelcast.operation.generic.thread.count", -1);
+    /**
+     * The number of priority generic operation handler threads per Member.
+     * <p/>
+     * The default is 1.
+     *
+     * Having at least 1 priority generic operation thread helps to improve cluster stability since a lot of the cluster
+     * operations are generic priority operations and they should get executed as soon as possible. If there is a dedicated
+     * generic operation thread, than these operations don't get delayed because the generic threads are busy executing regular
+     * user operations. So unless memory consumption is an issue, make sure there is at least 1 thread.
+     */
+    public static final HazelcastProperty PRIORITY_GENERIC_OPERATION_THREAD_COUNT
+            = new HazelcastProperty("hazelcast.operation.priority.generic.thread.count", 1);
 
     /**
      * The number of threads that the client engine has available for processing requests that are not partition specific.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
@@ -28,10 +28,10 @@ public final class GenericOperationThread extends OperationThread {
 
     private final OperationRunner operationRunner;
 
-    public GenericOperationThread(String name, int threadId, OperationQueue queue,
-                                  ILogger logger, HazelcastThreadGroup threadGroup,
-                                  NodeExtension nodeExtension, OperationRunner operationRunner) {
-        super(name, threadId, queue, logger, threadGroup, nodeExtension);
+    public GenericOperationThread(String name, int threadId, OperationQueue queue, ILogger logger,
+                                  HazelcastThreadGroup threadGroup, NodeExtension nodeExtension,
+                                  OperationRunner operationRunner, boolean priority) {
+        super(name, threadId, queue, logger, threadGroup, nodeExtension, priority);
         this.operationRunner = operationRunner;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueue.java
@@ -31,16 +31,6 @@ package com.hazelcast.spi.impl.operationexecutor.impl;
 public interface OperationQueue {
 
     /**
-     * Adds an task with normal priority to this queue.
-     * <p/>
-     * This method is thread safe.
-     *
-     * @param task the item to add
-     * @throws java.lang.NullPointerException if task is null
-     */
-    void add(Object task);
-
-    /**
      * Adds an task to this queue.
      * <p/>
      * This method is thread safe.
@@ -51,26 +41,17 @@ public interface OperationQueue {
      */
     void add(Object task, boolean priority);
 
-
-    /**
-     * Adds an task with normal priority to this queue.
-     * <p/>
-     * This method is thread safe.
-     *
-     * @param task the item to add
-     * @throws java.lang.NullPointerException if task is null
-     */
-    void addUrgent(Object task);
-
     /**
      * Takes an item from this queue. If no item is available, the call blocks.
      * <p/>
      * This method should always be called by the same thread.
      *
+     * @param priorityOnly true if only priority items should be taken. This is useful for priority generic threads since they
+     *                     should only take priority items.
      * @return the taken item.
      * @throws InterruptedException if the thread is interrupted while waiting.
      */
-    Object take() throws InterruptedException;
+    Object take(boolean priorityOnly) throws InterruptedException;
 
     /**
      * returns the number of normal operations pending.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -65,18 +65,20 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
     @Probe
     private final SwCounter errorCount = newSwCounter();
 
+    private final boolean priority;
     private final NodeExtension nodeExtension;
     private final ILogger logger;
     private volatile boolean shutdown;
 
-    public OperationThread(String name, int threadId, OperationQueue queue,
-                           ILogger logger, HazelcastThreadGroup threadGroup, NodeExtension nodeExtension) {
+    public OperationThread(String name, int threadId, OperationQueue queue, ILogger logger, HazelcastThreadGroup threadGroup,
+                           NodeExtension nodeExtension, boolean priority) {
         super(threadGroup.getInternalThreadGroup(), name);
         setContextClassLoader(threadGroup.getClassLoader());
         this.queue = queue;
         this.threadId = threadId;
         this.logger = logger;
         this.nodeExtension = nodeExtension;
+        this.priority = priority;
     }
 
     public int getThreadId() {
@@ -92,7 +94,7 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
             while (!shutdown) {
                 Object task;
                 try {
-                    task = queue.take();
+                    task = queue.take(priority);
                 } catch (InterruptedException e) {
                     continue;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionOperationThread.java
@@ -35,7 +35,7 @@ public final class PartitionOperationThread extends OperationThread {
                                     OperationQueue queue, ILogger logger,
                                     HazelcastThreadGroup threadGroup, NodeExtension nodeExtension,
                                     OperationRunner[] partitionOperationRunners) {
-        super(name, threadId, queue, logger, threadGroup, nodeExtension);
+        super(name, threadId, queue, logger, threadGroup, nodeExtension, false);
         this.partitionOperationRunners = partitionOperationRunners;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/DefaultOperationQueueStressTest.java
@@ -55,15 +55,15 @@ public class DefaultOperationQueueStressTest extends HazelcastTestSupport {
             Random random = new Random();
             while (!stop.get()) {
                 if (random.nextInt(5) == 0) {
-                    queue.addUrgent("foo");
+                    queue.add("foo", true);
                 } else {
-                    queue.add("foo");
+                    queue.add("foo", false);
                 }
                 produced++;
             }
 
             for (int k = 0; k < 100; k++) {
-                queue.add(POISON_PILL);
+                queue.add(POISON_PILL, false);
             }
         }
     }
@@ -78,7 +78,7 @@ public class DefaultOperationQueueStressTest extends HazelcastTestSupport {
         @Override
         public void doRun() throws Throwable {
             for (; ; ) {
-                Object item = queue.take();
+                Object item = queue.take(false);
                 if (item == POISON_PILL) {
                     break;
                 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -5,13 +5,9 @@ import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.DefaultNodeExtension;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
-import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
 import com.hazelcast.internal.properties.GroupProperties;
-import com.hazelcast.internal.properties.GroupProperty;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -19,6 +15,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
@@ -34,7 +31,6 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
-import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.internal.properties.GroupProperty.GENERIC_OPERATION_THREAD_COUNT;
 import static com.hazelcast.internal.properties.GroupProperty.PARTITION_COUNT;
 import static com.hazelcast.internal.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
@@ -52,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSupport {
 
     protected LoggingServiceImpl loggingService;
-    protected GroupProperties groupProperties;
+    protected GroupProperties props;
     protected Address thisAddress;
     protected HazelcastThreadGroup threadGroup;
     protected DefaultNodeExtension nodeExtension;
@@ -83,9 +79,9 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
     }
 
     protected OperationExecutorImpl initExecutor() {
-        groupProperties = new GroupProperties(config);
+        props = new GroupProperties(config);
         executor = new OperationExecutorImpl(
-                groupProperties, loggingService, thisAddress, handlerFactory,
+                props, loggingService, thisAddress, handlerFactory,
                 threadGroup, nodeExtension);
         executor.start();
         return executor;
@@ -235,6 +231,14 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
             } finally {
                 currentTask = null;
             }
+        }
+    }
+
+
+    protected static class UrgentDummyOperation extends DummyOperation implements UrgentSystemOperation {
+
+        public UrgentDummyOperation(int partitionId) {
+            super(partitionId);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_RunTest.java
@@ -1,7 +1,5 @@
 package com.hazelcast.spi.impl.operationexecutor.impl;
 
-import com.hazelcast.internal.properties.GroupProperty;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -12,6 +10,9 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
+import static com.hazelcast.internal.properties.GroupProperty.GENERIC_OPERATION_THREAD_COUNT;
+import static com.hazelcast.internal.properties.GroupProperty.PRIORITY_GENERIC_OPERATION_THREAD_COUNT;
+import static com.hazelcast.spi.Operation.GENERIC_PARTITION_ID;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -39,13 +40,14 @@ public class OperationExecutorImpl_RunTest extends OperationExecutorImpl_Abstrac
 
     @Test
     public void test_whenGenericOperation_andCallingFromGenericThread() {
-        config.setProperty(GroupProperty.GENERIC_OPERATION_THREAD_COUNT.getName(), "1");
+        config.setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "1");
+        config.setProperty(PRIORITY_GENERIC_OPERATION_THREAD_COUNT.getName(), "0");
         initExecutor();
 
         final DummyOperationRunner genericOperationHandler = ((DummyOperationRunnerFactory) handlerFactory).genericOperationHandlers.get(0);
         final DummyGenericOperation genericOperation = new DummyGenericOperation();
 
-        PartitionSpecificCallable task = new PartitionSpecificCallable(Operation.GENERIC_PARTITION_ID) {
+        PartitionSpecificCallable task = new PartitionSpecificCallable(GENERIC_PARTITION_ID) {
             @Override
             public Object call() {
                 executor.run(genericOperation);
@@ -130,7 +132,7 @@ public class OperationExecutorImpl_RunTest extends OperationExecutorImpl_Abstrac
 
         final DummyPartitionOperation partitionOperation = new DummyPartitionOperation();
 
-        PartitionSpecificCallable task = new PartitionSpecificCallable(Operation.GENERIC_PARTITION_ID) {
+        PartitionSpecificCallable task = new PartitionSpecificCallable(GENERIC_PARTITION_ID) {
             @Override
             public Object call() {
                 try {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_BasicTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.internal.properties.GroupProperty.GENERIC_OPERATION_THREAD_COUNT;
 import static com.hazelcast.internal.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
+import static com.hazelcast.internal.properties.GroupProperty.PRIORITY_GENERIC_OPERATION_THREAD_COUNT;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -67,10 +68,11 @@ public class OperationServiceImpl_BasicTest extends HazelcastTestSupport {
     public void testGetGenericThreadCount(){
         Config config = new Config();
         config.setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "5");
+        config.setProperty(PRIORITY_GENERIC_OPERATION_THREAD_COUNT.getName(), "1");
         HazelcastInstance hz = createHazelcastInstance(config);
         OperationServiceImpl operationService = getOperationServiceImpl(hz);
 
-        assertEquals(5, operationService.getGenericThreadCount());
+        assertEquals(6, operationService.getGenericThreadCount());
     }
 
     // there was a memory leak caused by the invocation not releasing the backup registration
@@ -132,7 +134,7 @@ public class OperationServiceImpl_BasicTest extends HazelcastTestSupport {
         HazelcastInstanceImpl impl = (HazelcastInstanceImpl) original.get(hz1);
         OperationService operationService = impl.node.nodeEngine.getOperationService();
 
-        Address address = ((MemberImpl) hz2.getCluster().getLocalMember()).getAddress();
+        Address address = hz2.getCluster().getLocalMember().getAddress();
 
         Operation operation = new GithubIssue2559Operation();
         String serviceName = DistributedExecutorService.SERVICE_NAME;


### PR DESCRIPTION
The OperationExecutor is now by default configured with 1 extra priority generic thread. This thread will only process generic priority operations; which still can be picked up by another regular generic thread if the priority thread for whatever reason is busy. But it can't happen that if only regular generic tasks are running that a priority generic task is not going to be picked up.

This should increase reliability since generic threads are used for all kinds of purposes, e.g. launching and syncing on queries. And stuff like heartbeats, cluster operations etc should be processed asap.