### PR TITLE
Added basic interfaces and extended AbstractDiscoveryStrategy

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -47,6 +47,7 @@ import com.hazelcast.spi.discovery.integration.DiscoveryMode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
+import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -314,6 +315,16 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
         @Override
         public void destroy() {
+        }
+
+        @Override
+        public PartitionGroupStrategy getPartitionGroupStrategy() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> discoverLocalMetadata() {
+            return Collections.emptyMap();
         }
     }
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryStrategy.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryStrategy.java
@@ -2,6 +2,10 @@ package com.hazelcast.spring;
 
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
+
+import java.util.Collections;
+import java.util.Map;
 
 public class DummyDiscoveryStrategy implements DiscoveryStrategy {
     @Override
@@ -17,5 +21,15 @@ public class DummyDiscoveryStrategy implements DiscoveryStrategy {
     @Override
     public void destroy() {
 
+    }
+
+    @Override
+    public PartitionGroupStrategy getPartitionGroupStrategy() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> discoverLocalMetadata() {
+        return Collections.emptyMap();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -123,7 +123,13 @@ public class PartitionGroupConfig {
         /**
          * Per member
          */
-        PER_MEMBER
+        PER_MEMBER,
+        /**
+         * Zone Aware. Backups will be created in other zones. If
+         * only one zone is available, backups will be created in the
+         * same zone.
+         */
+        ZONE_AWARE
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
@@ -19,8 +19,10 @@ package com.hazelcast.spi.discovery;
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.annotation.Beta;
+import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 import com.hazelcast.util.StringUtil;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static java.util.Collections.unmodifiableMap;
@@ -49,6 +51,16 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
 
     @Override
     public void start() {
+    }
+
+    @Override
+    public PartitionGroupStrategy getPartitionGroupStrategy() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> discoverLocalMetadata() {
+        return Collections.emptyMap();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -17,6 +17,9 @@
 package com.hazelcast.spi.discovery;
 
 import com.hazelcast.spi.annotation.Beta;
+import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
+
+import java.util.Map;
 
 /**
  * The <tt>DiscoveryStrategy</tt> itself is the actual implementation to discover
@@ -31,6 +34,10 @@ import com.hazelcast.spi.annotation.Beta;
  * Using the simple lifecycle management strategies like multicast discovery is able to
  * register and destroy sockets based on Hazelcast’s lifecycle. Deactivated services will
  * also never be started.
+ * <p/>
+ * <b>Attention:</b> Instead of implementing this interface directly, implementors should consider
+ * using the abstract class {@link AbstractDiscoveryStrategy} instead for easier upgradeability
+ * while this interface evolves.
  *
  * @since 3.6
  */
@@ -57,4 +64,34 @@ public interface DiscoveryStrategy {
      * kind of internal state.
      */
     void destroy();
+
+    /**
+     * Returns a custom implementation of a {@link PartitionGroupStrategy} to override
+     * default behavior of zone aware backup strategies {@link com.hazelcast.spi.partitiongroup.PartitionGroupMetaData}
+     * or to provide a specific behavior in case the discovery environment does not provide
+     * information about the infrastructure to be used for automatic configuration.
+     *
+     * @return a custom implementation of a <tt>PartitionGroupStrategy</tt> otherwise <tt>null</tt>
+     * in case of the default implementation is to be used
+     * @since 3.7
+     */
+    PartitionGroupStrategy getPartitionGroupStrategy();
+
+    /**
+     * Returns a map with discovered metadata provided by the runtime environment. Those information
+     * may include, but are not limited, to location information like datacenter, rack, host or additional
+     * tags to be used for custom purpose.
+     * <p/>
+     * Information discovered from this method are shaded into the {@link com.hazelcast.core.Member}s
+     * attributes. Existing attributes will not be overridden, that way local attribute configuration
+     * overrides provided metadata.
+     * <p/>
+     * The default implementation provides an empty map with no further metadata configured. Returning
+     * <tt>null</tt> is not permitted and will most probably result in an {@link NullPointerException}
+     * inside the cluster system.
+     *
+     * @return a map of discovered metadata as provided by the runtime environment
+     * @since 3.7
+     */
+    Map<String, Object> discoverLocalMetadata();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -21,6 +21,8 @@ import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.NodeFilter;
 
+import java.util.Map;
+
 /**
  * The <tt>DiscoveryService</tt> interface defines the basic entry point
  * into the Discovery SPI implementation. If not overridden explicitly the Hazelcast
@@ -65,4 +67,22 @@ public interface DiscoveryService {
      * before the service itself will be destroyed.
      */
     void destroy();
+
+    /**
+     * Returns a map with discovered metadata provided by the runtime environment. Those information
+     * may include, but are not limited, to location information like datacenter, rack, host or additional
+     * tags to be used for custom purpose.
+     * <p/>
+     * Information discovered from this method are shaded into the {@link com.hazelcast.core.Member}s
+     * attributes. Existing attributes will not be overridden, that way local attribute configuration
+     * overrides provided metadata.
+     * <p/>
+     * The default implementation provides an empty map with no further metadata configured. Returning
+     * <tt>null</tt> is not permitted and will most probably result in an {@link NullPointerException}
+     * inside the cluster system.
+     *
+     * @return a map of discovered metadata as provided by the runtime environment
+     * @since 3.7
+     */
+    Map<String, Object> discoverLocalMetadata();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupMetaData.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.partitiongroup;
+
+/**
+ * This class contains the definition of known Discovery SPI metadata to support automatic
+ * generation of zone aware backup strategies based on cloud or service discovery provided
+ * information. These information are split into three different levels of granularity:
+ * <ul>
+ * <li><b>Zone:</b> A low-latency link between (virtual) data centers in the same area</li>
+ * <li><b>Rack:</b> A low-latency link inside the same data center but for different racks</li>
+ * <li><b>Host:</b> A low-latency link on a shared physical node, in case of virtualization being used</li>
+ * </ul>
+ */
+public enum PartitionGroupMetaData {
+    ;
+
+    /**
+     * Metadata key definition for a low-latency link between (virtual) data centers in the same area
+     */
+    public static final String PARTITION_GROUP_ZONE = "hazelcast.partition.group.zone";
+
+    /**
+     * Metadata key definition for a low-latency link inside the same data center but for different racks
+     */
+    public static final String PARTITION_GROUP_RACK = "hazelcast.partition.group.rack";
+
+    /**
+     * Metadata key definition for a low-latency link on a shared physical node, in case of virtualization being used
+     */
+    public static final String PARTITION_GROUP_HOST = "hazelcast.partition.group.host";
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.partitiongroup;
+
+import com.hazelcast.partition.membergroup.MemberGroup;
+import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
+
+/**
+ * <p>A <tt>PartitionGroupStrategy</tt> implementation defines a strategy
+ * how backup groups are designed. Backup groups are units containing
+ * one or more Hazelcast nodes to share the same physical host, rack or
+ * zone and backups are stored on nodes being part of a different
+ * backup group. This behavior builds an additional layer of data
+ * reliability by making sure that, in case of two racks, if rack A
+ * fails, rack B will still have all the backups and is guaranteed
+ * to still provide all data. Similar is true for zones or physical hosts.</p>
+ * <p>Custom implementations of the PartitionGroupStrategy may add specific
+ * or additional behavior based on the provided environment and can
+ * be injected into Hazelcast by overriding
+ * {@link AbstractDiscoveryStrategy#getPartitionGroupStrategy()}.</p>
+ */
+public interface PartitionGroupStrategy {
+
+    /**
+     * TODO Has probably to be changed :)
+     */
+    Iterable<MemberGroup> getMemberGroups();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the basic SPI for the Partition Group SPI to define
+ * or configure how Hazelcast will configure and distribute backups in the
+ * cluster. The basic idea is to make sure that backups are stored on independent
+ * systems such as different physical hosts or zones.
+ */
+package com.hazelcast.spi.partitiongroup;

--- a/hazelcast/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/hazelcast/src/test/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,1 +1,2 @@
 com.hazelcast.spi.discovery.DiscoverySpiTest$TestDiscoveryStrategyFactory
+com.hazelcast.spi.discovery.DiscoverySpiTest$MetadataProvidingDiscoveryStrategyFactory

--- a/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+
+  <network>
+    <join>
+      <multicast enabled="false"/>
+      <tcp-ip enabled="false" />
+      <aws enabled="false"/>
+      <discovery-strategies>
+        <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.DiscoverySpiTest$MetadataProvidingDiscoveryStrategy">
+          <properties>
+            <property name="key-string">foo</property>
+            <property name="key-int">123</property>
+            <property name="key-boolean">true</property>
+          </properties>
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+  </network>
+
+</hazelcast>


### PR DESCRIPTION
Extended the DiscoveryStrategy interface and AbstractDiscoveryStrategy implementation to support discovery of a local's node metadata from the given runtime environment (like AWS, GCE, ...).