### PR TITLE
Fixed a possible race in PutAllOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -88,8 +88,10 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
         dataValue = getValueOrPostProcessedValue(dataKey, dataValue);
         mapServiceContext.interceptAfterPut(name, dataValue);
 
-        EntryEventType eventType = oldValue == null ? ADDED : UPDATED;
-        mapEventPublisher.publishEvent(getCallerAddress(), name, eventType, dataKey, oldValue, dataValue);
+        if (hasMapListener) {
+            EntryEventType eventType = oldValue == null ? ADDED : UPDATED;
+            mapEventPublisher.publishEvent(getCallerAddress(), name, eventType, dataKey, oldValue, dataValue);
+        }
 
         Record record = recordStore.getRecord(dataKey);
 


### PR DESCRIPTION
Fixed a possible race between `mapEventPublisher.hasEventListener()` and `mapEventPublisher.publishEvent()` in `PutAllOperation` if listeners are added between those calls.

Assumption: The map listener registrations in `EventServiceImpl` can be changed concurrently to a running `PutAllOperation`, which I think is correct since `RegistrationOperation` seems to be a generic operation.

A `PutAllOperation` is executed:
* The method `run()` is called
* The boolean field `hasMapListener = mapEventPublisher.hasEventListener(name);` is looked up *once* and remembers if map listeners are registered
* The method `put()` is called in a loop for each item
  * `Object oldValue = null;` is defined
  * `oldValue` is only set if `hasMapListener` is `true`
  * `EntryEventType eventType = oldValue == null ? ADDED : UPDATED;` will always be `ADDED` if `hasMapListener` was `false`, since no `oldValue` was retrieved
  * The method `mapEventPublisher.publishEvent()` is always called, so it may send the wrong `ADDED` event if a new listener was registered since `hasMapListener` was stored

Since we can add a lot of items in the loop there is a considerable time window in which a new map listener could be registered. The fix is to guard the `mapEventPublisher.publishEvent()` call with the `hasMapListener`, so all items of a `PutAllOperation` will send an event or not.

If there is no race this check should nevertheless save some lookups in the `ConcurrentMap<String, EventServiceSegment> segments;` of the `EventServiceImpl`.