### PR TITLE
Cleanup of MapEntries to reduce Map.Entry litter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
@@ -182,11 +182,7 @@ abstract class AbstractCacheProxy<K, V>
             Map<Integer, Object> responses = operationService.invokeOnPartitions(getServiceName(), factory, partitions);
             for (Object response : responses.values()) {
                 MapEntries mapEntries = serializationService.toObject(response);
-                for (Map.Entry<Data, Data> entry : mapEntries) {
-                    final V value = serializationService.toObject(entry.getValue());
-                    final K key = serializationService.toObject(entry.getKey());
-                    result.put(key, value);
-                }
+                mapEntries.putAllToMap(serializationService, result);
             }
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -1314,7 +1314,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     @Override
     public MapEntries getAll(Set<Data> keySet, ExpiryPolicy expiryPolicy) {
         expiryPolicy = getExpiryPolicy(expiryPolicy);
-        final MapEntries result = new MapEntries();
+        final MapEntries result = new MapEntries(keySet.size());
         for (Data key : keySet) {
             final Object value = get(key, expiryPolicy);
             if (value != null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAllMessageTask.java
@@ -73,9 +73,7 @@ public class CacheGetAllMessageTask
         List<Map.Entry<Data, Data>> reducedMap = new ArrayList<Map.Entry<Data, Data>>(map.size());
         for (Map.Entry<Integer, Object> entry : map.entrySet()) {
             MapEntries mapEntries = (MapEntries) nodeEngine.toObject(entry.getValue());
-            for (Map.Entry<Data, Data> dataEntry : mapEntries) {
-                reducedMap.add(dataEntry);
-            }
+            mapEntries.putAllToList(reducedMap);
         }
         return reducedMap;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnAllKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnAllKeysMessageTask.java
@@ -55,9 +55,7 @@ public class MapExecuteOnAllKeysMessageTask
         for (Object o : map.values()) {
             if (o != null) {
                 MapEntries entries = (MapEntries) mapService.getMapServiceContext().toObject(o);
-                for (Map.Entry<Data, Data> entry : entries) {
-                    dataMap.add(entry);
-                }
+                entries.putAllToList(dataMap);
             }
         }
         return dataMap;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteOnKeysMessageTask.java
@@ -62,9 +62,7 @@ public class MapExecuteOnKeysMessageTask
         for (Object o : map.values()) {
             if (o != null) {
                 MapEntries mapEntries = (MapEntries) mapService.getMapServiceContext().toObject(o);
-                for (Map.Entry<Data, Data> entry : mapEntries) {
-                    entries.add(entry);
-                }
+                mapEntries.putAllToList(entries);
             }
         }
         return entries;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapExecuteWithPredicateMessageTask.java
@@ -58,9 +58,7 @@ public class MapExecuteWithPredicateMessageTask
         for (Object o : map.values()) {
             if (o != null) {
                 MapEntries mapEntries = (MapEntries) mapService.getMapServiceContext().toObject(o);
-                for (Map.Entry<Data, Data> entry : mapEntries) {
-                    dataMap.add(entry);
-                }
+                mapEntries.putAllToList(dataMap);
             }
         }
         return dataMap;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
@@ -41,11 +41,7 @@ public class MapPutAllMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        MapEntries mapEntries = new MapEntries();
-        for (Map.Entry<Data, Data> entry : parameters.entries) {
-            mapEntries.add(entry.getKey(), entry.getValue());
-        }
-
+        MapEntries mapEntries = new MapEntries(parameters.entries);
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
         return operationProvider.createPutAllOperation(parameters.name, mapEntries);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntries.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntries.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 import java.util.AbstractMap;
@@ -30,51 +31,102 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * MapEntries is a collection of {@link java.util.Map.Entry} instances.
+ * MapEntries is a collection of {@link Data} instances for keys and values of a {@link java.util.Map.Entry}.
  */
-public final class MapEntries implements IdentifiedDataSerializable, Iterable<Map.Entry<Data, Data>> {
+public final class MapEntries implements IdentifiedDataSerializable {
 
-    private List<Map.Entry<Data, Data>> entries;
+    private List<Data> keys;
+    private List<Data> values;
 
     public MapEntries() {
     }
 
-    public MapEntries(Collection<Map.Entry<Data, Data>> entries) {
-        this.entries = new ArrayList<Map.Entry<Data, Data>>(entries);
+    public MapEntries(int initialSize) {
+        keys = new ArrayList<Data>(initialSize);
+        values = new ArrayList<Data>(initialSize);
     }
 
-    public Collection<Map.Entry<Data, Data>> entries() {
-        ensureEntriesCreated();
-        return entries;
+    public MapEntries(List<Data> keys, List<Data> values) {
+        if (!(values instanceof ArrayList)) {
+            throw new IllegalArgumentException("values has to be of type ArrayList<Data>");
+        }
+        this.keys = keys;
+        this.values = values;
     }
 
-    public void add(Map.Entry<Data, Data> entry) {
-        ensureEntriesCreated();
-        entries.add(entry);
+    public MapEntries(List<Map.Entry<Data, Data>> entries) {
+        int initialSize = entries.size();
+        keys = new ArrayList<Data>(initialSize);
+        values = new ArrayList<Data>(initialSize);
+        for (Map.Entry<Data, Data> entry : entries) {
+            keys.add(entry.getKey());
+            values.add(entry.getValue());
+        }
     }
 
     public void add(Data key, Data value) {
         ensureEntriesCreated();
-        entries.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(key, value));
+        keys.add(key);
+        values.add(value);
+    }
+
+    public List<Map.Entry<Data, Data>> entries() {
+        ArrayList<Map.Entry<Data, Data>> entries = new ArrayList<Map.Entry<Data, Data>>(keys.size());
+        putAllToList(entries);
+        return entries;
+    }
+
+    public List<Data> getKeys() {
+        ensureEntriesCreated();
+        return keys;
+    }
+
+    public Data getKey(int index) {
+        // we should not use this method if the MapEntries was created with a LinkedList for keys
+        assert keys instanceof ArrayList;
+        return keys.get(index);
+    }
+
+    public Data getValue(int index) {
+        return values.get(index);
     }
 
     public int size() {
-        return entries == null ? 0 : entries.size();
+        return (keys == null ? 0 : keys.size());
     }
 
     public boolean isEmpty() {
-        return size() == 0;
+        return (keys == null || keys.size() == 0);
     }
 
-    @Override
-    public Iterator<Map.Entry<Data, Data>> iterator() {
-        ensureEntriesCreated();
-        return entries.iterator();
+    public void putAllToList(Collection<Map.Entry<Data, Data>> targetList) {
+        if (keys == null) {
+            return;
+        }
+        Iterator<Data> keyIterator = keys.iterator();
+        Iterator<Data> valueIterator = values.iterator();
+        while (keyIterator.hasNext()) {
+            targetList.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(keyIterator.next(), valueIterator.next()));
+        }
+    }
+
+    public <K, V> void putAllToMap(SerializationService serializationService, Map<K, V> map) {
+        if (keys == null) {
+            return;
+        }
+        Iterator<Data> keyIterator = keys.iterator();
+        Iterator<Data> valueIterator = values.iterator();
+        while (keyIterator.hasNext()) {
+            K key = serializationService.toObject(keyIterator.next());
+            V value = serializationService.toObject(valueIterator.next());
+            map.put(key, value);
+        }
     }
 
     private void ensureEntriesCreated() {
-        if (entries == null) {
-            entries = new ArrayList<Map.Entry<Data, Data>>();
+        if (keys == null) {
+            keys = new ArrayList<Data>();
+            values = new ArrayList<Data>();
         }
     }
 
@@ -90,14 +142,14 @@ public final class MapEntries implements IdentifiedDataSerializable, Iterable<Ma
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        int size = entries == null ? 0 : entries.size();
+        int size = size();
         out.writeInt(size);
 
-        if (size > 0) {
-            for (Map.Entry<Data, Data> o : entries) {
-                out.writeData(o.getKey());
-                out.writeData(o.getValue());
-            }
+        // we use an iterator for the keys, since they can be stored in a LinkedList
+        int i = 0;
+        for (Data key : keys) {
+            out.writeData(key);
+            out.writeData(values.get(i++));
         }
     }
 
@@ -105,13 +157,12 @@ public final class MapEntries implements IdentifiedDataSerializable, Iterable<Ma
     public void readData(ObjectDataInput in) throws IOException {
         int size = in.readInt();
 
-        entries = new ArrayList<Map.Entry<Data, Data>>(size);
+        keys = new ArrayList<Data>(size);
+        values = new ArrayList<Data>(size);
 
         for (int i = 0; i < size; i++) {
-            Data key = in.readData();
-            Data value = in.readData();
-            Map.Entry<Data, Data> entry = new AbstractMap.SimpleImmutableEntry<Data, Data>(key, value);
-            entries.add(entry);
+            keys.add(in.readData());
+            values.add(in.readData());
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -34,7 +34,6 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.Clock;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -220,16 +219,6 @@ abstract class AbstractMultipleEntryOperation extends MapOperation implements Mu
 
     protected long getLatencyFrom(long begin) {
         return Clock.currentTimeMillis() - begin;
-    }
-
-    protected void addToResponses(Data key, Data response) {
-        if (response == null) {
-            return;
-        }
-        if (responses == null) {
-            responses = new MapEntries();
-        }
-        responses.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(key, response));
     }
 
     protected Data process(Map.Entry entry) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -60,6 +61,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
     public void run() {
         long now = getNow();
 
+        responses = new MapEntries(recordStore.size());
         Iterator<Record> iterator = recordStore.iterator(now, false);
         while (iterator.hasNext()) {
             Record record = iterator.next();
@@ -72,8 +74,9 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
 
             Map.Entry entry = createMapEntry(dataKey, oldValue);
             Data response = process(entry);
-
-            addToResponses(dataKey, response);
+            if (response != null) {
+                responses.add(dataKey, response);
+            }
 
             // first call noOp, other if checks below depends on it.
             if (noOp(entry, oldValue)) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
@@ -30,7 +30,6 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
 import static com.hazelcast.map.impl.record.Records.applyRecordInfo;
@@ -52,18 +51,18 @@ public class PutAllBackupOperation extends MapOperation implements PartitionAwar
     @Override
     public void run() {
         boolean wanEnabled = mapContainer.isWanReplicationEnabled();
-        int i = 0;
-        for (Map.Entry<Data, Data> entry : entries) {
-            Record record = recordStore.putBackup(entry.getKey(), entry.getValue());
+        for (int i = 0; i < entries.size(); i++) {
+            Data dataKey = entries.getKey(i);
+            Data dataValue = entries.getValue(i);
+            Record record = recordStore.putBackup(dataKey, dataValue);
             applyRecordInfo(record, recordInfos.get(i));
             if (wanEnabled) {
-                Data dataValueAsData = mapServiceContext.toData(entry.getValue());
-                EntryView entryView = createSimpleEntryView(entry.getKey(), dataValueAsData, record);
+                Data dataValueAsData = mapServiceContext.toData(dataValue);
+                EntryView entryView = createSimpleEntryView(dataKey, dataValueAsData, record);
                 mapEventPublisher.publishWanReplicationUpdateBackup(name, entryView);
             }
 
             evict();
-            i++;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -262,9 +262,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     @Override
     protected Future createPutAllOperationFuture(String name, MapEntries mapEntries, int partitionId) {
-        Collection<Entry<Data, Data>> collection = mapEntries.entries();
-        for (Entry<Data, Data> entry : collection) {
-            invalidateCache(entry.getKey());
+        for (Data key : mapEntries.getKeys()) {
+            invalidateCache(key);
         }
         return super.createPutAllOperationFuture(name, mapEntries, partitionId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -588,7 +588,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         checkIfLoaded();
         final long now = getNow();
 
-        final MapEntries mapEntries = new MapEntries();
+        final MapEntries mapEntries = new MapEntries(keys.size());
 
         final Iterator<Data> iterator = keys.iterator();
         while (iterator.hasNext()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -26,6 +26,8 @@ import com.hazelcast.map.impl.query.QueryResultSizeLimiter;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.query.impl.predicates.QueryOptimizerFactory;
 
+import java.util.Map;
+
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -181,6 +183,30 @@ public final class GroupProperty {
 
     public static final HazelcastProperty MAP_LOAD_CHUNK_SIZE
             = new HazelcastProperty("hazelcast.map.load.chunk.size", 1000);
+
+    /**
+     * Defines if {@link IMap#putAll(Map)} should estimate the size of arrays per partition or analyze them correctly.
+     *
+     * The default value of -1 disables the estimation, which is a good overall strategy. This strategy creates a fair amount of
+     * litter, which is an {@code int[]} of the size of the map and a {@code LinkedList$Node} for each key of the inserted map.
+     *
+     * If you insert entries which are distributed well among the partitions you can configure this factor.
+     * This safes the litter mentioned above, since we directly create {@code ArrayLists} of the estimated initial size.
+     * The initial size is calculated by this formula:
+     * {@code initialSize = ceil(MAP_PUT_ALL_INITIAL_SIZE_FACTOR * map.size() / PARTITION_COUNT)}
+     *
+     * As a rule of thumb you can try the following values:
+     * <ul>
+     *     <li>{@code 10} for map sizes about 100 entries</li>
+     *     <li>{@code 5} for map sizes between 500 and 5000 entries</li>
+     *     <li>{@code 1.5} for map sizes between about 50000 entries</li>
+     * </ul>
+     *
+     * If you set this value too high, you will waste memory.
+     * If you set this value too low, you will suffer from expensive {@link java.util.Arrays#copyOf} calls.
+     */
+    public static final HazelcastProperty MAP_PUT_ALL_INITIAL_SIZE_FACTOR
+            = new HazelcastProperty("hazelcast.map.put.all.initial.size.factor", -1);
 
     public static final HazelcastProperty MERGE_FIRST_RUN_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.merge.first.run.delay.seconds", 300, SECONDS);


### PR DESCRIPTION
This is an experiment to reduce the litter caused by `java.util.AbstractMap$SimpleImmutableEntry` in `MapEntries`. In many cases we don't need the data as `Map.Entry`, but use key and value separately. So we can save the creation of those wrapper objects until we return something like a map to the user.

Especially the `IMap.putAll()` with backups will profit from this, since we pass around huge `MapEntries` instances between the nodes. Let's have a look where the litter is created. Each creation of `MapEntries` creates an `AbstractMap.SimpleImmutableEntry<Data, Data>` wrapper object for each entry. This happens on the initial creation on the calling node and on each deserialization on the executing nodes. For `IMap.putAll()` there is an additional deserialization for each configured backup:

```
4 members, 4 partitions, 1 sync backup

IMap.putAll() with 500 entries on Member [172.16.18.1]:5702

(local execution on Member [172.16.18.1]:5702, so no deserialization)
PutAllOperation deserialized with 138 entries
PutAllOperation deserialized with 119 entries
PutAllOperation deserialized with 126 entries
PutAllOperation on Member [172.16.18.1]:5703 with 138 entries
PutAllOperation on Member [172.16.18.1]:5704 with 119 entries
PutAllOperation on Member [172.16.18.1]:5702 with 117 entries
PutAllOperation on Member [172.16.18.1]:5701 with 126 entries

PutAllBackupOperation deserialized with 126 entries
PutAllBackupOperation deserialized with 119 entries
PutAllBackupOperation deserialized with 117 entries
PutAllBackupOperation deserialized with 138 entries
PutAllBackupOperation on Member [172.16.18.1]:5702 with 126 entries
PutAllBackupOperation on Member [172.16.18.1]:5703 with 119 entries
PutAllBackupOperation on Member [172.16.18.1]:5704 with 117 entries
PutAllBackupOperation on Member [172.16.18.1]:5701 with 138 entries

=> 1383 wrapper objects
```
```
4 members, 4 partitions, 2 sync backups

IMap.putAll() with 500 entries on Member [172.16.18.1]:5702

(local execution on Member [172.16.18.1]:5702, so no deserialization)
PutAllOperation deserialized with 117 entries
PutAllOperation deserialized with 119 entries
PutAllOperation deserialized with 126 entries
PutAllOperation on Member [172.16.18.1]:5701 with 119 entries
PutAllOperation on Member [172.16.18.1]:5702 with 138 entries
PutAllOperation on Member [172.16.18.1]:5704 with 117 entries
PutAllOperation on Member [172.16.18.1]:5703 with 126 entries

PutAllBackupOperation deserialized with 117 entries
PutAllBackupOperation deserialized with 119 entries
PutAllBackupOperation deserialized with 138 entries
PutAllBackupOperation deserialized with 126 entries
PutAllBackupOperation on Member [172.16.18.1]:5703 with 117 entries
PutAllBackupOperation on Member [172.16.18.1]:5704 with 119 entries
PutAllBackupOperation on Member [172.16.18.1]:5701 with 138 entries
PutAllBackupOperation on Member [172.16.18.1]:5702 with 126 entries

PutAllBackupOperation deserialized with 138 entries
PutAllBackupOperation deserialized with 117 entries
PutAllBackupOperation deserialized with 126 entries
PutAllBackupOperation deserialized with 119 entries
PutAllBackupOperation on Member [172.16.18.1]:5701 with 126 entries
PutAllBackupOperation on Member [172.16.18.1]:5704 with 138 entries
PutAllBackupOperation on Member [172.16.18.1]:5701 with 117 entries
PutAllBackupOperation on Member [172.16.18.1]:5703 with 119 entries

=> 1883 wrapper objects
```
On top of that the `MapEntries` are often created without an initial size, so the internal `ArrayList` is resized frequently, which is quite expensive.

I changed the implementation from `List<Map.Entry<Data, Data>> entries` to two separate `List<Data>` for keys and values. I also added the initial size to the constructor, which is known in a lot of cases! The only headache is the initial creation of the `MapEntries` per partition in the `MapProxySupport.putAllInternal()` method. We don't know the distribution and the entries per partition may vary in size, depending on the user input. We also have a broad range from one to hundreds of thousands of possible entries.

I came up with two different strategies. The first creates a fair amount of litter to create the `MapEntries` instances (one `int[mapSize]` and a `LinkedList$Node` per entry), comparable to the old litter (see `invokePutAllWithAnalysis()`). The second one theoretically creates almost no litter (see `invokePutAllWithEstimation()`), but needs a good estimation about the partition distribution. I solved with a new property, since we cannot know this upfront, so it's tuneable. In all cases the `MapEntries` don't create the `AbstractMap.SimpleImmutableEntry<Data, Data>` litter anymore and are very efficient once being serialized.

| Name | Master | Cleanup |
| --- | ---: | ---: |
| Duration per operation | ~14010 µs | ~13370 µs |
| GC Count | 2918 | 2755 |
| Total GC Time | 3min 15s 268ms | 3min 5s 854ms |
| TLAB count | 6,967,200 | 6,620,614 |
| Allocation Rate for TLAB | 591.53 MB/s | 582.20 MB/s |

```
50000 operations done in  700546 ms (14010 µs per op avg) (master)...
vs.
50000 operations done in  668506 ms (13370 µs per op avg) (cleanup)...
```

There is a big variation in the runtime though. I got several runs on the master branch with 766576 ms (15331 µs per op avg) and also runs on the cleanup that didn't went that well. So I guess the pure throughput is not a good measurement. Maybe the invocation cleanup Peter is working on will help here. Nevertheless the allocation profile and GC times are constantly better with the cleanup, so we will profit from this PR.

**Allocation pressure**
![master](https://cloud.githubusercontent.com/assets/4196298/14350492/f48855e8-fcc9-11e5-8c13-7007252a6c24.png)
![cleanup](https://cloud.githubusercontent.com/assets/4196298/14350496/f772baa0-fcc9-11e5-9dc1-e9da1bf850a9.png)
The `java.util.AbstractMap$SimpleImmutableEntry` allocation pressure of 8.18% is gone.

If I interpret the affected classes correctly we may also benefit when using `EntryProcessors` between members (due to `AbstractMultipleEntryOperation`). When using clients I think there is no change, since I still create the `AbstractMap.SimpleImmutableEntry` instances in the new `MapEntries.putAllToList()` method.

**Question**
Will this break the client protocol in any way? The serialization of `MapEntries`, `PutAllOperation`, `PutAllBackupOperation` etc. have been changed. I hope this is not the case, since I could re-use all task and codec classes as they are. I think we're just changing the member-to-member communication, which should be fine for a minor release.

If we want to merge this, I'll have to prepare an EE PR as well.