### PR TITLE
Cleanup of PutAllBackupOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -50,7 +50,6 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
     private boolean hasInvalidation;
 
     private List<RecordInfo> backupRecordInfos;
-    private List<Map.Entry<Data, Data>> backupEntries;
     private List<Data> invalidationKeys;
 
     public PutAllOperation() {
@@ -70,7 +69,6 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
 
         if (hasBackups) {
             backupRecordInfos = new ArrayList<RecordInfo>(mapEntries.size());
-            backupEntries = new ArrayList<Map.Entry<Data, Data>>(mapEntries.size());
         }
         if (hasInvalidation) {
             invalidationKeys = new ArrayList<Data>(mapEntries.size());
@@ -108,7 +106,6 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
             mapEventPublisher.publishWanReplicationUpdate(name, entryView);
         }
         if (hasBackups) {
-            backupEntries.add(entry);
             RecordInfo replicationInfo = buildRecordInfo(record);
             backupRecordInfos.add(replicationInfo);
         }
@@ -154,7 +151,7 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
 
     @Override
     public boolean shouldBackup() {
-        return (hasBackups && !backupEntries.isEmpty());
+        return (hasBackups && !mapEntries.isEmpty());
     }
 
     @Override
@@ -169,7 +166,7 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
 
     @Override
     public Operation getBackupOperation() {
-        return new PutAllBackupOperation(name, backupEntries, backupRecordInfos);
+        return new PutAllBackupOperation(name, mapEntries, backupRecordInfos);
     }
 
     @Override


### PR DESCRIPTION
Another simplification in the code, this time for the `PutAllBackupOperation`.

If we have backups enabled we transfer *all* entries into the `PutAllBackupOperation`. There is no need to copy them one by one into a new list, we can just re-use the existing `MapEntries` instance from the `PutAllOperation`. On the receiving side this will just create a single additional `MapEntries` wrapper object, which we saved on the sending side `List<Map.Entry<Data, Data>>`.

The performance measurement showed a massive improvement, which I don't really believe. I think that was a very bad master vs. a very good cleanup run. But at least there is surely no negative impact :)
```
50000 operations done in  842382 ms (16847 µs per op avg) (master)...
vs.
50000 operations done in  749940 ms (14998 µs per op avg) (cleanup)...
```
Memory profiles in JFR look the same.

I will create the EE counterpart after the review of this PR, but want to have your feedback first.