### PR TITLE
Retrieve already published messages on registration of client ReliableMessageListener when StaleSequenceException occurs

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -45,6 +45,7 @@ import com.hazelcast.util.UuidUtil;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferService.TOPIC_RB_PREFIX;
@@ -271,23 +272,24 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
                 return;
             }
 
-            if (t instanceof StaleSequenceException) {
-                StaleSequenceException staleSequenceException = (StaleSequenceException) t;
+            if (t instanceof ExecutionException && t.getCause() instanceof StaleSequenceException) {
+                // StaleSequenceException.getHeadSeq() is not available on the client-side, see #7317
+                long remoteHeadSeq = ringbuffer.headSequence();
 
                 if (listener.isLossTolerant()) {
                     if (logger.isFinestEnabled()) {
                         logger.finest("MessageListener " + listener + " on topic: " + name + " ran into a stale sequence. "
                                 + "Jumping from oldSequence: " + sequence
-                                + " to sequence: " + staleSequenceException.getHeadSeq());
+                                + " to sequence: " + remoteHeadSeq);
                     }
-                    sequence = staleSequenceException.getHeadSeq();
+                    sequence = remoteHeadSeq;
                     next();
                     return;
                 }
 
                 logger.warning("Terminating MessageListener:" + listener + " on topic: " + name + ". "
                         + "Reason: The listener was too slow or the retention period of the message has been violated. "
-                        + "head: " + staleSequenceException.getHeadSeq() + " sequence:" + sequence);
+                        + "head: " + remoteHeadSeq + " sequence:" + sequence);
             } else if (t instanceof HazelcastInstanceNotActiveException) {
                 if (logger.isFinestEnabled()) {
                     logger.finest("Terminating MessageListener " + listener + " on topic: " + name + ". "

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.client.topic;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.Message;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.ReliableMessageListener;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for #7317 (https://github.com/hazelcast/hazelcast/issues/7317), contributed
+ * by @nilskp (https://github.com/nilskp). Test retrieval of already published messages
+ * after a loss-tolerant {@link ReliableMessageListener} registers with an initial
+ * sequence outside head-tail sequence range, which results in a {@link com.hazelcast.ringbuffer.StaleSequenceException}.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Issue7317Test {
+
+    static final String smallRB = "foo";
+    static final int smallRBCapacity = 3;
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        Config serverConfig = new Config();
+        RingbufferConfig rbConf = new RingbufferConfig(smallRB);
+        rbConf.setCapacity(smallRBCapacity);
+        serverConfig.addRingBufferConfig(rbConf);
+        hazelcastFactory.newHazelcastInstance(serverConfig);
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    static class Issue7317MessageListener
+            implements ReliableMessageListener<String> {
+
+        private final List<String> messages;
+        private final CountDownLatch cdl;
+        private long seq;
+
+        public Issue7317MessageListener(List<String> messages, CountDownLatch cdl) {
+            this.messages = messages;
+            this.cdl = cdl;
+        }
+
+        public void onMessage(Message<String> msg) {
+            assertEquals(messages.size() - cdl.getCount(), (int) seq);
+            assertEquals(messages.get((int) seq), msg.getMessageObject());
+            cdl.countDown();
+        }
+
+        public long retrieveInitialSequence() {
+            return 0;
+        }
+
+        public void storeSequence(long sequence) {
+            seq = sequence;
+        }
+
+        public boolean isLossTolerant() {
+            return true;
+        }
+
+        public boolean isTerminal(Throwable failure) {
+            return true;
+        }
+    }
+
+    @Test
+    public void registerListenerOnStaleSequenceClientServer()
+            throws InterruptedException {
+
+        final List<String> messages = Arrays.asList("a", "b", "c", "d", "e");
+        final CountDownLatch cdl = new CountDownLatch(smallRBCapacity);
+        ITopic<String> rTopic = client.getReliableTopic(smallRB);
+        for (String message : messages) {
+            rTopic.publish(message);
+        }
+        ReliableMessageListener<String> listener = new Issue7317MessageListener(messages, cdl);
+        String reg = rTopic.addMessageListener(listener);
+        assertTrue(cdl.await(5, TimeUnit.SECONDS));
+        rTopic.removeMessageListener(reg);
+
+    }
+}


### PR DESCRIPTION
A client-side `ReliableMessageListener` registering with an `initialSequence` outside head-tail sequence should now retrieve already published messages upon registration. Fixes #7317.