### PR TITLE
Nonblocking invocationfutures

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -152,7 +152,7 @@ public class ClientInvocation implements Runnable {
         try {
             invoke();
         } catch (Throwable e) {
-            clientInvocationFuture.setResponse(e);
+            clientInvocationFuture.complete(e);
         }
     }
 
@@ -160,14 +160,14 @@ public class ClientInvocation implements Runnable {
         if (clientMessage == null) {
             throw new IllegalArgumentException("response can't be null");
         }
-        clientInvocationFuture.setResponse(clientMessage);
+        clientInvocationFuture.complete(clientMessage);
 
     }
 
     public void notifyException(Throwable exception) {
 
         if (!lifecycleService.isRunning()) {
-            clientInvocationFuture.setResponse(new HazelcastClientNotActiveException(exception.getMessage()));
+            clientInvocationFuture.complete(new HazelcastClientNotActiveException(exception.getMessage()));
             return;
         }
 
@@ -183,7 +183,7 @@ public class ClientInvocation implements Runnable {
                 }
             }
         }
-        clientInvocationFuture.setResponse(exception);
+        clientInvocationFuture.complete(exception);
     }
 
     private boolean handleRetry() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -16,123 +16,64 @@
 
 package com.hazelcast.client.spi.impl;
 
-import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.util.Clock;
-import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.spi.impl.AbstractInvocationFuture;
 
-import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.util.ExceptionUtil.fixAsyncStackTrace;
 
-public class ClientInvocationFuture implements ICompletableFuture<ClientMessage> {
+public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessage> {
 
-    protected final ILogger logger;
-
-    protected final ClientMessage clientMessage;
-    protected volatile Object response;
-
-    private final ClientExecutionServiceImpl executionService;
-    private final List<ExecutionCallbackNode> callbackNodeList = new LinkedList<ExecutionCallbackNode>();
+    protected final ClientMessage request;
     private final ClientInvocation invocation;
 
     public ClientInvocationFuture(ClientInvocation invocation, HazelcastClientInstanceImpl client,
-                                  ClientMessage clientMessage, ILogger logger) {
+                                  ClientMessage request, ILogger logger) {
 
-        this.executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
-        this.clientMessage = clientMessage;
+        super(client.getClientExecutionService(), logger);
+        this.request = request;
         this.invocation = invocation;
-        this.logger = logger;
     }
 
     @Override
-    public boolean cancel(boolean mayInterruptIfRunning) {
-        return false;
+    protected String invocationToString() {
+        return request.toString();
     }
 
     @Override
-    public boolean isCancelled() {
-        return false;
+    protected void onInterruptDetected() {
+        complete(new InterruptedException());
     }
 
     @Override
-    public boolean isDone() {
-        return response != null;
+    protected TimeoutException newTimeoutException(long timeout, TimeUnit unit) {
+        return new TimeoutException();
     }
 
     @Override
-    public ClientMessage get() throws InterruptedException, ExecutionException {
-        try {
-            return get(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException exception) {
-            throw ExceptionUtil.rethrow(exception);
+    protected Throwable unwrap(Throwable throwable) {
+        return throwable;
+    }
+
+    @Override
+    protected Object resolve(Object value) {
+        if (value instanceof Throwable) {
+            return new ExecutionException((Throwable) value);
         }
+        return value;
     }
 
     @Override
-    public ClientMessage get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        if (response == null) {
-            long waitMillis = unit.toMillis(timeout);
-            if (waitMillis > 0) {
-                synchronized (this) {
-                    while (waitMillis > 0 && response == null) {
-                        long start = Clock.currentTimeMillis();
-                        wait(waitMillis);
-                        long elapsed = Clock.currentTimeMillis() - start;
-                        waitMillis -= elapsed;
-                    }
-                }
-            }
-        }
-        return resolveResponse();
-    }
-
-    /**
-     * @param response coming from server
-     * @return true if response coming from server should be set
-     */
-    boolean shouldSetResponse(Object response) {
-        if (this.response != null) {
-            logger.warning("The Future.set() method can only be called once. Request: " + clientMessage
-                    + ", current response: " + this.response + ", new response: " + response);
-            return false;
-        }
-        return true;
-    }
-
-    void setResponse(Object response) {
-        synchronized (this) {
-            if (!shouldSetResponse(response)) {
-                return;
-            }
-
-            this.response = response;
-            notifyAll();
-            for (ExecutionCallbackNode node : callbackNodeList) {
-                runAsynchronous(node.callback, node.executor);
-            }
-            callbackNodeList.clear();
-        }
-    }
-
-    private ClientMessage resolveResponse() throws ExecutionException, TimeoutException, InterruptedException {
+    public ClientMessage resolveAndThrow(Object response) throws ExecutionException, InterruptedException {
         if (response instanceof Throwable) {
             fixAsyncStackTrace((Throwable) response, Thread.currentThread().getStackTrace());
             if (response instanceof ExecutionException) {
                 throw (ExecutionException) response;
-            }
-            if (response instanceof TimeoutException) {
-                throw (TimeoutException) response;
             }
             if (response instanceof Error) {
                 throw (Error) response;
@@ -142,66 +83,11 @@ public class ClientInvocationFuture implements ICompletableFuture<ClientMessage>
             }
             throw new ExecutionException((Throwable) response);
         }
-        if (response == null) {
-            throw new TimeoutException();
-        }
         return (ClientMessage) response;
-    }
-
-    @Override
-    public void andThen(ExecutionCallback<ClientMessage> callback) {
-        andThen(callback, executionService.getAsyncExecutor());
-    }
-
-    @Override
-    public void andThen(ExecutionCallback<ClientMessage> callback, Executor executor) {
-        synchronized (this) {
-            if (response != null) {
-                runAsynchronous(callback, executor);
-                return;
-            }
-            callbackNodeList.add(new ExecutionCallbackNode(callback, executor));
-        }
-    }
-
-    private void runAsynchronous(final ExecutionCallback callback, Executor executor) {
-        try {
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        ClientMessage resp;
-                        try {
-                            resp = resolveResponse();
-                        } catch (Throwable t) {
-                            callback.onFailure(t);
-                            return;
-                        }
-                        callback.onResponse(resp);
-                    } catch (Throwable t) {
-                        logger.severe("Failed to execute callback: " + callback
-                                + "! Request: " + clientMessage + ", response: " + response, t);
-                    }
-                }
-            });
-        } catch (RejectedExecutionException e) {
-            logger.warning("Execution of callback: " + callback + " is rejected!", e);
-            callback.onFailure(new HazelcastClientNotActiveException(e.getMessage()));
-        }
     }
 
     public ClientInvocation getInvocation() {
         return invocation;
     }
-
-    static class ExecutionCallbackNode {
-
-        final ExecutionCallback callback;
-        final Executor executor;
-
-        ExecutionCallbackNode(ExecutionCallback callback, Executor executor) {
-            this.callback = callback;
-            this.executor = executor;
-        }
-    }
 }
+

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.InternalCompletableFuture;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.LockSupport;
+
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static com.hazelcast.util.Preconditions.isNotNull;
+import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
+import static java.util.concurrent.locks.LockSupport.park;
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+import static java.util.concurrent.locks.LockSupport.unpark;
+
+/**
+ * todo:
+ * - thread value protection
+ *
+ * The long term goal is that this whole class can be ripped out and replaced by the
+ * {@link java.util.concurrent.java.util.concurrent.CompletableFuture}. So we need to be very careful with adding more
+ * functionality to this class because the more we add, the more difficult the replacement will be.
+ *
+ * @param <V>
+ */
+public abstract class AbstractInvocationFuture<V> implements InternalCompletableFuture<V> {
+
+    static final Object VOID = "VOID";
+
+    // Reduce the risk of rare disastrous classloading in first call to
+    // LockSupport.park: https://bugs.openjdk.java.net/browse/JDK-8074773
+    static {
+        Class<?> ensureLoaded = LockSupport.class;
+    }
+
+    private static final AtomicReferenceFieldUpdater<AbstractInvocationFuture, Object> STATE =
+            newUpdater(AbstractInvocationFuture.class, Object.class, "state");
+
+    protected final Executor defaultExecutor;
+    protected final ILogger logger;
+
+    /**
+     * This field contain the state of the future. Either the future is not complete and the state is:
+     * <ol>
+     * <li>VOID: no response is available.</li>
+     * <li>Thread instance: no response is available and a thread has blocked on completion (e.g. future.get)</li>
+     * <li>{@link ExecutionCallback} instance: no response is available and 1 {@link #andThen(ExecutionCallback)}
+     * was done using the default executor</li>
+     * <li>{@link WaitNode} instance: in case of multiple andThen registrations or future.gets or andThen with custom Executor
+     * </li>
+     * </ol>
+     *
+     * If the state is anything else, it is completed.
+     *
+     * The reason why a single future.get or registered ExecutionCallback doesn't create a WaitNode is that we don't want to cause
+     * additional litter since most of our API calls are a get or a single ExecutionCallback.
+     *
+     * The state field is replaced using a cas, so registration or setting a response is an atomic operation and therefor not
+     * prone to data-races. There is no need to use synchronized blocks.
+     */
+    private volatile Object state = VOID;
+
+    public AbstractInvocationFuture(Executor defaultExecutor, ILogger logger) {
+        this.defaultExecutor = defaultExecutor;
+        this.logger = logger;
+    }
+
+    boolean compareAndSetState(Object oldState, Object newState) {
+        return STATE.compareAndSet(this, oldState, newState);
+    }
+
+    protected final Object getState() {
+        return state;
+    }
+
+    @Override
+    public final boolean isDone() {
+        return isDone(state);
+    }
+
+    private boolean isDone(final Object state) {
+        if (state == null) {
+            return true;
+        }
+
+        return !(state == VOID
+                || state.getClass() == WaitNode.class
+                || state instanceof Thread
+                || state instanceof ExecutionCallback);
+    }
+
+    protected void onInterruptDetected() {
+    }
+
+    @Override
+    public final boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    @Override
+    public final boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public final V join() {
+        try {
+            // this method is quite inefficient when there is unchecked exception, because it will be wrapped
+            // in a ExecutionException, and then it is unwrapped again.
+            return get();
+        } catch (Throwable throwable) {
+            throw rethrow(throwable);
+        }
+    }
+
+    @Override
+    public final V getSafely() {
+        return join();
+    }
+
+    @Override
+    public final V get() throws InterruptedException, ExecutionException {
+        Object response = registerWaiter(Thread.currentThread(), null);
+        if (response != VOID) {
+            // no registration was done since a value is available.
+            return resolveAndThrow(response);
+        }
+
+        boolean interrupted = false;
+        try {
+            for (; ; ) {
+                park();
+                if (isDone()) {
+                    return resolveAndThrow(state);
+                } else if (Thread.interrupted()) {
+                    interrupted = true;
+                    onInterruptDetected();
+                }
+            }
+        } finally {
+            restoreInterrupt(interrupted);
+        }
+    }
+
+    @Override
+    public final V get(final long timeout, final TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        Object response = registerWaiter(Thread.currentThread(), null);
+        if (response != VOID) {
+            return resolveAndThrow(response);
+        }
+
+        long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+        boolean interrupted = false;
+        try {
+            long timeoutNanos = unit.toNanos(timeout);
+            while (timeoutNanos > 0) {
+                parkNanos(timeoutNanos);
+                timeoutNanos = deadlineNanos - System.nanoTime();
+
+                if (isDone()) {
+                    return resolveAndThrow(state);
+                } else if (Thread.interrupted()) {
+                    interrupted = true;
+                    onInterruptDetected();
+                }
+            }
+        } finally {
+            restoreInterrupt(interrupted);
+        }
+
+        unregisterWaiter(Thread.currentThread());
+        throw newTimeoutException(timeout, unit);
+    }
+
+    private void restoreInterrupt(boolean interrupted) {
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public final void andThen(ExecutionCallback<V> callback) {
+        andThen(callback, defaultExecutor);
+    }
+
+    @Override
+    public final void andThen(ExecutionCallback<V> callback, Executor executor) {
+        isNotNull(callback, "callback");
+        isNotNull(executor, "executor");
+
+        Object response = registerWaiter(callback, executor);
+        if (response != VOID) {
+            unblock(callback, executor);
+        }
+    }
+
+    private void unblockAll(Object waiter, Executor executor) {
+        while (waiter != null) {
+            if (waiter instanceof Thread) {
+                unpark((Thread) waiter);
+                return;
+            } else if (waiter instanceof ExecutionCallback) {
+                unblock((ExecutionCallback) waiter, executor);
+                return;
+            } else if (waiter.getClass() == WaitNode.class) {
+                WaitNode waitNode = (WaitNode) waiter;
+                unblockAll(waitNode.waiter, waitNode.executor);
+                waiter = waitNode.next;
+            } else {
+                return;
+            }
+        }
+    }
+
+    private void unblock(final ExecutionCallback<V> callback, Executor executor) {
+        try {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        Object value = resolve(state);
+                        if (value instanceof Throwable) {
+                            Throwable error = unwrap((Throwable) value);
+                            callback.onFailure(error);
+                        } else {
+                            callback.onResponse((V) value);
+                        }
+                    } catch (Throwable cause) {
+                        logger.severe("Failed asynchronous execution of execution callback: " + callback
+                                + "for call " + invocationToString(), cause);
+                    }
+                }
+
+            });
+        } catch (RejectedExecutionException e) {
+            logger.warning("Execution of callback: " + callback + " is rejected!", e);
+        }
+    }
+
+    // this method should not be needed; but there is a difference between client and server how it handles async throwables.
+    protected Throwable unwrap(Throwable throwable) {
+        if (throwable instanceof ExecutionException) {
+            return throwable.getCause();
+        }
+        return throwable;
+    }
+
+    protected abstract String invocationToString();
+
+    protected Object resolve(Object value) {
+        return value;
+    }
+
+    protected abstract V resolveAndThrow(Object state) throws ExecutionException, InterruptedException;
+
+    protected abstract TimeoutException newTimeoutException(long timeout, TimeUnit unit);
+
+    /**
+     * Registers a waiter (thread/ExecutionCallback) that gets notified when the future completes.
+     *
+     * @param waiter   the waiter
+     * @param executor the {@link Executor} to use in case of an {@link ExecutionCallback}.
+     * @return VOID if the registration was a success, anything else but void is the response.
+     */
+    private Object registerWaiter(Object waiter, Executor executor) {
+        WaitNode waitNode = null;
+        for (; ; ) {
+            final Object oldState = state;
+            if (isDone(oldState)) {
+                return oldState;
+            }
+
+            Object newState;
+            if (oldState == VOID && (executor == null || executor == defaultExecutor)) {
+                // Nothing is syncing on this future, so instead of creating a WaitNode, we just try to cas the waiter
+                newState = waiter;
+            } else {
+                // something already has been registered for syncing. So we need to create a WaitNode.
+                if (waitNode == null) {
+                    waitNode = new WaitNode(waiter, executor);
+                }
+                waitNode.next = oldState;
+                newState = waitNode;
+            }
+
+            if (compareAndSetState(oldState, newState)) {
+                // we have successfully registered
+                return VOID;
+            }
+        }
+    }
+
+    void unregisterWaiter(Thread waiter) {
+        WaitNode prev = null;
+        Object current = state;
+
+        while (current != null) {
+            Object currentWaiter = current.getClass() == WaitNode.class ? ((WaitNode) current).waiter : current;
+            Object next = current.getClass() == WaitNode.class ? ((WaitNode) current).next : null;
+
+            if (currentWaiter == waiter) {
+                // it is the item we are looking for; so lets try to remove it,
+                if (prev == null) {
+                    // it is the first item of the stack; so we need to change the head to the next.
+                    Object n = next == null ? VOID : next;
+                    // if we manage to cas, we are done, else we need to restart.
+                    current = compareAndSetState(current, n) ? null : state;
+                } else {
+                    // remove the current item; this is done by letting the prev.next point to the next instead of current.
+                    prev.next = next;
+                    // end the loop
+                    current = null;
+                }
+            } else {
+                // it isn't the item we are looking for; so lets move on to the next.
+                prev = current.getClass() == WaitNode.class ? (WaitNode) current : null;
+                current = next;
+            }
+        }
+    }
+
+    /**
+     * Can be called multiple times, but only the first answer will lead to the future getting triggered. All subsequent
+     * complete calls are ignored.
+     *
+     * @param value The type of response to offer.
+     * @return <tt>true</tt> if offered response, either a final response or an internal response,
+     * is set/applied, <tt>false</tt> otherwise. If <tt>false</tt> is returned, that means offered response is ignored
+     * because a final response is already set to this future.
+     */
+    public final boolean complete(Object value) {
+        for (; ; ) {
+            final Object oldState = state;
+            if (isDone(oldState)) {
+                // it can be that this invocation future already received an answer, e.g. when an invocation already received a
+                // response, but before it cleans up itself, it receives a HazelcastInstanceNotActiveException.
+                logger.warning("The Future.complete(Object value) can only be called once. Request: " + invocationToString()
+                        + ", current response: " + getState() + ", new response: " + value);
+
+                return false;
+            }
+
+            if (compareAndSetState(oldState, value)) {
+                unblockAll(oldState, defaultExecutor);
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        Object state = getState();
+        if (isDone(state)) {
+            return "InvocationFuture{invocation=" + invocationToString() + ", value=" + state + '}';
+        } else {
+            return "InvocationFuture{invocation=" + invocationToString() + ", done=false}";
+        }
+    }
+
+    /**
+     * Linked nodes to record waiting {@link Thread} or {@link ExecutionCallback} instances using a Treiber stack.
+     *
+     * A waiter is something that gets triggered when a response comes in. There are 2 types of waiters:
+     * <ol>
+     * <li>Thread: when a future.get is done.</li>
+     * <li>ExecutionCallback: when a future.andThen is done</li>
+     * </ol>
+     * The waiter is either a Thread or an ExecutionCallback.
+     *
+     * The {@link WaitNode} is effectively immutable. Once the WaitNode is set in the 'state' field, it will not be modified.
+     * Also updating the state, introduces a happens before relation so the 'next' field can be read safely.
+     */
+    static final class WaitNode {
+        final Object waiter;
+        volatile Object next;
+        private final Executor executor;
+
+        WaitNode(Object waiter, Executor executor) {
+            this.waiter = waiter;
+            this.executor = executor;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -16,25 +16,18 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.InternalCompletableFuture;
-import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
+import com.hazelcast.spi.impl.AbstractInvocationFuture;
 
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.CALL_TIMEOUT;
-import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.HEARTBEAT_TIMEOUT;
-import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.INTERRUPTED;
-import static com.hazelcast.spi.impl.operationservice.impl.InternalResponse.VOID;
+import static com.hazelcast.spi.impl.operationservice.impl.InvocationValue.CALL_TIMEOUT;
+import static com.hazelcast.spi.impl.operationservice.impl.InvocationValue.HEARTBEAT_TIMEOUT;
+import static com.hazelcast.spi.impl.operationservice.impl.InvocationValue.INTERRUPTED;
 import static com.hazelcast.util.ExceptionUtil.fixAsyncStackTrace;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
-import static com.hazelcast.util.Preconditions.isNotNull;
 import static com.hazelcast.util.StringUtil.timeToString;
 import static java.lang.System.currentTimeMillis;
 
@@ -43,219 +36,58 @@ import static java.lang.System.currentTimeMillis;
  * of a {@link Invocation}. The Invocation executes an operation.
  *
  * In the past the InvocationFuture.get logic was also responsible for detecting the heartbeat for blocking operations
- * using the CONTINUE_WAIT and detecting if an operation is still running using the IsStillRunning funtionality. This
+ * using the CONTINUE_WAIT and detecting if an operation is still running using the IsStillRunning functionality. This
  * has been removed from the future and moved into the {@link InvocationMonitor}.
  *
  * @param <E>
  */
-final class InvocationFuture<E> implements InternalCompletableFuture<E> {
+final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
 
     volatile boolean interrupted;
-    volatile Object response = VOID;
-
     final Invocation invocation;
     private final boolean deserialize;
-    private final OperationServiceImpl operationService;
-    private volatile ExecutionCallbackNode<E> callbackHead;
 
     InvocationFuture(OperationServiceImpl operationService, Invocation invocation, boolean deserialize) {
+        super(operationService.asyncExecutor, invocation.logger);
         this.invocation = invocation;
-        this.operationService = operationService;
         this.deserialize = deserialize;
     }
 
     @Override
-    public void andThen(ExecutionCallback<E> callback) {
-        andThen(callback, operationService.asyncExecutor);
+    protected String invocationToString() {
+        return invocation.toString();
     }
 
     @Override
-    public void andThen(ExecutionCallback<E> callback, Executor executor) {
-        isNotNull(callback, "callback");
-        isNotNull(executor, "executor");
-
-        synchronized (this) {
-            if (response != VOID) {
-                runAsynchronous(callback, executor);
-                return;
-            }
-
-            this.callbackHead = new ExecutionCallbackNode<E>(callback, executor, callbackHead);
-        }
-    }
-
-    private void runAsynchronous(final ExecutionCallback<E> callback, Executor executor) {
-        try {
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        Object resolvedResponse = resolve(response);
-
-                        if (resolvedResponse == null || !(resolvedResponse instanceof Throwable)) {
-                            callback.onResponse((E) resolvedResponse);
-                        } else {
-                            Throwable error = (Throwable) resolvedResponse;
-                            if (error instanceof ExecutionException) {
-                                error = error.getCause();
-                            }
-                            callback.onFailure(error);
-                        }
-                    } catch (Throwable cause) {
-                        invocation.logger.severe("Failed asynchronous execution of execution callback: " + callback
-                                + "for call " + invocation, cause);
-                    }
-                }
-            });
-        } catch (RejectedExecutionException e) {
-            invocation.logger.warning("Execution of callback: " + callback + " is rejected!", e);
-        }
-    }
-
-    /**
-     * Can be called multiple times, but only the first answer will lead to the future getting triggered. All subsequent
-     * 'set' calls are ignored.
-     *
-     * @param offeredResponse The type of response to offer.
-     * @return <tt>true</tt> if offered response, either a final response or an internal response,
-     * is set/applied, <tt>false</tt> otherwise. If <tt>false</tt> is returned, that means offered response is ignored
-     * because a final response is already set to this future.
-     */
-    public boolean complete(Object offeredResponse) {
-        assert !(offeredResponse instanceof Response) : "unexpected response found: " + offeredResponse;
-
-        ExecutionCallbackNode<E> callbackChain;
-        synchronized (this) {
-            if (response != VOID) {
-                // it can be that this invocation future already received an answer, e.g. when an invocation already received a
-                // response, but before it cleans up itself, it receives a HazelcastInstanceNotActiveException.
-
-                if (invocation.logger.isFinestEnabled()) {
-                    invocation.logger.finest("Future response is already set! Current response: "
-                            + response + ", Offered response: " + offeredResponse + ", Invocation: " + invocation);
-                }
-
-                return false;
-            }
-
-            response = offeredResponse;
-            callbackChain = callbackHead;
-            callbackHead = null;
-            notifyAll();
-
-            operationService.invocationRegistry.deregister(invocation);
-        }
-
-        notifyCallbacks(callbackChain);
-        return true;
-    }
-
-    private void notifyCallbacks(ExecutionCallbackNode<E> callbackChain) {
-        while (callbackChain != null) {
-            runAsynchronous(callbackChain.callback, callbackChain.executor);
-            callbackChain = callbackChain.next;
-        }
+    protected TimeoutException newTimeoutException(long timeout, TimeUnit unit) {
+        return new TimeoutException(invocation.op.getClass().getSimpleName() + " failed to complete within "
+                + timeout + " " + unit + ". " + invocation);
     }
 
     @Override
-    public E join() {
-        try {
-            // this method is quite inefficient when there is unchecked exception, because it will be wrapped
-            // in a ExecutionException, and then it is unwrapped again.
-            return get();
-        } catch (Throwable throwable) {
-            throw rethrow(throwable);
-        }
+    protected void onInterruptDetected() {
+        interrupted = true;
     }
 
     @Override
-    public E getSafely() {
-        return join();
-    }
+    protected E resolveAndThrow(Object unresolved) throws ExecutionException, InterruptedException {
+        Object value = resolve(unresolved);
 
-    @Override
-    public E get() throws InterruptedException, ExecutionException {
-        if (response != VOID) {
-            return resolveAndThrow(response);
-        }
-
-        boolean threadInterrupted = false;
-        try {
-            synchronized (this) {
-                while (response == VOID) {
-                    try {
-                        wait();
-                    } catch (InterruptedException e) {
-                        threadInterrupted = true;
-                        interrupted = true;
-                    }
-                }
-            }
-
-            return resolveAndThrow(response);
-        } finally {
-            restoreInterrupt(threadInterrupted);
-        }
-    }
-
-    @Override
-    public E get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        if (response != VOID) {
-            return resolveAndThrow(response);
-        }
-
-        boolean threadInterrupted = false;
-        long timeoutMillis = unit.toMillis(timeout);
-        final long deadLineMillis = currentTimeMillis() + timeoutMillis;
-        try {
-            synchronized (this) {
-                while (response == VOID) {
-                    if (timeoutMillis <= 0) {
-                        throw new TimeoutException(invocation.op.getClass().getSimpleName() + " failed to complete within "
-                                + timeout + " " + unit + ". " + invocation);
-                    }
-
-                    try {
-                        wait(timeoutMillis);
-                    } catch (InterruptedException e) {
-                        interrupted = true;
-                    }
-
-                    timeoutMillis = deadLineMillis - currentTimeMillis();
-                }
-            }
-
-            return resolveAndThrow(response);
-        } finally {
-            restoreInterrupt(threadInterrupted);
-        }
-    }
-
-    private void restoreInterrupt(boolean threadInterrupted) {
-        if (threadInterrupted && response != INTERRUPTED) {
-            // if the thread got interrupted, but we did not manage to interrupt the invocation, we need to restore
-            // the interrupt flag
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    private E resolveAndThrow(Object unresolved) throws ExecutionException, InterruptedException {
-        Object response = resolve(unresolved);
-
-        if (response == null || !(response instanceof Throwable)) {
-            return (E) response;
-        } else if (response instanceof ExecutionException) {
-            throw (ExecutionException) response;
-        } else if (response instanceof InterruptedException) {
-            throw (InterruptedException) response;
-        } else if (response instanceof Error) {
-            throw (Error) response;
+        if (value == null || !(value instanceof Throwable)) {
+            return (E) value;
+        } else if (value instanceof ExecutionException) {
+            throw (ExecutionException) value;
+        } else if (value instanceof InterruptedException) {
+            throw (InterruptedException) value;
+        } else if (value instanceof Error) {
+            throw (Error) value;
         } else {
-            throw new ExecutionException((Throwable) response);
+            throw new ExecutionException((Throwable) value);
         }
     }
 
-    private Object resolve(Object unresolved) {
+    @Override
+    protected Object resolve(Object unresolved) {
         if (unresolved == null) {
             return null;
         } else if (unresolved == INTERRUPTED) {
@@ -266,21 +98,21 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
             return newOperationTimeoutException(true);
         }
 
-        Object response = unresolved;
-        if (deserialize && response instanceof Data) {
-            response = invocation.nodeEngine.toObject(response);
-            if (response == null) {
+        Object value = unresolved;
+        if (deserialize && value instanceof Data) {
+            value = invocation.nodeEngine.toObject(value);
+            if (value == null) {
                 return null;
             }
         }
 
-        if (response instanceof Throwable) {
-            Throwable throwable = ((Throwable) response);
-            fixAsyncStackTrace((Throwable) response, Thread.currentThread().getStackTrace());
+        if (value instanceof Throwable) {
+            Throwable throwable = ((Throwable) value);
+            fixAsyncStackTrace((Throwable) value, Thread.currentThread().getStackTrace());
             return throwable;
         }
 
-        return response;
+        return value;
     }
 
     private Object newOperationTimeoutException(boolean heartbeatTimeout) {
@@ -291,25 +123,17 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
 
             sb.append("Current time: ").append(timeToString(currentTimeMillis())).append(". ");
 
-
             sb.append("Total elapsed time: ")
                     .append(currentTimeMillis() - invocation.firstInvocationTimeMillis).append(" ms. ");
+
             long lastHeartbeatMillis = invocation.lastHeartbeatMillis;
             sb.append("Last heartbeat: ");
-            if (lastHeartbeatMillis == 0) {
-                sb.append("never. ");
-            } else {
-                sb.append(timeToString(lastHeartbeatMillis)).append(". ");
-            }
+            appendHeartbeat(sb, lastHeartbeatMillis);
 
             long lastHeartbeatFromMemberMillis = invocation.operationService.invocationMonitor
                     .getLastMemberHeartbeatMillis(invocation.invTarget);
             sb.append("Last member heartbeat: ");
-            if (lastHeartbeatFromMemberMillis == 0) {
-                sb.append("never. ");
-            } else {
-                sb.append(timeToString(lastHeartbeatFromMemberMillis)).append(". ");
-            }
+            appendHeartbeat(sb, lastHeartbeatFromMemberMillis);
         } else {
             sb.append(invocation.op.getClass().getSimpleName())
                     .append(" got rejected before execution due to not starting within the operation-call-timeout of: ")
@@ -326,35 +150,11 @@ final class InvocationFuture<E> implements InternalCompletableFuture<E> {
         return new ExecutionException(msg, new OperationTimeoutException(msg));
     }
 
-    @Override
-    public boolean cancel(boolean mayInterruptIfRunning) {
-        return false;
-    }
-
-    @Override
-    public boolean isCancelled() {
-        return false;
-    }
-
-    @Override
-    public boolean isDone() {
-        return response != VOID;
-    }
-
-    @Override
-    public String toString() {
-        return "InvocationFuture{invocation=" + invocation.toString() + ", response=" + response + ", done=" + isDone() + '}';
-    }
-
-    private static final class ExecutionCallbackNode<E> {
-        private final ExecutionCallback<E> callback;
-        private final Executor executor;
-        private final ExecutionCallbackNode<E> next;
-
-        private ExecutionCallbackNode(ExecutionCallback<E> callback, Executor executor, ExecutionCallbackNode<E> next) {
-            this.callback = callback;
-            this.executor = executor;
-            this.next = next;
+    private void appendHeartbeat(StringBuilder sb, long lastHeartbeatMillis) {
+        if (lastHeartbeatMillis == 0) {
+            sb.append("never. ");
+        } else {
+            sb.append(timeToString(lastHeartbeatMillis)).append(". ");
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationValue.java
@@ -16,29 +16,32 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
-final class InternalResponse {
+/**
+ * Contains some predefined values for the Invocation.
+ */
+final class InvocationValue {
 
     /**
-     * A response indicating that an operation is considered to be dead. So the system has no way of
+     * A value indicating that an operation is considered to be dead. So the system has no way of
      * figuring out what happened to the operation or to its response.
      */
-    static final Object HEARTBEAT_TIMEOUT = new InternalResponse("Invocation::HEARTBEAT_TIMEOUT");
+    static final Object HEARTBEAT_TIMEOUT = new InvocationValue("Invocation::HEARTBEAT_TIMEOUT");
 
     /**
-     * A response indicating that an operation got rejected on the executing side because its call timeout expired.
+     * A value indicating that an operation got rejected on the executing side because its call timeout expired.
      */
-    static final Object CALL_TIMEOUT = new InternalResponse("Invocation::CALL_TIMEOUT");
+    static final Object CALL_TIMEOUT = new InvocationValue("Invocation::CALL_TIMEOUT");
 
     /**
-     * A response indicating that the operation execution was interrupted.
+     * A value indicating that the operation execution was interrupted.
      */
-    static final Object INTERRUPTED = new InternalResponse("Invocation::INTERRUPTED");
+    static final Object INTERRUPTED = new InvocationValue("Invocation::INTERRUPTED");
 
-    static final Object VOID = new InternalResponse("VOID");
+    static final Object VOID = new InvocationValue("VOID");
 
     private String toString;
 
-    InternalResponse(String toString) {
+    private InvocationValue(String toString) {
         this.toString = toString;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
@@ -1,0 +1,72 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public abstract class AbstractInvocationFuture_AbstractTest extends HazelcastTestSupport {
+
+    protected ILogger logger;
+    protected Executor executor;
+    protected TestFuture future;
+    protected Object value = "somevalue";
+
+    @Before
+    public void setup() {
+        logger = Logger.getLogger(getClass());
+        executor = Executors.newSingleThreadExecutor();
+        future = new TestFuture();
+    }
+
+
+    class TestFuture extends AbstractInvocationFuture {
+        volatile boolean interruptDetected;
+
+        public TestFuture() {
+            super(AbstractInvocationFuture_AbstractTest.this.executor, AbstractInvocationFuture_AbstractTest.this.logger);
+        }
+
+        public TestFuture(Executor executor, ILogger logger) {
+            super(executor, logger);
+        }
+
+        @Override
+        protected void onInterruptDetected() {
+            interruptDetected = true;
+            complete(new InterruptedException());
+        }
+
+        @Override
+        protected String invocationToString() {
+            return "someinvocation";
+        }
+
+        @Override
+        protected Object resolveAndThrow(Object state) throws ExecutionException, InterruptedException {
+            if (state instanceof Throwable) {
+                if (state instanceof Error) {
+                    throw (Error) state;
+                } else if (state instanceof RuntimeException) {
+                    throw (RuntimeException) state;
+                } else if (state instanceof InterruptedException) {
+                    throw (InterruptedException) state;
+                } else {
+                    throw new ExecutionException((Throwable) state);
+                }
+            }
+            return state;
+        }
+
+        @Override
+        protected TimeoutException newTimeoutException(long timeout, TimeUnit unit) {
+            return new TimeoutException();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AndThenTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AndThenTest.java
@@ -1,0 +1,138 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.ExpectedRuntimeException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractInvocationFuture_AndThenTest extends AbstractInvocationFuture_AbstractTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenNullCallback0() {
+        future.andThen(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenNullCallback1() {
+        future.andThen(null, mock(Executor.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenNullExecutor() {
+        future.andThen(mock(ExecutionCallback.class), null);
+    }
+
+    @Test
+    public void whenCustomerExecutor() {
+        Executor defaultExecutor = mock(Executor.class);
+        Executor customExecutor = mock(Executor.class);
+        TestFuture future = new TestFuture(defaultExecutor, logger);
+        final ExecutionCallback callback = mock(ExecutionCallback.class);
+        future.andThen(callback, customExecutor);
+
+        future.complete(value);
+
+        verify(customExecutor).execute(any(Runnable.class));
+        verifyZeroInteractions(defaultExecutor);
+    }
+
+    @Test
+    public void whenDefaultExecutor() {
+        Executor defaultExecutor = mock(Executor.class);
+        TestFuture future = new TestFuture(defaultExecutor, logger);
+        final ExecutionCallback callback = mock(ExecutionCallback.class);
+        future.andThen(callback);
+
+        future.complete(value);
+
+        verify(defaultExecutor).execute(any(Runnable.class));
+    }
+
+    @Test
+    public void whenResponseAlreadyAvailable() {
+        future.complete(value);
+
+        final ExecutionCallback callback = mock(ExecutionCallback.class);
+        future.andThen(callback);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                verify(callback).onResponse(value);
+            }
+        });
+    }
+
+    @Test
+    public void whenResponseAvailableAfterSomeWaiting() {
+        final ExecutionCallback callback = mock(ExecutionCallback.class);
+        future.andThen(callback);
+
+        sleepSeconds(5);
+        verifyZeroInteractions(callback);
+
+        future.complete(value);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                verify(callback).onResponse(value);
+            }
+        });
+    }
+
+    @Test
+    public void whenExceptionalResponseAvailableAfterSomeWaiting() {
+        final ExecutionCallback callback = mock(ExecutionCallback.class);
+        future.andThen(callback);
+
+        sleepSeconds(5);
+        verifyZeroInteractions(callback);
+
+        final ExpectedRuntimeException ex = new ExpectedRuntimeException();
+        future.complete(ex);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                verify(callback).onFailure(ex);
+            }
+        });
+    }
+
+    @Test
+    public void whenMultipleCallbacks() throws ExecutionException, InterruptedException {
+        List<ExecutionCallback> callbacks = new LinkedList<ExecutionCallback>();
+        for (int k = 0; k < 10; k++) {
+            ExecutionCallback callback = mock(ExecutionCallback.class);
+            future.andThen(callback);
+        }
+
+        sleepSeconds(5);
+        future.complete(value);
+
+        for (ExecutionCallback callback : callbacks) {
+            verify(callback).onResponse(value);
+        }
+
+        assertSame(value, future.getState());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_CancelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_CancelTest.java
@@ -1,0 +1,25 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractInvocationFuture_CancelTest extends AbstractInvocationFuture_AbstractTest {
+
+    @Test
+    public void whenCalled_thenIgnored() {
+        assertFalse(future.cancel(true));
+        assertFalse(future.isCancelled());
+
+        future.complete(value);
+        assertSame(value, future.join());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_CompleteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_CompleteTest.java
@@ -1,0 +1,26 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractInvocationFuture_CompleteTest extends AbstractInvocationFuture_AbstractTest {
+
+    @Test
+    public void whenAlreadyCompleted_thenIgnored(){
+        future.complete(value);
+
+        Object newValue = new Object();
+        future.complete(newValue);
+
+        assertSame(value, future.getState());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetSafely.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetSafely.java
@@ -1,0 +1,82 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.ExpectedRuntimeException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractInvocationFuture_GetSafely extends AbstractInvocationFuture_AbstractTest{
+
+    @Test
+    public void whenNormalResponse() throws ExecutionException, InterruptedException {
+        future.complete(value);
+
+        Future joinFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.getSafely();
+            }
+        });
+
+        assertCompletesEventually(joinFuture);
+        assertSame(value, joinFuture.get());
+    }
+
+    @Test
+    public void whenRuntimeException() throws Exception {
+        ExpectedRuntimeException ex = new ExpectedRuntimeException();
+        future.complete(ex);
+
+        Future joinFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.getSafely();
+            }
+        });
+
+        assertCompletesEventually(joinFuture);
+        try {
+            joinFuture.get();
+            fail();
+        } catch (ExecutionException e) {
+            assertSame(ex, e.getCause());
+        }
+    }
+
+    @Test
+    public void whenRegularException() throws Exception {
+        Exception ex = new Exception();
+        future.complete(ex);
+
+        Future joinFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.getSafely();
+            }
+        });
+
+        assertCompletesEventually(joinFuture);
+        try {
+            joinFuture.get();
+            fail();
+        } catch (ExecutionException e) {
+            // The 'ex' is wrapped in an unchecked HazelcastException
+            HazelcastException hzEx = assertInstanceOf(HazelcastException.class, e.getCause());
+            assertSame(ex, hzEx.getCause());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetTest.java
@@ -1,0 +1,156 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.spi.impl.AbstractInvocationFuture.VOID;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractInvocationFuture_GetTest extends AbstractInvocationFuture_AbstractTest {
+
+    @Test
+    public void whenResultAlreadyAvailable() throws Exception {
+        future.complete(value);
+
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.get();
+            }
+        });
+
+        assertCompletesEventually(getFuture);
+        assertSame(value, future.get());
+    }
+
+    @Test
+    public void whenResultAlreadyAvailable_andInterruptFlagSet() throws Exception {
+        future.complete(value);
+
+        final AtomicBoolean interrupted = new AtomicBoolean();
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                // we set the interrupt flag.
+                Thread.currentThread().interrupt();
+                Object value = future.get();
+                // and then we check if the interrupt flag is still set
+                interrupted.set(Thread.currentThread().isInterrupted());
+                return value;
+            }
+        });
+
+        assertCompletesEventually(getFuture);
+        assertSame(value, future.get());
+        assertTrue(interrupted.get());
+    }
+
+    @Test
+    public void whenSomeWaitingNeeded() throws ExecutionException, InterruptedException {
+        future.complete(value);
+
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.get();
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotSame(VOID, future.getState());
+            }
+        });
+
+        sleepSeconds(5);
+
+        assertCompletesEventually(getFuture);
+        assertSame(value, future.get());
+
+    }
+
+    @Test
+    public void whenInterruptedWhileWaiting() throws Exception {
+        final AtomicReference<Thread> thread = new AtomicReference<Thread>();
+        final AtomicBoolean interrupted = new AtomicBoolean();
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                thread.set(Thread.currentThread());
+                try {
+                    return future.get();
+                } finally {
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                }
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotSame(VOID, future.getState());
+            }
+        });
+
+        sleepSeconds(5);
+        thread.get().interrupt();
+
+        assertCompletesEventually(getFuture);
+        assertTrue(interrupted.get());
+
+        try {
+            future.get();
+            fail();
+        } catch (InterruptedException e) {
+        }
+    }
+
+    @Test
+    public void whenMultipleGetters() throws ExecutionException, InterruptedException {
+        List<Future> getFutures = new LinkedList<Future>();
+        for (int k = 0; k < 10; k++) {
+            getFutures.add(spawn(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return future.get();
+                }
+            }));
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotSame(VOID, future.getState());
+            }
+        });
+
+        sleepSeconds(5);
+        future.complete(value);
+
+        for (Future getFuture : getFutures) {
+            assertCompletesEventually(getFuture);
+            assertSame(value, future.get());
+        }
+
+        assertSame(value, future.getState());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetWithTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetWithTimeoutTest.java
@@ -1,0 +1,276 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.spi.impl.AbstractInvocationFuture.WaitNode;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.spi.impl.AbstractInvocationFuture.VOID;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractInvocationFuture_GetWithTimeoutTest extends AbstractInvocationFuture_AbstractTest {
+
+    @Test(expected = NullPointerException.class)
+    public void whenNullTimeunit() throws Exception {
+        future.get(1, null);
+    }
+
+    @Test
+    public void whenZeroTimeout_butResponseAvailable() throws Exception {
+        future.complete(value);
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.get(0, SECONDS);
+            }
+        });
+        assertCompletesEventually(getFuture);
+        assertSame(value, getFuture.get());
+    }
+
+    @Test
+    public void whenZeroTimeout_andNoResponseAvailable() throws Exception {
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.get(0, SECONDS);
+            }
+        });
+
+        assertCompletesEventually(getFuture);
+
+        try {
+            getFuture.get();
+            fail();
+        } catch (ExecutionException e) {
+            assertInstanceOf(TimeoutException.class, e.getCause());
+        }
+
+        // we need to make sure the thread is removed from the waiters.
+        assertSame(VOID, future.getState());
+    }
+
+    @Test
+    public void whenResponseAvailable() throws Exception {
+        future.complete(value);
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.get(10, SECONDS);
+            }
+        });
+        assertCompletesEventually(getFuture);
+        assertSame(value, getFuture.get());
+    }
+
+    @Test
+    public void whenResultAlreadyAvailable_andInterruptFlagSet() throws Exception {
+        future.complete(value);
+
+        final AtomicBoolean interrupted = new AtomicBoolean();
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                // we set the interrupt flag.
+                Thread.currentThread().interrupt();
+                Object value = future.get(1, SECONDS);
+                // and then we check if the interrupt flag is still set
+                interrupted.set(Thread.currentThread().isInterrupted());
+                return value;
+            }
+        });
+
+        assertCompletesEventually(getFuture);
+        assertSame(value, future.get());
+        assertTrue(interrupted.get());
+    }
+
+    @Test
+    public void whenResponseAvailableAfterSomeDelay() throws Exception {
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.get(60, SECONDS);
+            }
+        });
+
+        // wait till the thread is registered.
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotSame(VOID, future.getState());
+            }
+        });
+
+        future.complete(value);
+
+        assertCompletesEventually(getFuture);
+        assertSame(value, getFuture.get());
+    }
+
+    @Test
+    public void whenTimeout() throws ExecutionException, InterruptedException {
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.get(1, SECONDS);
+            }
+        });
+
+        assertCompletesEventually(getFuture);
+
+        try {
+            getFuture.get();
+            fail();
+        } catch (ExecutionException e) {
+            assertInstanceOf(TimeoutException.class, e.getCause());
+        }
+
+        // we need to make sure the thread is removed from the waiters.
+        assertSame(VOID, future.getState());
+    }
+
+    @Test
+    public void whenInterruptedWhileWaiting() throws Exception {
+        final AtomicReference<Thread> thread = new AtomicReference<Thread>();
+        final AtomicBoolean interrupted = new AtomicBoolean();
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                thread.set(Thread.currentThread());
+                try {
+                    return future.get(1, HOURS);
+                } finally {
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                }
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotSame(VOID, future.getState());
+            }
+        });
+
+        sleepSeconds(5);
+        thread.get().interrupt();
+
+        assertCompletesEventually(getFuture);
+        assertTrue(interrupted.get());
+
+        try {
+            future.get();
+            fail();
+        } catch (InterruptedException e) {
+        }
+    }
+
+    @Test
+    public void whenMultipleGetters() throws Exception {
+        List<Future> getFutures = new LinkedList<Future>();
+        for (int k = 0; k < 10; k++) {
+            getFutures.add(spawn(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return future.get(1, DAYS);
+                }
+            }));
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotSame(VOID, future.getState());
+            }
+        });
+
+        sleepSeconds(5);
+        future.complete(value);
+
+        for (Future getFuture : getFutures) {
+            assertCompletesEventually(getFuture);
+            assertSame(value, future.get());
+        }
+
+        assertSame(value, future.getState());
+    }
+
+    @Test
+    public void unregister() {
+        for (int length = 1; length <= 5; length++) {
+            for (int position = 0; position < length; position++) {
+                unregister(length, position);
+            }
+        }
+    }
+
+    private void unregister(int length, int position) {
+        TestFuture future = new TestFuture();
+        Thread[] threads = createThread(length);
+        for (int k = 0; k < length; k++) {
+            if (k == 0) {
+                future.compareAndSetState(VOID, threads[k]);
+            } else {
+                WaitNode node = new WaitNode(threads[k], null);
+                node.next = future.getState();
+                future.compareAndSetState(future.getState(), node);
+            }
+        }
+
+        future.unregisterWaiter(threads[position]);
+
+        for (int k = 0; k < length; k++) {
+            assertContains(future.getState(), threads[k], k != position);
+        }
+    }
+
+    private void assertContains(Object state, Thread waiter, boolean contains) {
+        boolean found = false;
+
+        Object current = state;
+        while (current != null) {
+            Object currentWaiter = current.getClass() == WaitNode.class ? ((WaitNode) current).waiter : current;
+            Object next = current.getClass() == WaitNode.class ? ((WaitNode) current).next : null;
+
+            if (currentWaiter == waiter) {
+                found = true;
+                current = null;
+            } else {
+                current = next;
+            }
+        }
+
+        assertEquals(contains, found);
+    }
+
+    private Thread[] createThread(int length) {
+        Thread[] threads = new Thread[length];
+        for (int k = 0; k < threads.length; k++) {
+            threads[k] = new Thread();
+        }
+        return threads;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_IsDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_IsDoneTest.java
@@ -1,0 +1,88 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractInvocationFuture_IsDoneTest extends AbstractInvocationFuture_AbstractTest {
+
+    @Test
+    public void whenVoid() {
+        assertFalse(future.isDone());
+    }
+
+    @Test
+    public void whenNullResult() {
+        future.complete(null);
+        assertTrue(future.isDone());
+    }
+
+    @Test
+    public void whenNoneNullResult() {
+        future.complete(value);
+        assertTrue(future.isDone());
+    }
+
+    @Test
+    public void whenExceptionalResult() {
+        future.complete(new RuntimeException());
+        assertTrue(future.isDone());
+    }
+
+    @Test
+    public void whenBlockingThread() {
+        spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.get();
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotSame(AbstractInvocationFuture.VOID, future.getState());
+            }
+        });
+
+        assertFalse(future.isDone());
+    }
+
+    @Test
+    public void whenCallbackWithoutCustomExecutor() {
+        future.andThen(mock(ExecutionCallback.class));
+
+        assertFalse(future.isDone());
+    }
+
+    @Test
+    public void whenCallbackWithCustomExecutor() {
+        future.andThen(mock(ExecutionCallback.class), mock(Executor.class));
+
+        assertFalse(future.isDone());
+    }
+
+    @Test
+    public void whenMultipleWaiters() {
+        future.andThen(mock(ExecutionCallback.class), mock(Executor.class));
+        future.andThen(mock(ExecutionCallback.class), mock(Executor.class));
+
+        assertFalse(future.isDone());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_JoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_JoinTest.java
@@ -1,0 +1,129 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.ExpectedRuntimeException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.spi.impl.AbstractInvocationFuture.VOID;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * The Join forwards to {@link AbstractInvocationFuture#get()}. So most of the testing will be
+ * in the {@link AbstractInvocationFuture_GetTest}. This test contains mostly the exception handling.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractInvocationFuture_JoinTest extends AbstractInvocationFuture_AbstractTest {
+
+    @Test
+    public void whenNormalResponse() throws ExecutionException, InterruptedException {
+        future.complete(value);
+
+        Future joinFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.join();
+            }
+        });
+
+        assertCompletesEventually(joinFuture);
+        assertSame(value, joinFuture.get());
+    }
+
+    @Test
+    public void whenRuntimeException() throws Exception {
+        ExpectedRuntimeException ex = new ExpectedRuntimeException();
+        future.complete(ex);
+
+        Future joinFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.join();
+            }
+        });
+
+        assertCompletesEventually(joinFuture);
+        try {
+            joinFuture.get();
+            fail();
+        } catch (ExecutionException e) {
+            assertSame(ex, e.getCause());
+        }
+    }
+
+    @Test
+    public void whenRegularException() throws Exception {
+        Exception ex = new Exception();
+        future.complete(ex);
+
+        Future joinFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return future.join();
+            }
+        });
+
+        assertCompletesEventually(joinFuture);
+        try {
+            joinFuture.get();
+            fail();
+        } catch (ExecutionException e) {
+            // The 'ex' is wrapped in an unchecked HazelcastException
+            HazelcastException hzEx = assertInstanceOf(HazelcastException.class, e.getCause());
+            assertSame(ex, hzEx.getCause());
+        }
+    }
+
+    @Test
+    public void whenInterrupted() throws Exception {
+        final AtomicReference<Thread> thread = new AtomicReference<Thread>();
+        final AtomicBoolean interrupted = new AtomicBoolean();
+        Future getFuture = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                thread.set(Thread.currentThread());
+                try {
+                    return future.join();
+                } finally {
+                    interrupted.set(Thread.currentThread().isInterrupted());
+                }
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNotSame(VOID, future.getState());
+            }
+        });
+
+        sleepSeconds(5);
+        thread.get().interrupt();
+
+        assertCompletesEventually(getFuture);
+        assertTrue(interrupted.get());
+
+        try {
+            future.join();
+            fail();
+        } catch (HazelcastException e) {
+            assertInstanceOf(InterruptedException.class, e.getCause());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_MiscTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_MiscTest.java
@@ -1,0 +1,28 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractInvocationFuture_MiscTest extends AbstractInvocationFuture_AbstractTest {
+
+    @Test
+    public void toString_whenNotCompleted() {
+        String s = future.toString();
+        assertEquals("InvocationFuture{invocation=someinvocation, done=false}", s);
+    }
+
+    @Test
+    public void toString_whenCompleted() {
+        future.complete(value);
+        String s = future.toString();
+        assertEquals("InvocationFuture{invocation=someinvocation, value=somevalue}", s);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
@@ -46,7 +46,7 @@ public class InvocationFuture_IsDoneTest extends HazelcastTestSupport {
         DummyOperation op = new GetLostPartitionOperation();
 
         InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null, op, getAddress(local));
-        future.complete(InternalResponse.INTERRUPTED);
+        future.complete(InvocationValue.INTERRUPTED);
 
         assertTrue(future.isDone());
     }
@@ -56,7 +56,7 @@ public class InvocationFuture_IsDoneTest extends HazelcastTestSupport {
         DummyOperation op = new GetLostPartitionOperation();
 
         InvocationFuture future = (InvocationFuture) operationService.invokeOnTarget(null, op, getAddress(local));
-        future.complete(InternalResponse.CALL_TIMEOUT);
+        future.complete(InvocationValue.CALL_TIMEOUT);
 
         assertTrue(future.isDone());
     }


### PR DESCRIPTION
The server and client invocation future are now dumb and make use of the AbstractInvocationFuture. The idea behind the AbstractInvocationFuture is:
- it is lock free
- it relies on LockSupport.park/unpark for notification. 
- in case of the ClientInvocationFuture it creates less litter since no LinkedList for callbacks is created. 
- there is less need for lock deflation since the new approach doesn't rely on a intrinsic lock. Therefore you get less gc hiccups (lock deflation is done when a the system does a gc).

This is one of the PRD's for increased performance.

Some performance impressions:
On the old lab using atomiclong.get and pure remote calls; they is roughly a 15% throughput improvement. Using pure local calls, there is roughly a 30% throughput improvement. Also latency goes down a lot; e.g. in case of the local one, max latencies goes from >1s to <30ms. 

Performance improvements on client are less spectacular; +/- 5% increased throughput. 

This is a piece of worked chopped of from:
https://github.com/hazelcast/hazelcast/pull/7915