### PR TITLE
Fixes a deadlock on internal executor when listeners are used

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
@@ -83,7 +83,12 @@ public enum ClientProperty implements HazelcastProperty {
      * eventually be removed when the experimental marker is removed.</p>
      * <p>Discovery SPI is <b>disabled</b> by default</p>
      */
-    DISCOVERY_SPI_ENABLED("hazelcast.discovery.enabled", false);
+    DISCOVERY_SPI_ENABLED("hazelcast.discovery.enabled", false),
+
+    /**
+     * Configures pool size of internal client executor. Private configuration, for internal usage only.
+     */
+    INTERNAL_EXECUTOR_POOL_SIZE("hazelcast.client.internal.executor.pool.size", 3);
 
     private final String name;
     private final String defaultValue;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -296,7 +296,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     private ClientExecutionServiceImpl initExecutionService() {
-        return new ClientExecutionServiceImpl(instanceName, threadGroup, config.getClassLoader(), config.getExecutorPoolSize());
+        return new ClientExecutionServiceImpl(instanceName, threadGroup, config.getClassLoader(), clientProperties,
+                config.getExecutorPoolSize());
     }
 
     public void start() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -34,7 +34,7 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.executor.PoolExecutorThreadFactory;
+import com.hazelcast.util.executor.SingleExecutorThreadFactory;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
@@ -75,8 +75,8 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     private ExecutorService createSingleThreadExecutorService(HazelcastClientInstanceImpl client) {
         ThreadGroup threadGroup = client.getThreadGroup();
         ClassLoader classLoader = client.getClientConfig().getClassLoader();
-        PoolExecutorThreadFactory threadFactory =
-                new PoolExecutorThreadFactory(threadGroup, client.getName() + ".cluster-", classLoader);
+        SingleExecutorThreadFactory threadFactory =
+                new SingleExecutorThreadFactory(threadGroup, classLoader, client.getName() + ".cluster-");
         return Executors.newSingleThreadExecutor(threadFactory);
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -27,13 +27,17 @@ import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.util.executor.SingleExecutorThreadFactory;
 import com.hazelcast.util.executor.StripedExecutor;
 import com.hazelcast.util.executor.StripedRunnable;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import java.util.logging.Level;
 
 public abstract class ClientListenerServiceImpl implements ClientListenerService {
@@ -43,6 +47,7 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
     protected final SerializationService serializationService;
     protected final ClientInvocationService invocationService;
     protected final ILogger logger = Logger.getLogger(ClientListenerService.class);
+    protected final ExecutorService registrationExecutor;
     private final ConcurrentMap<Long, EventHandler> eventHandlerMap
             = new ConcurrentHashMap<Long, EventHandler>();
 
@@ -50,11 +55,17 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
 
     public ClientListenerServiceImpl(HazelcastClientInstanceImpl client, int eventThreadCount, int eventQueueCapacity) {
         this.client = client;
-        this.executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
-        this.invocationService = client.getInvocationService();
-        this.serializationService = client.getSerializationService();
-        this.eventExecutor = new StripedExecutor(logger, client.getName() + ".event",
-                client.getThreadGroup(), eventThreadCount, eventQueueCapacity);
+        executionService = (ClientExecutionServiceImpl) client.getClientExecutionService();
+        invocationService = client.getInvocationService();
+        serializationService = client.getSerializationService();
+        ThreadGroup threadGroup = client.getThreadGroup();
+        String name = client.getName();
+        eventExecutor = new StripedExecutor(logger, name + ".event",
+                threadGroup, eventThreadCount, eventQueueCapacity);
+        ClassLoader classLoader = client.getClientConfig().getClassLoader();
+
+        ThreadFactory threadFactory = new SingleExecutorThreadFactory(threadGroup, classLoader, name + ".eventRegistration-");
+        registrationExecutor = Executors.newSingleThreadExecutor(threadFactory);
     }
 
     public void addEventHandler(long callId, EventHandler handler) {
@@ -79,6 +90,7 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
 
     public void shutdown() {
         eventExecutor.shutdown();
+        ClientExecutionServiceImpl.shutdownExecutor("registrationExecutor", registrationExecutor, logger);
     }
 
     public StripedExecutor getEventExecutor() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -28,6 +28,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.nio.Address;
+import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.UuidUtil;
 
 import java.util.Collection;
@@ -36,6 +37,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 
@@ -44,7 +46,6 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
     private final Set<Member> members = new HashSet<Member>();
     private final Map<ClientRegistrationKey, Map<Address, ClientEventRegistration>> registrations
             = new ConcurrentHashMap<ClientRegistrationKey, Map<Address, ClientEventRegistration>>();
-    private final Object listenerRegLock = new Object();
     private String membershipListenerId;
 
     public ClientSmartListenerService(HazelcastClientInstanceImpl client,
@@ -53,21 +54,29 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
     }
 
     @Override
-    public String registerListener(ListenerMessageCodec codec, EventHandler handler) {
-        String userRegistrationId = UuidUtil.newUnsecureUuidString();
-        synchronized (listenerRegLock) {
+    public String registerListener(final ListenerMessageCodec codec, final EventHandler handler) {
+        Future<String> future = registrationExecutor.submit(new Callable<String>() {
+            @Override
+            public String call() {
+                String userRegistrationId = UuidUtil.newUnsecureUuidString();
 
-            ClientRegistrationKey registrationKey = new ClientRegistrationKey(userRegistrationId, handler, codec);
-            registrations.put(registrationKey, new ConcurrentHashMap<Address, ClientEventRegistration>());
-            try {
-                for (Member member : this.members) {
-                    invoke(registrationKey, member.getAddress());
+                ClientRegistrationKey registrationKey = new ClientRegistrationKey(userRegistrationId, handler, codec);
+                registrations.put(registrationKey, new ConcurrentHashMap<Address, ClientEventRegistration>());
+                try {
+                    for (Member member : members) {
+                        invoke(registrationKey, member.getAddress());
+                    }
+                } catch (Exception e) {
+                    deregisterListener(userRegistrationId);
+                    throw new HazelcastException("Listener can not be added", e);
                 }
-            } catch (Exception e) {
-                deregisterListener(userRegistrationId);
-                throw new HazelcastException("Listener can not be added", e);
+                return userRegistrationId;
             }
-            return userRegistrationId;
+        });
+        try {
+            return future.get();
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
         }
     }
 
@@ -92,38 +101,42 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
     }
 
     @Override
-    public boolean deregisterListener(String userRegistrationId) {
-        synchronized (listenerRegLock) {
-            ClientRegistrationKey key = new ClientRegistrationKey(userRegistrationId);
-            Map<Address, ClientEventRegistration> registrationMap = registrations.get(key);
-
-            if (registrationMap == null) {
-                return false;
-            }
-
-
-            boolean successful = true;
-            for (ClientEventRegistration registration : registrationMap.values()) {
-                Address subscriber = registration.getSubscriber();
-                try {
-                    ListenerMessageCodec listenerMessageCodec = registration.getCodec();
-                    String serverRegistrationId = registration.getServerRegistrationId();
-                    ClientMessage request = listenerMessageCodec.encodeRemoveRequest(serverRegistrationId);
-                    Future future = new ClientInvocation(client, request, subscriber).invoke();
-                    future.get();
-                    removeEventHandler(registration.getCallId());
-                    registrationMap.remove(subscriber);
-                } catch (Exception e) {
-                    successful = false;
-                    logger.warning("Deregistration of listener with id " + userRegistrationId
-                            + " has failed to address " + subscriber, e);
+    public boolean deregisterListener(final String userRegistrationId) {
+        Future<Boolean> future = registrationExecutor.submit(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                ClientRegistrationKey key = new ClientRegistrationKey(userRegistrationId);
+                Map<Address, ClientEventRegistration> registrationMap = registrations.get(key);
+                if (registrationMap == null) {
+                    return false;
                 }
+                boolean successful = true;
+                for (ClientEventRegistration registration : registrationMap.values()) {
+                    Address subscriber = registration.getSubscriber();
+                    try {
+                        ListenerMessageCodec listenerMessageCodec = registration.getCodec();
+                        String serverRegistrationId = registration.getServerRegistrationId();
+                        ClientMessage request = listenerMessageCodec.encodeRemoveRequest(serverRegistrationId);
+                        new ClientInvocation(client, request, subscriber).invoke().get();
+                        removeEventHandler(registration.getCallId());
+                        registrationMap.remove(subscriber);
+                    } catch (Exception e) {
+                        successful = false;
+                        logger.warning("Deregistration of listener with id " + userRegistrationId
+                                + " has failed to address " + subscriber, e);
+                    }
+                }
+                if (successful) {
+                    registrations.remove(key);
+                }
+                return successful;
             }
+        });
 
-            if (successful) {
-                registrations.remove(key);
-            }
-            return successful;
+        try {
+            return future.get();
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
         }
 
     }
@@ -143,12 +156,49 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
 
     @Override
     public void memberAdded(final MembershipEvent membershipEvent) {
-        executionService.executeInternal(new Runnable() {
+        registrationExecutor.submit(new Runnable() {
             @Override
             public void run() {
-                synchronized (listenerRegLock) {
-                    Member member = membershipEvent.getMember();
-                    members.add(member);
+                Member member = membershipEvent.getMember();
+                members.add(member);
+                for (ClientRegistrationKey registrationKey : registrations.keySet()) {
+                    try {
+                        invoke(registrationKey, member.getAddress());
+                    } catch (Exception e) {
+                        logger.warning("Listener " + registrationKey + " can not added to new member " + member);
+                    }
+                }
+            }
+        });
+    }
+
+    @Override
+    public void memberRemoved(final MembershipEvent membershipEvent) {
+        registrationExecutor.submit(new Runnable() {
+            @Override
+            public void run() {
+                Member member = membershipEvent.getMember();
+                members.remove(member);
+                for (Map<Address, ClientEventRegistration> registrationMap : registrations.values()) {
+                    ClientEventRegistration registration = registrationMap.remove(member.getAddress());
+                    removeEventHandler(registration.getCallId());
+                }
+            }
+        });
+    }
+
+    @Override
+    public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+        //nothing to do
+    }
+
+    @Override
+    public void init(final InitialMembershipEvent event) {
+        registrationExecutor.submit(new Runnable() {
+            @Override
+            public void run() {
+                members.addAll(event.getMembers());
+                for (Member member : members) {
                     for (ClientRegistrationKey registrationKey : registrations.keySet()) {
                         try {
                             invoke(registrationKey, member.getAddress());
@@ -161,56 +211,32 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
         });
     }
 
-    @Override
-    public void memberRemoved(MembershipEvent membershipEvent) {
-        synchronized (listenerRegLock) {
-            Member member = membershipEvent.getMember();
-            members.remove(member);
-            for (Map<Address, ClientEventRegistration> registrationMap : registrations.values()) {
-                ClientEventRegistration registration = registrationMap.remove(member.getAddress());
-                removeEventHandler(registration.getCallId());
-            }
-
-        }
-    }
-
-    @Override
-    public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-        //nothing to do
-    }
-
-    @Override
-    public void init(InitialMembershipEvent event) {
-        synchronized (listenerRegLock) {
-            members.addAll(event.getMembers());
-            for (Member member : members) {
-                for (ClientRegistrationKey registrationKey : registrations.keySet()) {
-                    try {
-                        invoke(registrationKey, member.getAddress());
-                    } catch (Exception e) {
-                        logger.warning("Listener " + registrationKey + " can not added to new member " + member);
-                    }
-                }
-            }
-        }
-    }
-
     //For Testing
-    public Collection<ClientEventRegistration> getActiveRegistrations(String uuid) {
-        synchronized (listenerRegLock) {
-            Map<Address, ClientEventRegistration> registrationMap = registrations.get(new ClientRegistrationKey(uuid));
-            if (registrationMap == null) {
-                return Collections.EMPTY_LIST;
-            }
-            LinkedList<ClientEventRegistration> activeRegistrations = new LinkedList<ClientEventRegistration>();
-            for (ClientEventRegistration registration : registrationMap.values()) {
-                for (Member member : members) {
-                    if (member.getAddress().equals(registration.getSubscriber())) {
-                        activeRegistrations.add(registration);
+    public Collection<ClientEventRegistration> getActiveRegistrations(final String uuid) {
+        Future<Collection<ClientEventRegistration>> future = registrationExecutor.submit(
+                new Callable<Collection<ClientEventRegistration>>() {
+                    @Override
+                    public Collection<ClientEventRegistration> call() {
+                        ClientRegistrationKey key = new ClientRegistrationKey(uuid);
+                        Map<Address, ClientEventRegistration> registrationMap = registrations.get(key);
+                        if (registrationMap == null) {
+                            return Collections.EMPTY_LIST;
+                        }
+                        LinkedList<ClientEventRegistration> activeRegistrations = new LinkedList<ClientEventRegistration>();
+                        for (ClientEventRegistration registration : registrationMap.values()) {
+                            for (Member member : members) {
+                                if (member.getAddress().equals(registration.getSubscriber())) {
+                                    activeRegistrations.add(registration);
+                                }
+                            }
+                        }
+                        return activeRegistrations;
                     }
-                }
-            }
-            return activeRegistrations;
+                });
+        try {
+            return future.get();
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
         }
     }
 


### PR DESCRIPTION
A similar deadlock was detected and fixed here
hazelcast#7673

Both have the same reason. When remote invocation is waited
indefinetely on internal executor since response also same via
same executor and invocation monitor also runs on same executor,
there is change of deadlock.

As a fix, I have introduced a dedicated single thread executor to
 be used by listener registration logic. This way, internal
 executor will not be blocked.

I have introduced a property to make the test fail constantly.
"hazelcast.client.internal.executor.pool.size" . We should not
need to expose this to user right now. This is just for testing.