### PR TITLE
Fix #1156/#1719 with @torkeld - Ensure that IndexAwarePredicates actually use indices for IMap.executeOnEntries

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
@@ -17,18 +17,26 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class PartitionWideEntryWithPredicateOperationFactory implements OperationFactory {
     private String name;
     private EntryProcessor entryProcessor;
     private Predicate predicate;
+    private boolean hasIndex;
+    private Set<Data> keySet;
 
     public PartitionWideEntryWithPredicateOperationFactory() {
     }
@@ -41,7 +49,23 @@ public class PartitionWideEntryWithPredicateOperationFactory implements Operatio
 
     @Override
     public Operation createOperation() {
+        if (hasIndex) {
+            return new MultipleEntryOperation(name, keySet, entryProcessor);
+        }
         return new PartitionWideEntryWithPredicateOperation(name, entryProcessor, predicate);
+    }
+
+    public void queryIndex(MapService mapService) {
+        Indexes indexService = mapService.getMapServiceContext().getMapContainer(name).getIndexes();
+        Set<QueryableEntry> querySet = indexService.query(predicate);
+        if (querySet != null) {
+            Set<Data> keys = new HashSet<Data>();
+            for (QueryableEntry e: querySet) {
+                keys.add(e.getKeyData());
+            }
+            hasIndex = true;
+            keySet = keys;
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -18,6 +18,8 @@ package com.hazelcast.spi.impl.operationservice.impl.operations;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.operation.PartitionWideEntryWithPredicateOperationFactory;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -55,6 +57,10 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
     @Override
     public void run() throws Exception {
         try {
+            if (operationFactory instanceof PartitionWideEntryWithPredicateOperationFactory) {
+                MapService mapService = getService();
+                ((PartitionWideEntryWithPredicateOperationFactory) operationFactory).queryIndex(mapService);
+            }
             Object[] responses = executeOperations();
             results = resolveResponses(responses);
         } catch (Exception e) {

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -161,7 +161,8 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         map.put("b", new TempData("abc", "123"));
         TestPredicate predicate = new TestPredicate("foo");
         Map<String, Object> entries = map.executeOnEntries(new LoggingEntryProcessor(), predicate);
-        assertEquals("The predicate should be applied to only one entry if indexing works!", entries.size(), 1);
+        assertEquals("The predicate should only relate to one entry!", entries.size(), 1);
+        assertTrue("The predicate should only be used via index service!", predicate.isFilteredAndNotApplied());
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
@@ -26,19 +26,20 @@ import java.util.Set;
 public class TestPredicate implements IndexAwarePredicate<String, TempData> {
 
     private String value;
-    private boolean didApply;
+    private boolean applied, filtered;
 
     public TestPredicate(String value) {
         this.value = value;
     }
 
     public boolean apply(Map.Entry<String, TempData> mapEntry) {
-        didApply = true;
+        applied = true;
         TempData data = (TempData) mapEntry.getValue();
         return data.getAttr1().equals(value);
     }
 
     public Set<QueryableEntry<String, TempData>> filter(QueryContext queryContext) {
+        filtered = true;
         return (Set) queryContext.getIndex("attr1").getRecords(value);
     }
 
@@ -46,8 +47,8 @@ public class TestPredicate implements IndexAwarePredicate<String, TempData> {
         return queryContext.getIndex("attr1") != null;
     }
 
-    public boolean didApply() {
-        return didApply;
+    public boolean isFilteredAndNotApplied() {
+        return filtered && !applied;
     }
 
 }


### PR DESCRIPTION
* If the PartitionIteratingOperation has a PartitionWideEntryWithPredicateOperationFactory, try to query the indices associated with the map that the factory is scoped for.
* In the factory itself, if the index service returns keys given a predicate query, retain them and issue a MultipleEntryOperation containing those keys instead of a PartitionWideEntryWithPredicateOperation.

Fixes #1156 and #1719, which are identical.

Credit to @torkeld for the original commit at torkeld@0b15cc1