### PR TITLE
Introduction of async atomic long API

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.proxy;
 
+import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongAddAndGetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongAlterAndGetCodec;
@@ -31,6 +32,7 @@ import com.hazelcast.client.impl.protocol.codec.AtomicLongGetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongIncrementAndGetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongSetCodec;
 import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IFunction;
 
 import static com.hazelcast.util.Preconditions.isNotNull;
@@ -38,7 +40,99 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 /**
  * Proxy implementation of {@link IAtomicLong}.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class ClientAtomicLongProxy extends PartitionSpecificClientProxy implements IAtomicLong {
+
+    private static final ClientMessageDecoder ADD_AND_GET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Long decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongAddAndGetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder COMPARE_AND_SET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Boolean decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongCompareAndSetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder DECREMENT_AND_GET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Long decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongDecrementAndGetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder GET_AND_ADD_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Long decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongGetAndAddCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder GET_AND_SET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Long decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongGetAndSetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder INCREMENT_AND_GET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Long decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongIncrementAndGetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder GET_AND_INCREMENT_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Long decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongGetAndIncrementCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder SET_ASYNC_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Void decodeClientMessage(ClientMessage clientMessage) {
+            return null;
+        }
+    };
+
+    private static final ClientMessageDecoder ALTER_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Void decodeClientMessage(ClientMessage clientMessage) {
+            return null;
+        }
+    };
+
+    private static final ClientMessageDecoder GET_AND_ALTER_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Long decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongGetAndAlterCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder ALTER_AND_GET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Long decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongAlterAndGetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder APPLY_DECODER = new ClientMessageDecoder() {
+        @Override
+        public <V> V decodeClientMessage(ClientMessage clientMessage) {
+            return (V) AtomicLongApplyCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder GET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Long decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicLongGetCodec.decodeResponse(clientMessage).response;
+        }
+    };
 
     public ClientAtomicLongProxy(String serviceName, String objectId) {
         super(serviceName, objectId);
@@ -146,6 +240,88 @@ public class ClientAtomicLongProxy extends PartitionSpecificClientProxy implemen
     public void set(long newValue) {
         ClientMessage request = AtomicLongSetCodec.encodeRequest(name, newValue);
         invokeOnPartition(request);
+    }
+
+    @Override
+    public ICompletableFuture<Long> addAndGetAsync(long delta) {
+        ClientMessage request = AtomicLongAddAndGetCodec.encodeRequest(name, delta);
+        return invokeOnPartitionAsync(request, ADD_AND_GET_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Boolean> compareAndSetAsync(long expect, long update) {
+        ClientMessage request = AtomicLongCompareAndSetCodec.encodeRequest(name, expect, update);
+        return invokeOnPartitionAsync(request, COMPARE_AND_SET_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Long> decrementAndGetAsync() {
+        ClientMessage request = AtomicLongDecrementAndGetCodec.encodeRequest(name);
+        return invokeOnPartitionAsync(request, DECREMENT_AND_GET_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Long> getAsync() {
+        ClientMessage request = AtomicLongGetCodec.encodeRequest(name);
+        return invokeOnPartitionAsync(request, GET_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Long> getAndAddAsync(long delta) {
+        ClientMessage request = AtomicLongGetAndAddCodec.encodeRequest(name, delta);
+        return invokeOnPartitionAsync(request, GET_AND_ADD_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Long> getAndSetAsync(long newValue) {
+        ClientMessage request = AtomicLongGetAndSetCodec.encodeRequest(name, newValue);
+        return invokeOnPartitionAsync(request, GET_AND_SET_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Long> incrementAndGetAsync() {
+        ClientMessage request = AtomicLongIncrementAndGetCodec.encodeRequest(name);
+        return invokeOnPartitionAsync(request, INCREMENT_AND_GET_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Long> getAndIncrementAsync() {
+        ClientMessage request = AtomicLongGetAndIncrementCodec.encodeRequest(name);
+        return invokeOnPartitionAsync(request, GET_AND_INCREMENT_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Void> setAsync(long newValue) {
+        ClientMessage request = AtomicLongSetCodec.encodeRequest(name, newValue);
+        return invokeOnPartitionAsync(request, SET_ASYNC_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Void> alterAsync(IFunction<Long, Long> function) {
+        isNotNull(function, "function");
+        ClientMessage request = AtomicLongAlterCodec.encodeRequest(name, toData(function));
+        return invokeOnPartitionAsync(request, ALTER_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Long> alterAndGetAsync(IFunction<Long, Long> function) {
+        isNotNull(function, "function");
+        ClientMessage request = AtomicLongAlterAndGetCodec.encodeRequest(name, toData(function));
+        return invokeOnPartitionAsync(request, ALTER_AND_GET_DECODER);
+    }
+
+    @Override
+    public ICompletableFuture<Long> getAndAlterAsync(IFunction<Long, Long> function) {
+        isNotNull(function, "function");
+        ClientMessage request = AtomicLongGetAndAlterCodec.encodeRequest(name, toData(function));
+        return invokeOnPartitionAsync(request, GET_AND_ALTER_DECODER);
+    }
+
+    @Override
+    public <R> ICompletableFuture<R> applyAsync(IFunction<Long, R> function) {
+        isNotNull(function, "function");
+        ClientMessage request = AtomicLongApplyCodec.encodeRequest(name, toData(function));
+        return invokeOnPartitionAsync(request, APPLY_DECODER);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/atomiclong/ClientAtomicLongTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/atomiclong/ClientAtomicLongTest.java
@@ -18,8 +18,10 @@ package com.hazelcast.client.atomiclong;
 
 import com.hazelcast.client.UndefinedErrorCodeException;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -31,6 +33,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -77,6 +84,28 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
 
     }
 
+    @Test
+    public void testAsync() throws Exception {
+        ICompletableFuture<Long> future = l.getAndAddAsync(10);
+        assertEquals(0, future.get().longValue());
+
+        ICompletableFuture<Boolean> booleanFuture = l.compareAndSetAsync(10, 42);
+        assertTrue(booleanFuture.get());
+
+        future = l.getAsync();
+        assertEquals(42, future.get().longValue());
+
+        future = l.incrementAndGetAsync();
+        assertEquals(43, future.get().longValue());
+
+        future = l.addAndGetAsync(-13);
+        assertEquals(30, future.get().longValue());
+
+        future = l.alterAndGetAsync(new AddOneFunction());
+        assertEquals(31, future.get().longValue());
+
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void apply_whenCalledWithNullFunction() {
         IAtomicLong ref = client.getAtomicLong("apply_whenCalledWithNullFunction");
@@ -93,6 +122,50 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void applyAsync()
+            throws ExecutionException, InterruptedException {
+        IAtomicLong ref = client.getAtomicLong("apply");
+        ICompletableFuture<Long> future =ref.applyAsync(new AddOneFunction());
+        assertEquals(new Long(1), future.get());
+        assertEquals(0, ref.get());
+    }
+
+    @Test
+    public void applyBooleanAsync() throws ExecutionException, InterruptedException {
+        final CountDownLatch cdl = new CountDownLatch(1);
+        final IAtomicLong ref = client.getAtomicLong("apply");
+        ICompletableFuture<Void> incAndGetFuture = ref.setAsync(1);
+        final AtomicBoolean failed = new AtomicBoolean(true);
+        incAndGetFuture.andThen(new ExecutionCallback<Void>() {
+            @Override
+            public void onResponse(Void response) {
+                ICompletableFuture<Boolean> future = ref.applyAsync(new FilterOnesFunction());
+                try {
+                    assertEquals(Boolean.TRUE, future.get());
+                    failed.set(false);
+                    cdl.countDown();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                } catch (ExecutionException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                t.printStackTrace();
+            }
+        });
+        if (cdl.await(15, TimeUnit.SECONDS)){
+            assertEquals(1, ref.get());
+            assertEquals(false, failed.get());
+        }
+        else {
+            fail("Timeout after 15 seconds");
+        }
+    }
+
+    @Test
     public void apply_whenException() {
         IAtomicLong ref = client.getAtomicLong("apply_whenException");
         ref.set(1);
@@ -101,6 +174,24 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
             fail();
         } catch (UndefinedErrorCodeException expected) {
             assertEquals(expected.getOriginClassName(), ExpectedRuntimeException.class.getName());
+        }
+
+        assertEquals(1, ref.get());
+    }
+
+    @Test
+    public void applyAsync_whenException() {
+        IAtomicLong ref = client.getAtomicLong("applyAsync_whenException");
+        ref.set(1);
+        try {
+            ICompletableFuture<Long> future = ref.applyAsync(new FailingFunction());
+            future.get();
+        } catch (InterruptedException e) {
+            fail();
+        } catch (ExecutionException e) {
+            assertEquals(e.getCause().getClass(), UndefinedErrorCodeException.class);
+            assertEquals(((UndefinedErrorCodeException)e.getCause()).getOriginClassName(),
+                    ExpectedRuntimeException.class.getName());
         }
 
         assertEquals(1, ref.get());
@@ -129,11 +220,42 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void alterAsync_whenException() {
+        IAtomicLong ref = client.getAtomicLong("alterAsync_whenException");
+        ref.set(10);
+
+        try {
+            ICompletableFuture<Void> future = ref.alterAsync(new FailingFunction());
+            future.get();
+        } catch (InterruptedException e) {
+            fail();
+        } catch (ExecutionException e) {
+            assertEquals(e.getCause().getClass(), UndefinedErrorCodeException.class);
+            assertEquals(((UndefinedErrorCodeException)e.getCause()).getOriginClassName(),
+                    ExpectedRuntimeException.class.getName());
+        }
+
+        assertEquals(10, ref.get());
+    }
+
+    @Test
     public void alter() {
         IAtomicLong ref = client.getAtomicLong("alter");
 
         ref.set(10);
         ref.alter(new AddOneFunction());
+        assertEquals(11, ref.get());
+
+    }
+
+    @Test
+    public void alterAsync()
+            throws ExecutionException, InterruptedException {
+        IAtomicLong ref = client.getAtomicLong("alterAsync");
+
+        ref.set(10);
+        ICompletableFuture<Void> future = ref.alterAsync(new AddOneFunction());
+        future.get();
         assertEquals(11, ref.get());
 
     }
@@ -161,11 +283,40 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void alterAndGetAsync_whenException() {
+        IAtomicLong ref = client.getAtomicLong("alterAndGetAsync_whenException");
+        ref.set(10);
+
+        try {
+            ICompletableFuture<Long> future = ref.alterAndGetAsync(new FailingFunction());
+            future.get();
+        } catch (InterruptedException e) {
+            fail();
+        } catch (ExecutionException e) {
+            assertEquals(e.getCause().getClass(), UndefinedErrorCodeException.class);
+            assertEquals(((UndefinedErrorCodeException)e.getCause()).getOriginClassName(),
+                         ExpectedRuntimeException.class.getName());
+        }
+
+        assertEquals(10, ref.get());
+    }
+
+    @Test
     public void alterAndGet() {
         IAtomicLong ref = client.getAtomicLong("alterAndGet");
 
         ref.set(10);
         assertEquals(11, ref.alterAndGet(new AddOneFunction()));
+        assertEquals(11, ref.get());
+    }
+
+    @Test
+    public void alterAndGetAsync() throws ExecutionException, InterruptedException {
+        IAtomicLong ref = client.getAtomicLong("alterAndGetAsync");
+
+        ICompletableFuture<Void> future = ref.setAsync(10);
+        future.get();
+        assertEquals(11, ref.alterAndGetAsync(new AddOneFunction()).get().longValue());
         assertEquals(11, ref.get());
     }
 
@@ -192,6 +343,26 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void getAndAlterAsync_whenException() {
+        IAtomicLong ref = client.getAtomicLong("getAndAlterAsync_whenException");
+        ref.set(10);
+
+        try {
+            ICompletableFuture<Long> future = ref.getAndAlterAsync(new FailingFunction());
+            future.get();
+            fail();
+        } catch (InterruptedException e) {
+            assertEquals(e.getCause().getClass().getName(), UndefinedErrorCodeException.class.getName());
+            assertEquals(((UndefinedErrorCodeException)e.getCause()).getOriginClassName(), ExpectedRuntimeException.class.getName());
+        } catch (ExecutionException e) {
+            assertEquals(e.getCause().getClass().getName(), UndefinedErrorCodeException.class.getName());
+            assertEquals(((UndefinedErrorCodeException)e.getCause()).getOriginClassName(), ExpectedRuntimeException.class.getName());
+        }
+
+        assertEquals(10, ref.get());
+    }
+
+    @Test
     public void getAndAlter() {
         IAtomicLong ref = client.getAtomicLong("getAndAlter");
 
@@ -200,10 +371,28 @@ public class ClientAtomicLongTest extends HazelcastTestSupport {
         assertEquals(11, ref.get());
     }
 
+    @Test
+    public void getAndAlterAsync() throws ExecutionException, InterruptedException {
+        IAtomicLong ref = client.getAtomicLong("getAndAlterAsync");
+
+        ref.set(10);
+
+        ICompletableFuture<Long> future = ref.getAndAlterAsync(new AddOneFunction());
+        assertEquals(10, future.get().longValue());
+        assertEquals(11, ref.get());
+    }
+
     private static class AddOneFunction implements IFunction<Long, Long> {
         @Override
         public Long apply(Long input) {
             return input + 1;
+        }
+    }
+
+    private static class FilterOnesFunction implements IFunction<Long, Boolean> {
+        @Override
+        public Boolean apply(Long input) {
+            return input.equals(1L);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongProxy.java
@@ -62,113 +62,157 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
 
     @Override
     public long addAndGet(long delta) {
-        return asyncAddAndGet(delta).join();
+        return addAndGetAsync(delta).join();
     }
 
     @Override
-    public InternalCompletableFuture<Long> asyncAddAndGet(long delta) {
-        Operation operation = new AddAndGetOperation(name, delta)
-                .setPartitionId(partitionId);
+    public InternalCompletableFuture<Long> addAndGetAsync(long delta) {
+        Operation operation = new AddAndGetOperation(name, delta).setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
-    public boolean compareAndSet(long expect, long update) {
-        return asyncCompareAndSet(expect, update).join();
+    public InternalCompletableFuture<Long> asyncAddAndGet(long delta) {
+        return addAndGetAsync(delta);
     }
 
     @Override
-    public InternalCompletableFuture<Boolean> asyncCompareAndSet(long expect, long update) {
+    public boolean compareAndSet(long expect, long update) {
+        return compareAndSetAsync(expect, update).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Boolean> compareAndSetAsync(long expect, long update) {
         Operation operation = new CompareAndSetOperation(name, expect, update)
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
-    public void set(long newValue) {
-        asyncSet(newValue).join();
+    public InternalCompletableFuture<Boolean> asyncCompareAndSet(long expect, long update) {
+        return compareAndSetAsync(expect, update);
     }
 
     @Override
-    public InternalCompletableFuture<Void> asyncSet(long newValue) {
+    public void set(long newValue) {
+        setAsync(newValue).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Void> setAsync(long newValue) {
         Operation operation = new SetOperation(name, newValue)
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
-    public long getAndSet(long newValue) {
-        return asyncGetAndSet(newValue).join();
+    public InternalCompletableFuture<Void> asyncSet(long newValue) {
+        return setAsync(newValue);
     }
 
     @Override
-    public InternalCompletableFuture<Long> asyncGetAndSet(long newValue) {
+    public long getAndSet(long newValue) {
+        return getAndSetAsync(newValue).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> getAndSetAsync(long newValue) {
         Operation operation = new GetAndSetOperation(name, newValue)
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
-    public long getAndAdd(long delta) {
-        return asyncGetAndAdd(delta).join();
+    public InternalCompletableFuture<Long> asyncGetAndSet(long newValue) {
+        return getAndSetAsync(newValue);
     }
 
     @Override
-    public InternalCompletableFuture<Long> asyncGetAndAdd(long delta) {
+    public long getAndAdd(long delta) {
+        return getAndAddAsync(delta).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> getAndAddAsync(long delta) {
         Operation operation = new GetAndAddOperation(name, delta)
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
+    public InternalCompletableFuture<Long> asyncGetAndAdd(long delta) {
+        return getAndAddAsync(delta);
+    }
+
+    @Override
     public long decrementAndGet() {
-        return asyncDecrementAndGet().join();
+        return decrementAndGetAsync().join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> decrementAndGetAsync() {
+        return addAndGetAsync(-1);
     }
 
     @Override
     public InternalCompletableFuture<Long> asyncDecrementAndGet() {
-        return asyncAddAndGet(-1);
+        return addAndGetAsync(-1);
     }
 
     @Override
     public long get() {
-        return asyncGet().join();
+        return getAsync().join();
     }
 
     @Override
-    public InternalCompletableFuture<Long> asyncGet() {
+    public InternalCompletableFuture<Long> getAsync() {
         Operation operation = new GetOperation(name)
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
+    public InternalCompletableFuture<Long> asyncGet() {
+        return getAsync();
+    }
+
+    @Override
     public long incrementAndGet() {
-        return asyncIncrementAndGet().join();
+        return incrementAndGetAsync().join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> incrementAndGetAsync() {
+        return addAndGetAsync(1);
     }
 
     @Override
     public InternalCompletableFuture<Long> asyncIncrementAndGet() {
-        return asyncAddAndGet(1);
+        return addAndGetAsync(1);
     }
 
     @Override
     public long getAndIncrement() {
-        return asyncGetAndIncrement().join();
+        return getAndIncrementAsync().join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> getAndIncrementAsync() {
+        return getAndAddAsync(1);
     }
 
     @Override
     public InternalCompletableFuture<Long> asyncGetAndIncrement() {
-        return asyncGetAndAdd(1);
+        return getAndAddAsync(1);
     }
 
     @Override
     public void alter(IFunction<Long, Long> function) {
-        asyncAlter(function).join();
+        alterAsync(function).join();
     }
 
     @Override
-    public InternalCompletableFuture<Void> asyncAlter(IFunction<Long, Long> function) {
+    public InternalCompletableFuture<Void> alterAsync(IFunction<Long, Long> function) {
         isNotNull(function, "function");
 
         Operation operation = new AlterOperation(name, function)
@@ -177,12 +221,17 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
     }
 
     @Override
-    public long alterAndGet(IFunction<Long, Long> function) {
-        return asyncAlterAndGet(function).join();
+    public InternalCompletableFuture<Void> asyncAlter(IFunction<Long, Long> function) {
+        return alterAsync(function);
     }
 
     @Override
-    public InternalCompletableFuture<Long> asyncAlterAndGet(IFunction<Long, Long> function) {
+    public long alterAndGet(IFunction<Long, Long> function) {
+        return alterAndGetAsync(function).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> alterAndGetAsync(IFunction<Long, Long> function) {
         isNotNull(function, "function");
 
         Operation operation = new AlterAndGetOperation(name, function)
@@ -191,12 +240,17 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
     }
 
     @Override
-    public long getAndAlter(IFunction<Long, Long> function) {
-        return asyncGetAndAlter(function).join();
+    public InternalCompletableFuture<Long> asyncAlterAndGet(IFunction<Long, Long> function) {
+        return alterAndGetAsync(function);
     }
 
     @Override
-    public InternalCompletableFuture<Long> asyncGetAndAlter(IFunction<Long, Long> function) {
+    public long getAndAlter(IFunction<Long, Long> function) {
+        return getAndAlterAsync(function).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Long> getAndAlterAsync(IFunction<Long, Long> function) {
         isNotNull(function, "function");
 
         Operation operation = new GetAndAlterOperation(name, function)
@@ -205,17 +259,27 @@ public class AtomicLongProxy extends AbstractDistributedObject<AtomicLongService
     }
 
     @Override
-    public <R> R apply(IFunction<Long, R> function) {
-        return asyncApply(function).join();
+    public InternalCompletableFuture<Long> asyncGetAndAlter(IFunction<Long, Long> function) {
+        return getAndAlterAsync(function);
     }
 
     @Override
-    public <R> InternalCompletableFuture<R> asyncApply(IFunction<Long, R> function) {
+    public <R> R apply(IFunction<Long, R> function) {
+        return applyAsync(function).join();
+    }
+
+    @Override
+    public <R> InternalCompletableFuture<R> applyAsync(IFunction<Long, R> function) {
         isNotNull(function, "function");
 
         Operation operation = new ApplyOperation<R>(name, function)
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
+    }
+
+    @Override
+    public <R> InternalCompletableFuture<R> asyncApply(IFunction<Long, R> function) {
+        return applyAsync(function);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicLong.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.annotation.Beta;
  * @since 3.2
  */
 @Beta
+@Deprecated
 public interface AsyncAtomicLong extends IAtomicLong {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
@@ -20,6 +20,26 @@ package com.hazelcast.core;
  * IAtomicLong is a redundant and highly available distributed alternative to the
  * {@link java.util.concurrent.atomic.AtomicLong java.util.concurrent.atomic.AtomicLong}.
  *
+ * Asynchronous variants of all methods have been introduced in version 3.7.
+ * Async methods return immediately an {@link ICompletableFuture} from which the operation's result
+ * can be obtained either in a blocking manner or by registering a callback to be executed
+ * upon completion. For example:
+ *
+ * <p>
+ * <pre>
+ *     ICompletableFuture&lt;Long&gt; future = atomicLong.addAndGetAsync(13);
+ *     future.andThen(new ExecutionCallback&lt;Long&gt;() {
+ *          void onResponse(Long response) {
+ *              // do something with the result
+ *          }
+ *
+ *          void onFailure(Throwable t) {
+ *              // handle failure
+ *          }
+ *     });
+ * </pre>
+ * </p>
+ *
  * @see IAtomicReference
  */
 public interface IAtomicLong extends DistributedObject {
@@ -139,4 +159,181 @@ public interface IAtomicLong extends DistributedObject {
      * @since 3.2
      */
     <R> R apply(IFunction<Long, R> function);
+
+    /**
+     * Atomically adds the given value to the current value.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * The operations result can be obtained in a blocking way, or a
+     * callback can be provided for execution upon completion, as demonstrated in the following examples:
+     * <p>
+     * <pre>
+     *     ICompletableFuture&lt;Long&gt; future = atomicLong.addAndGetAsync(13);
+     *     // do something else, then read the result
+     *     Long result = future.get(); // this method will block until the result is available
+     * </pre>
+     * </p>
+     * <p>
+     * <pre>
+     *     ICompletableFuture&lt;Long&gt; future = atomicLong.addAndGetAsync(13);
+     *     future.andThen(new ExecutionCallback&lt;Long&gt;() {
+     *          void onResponse(Long response) {
+     *              // do something with the result
+     *          }
+     *
+     *          void onFailure(Throwable t) {
+     *              // handle failure
+     *          }
+     *     });
+     * </pre>
+     * </p>
+     *
+     * @param delta the value to add
+     * @return an {@link ICompletableFuture} bearing the response
+     * @since 3.7
+     */
+    ICompletableFuture<Long> addAndGetAsync(long delta);
+
+    /**
+     * Atomically sets the value to the given updated value
+     * only if the current value {@code ==} the expected value.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @param expect the expected value
+     * @param update the new value
+     * @return an {@link ICompletableFuture} with value true if successful; or false if the actual value
+     *         was not equal to the expected value.
+     * @since 3.7
+     */
+    ICompletableFuture<Boolean> compareAndSetAsync(long expect, long update);
+
+    /**
+     * Atomically decrements the current value by one.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @return an {@link ICompletableFuture} with the updated value.
+     * @since 3.7
+     */
+    ICompletableFuture<Long> decrementAndGetAsync();
+
+    /**
+     * Gets the current value. This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @return an {@link ICompletableFuture} with the current value
+     * @since 3.7
+     */
+    ICompletableFuture<Long> getAsync();
+
+    /**
+     * Atomically adds the given value to the current value.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @param delta the value to add
+     * @return an {@link ICompletableFuture} with the old value before the addition
+     * @since 3.7
+     */
+    ICompletableFuture<Long> getAndAddAsync(long delta);
+
+    /**
+     * Atomically sets the given value and returns the old value.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @param newValue the new value
+     * @return an {@link ICompletableFuture} with the old value
+     * @since 3.7
+     */
+    ICompletableFuture<Long> getAndSetAsync(long newValue);
+
+    /**
+     * Atomically increments the current value by one.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @return an {@link ICompletableFuture} with the updated value
+     * @since 3.7
+     */
+    ICompletableFuture<Long> incrementAndGetAsync();
+
+    /**
+     * Atomically increments the current value by one.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @return an {@link ICompletableFuture} with the old value
+     * @since 3.7
+     */
+    ICompletableFuture<Long> getAndIncrementAsync();
+
+    /**
+     * Atomically sets the given value.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @param newValue the new value
+     * @return an {@link ICompletableFuture} API consumers can use to track execution of this request
+     * @since 3.7
+     */
+    ICompletableFuture<Void> setAsync(long newValue);
+
+    /**
+     * Alters the currently stored value by applying a function on it.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @param function the function
+     * @throws IllegalArgumentException if function is null.
+     * @return an {@link ICompletableFuture} API consumers can use to track execution of this request
+     * @since 3.7
+     */
+    ICompletableFuture<Void> alterAsync(IFunction<Long, Long> function);
+
+    /**
+     * Alters the currently stored value by applying a function on it and gets the result.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @param function the function
+     * @return an {@link ICompletableFuture} with the new value.
+     * @throws IllegalArgumentException if function is null.
+     * @since 3.7
+     */
+    ICompletableFuture<Long> alterAndGetAsync(IFunction<Long, Long> function);
+
+    /**
+     * Alters the currently stored value by applying a function on it on and gets the old value.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     *
+     * @param function the function
+     * @return an {@link ICompletableFuture} with the old value
+     * @throws IllegalArgumentException if function is null.
+     * @since 3.7
+     */
+    ICompletableFuture<Long> getAndAlterAsync(IFunction<Long, Long> function);
+
+    /**
+     * Applies a function on the value, the actual stored value will not change.
+     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * Example:
+     * <p>
+     * <pre>
+     *     class IsOneFunction implements IFunction&lt;Long, Boolean&gt; {
+     *       &#64;Override
+     *       public Boolean apply(Long input) {
+     *         return input.equals(1L);
+     *       }
+     *     }
+     *
+     *     ICompletableFuture<Boolean> future = atomicLong.applyAsync(new IsOneFunction());
+     *     future.andThen(new ExecutionCallback&lt;Boolean&gt;() {
+     *        void onResponse(Boolean response) {
+     *            // do something with the response
+     *        }
+     *
+     *        void onFailure(Throwable t) {
+     *            // handle failure
+     *        }
+     *     });
+     * </pre>
+     * </p>
+     *
+     * @param function the function
+     * @return an {@link ICompletableFuture} with the result of the function application
+     * @throws IllegalArgumentException if function is null.
+     * @since 3.7
+     */
+    <R> ICompletableFuture<R> applyAsync(IFunction<Long, R> function);
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/ICompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICompletableFuture.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.spi.annotation.Beta;
-
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 
@@ -34,7 +32,6 @@ import java.util.concurrent.Future;
  * @param <V>
  * @since 3.2
  */
-@Beta
 public interface ICompletableFuture<V> extends Future<V> {
 
     /**


### PR DESCRIPTION
This PR fixes #7957 by providing async variants of existing methods in `IAtomicLong`. All async methods return `ICompletableFuture`, enabling reactive style invocation of execution callbacks by means of `andThen(...)`. `@Beta` annotation was removed from `ICompletableFuture` which exists since version 3.2. `AsyncAtomicLong` is marked as deprecated and will be removed in a future version.