### PR TITLE
Backport of PR #7975

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -37,7 +37,9 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.SampleObjects;
 import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.query.impl.predicates.InstanceOfPredicate;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -137,6 +139,14 @@ public class ClientMapTest extends HazelcastTestSupport {
         map.removeEntryListener(id);
         map.put("key2", new GenericEvent("value2"));
         assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testSerializationServiceNullClassLoaderProblem() throws Exception {
+        IMap<Integer, SampleObjects.PortableEmployee> map = client.getMap("test");
+
+        // If the classloader is null the following call throws NullPointerException
+        map.values(new InstanceOfPredicate(SampleObjects.PortableEmployee.class));
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -60,7 +61,7 @@ public class InstanceOfPredicate
     public void readData(ObjectDataInput in) throws IOException {
         String klassName = in.readUTF();
         try {
-            klass = in.getClassLoader().loadClass(klassName);
+            klass = ClassLoaderUtil.loadClass(in.getClassLoader(), klassName);
         } catch (ClassNotFoundException e) {
             throw new HazelcastSerializationException("Failed to load class: " + klass, e);
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapValuesTest.java
@@ -4,7 +4,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.SampleObjects;
 import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.predicates.InstanceOfPredicate;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -99,6 +101,12 @@ public class MapValuesTest extends HazelcastTestSupport {
         // there should only be a value; no key.
         assertNull(row.getKey());
         assertEquals(serializationService.toData("a"), row.getValue());
+    }
+
+    @Test
+    public void testSerializationServiceNullClassLoaderProblem() throws Exception {
+        // If the classloader is null the following call throws NullPointerException
+        map.values(new InstanceOfPredicate(SampleObjects.PortableEmployee.class));
     }
 
     static class GoodPredicate implements Predicate<String, String> {


### PR DESCRIPTION
Backports PR #7975   
When using InstanceOfPredicate, the server side toObject method causes NullPointerException, since the classloader is not set and it is null. This fix uses the default classloader if it is not set by the config to avoid the null pointer exception.