### PR TITLE
Option to let the PerformanceMonitor write to logger

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -347,7 +347,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         partitionService.start();
         clientExtension.afterStart(this);
 
-        performanceMonitor.start();
         performanceMonitor.register(
                 new ConfigPropertiesPlugin(loggingService.getLogger(ConfigPropertiesPlugin.class), properties));
         performanceMonitor.register(

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogFile.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogFile.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.monitors;
+
+import com.hazelcast.logging.ILogger;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.internal.monitors.PerformanceMonitor.DIRECTORY;
+import static com.hazelcast.internal.monitors.PerformanceMonitor.MAX_ROLLED_FILE_COUNT;
+import static com.hazelcast.internal.monitors.PerformanceMonitor.MAX_ROLLED_FILE_SIZE_MB;
+import static com.hazelcast.nio.IOUtil.closeResource;
+import static java.lang.Math.round;
+import static java.lang.String.format;
+import static java.lang.System.arraycopy;
+
+/**
+ * A {@link PerformanceLog} that writes to file.
+ */
+final class PerformanceLogFile extends PerformanceLog {
+
+    private static final int ONE_MB = 1024 * 1024;
+    private static final int INITIAL_CHAR_BUFF_SIZE = 4 * 1024;
+
+    final AtomicReference<PerformanceMonitorPlugin[]> staticPlugins = new AtomicReference<PerformanceMonitorPlugin[]>(
+            new PerformanceMonitorPlugin[0]
+    );
+
+     // points to the file where the log content is written to
+    volatile File file;
+
+    private final ILogger logger;
+    private final String fileName;
+    private final String directory;
+    private char[] charBuff = new char[INITIAL_CHAR_BUFF_SIZE];
+    private int index;
+    private BufferedWriter bufferedWriter;
+    private int maxRollingFileCount;
+    private int maxRollingFileSizeBytes;
+    // calling File.length generates a lot of litter; so we'll track it ourselves
+    private long fileLength;
+
+    PerformanceLogFile(PerformanceMonitor performanceMonitor) {
+        super(performanceMonitor);
+        this.logger = performanceMonitor.logger;
+        this.fileName = performanceMonitor.fileName + "-%03d.log";
+        this.directory = performanceMonitor.properties.getString(DIRECTORY);
+
+        this.maxRollingFileCount = performanceMonitor.properties.getInteger(MAX_ROLLED_FILE_COUNT);
+        // we accept a float so it becomes easier to testing to create a small file
+        this.maxRollingFileSizeBytes = round(
+                ONE_MB * performanceMonitor.properties.getFloat(MAX_ROLLED_FILE_SIZE_MB));
+
+        logger.finest("maxRollingFileSizeBytes:" + maxRollingFileSizeBytes + " maxRollingFileCount:" + maxRollingFileCount);
+    }
+
+    @Override
+    public void addStaticPlugin(PerformanceMonitorPlugin plugin) {
+        for (; ; ) {
+            PerformanceMonitorPlugin[] oldPlugins = staticPlugins.get();
+            PerformanceMonitorPlugin[] newPlugins = new PerformanceMonitorPlugin[oldPlugins.length + 1];
+            arraycopy(oldPlugins, 0, newPlugins, 0, oldPlugins.length);
+            newPlugins[oldPlugins.length] = plugin;
+            if (staticPlugins.compareAndSet(oldPlugins, newPlugins)) {
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void render(PerformanceMonitorPlugin plugin) {
+        try {
+            if (file == null) {
+                file = new File(directory, format(fileName, index));
+                bufferedWriter = newWriter();
+                for (PerformanceMonitorPlugin staticPlugin : staticPlugins.get()) {
+                    render(staticPlugin);
+                }
+            }
+
+            render0(plugin);
+
+            bufferedWriter.flush();
+            if (fileLength >= maxRollingFileSizeBytes) {
+                rollover();
+            }
+        } catch (IOException e) {
+            logger.warning("Failed to write to file:" + file.getAbsolutePath(), e);
+            file = null;
+            closeResource(bufferedWriter);
+            bufferedWriter = null;
+        } catch (RuntimeException e) {
+            logger.warning("Failed to write file: " + file, e);
+        }
+    }
+
+    private void render0(PerformanceMonitorPlugin plugin) throws IOException {
+        logWriter.write(plugin);
+        //bufferedWriter.append()
+        int desiredLength = charBuff.length;
+        int actualSize = logWriter.length();
+        while (desiredLength < actualSize) {
+            desiredLength *= 2;
+        }
+
+        if (desiredLength != charBuff.length) {
+            charBuff = new char[desiredLength];
+        }
+
+        logWriter.copyInto(charBuff);
+        bufferedWriter.write(charBuff, 0, actualSize);
+        fileLength += actualSize;
+    }
+
+    private BufferedWriter newWriter() throws FileNotFoundException {
+        FileOutputStream fos = new FileOutputStream(file, true);
+        CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
+        return new BufferedWriter(new OutputStreamWriter(fos, encoder));
+    }
+
+    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+    private void rollover() {
+        closeResource(bufferedWriter);
+        bufferedWriter = null;
+        file = null;
+        fileLength = 0;
+        index++;
+
+        File file = new File(format(fileName, index - maxRollingFileCount));
+        // we don't care if the file was deleted or not
+        file.delete();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/monitors/PerformanceLogLogger.java
@@ -16,25 +16,30 @@
 
 package com.hazelcast.internal.monitors;
 
-import static com.hazelcast.internal.monitors.PerformanceMonitor.HUMAN_FRIENDLY_FORMAT;
+import com.hazelcast.logging.ILogger;
 
-abstract class PerformanceLog {
+/**
+ * A {@link PerformanceLog} that writes to the general logger. See {@link PerformanceMonitor#SKIP_FILE}.
+ */
+class PerformanceLogLogger extends PerformanceLog {
 
-    protected final PerformanceMonitor monitor;
-    protected final PerformanceLogWriter logWriter;
+     private final ILogger logger;
 
-    PerformanceLog(PerformanceMonitor monitor) {
-        this.monitor = monitor;
-        this.logWriter = monitor.properties.getBoolean(HUMAN_FRIENDLY_FORMAT)
-                ? new MultiLinePerformanceLogWriter()
-                : new SingleLinePerformanceLogWriter() ;
+    PerformanceLogLogger(PerformanceMonitor monitor) {
+        super(monitor);
+
+        this.logger = monitor.logger;
     }
 
-
-    abstract void render(PerformanceMonitorPlugin plugin);
-
-     void close() {
+    @Override
+    public void addStaticPlugin(PerformanceMonitorPlugin plugin) {
+        render(plugin);
     }
 
-    public abstract void addStaticPlugin(PerformanceMonitorPlugin plugin);
+    @Override
+    public void render(PerformanceMonitorPlugin plugin) {
+        logWriter.clean();
+        logWriter.write(plugin);
+        logger.info(logWriter.sb.toString());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -177,7 +177,6 @@ public class NodeEngineImpl implements NodeEngine {
         proxyService.init();
         operationService.start();
         quorumService.start();
-        performanceMonitor.start();
 
         // static loggers at beginning of file
         performanceMonitor.register(new BuildInfoPlugin(this));

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceLogFileTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceLogFileTest.java
@@ -33,9 +33,9 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class PerformanceLogTest extends HazelcastTestSupport {
+public class PerformanceLogFileTest extends HazelcastTestSupport {
 
-    private PerformanceLog performanceLog;
+    private PerformanceLogFile performanceLog;
     private MetricsRegistry metricsRegistry;
 
     @Before
@@ -50,7 +50,7 @@ public class PerformanceLogTest extends HazelcastTestSupport {
 
         PerformanceMonitor performanceMonitor = getPerformanceMonitor(hz);
 
-        performanceLog = performanceMonitor.performanceLog;
+        performanceLog = (PerformanceLogFile)performanceMonitor.performanceLog;
         metricsRegistry = getMetricsRegistry(hz);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceLogLoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/monitors/PerformanceLogLoggerTest.java
@@ -1,0 +1,95 @@
+package com.hazelcast.internal.monitors;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.internal.metrics.ProbeLevel;
+import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
+import com.hazelcast.logging.AbstractLogger;
+import com.hazelcast.logging.LogEvent;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.logging.Level;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class PerformanceLogLoggerTest extends HazelcastTestSupport {
+    private PerformanceLogLogger performanceLog;
+    private MockLogger logger;
+
+    @Before
+    public void setup() {
+        Config config = new Config();
+        config.setProperty(PerformanceMonitor.ENABLED.getName(), "true");
+        config.setProperty(PerformanceMonitor.SKIP_FILE.getName(), "true");
+        config.setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
+        HazelcastProperties properties = new HazelcastProperties(config);
+
+        logger = new MockLogger();
+        HazelcastThreadGroup threadGroup = new HazelcastThreadGroup("foo", logger, getClass().getClassLoader());
+        PerformanceMonitor performanceMonitor = new PerformanceMonitor("dontcare", logger, threadGroup, properties);
+        MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(logger, ProbeLevel.INFO);
+
+        performanceMonitor.register(new MetricsPlugin(logger, metricsRegistry, properties));
+        performanceMonitor.register(new SystemPropertiesPlugin(logger));
+
+        performanceLog = (PerformanceLogLogger) performanceMonitor.performanceLog;
+    }
+
+    @Test
+    public void test() throws InterruptedException {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                String content = logger.sb.toString();
+
+                System.out.println(content);
+
+                assertNotNull(content);
+
+                assertTrue(content.contains("SystemProperties["));
+                assertTrue(content.contains("Metrics["));
+            }
+        });
+    }
+
+    private class MockLogger extends AbstractLogger {
+        private StringBuffer sb = new StringBuffer();
+
+        @Override
+        public void log(Level level, String message) {
+            sb.append(message).append("\n");
+        }
+
+        @Override
+        public void log(Level level, String message, Throwable thrown) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void log(LogEvent logEvent) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Level getLevel() {
+            return Level.ALL;
+        }
+
+        @Override
+        public boolean isLoggable(Level level) {
+            return true;
+        }
+    }
+
+}


### PR DESCRIPTION
In some cases having a dedicated performance log file is not an option; so for these crazy situations it is possible to write to the 'general' logger.

Fixes: https://github.com/hazelcast/hazelcast/issues/7973