### PR TITLE
Add slotHash() to HashSlotArray to enable hashcode caching

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImpl.java
@@ -108,7 +108,7 @@ public final class HashSlotArray12byteKeyImpl extends HashSlotArrayBase implemen
         return mem.getInt(slotBase(baseAddress, slot) + offsetOfUnassignedSentinel) != unassignedSentinel;
     }
 
-    @Override protected long hash(long key1, long key2) {
+    @Override protected long keyHash(long key1, long key2) {
         return fastLongMix(key1 + fastIntMix((int) key2));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImpl.java
@@ -95,7 +95,7 @@ public class HashSlotArray8byteKeyImpl extends HashSlotArrayBase implements Hash
         mem.putLong(slotBase(baseAddress, slot) + KEY_1_OFFSET, key);
     }
 
-    @Override protected long hash(long key, long ignored) {
+    @Override protected long keyHash(long key, long ignored) {
         return fastLongMix(key);
     }
 }


### PR DESCRIPTION
There is a use case of HashSlotArray where the key stored in the slot is only a pointer to the actual key blob. In such a case it is important for performance to cache the hashcode of the blob. This PR adds a method which can be overridden such that this cached value is used.