### PR TITLE
Fixes #7959 & #6056

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -106,6 +106,8 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     RecordStore getRecordStore(int partitionId, String mapName);
 
+    RecordStore getRecordStore(int partitionId, String mapName, boolean skipLoadingOnCreate);
+
     RecordStore getExistingRecordStore(int partitionId, String mapName);
 
     Collection<Integer> getOwnedPartitions();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -300,6 +300,11 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
+    public RecordStore getRecordStore(int partitionId, String mapName, boolean skipLoadingOnCreate) {
+        return getPartitionContainer(partitionId).getRecordStore(mapName, skipLoadingOnCreate);
+    }
+
+    @Override
     public RecordStore getExistingRecordStore(int partitionId, String mapName) {
         return getPartitionContainer(partitionId).getExistingRecordStore(mapName);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -101,6 +101,12 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
         return new RecordReplicationInfo(key, mapServiceContext.toData(record.getValue()), info);
     }
 
+    private RecordStore getRecordStore(String mapName) {
+        final boolean skipLoadingOnRecordStoreCreate = true;
+        MapService mapService = getService();
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        return mapServiceContext.getRecordStore(getPartitionId(), mapName, skipLoadingOnRecordStoreCreate);
+    }
 
     /**
      * Holder for raw IMap key-value pairs and their metadata.
@@ -137,13 +143,10 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
 
         private void applyState() {
             if (data != null) {
-                MapService mapService = getService();
-                MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-
                 for (Entry<String, Set<RecordReplicationInfo>> dataEntry : data.entrySet()) {
                     Set<RecordReplicationInfo> recordReplicationInfos = dataEntry.getValue();
                     final String mapName = dataEntry.getKey();
-                    RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), mapName);
+                    RecordStore recordStore = getRecordStore(mapName);
                     recordStore.reset();
 
                     for (RecordReplicationInfo recordReplicationInfo : recordReplicationInfos) {
@@ -232,12 +235,9 @@ public class MapReplicationOperation extends AbstractOperation implements Mutati
 
 
         private void applyState() {
-            MapService mapService = getService();
-            MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-
             for (Entry<String, List<DelayedEntry>> entry : delayedEntries.entrySet()) {
                 String mapName = entry.getKey();
-                RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), mapName);
+                RecordStore recordStore = getRecordStore(mapName);
                 WriteBehindStore mapDataStore = (WriteBehindStore) recordStore.getMapDataStore();
 
                 mapDataStore.reset();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -74,8 +74,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     // loadingFutures are modified by partition threads and could be accessed by query threads
     protected final Collection<Future> loadingFutures = new ConcurrentLinkedQueue<Future>();
     // record store may be created with or without triggering the load
-    // this flag guards that the loading on create is invoked not more than once.
+    // this flag guards that the loading on create is invoked not more than once should the record store be migrated.
     private boolean loadedOnCreate;
+    // records if the record store has been loaded just before the migrations starts
+    // if so, the loading should NOT be started after the migration commit
+    private boolean loadedOnPreMigration;
 
     public DefaultRecordStore(MapContainer mapContainer, int partitionId,
                               MapKeyLoader keyLoader, ILogger logger) {
@@ -88,10 +91,28 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     public void startLoading() {
-        if (mapStoreContext.isMapLoader() && !loadedOnCreate) {
-            loadedOnCreate = true;
-            loadingFutures.add(keyLoader.startInitialLoad(mapStoreContext, partitionId));
+        if (logger.isFinestEnabled()) {
+            logger.finest("StartLoading invoked " + getStateMessage());
         }
+        if (mapStoreContext.isMapLoader() && !loadedOnCreate) {
+            if (!loadedOnPreMigration) {
+                if (logger.isFinestEnabled()) {
+                    logger.finest("Triggering load " + getStateMessage());
+                }
+                loadedOnCreate = true;
+                loadingFutures.add(keyLoader.startInitialLoad(mapStoreContext, partitionId));
+            } else {
+                if (logger.isFinestEnabled()) {
+                    logger.finest("Promoting to loaded on migration " + getStateMessage());
+                }
+                keyLoader.promoteToLoadedOnMigration();
+            }
+        }
+    }
+
+    @Override
+    public void setPreMigrationLoadedStatus(boolean loaded) {
+        loadedOnPreMigration = loaded;
     }
 
     @Override
@@ -101,6 +122,10 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     @Override
     public void loadAll(boolean replaceExistingValues) {
+        if (logger.isFinestEnabled()) {
+            logger.finest("loadAll invoked " + getStateMessage());
+        }
+
         logger.info("Starting to load all keys for map " + name + " on partitionId=" + partitionId);
         Future<?> loadingKeysFuture = keyLoader.startLoading(mapStoreContext, replaceExistingValues);
         loadingFutures.add(loadingKeysFuture);
@@ -960,5 +985,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             Record record = getRecordOrNull(toData(delayedEntry.getKey()), now, false);
             onStore(record);
         }
+    }
+
+    private String getStateMessage() {
+        return "on partitionId=" + partitionId + " on " + mapServiceContext.getNodeEngine().getThisAddress()
+                + " loadedOnCreate=" + loadedOnCreate + " loadedOnPreMigration=" + loadedOnPreMigration
+                + " isLoaded=" + isLoaded();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -349,6 +349,17 @@ public interface RecordStore<R extends Record> {
     void startLoading();
 
     /**
+     * Informs this recordStore about the loading status of the recordStore that this store is migrated from.
+     * If the 'predecessor' has been loaded this record store should trigger the load again.
+     * Will be taken into account only if invoked before the startLoading method. Otherwise has no effect.
+     *
+     * This method should be deleted when the map's lifecycle has been cleaned-up. Currently it's impossible to
+     * pass additional state when the record store is created, thus this this state has to be passed in post-creation
+     * setters which is cumbersome and error-prone.
+     */
+    void setPreMigrationLoadedStatus(boolean loaded);
+
+    /**
      * Initialize the recordStore after creation
      */
     void init();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
@@ -94,7 +94,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = MINUTE)
-    // FIXED @Ignore //https://github.com/hazelcast/hazelcast/issues/6056
+    // FIXES https://github.com/hazelcast/hazelcast/issues/6056
     public void testLoadsAll_whenInitialLoaderNodeRemovedAfterLoading() throws Exception {
         Config cfg = newConfig("default", LAZY);
         HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
@@ -108,6 +108,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
 
         hz3.getLifecycleService().terminate();
         assertClusterSizeEventually(2, nodes[0]);
+
         map.loadAll(true);
 
         assertSizeEventually(MAP_STORE_ENTRY_COUNT, map);
@@ -142,7 +143,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = MINUTE)
-    // FIXED https://github.com/hazelcast/hazelcast/issues/7959
+    // FIXES https://github.com/hazelcast/hazelcast/issues/7959
     public void testLoadsAll_whenInitialLoaderNodeRemovedWhileLoadingAndNoBackups() throws Exception {
         PausingMapLoader<Integer, Integer> pausingLoader = new PausingMapLoader<Integer, Integer>(mapLoader, 5000);
 
@@ -181,7 +182,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
         Config cfg = new Config();
         cfg.setGroupConfig(new GroupConfig(getClass().getSimpleName()));
         cfg.setProperty(GroupProperty.MAP_LOAD_CHUNK_SIZE.getName(), Integer.toString(BATCH_SIZE));
-        cfg.setProperty(GroupProperty.PARTITION_COUNT.getName(), "31");
+        cfg.setProperty(GroupProperty.PARTITION_COUNT.getName(), "13");
 
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setImplementation(loader).setInitialLoadMode(loadMode);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderFailoverTest.java
@@ -29,7 +29,6 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -95,7 +94,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = MINUTE)
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/6056
+    // FIXED @Ignore //https://github.com/hazelcast/hazelcast/issues/6056
     public void testLoadsAll_whenInitialLoaderNodeRemovedAfterLoading() throws Exception {
         Config cfg = newConfig("default", LAZY);
         HazelcastInstance[] nodes = nodeFactory.newInstances(cfg, 3);
@@ -143,7 +142,7 @@ public class MapLoaderFailoverTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = MINUTE)
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/3796
+    // FIXED https://github.com/hazelcast/hazelcast/issues/7959
     public void testLoadsAll_whenInitialLoaderNodeRemovedWhileLoadingAndNoBackups() throws Exception {
         PausingMapLoader<Integer, Integer> pausingLoader = new PausingMapLoader<Integer, Integer>(mapLoader, 5000);
 


### PR DESCRIPTION
closes #7959 

How it is fixed: The startLoading call is deferred to the commitMigration call if the RecordStore is created during a Migration. Otherwise the startLoading call does not see a proper state of the partitionTable and it's needed to calculate the roles of the recordStore in the loading process.

closes #6056

How it is fixed: The problem with the current migration algorithm is that it may promote & migrate a record store. It means that there's not only a "local" promotion, but there's also a "remote" promotion, meaning that a recordStore with replicaIndex==1 may be migrated to other node with replicaIndex==0. In order not to trigger a load again the loadStatus has to be migrated too. Earlier it wasn't the cases since there was no promotion & migration - a promotion was always a "local" operation. Thus to fix it I had to send a migration flag whether the load has been finished or not. It's the preMigrationLoadedStatus