### PR TITLE
Do not bypass regular operation infrastructure when readBackupData = true

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -255,6 +255,9 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     private Data readBackupDataOrNull(Data key) {
         int partitionId = partitionService.getPartitionId(key);
         IPartition partition = partitionService.getPartition(partitionId, false);
+        if (partition.isLocal()) {
+            return null;
+        }
         if (!partition.isOwnerOrBackup(thisAddress)) {
             return null;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -10,7 +10,7 @@ import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -19,7 +19,9 @@ import com.hazelcast.util.Clock;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,9 +29,21 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class LocalMapStatsTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameters(name = "readBackupData:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {false},
+                {true}
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public boolean readBackupData;
 
     @Test
     public void testHitsGenerated() throws Exception {
@@ -345,7 +359,10 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
     }
 
     private <K, V> IMap<K, V> getMap() {
-        HazelcastInstance instance = createHazelcastInstance(getConfig());
-        return instance.getMap(randomString());
+        Config config = getConfig();
+        String mapName = randomString();
+        config.getMapConfig(mapName).setReadBackupData(readBackupData);
+        HazelcastInstance instance = createHazelcastInstance(config);
+        return instance.getMap(mapName);
     }
 }


### PR DESCRIPTION
Fixes #7354

We bypass a normal operation infrastructure when reading from a backup.
However we should not bypass it when the current member happens to be owner
and not just a backup of a given partition. As it has an impact on statistics,
it violates a thread model, etc.