### PR TITLE
[BACKPORT] fix issue #3752: do not transform a URL with spaces into a URI

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
@@ -110,7 +110,7 @@ public final class ServiceLoader {
             Set<URLDefinition> urlDefinitions = new HashSet<URLDefinition>();
             while (configs.hasMoreElements()) {
                 URL url = configs.nextElement();
-                final URI uri = url.toURI();
+                final URI uri = new URI(url.toExternalForm().replace(" ", "%20"));
 
                 ClassLoader highestClassLoader = findHighestReachableClassLoader(url, classLoader, resourceName);
                 if (!highestClassLoader.getClass().getName().equals(IGNORED_GLASSFISH_MAGIC_CLASSLOADER)) {

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -191,10 +191,35 @@ public class ServiceLoaderTest {
         assertEquals(1, implementations.size());
     }
 
-    public static interface ServiceLoaderTestInterface {
+    @Test
+    public void loadServicesWithSpaceInURL()
+            throws Exception {
+
+        Class<ServiceLoaderSpacesTestInterface> type = ServiceLoaderSpacesTestInterface.class;
+        String factoryId = "com.hazelcast.ServiceLoaderSpacesTestInterface";
+
+        ClassLoader given = new URLClassLoader(new URL[] { new URL(ClassLoader.getSystemResource("test with spaces").toExternalForm().replace("%20", " ") + "/") });
+
+        Set<ServiceLoaderSpacesTestInterface> implementations = new HashSet<ServiceLoaderSpacesTestInterface>();
+        Iterator<ServiceLoaderSpacesTestInterface> iterator = ServiceLoader.iterator(type, factoryId, given);
+        while (iterator.hasNext()) {
+            implementations.add(iterator.next());
+        }
+
+        assertEquals(1, implementations.size());
+    }
+
+    public interface ServiceLoaderTestInterface {
     }
 
     public static class ServiceLoaderTestInterfaceImpl
             implements ServiceLoaderTestInterface {
+    }
+
+    public interface ServiceLoaderSpacesTestInterface {
+    }
+
+    public static class ServiceLoaderSpacesTestInterfaceImpl
+            implements ServiceLoaderSpacesTestInterface {
     }
 }

--- a/hazelcast/src/test/resources/test with spaces/META-INF/services/com.hazelcast.ServiceLoaderSpacesTestInterface
+++ b/hazelcast/src/test/resources/test with spaces/META-INF/services/com.hazelcast.ServiceLoaderSpacesTestInterface
@@ -1,0 +1,1 @@
+com.hazelcast.util.ServiceLoaderTest$ServiceLoaderSpacesTestInterfaceImpl


### PR DESCRIPTION
This is a backport of #7310 from @Vampire for `maintenance-3.x` branch.