### PR TITLE
Replaced cast to ConnectionImpl, now casts to Interface.

### DIFF
--- a/hazelcast-ra/hazelcast-jca/src/main/java/com/hazelcast/jca/ConnectionFactoryImpl.java
+++ b/hazelcast-ra/hazelcast-jca/src/main/java/com/hazelcast/jca/ConnectionFactoryImpl.java
@@ -86,7 +86,7 @@ public class ConnectionFactoryImpl implements HazelcastConnectionFactory {
         if (LOGGER.isFinestEnabled()) {
             LOGGER.finest("getConnection spec: " + connSpec);
         }
-        return (HazelcastConnectionImpl) cm.allocateConnection(mcf, null);
+        return (HazelcastConnection) cm.allocateConnection(mcf, null);
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
Replaced cast to ConnectionImpl, now casts to Interface. This to avoid problems with JDK proxies on TomEE, where these cannot be cast to the implementation, only the interface.

Backport of : https://github.com/hazelcast/hazelcast-ra/pull/2