### PR TITLE
InvocationFuture: supress logging in case racy completion

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -357,11 +357,12 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
         for (; ; ) {
             final Object oldState = state;
             if (isDone(oldState)) {
-                // it can be that this invocation future already received an answer, e.g. when an invocation already received a
-                // response, but before it cleans up itself, it receives a HazelcastInstanceNotActiveException.
-                logger.warning("The Future.complete(Object value) can only be called once. Request: " + invocationToString()
-                        + ", current response: " + getState() + ", new response: " + value);
-
+                if (oldState != value) {
+                    // it can be that this future already completed, e.g. when an invocation already
+                    // received a response, but before it cleans up itself, it receives a HazelcastInstanceNotActiveException.
+                    logger.warning("Future.complete(Object value) can only be called once. Request: " + invocationToString()
+                            + ", current value: " + oldState + ", offered value: " + value);
+                }
                 return false;
             }
 


### PR DESCRIPTION
It can happen that both backup and response handling thread, decide that the invocation can be completed with exactly the same pending value. In this case; don't log a warning, but accept it as part of
the lock free design.

So only in case of a future being completed with a different value than it already completed with, a log warning is made.

This logging is not only irritating for end users since it scares them even though it is accepted behavior. It could also be a performance problem due to excess logging. 