### PR TITLE
Improved client TargetDisconnectException

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientNotActiveException.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientNotActiveException.java
@@ -24,4 +24,8 @@ public class HazelcastClientNotActiveException extends IllegalStateException {
     public HazelcastClientNotActiveException(String message) {
         super(message);
     }
+
+    public HazelcastClientNotActiveException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -167,7 +167,7 @@ public class ClientInvocation implements Runnable {
     public void notifyException(Throwable exception) {
 
         if (!lifecycleService.isRunning()) {
-            clientInvocationFuture.complete(new HazelcastClientNotActiveException(exception.getMessage()));
+            clientInvocationFuture.complete(new HazelcastClientNotActiveException(exception.getMessage(), exception));
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
@@ -34,4 +34,8 @@ public class TargetDisconnectedException extends RetryableHazelcastException {
     public TargetDisconnectedException(String message) {
         super(message);
     }
+
+    public TargetDisconnectedException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }


### PR DESCRIPTION
The exception message proves more context of the cause. Also the client connection has been modified to store the cause of the connection close so it can be included in the TargetDisconnectException. 