### PR TITLE
Per key locking on MapServiceContextImpl.mapContainers

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoaderLifecycleSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoaderLifecycleSupport.java
@@ -32,7 +32,18 @@ public interface MapLoaderLifecycleSupport {
      * HazelcastInstance. Implementation can
      * initialize required resources for the implementing
      * mapLoader, such as reading a config file and/or creating a
-     * database connection.
+     * database connection. References to maps, other than the one on which
+     * this {@code MapLoader} is configured, can be obtained from the
+     * {@code hazelcastInstance} in this method's implementation.
+     * <p>
+     * On members joining a cluster, this method is executed during finalization
+     * of the join operation; if the implementation executes operations which
+     * may wait on locks or otherwise block (e.g. waiting for network operations),
+     * this may result in a time-out and potentialy obstruct the new member from
+     * joining the cluster.
+     * If blocking operations are required for initialization of the {@code MapLoader},
+     * consider deferring them with a lazy initialization scheme.
+     * </p>
      *
      * @param hazelcastInstance HazelcastInstance of this mapLoader.
      * @param properties        Properties set for this mapStore. see MapStoreConfig

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -52,6 +52,7 @@ import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.ContextMutexFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -106,6 +107,8 @@ class MapServiceContextImpl implements MapServiceContext {
     protected EventService eventService;
     protected MapOperationProviders operationProviders;
 
+    private final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
+
     MapServiceContextImpl(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
         this.partitionContainers = createPartitionContainers();
@@ -152,7 +155,7 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public MapContainer getMapContainer(String mapName) {
-        return ConcurrencyUtil.getOrPutSynchronized(mapContainers, mapName, mapContainers, mapConstructor);
+        return ConcurrencyUtil.getOrPutSynchronized(mapContainers, mapName, contextMutexFactory, mapConstructor);
     }
 
 

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
@@ -45,6 +45,30 @@ public final class ConcurrencyUtil {
         return value;
     }
 
+    public static <K, V> V getOrPutSynchronized(ConcurrentMap<K, V> map, K key,
+                                                ContextMutexFactory contextMutexFactory,
+                                                ConstructorFunction<K, V> func) {
+        if (contextMutexFactory == null) {
+            throw new NullPointerException();
+        }
+        V value = map.get(key);
+        if (value == null) {
+            ContextMutexFactory.Mutex mutex = contextMutexFactory.mutexFor(key);
+            try {
+                synchronized (mutex) {
+                    value = map.get(key);
+                    if (value == null) {
+                        value = func.createNew(key);
+                        map.put(key, value);
+                    }
+                }
+            } finally {
+                mutex.close();
+            }
+        }
+        return value;
+    }
+
     public static <K, V> V getOrPutIfAbsent(ConcurrentMap<K, V> map, K key, ConstructorFunction<K, V> func) {
         V value = map.get(key);
         if (value == null) {

--- a/hazelcast/src/main/java/com/hazelcast/util/ContextMutexFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ContextMutexFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+
+import java.io.Closeable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class that provides reference-counted mutexes suitable for synchronization in the context of a supplied object.
+ * Context objects and their associated mutexes are stored in a {@code Map}. Client code is responsible to invoke
+ * {@link Mutex#close()} on the obtained {@code Mutex} after having synchronized on the mutex; failure to do so, will leave an
+ * entry residing in the internal {@code Map} which may have adverse effects on the ability to garbage collect the context object
+ * and the mutex. The returned {@link Mutex}es implement Closeable, so can be conveniently used in a try-with-resources statement.
+ * Typical usage would allow, for example, synchronizing access to a non-thread-safe {@code Map} on a per-key basis,
+ * to avoid blocking other threads who would perform updates on other entries of the {@code Map}.
+ * <pre>
+ *     class Test {
+ *
+ *         private static final ContextMutexFactory mutexFactory = new ContextMutexFactory();
+ *         private Map&lt;String, String&gt; mapToSync = new HashMap&lt;String, String&gt;();
+ *
+ *         public void test(String key, String value) {
+ *             // critical section
+ *             ContextMutexFactory.Mutex mutex = mutexFactory.mutexFor(key);
+ *             try {
+ *                 synchronized (mutex) {
+ *                      if (mapToSync.get(key) == null) {
+ *                          mapToSync.put(key, value);
+ *                      }
+ *                 }
+ *             }
+ *             finally {
+ *                 mutex.close();
+ *             }
+ *         }
+ *     }
+ * </pre>
+ *
+ */
+public final class ContextMutexFactory {
+    Map<Object, Mutex> mutexMap = new HashMap<Object, Mutex>();
+    // synchronizes access to mutexMap and Mutex.referenceCount
+    private Object mainMutex = new Object();
+
+    public Mutex mutexFor(Object mutexKey) {
+        Mutex mutex;
+        synchronized (mainMutex) {
+            mutex = mutexMap.get(mutexKey);
+            if (mutex == null) {
+                mutex = new Mutex(mutexKey);
+                mutexMap.put(mutexKey, mutex);
+            }
+            mutex.referenceCount++;
+        }
+        return mutex;
+    }
+
+    /**
+     * Reference counted mutex, which will remove itself from the mutexMap when it is no longer referenced.
+     */
+    public final class Mutex implements Closeable {
+        private final Object key;
+        private int referenceCount;
+
+        private Mutex(Object key) {
+            this.key = key;
+        }
+
+        @Override
+        public void close() {
+            synchronized (mainMutex) {
+                referenceCount--;
+                if (referenceCount == 0) {
+                    mutexMap.remove(key);
+                }
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/ContextMutexFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ContextMutexFactoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test basic lock operation of {@link ContextMutexFactory}
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class ContextMutexFactoryTest {
+
+    private ContextMutexFactory contextMutexFactory;
+    private final AtomicBoolean testFailed = new AtomicBoolean(false);
+
+    @Before
+    public void setup() {
+        contextMutexFactory = new ContextMutexFactory();
+    }
+
+    @Test
+    public void testConcurrentMutexOperation() {
+        final String[] keys = new String[] {"a", "b", "c"};
+        final Map<String, Integer> timesAcquired = new HashMap<String, Integer>();
+
+        int concurrency = Runtime.getRuntime().availableProcessors()*3;
+        final CyclicBarrier cyc = new CyclicBarrier(concurrency+1);
+
+        for (int i=0; i<concurrency; i++) {
+            new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    await(cyc);
+
+                    for (String key : keys) {
+                        ContextMutexFactory.Mutex mutex = contextMutexFactory.mutexFor(key);
+                        try {
+                            synchronized (mutex) {
+                                Integer value = timesAcquired.get(key);
+                                if (value == null) {
+                                    timesAcquired.put(key, 1);
+                                } else {
+                                    timesAcquired.put(key, value + 1);
+                                }
+                            }
+                        }
+                        finally {
+                            mutex.close();
+                        }
+                    }
+
+                    await(cyc);
+                }
+            }).start();
+        }
+        // start threads, wait for them to finish
+        await(cyc);
+        await(cyc);
+
+        // assert each key's lock was acquired by each thread
+        for (String key : keys) {
+            assertEquals(concurrency, timesAcquired.get(key).longValue());
+        }
+        // assert there are no mutexes leftover
+        assertEquals(0, contextMutexFactory.mutexMap.size());
+
+        if (testFailed.get()) {
+            fail("Failure due to exception while waiting on cyclic barrier.");
+        }
+    }
+
+    private void await(CyclicBarrier cyc) {
+        try {
+            cyc.await();
+        } catch (InterruptedException e) {
+            testFailed.set(true);
+        } catch (BrokenBarrierException e) {
+            testFailed.set(true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the use case described in #7987 (obtaining a reference to a map in  `MapLoaderLifecycleSupport.init` user code, while initializing another map on a node that just joined the cluster). Introduces finer-grained locking during get-or-createAndPut operations on `MapServiceContextImpl.mapContainers`.