### PR TITLE
Fix migration & promotion to handle member restart

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
@@ -68,7 +68,9 @@ public class MigrationInfo implements DataSerializable {
     private int partitionId;
 
     private Address source;
+    private String sourceUuid;
     private Address destination;
+    private String destinationUuid;
     private Address master;
 
     private int sourceCurrentReplicaIndex;
@@ -82,12 +84,15 @@ public class MigrationInfo implements DataSerializable {
     public MigrationInfo() {
     }
 
-    public MigrationInfo(int partitionId, Address source, Address destination, int sourceCurrentReplicaIndex,
-                         int sourceNewReplicaIndex, int destinationCurrentReplicaIndex, int destinationNewReplicaIndex) {
+    public MigrationInfo(int partitionId, Address source, String sourceUuid, Address destination, String destinationUuid,
+                         int sourceCurrentReplicaIndex, int sourceNewReplicaIndex,
+                         int destinationCurrentReplicaIndex, int destinationNewReplicaIndex) {
         this.uuid = UuidUtil.newUnsecureUuidString();
         this.partitionId = partitionId;
         this.source = source;
+        this.sourceUuid = sourceUuid;
         this.destination = destination;
+        this.destinationUuid = destinationUuid;
         this.sourceCurrentReplicaIndex = sourceCurrentReplicaIndex;
         this.sourceNewReplicaIndex = sourceNewReplicaIndex;
         this.destinationCurrentReplicaIndex = destinationCurrentReplicaIndex;
@@ -99,8 +104,16 @@ public class MigrationInfo implements DataSerializable {
         return source;
     }
 
+    public String getSourceUuid() {
+        return sourceUuid;
+    }
+
     public Address getDestination() {
         return destination;
+    }
+
+    public String getDestinationUuid() {
+        return destinationUuid;
     }
 
     public int getPartitionId() {
@@ -171,12 +184,14 @@ public class MigrationInfo implements DataSerializable {
         out.writeBoolean(hasSource);
         if (hasSource) {
             source.writeData(out);
+            out.writeUTF(sourceUuid);
         }
 
         boolean hasDestination = destination != null;
         out.writeBoolean(hasDestination);
         if (hasDestination) {
             destination.writeData(out);
+            out.writeUTF(destinationUuid);
         }
 
         master.writeData(out);
@@ -196,12 +211,14 @@ public class MigrationInfo implements DataSerializable {
         if (hasSource) {
             source = new Address();
             source.readData(in);
+            sourceUuid = in.readUTF();
         }
 
         boolean hasDestination = in.readBoolean();
         if (hasDestination) {
             destination = new Address();
             destination.readData(in);
+            destinationUuid = in.readUTF();
         }
 
         master = new Address();
@@ -234,9 +251,11 @@ public class MigrationInfo implements DataSerializable {
         sb.append("uuid=").append(uuid);
         sb.append(", partitionId=").append(partitionId);
         sb.append(", source=").append(source);
+        sb.append(", sourceUuid=").append(sourceUuid);
         sb.append(", sourceCurrentReplicaIndex=").append(sourceCurrentReplicaIndex);
         sb.append(", sourceNewReplicaIndex=").append(sourceNewReplicaIndex);
         sb.append(", destination=").append(destination);
+        sb.append(", destinationUuid=").append(destinationUuid);
         sb.append(", destinationCurrentReplicaIndex=").append(destinationCurrentReplicaIndex);
         sb.append(", destinationNewReplicaIndex=").append(destinationNewReplicaIndex);
         sb.append(", master=").append(master);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.partition;
 
+import com.hazelcast.core.Member;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.logging.ILogger;
@@ -155,6 +156,16 @@ public final class PartitionRuntimeState implements IdentifiedDataSerializable {
         this.completedMigrations = completedMigrations;
     }
 
+    public boolean isKnownOrNewMember(Member member) {
+        for (MemberInfo m : members) {
+            if (member.getAddress().equals(m.getAddress())) {
+                return member.getUuid().equals(m.getUuid());
+            }
+        }
+
+        return true;
+    }
+
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         version = in.readInt();
@@ -253,4 +264,5 @@ public final class PartitionRuntimeState implements IdentifiedDataSerializable {
     public int getId() {
         return PartitionDataSerializerHook.PARTITION_STATE;
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -547,6 +547,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             }
         }
 
+
+
         return applyNewState(partitionState, sender);
     }
 
@@ -567,6 +569,12 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                 }
 
                 return true;
+            }
+
+            if (node.getClusterService().getClusterState() == ClusterState.ACTIVE
+                    && !partitionState.isKnownOrNewMember(nodeEngine.getLocalMember())) {
+                logger.warning("Ignoring partition table update since this member is not a known member in partition table yet");
+                return false;
             }
 
             partitionStateManager.setVersion(newVersion);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -196,6 +196,10 @@ public class PartitionStateManager {
         }
     }
 
+    String getMemberUuid(Address address) {
+        return address != null ? memberUuidMap.get(address) : null;
+    }
+
     boolean isKnownMemberUuid(Address address, String uuid) {
         String currentUuid = memberUuidMap.get(address);
         assert currentUuid != null : "Unknown Member! " + address + " - " + uuid;

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
@@ -301,26 +301,38 @@ public class MigrationCommitServiceTest
     private MigrationInfo createMoveMigration(final int partitionId, final int replicaIndex, final Address destination) {
         final InternalPartition partition = getPartition(instances[0], partitionId);
         final Address source = partition.getReplicaAddress(replicaIndex);
-        return new MigrationInfo(partitionId, source, destination, replicaIndex, -1, -1, replicaIndex);
+        final String sourceUuid = getMemberUuid(source);
+        final String destinationUuid = getMemberUuid(destination);
+
+        return new MigrationInfo(partitionId, source, sourceUuid, destination, destinationUuid, replicaIndex, -1, -1, replicaIndex);
     }
 
     private MigrationInfo createShiftDownMigration(final int partitionId, final int oldReplicaIndex, final int newReplicaIndex,
                                                    final Address destination) {
         final InternalPartitionImpl partition = getPartition(instances[0], partitionId);
         final Address source = partition.getReplicaAddress(oldReplicaIndex);
-        return new MigrationInfo(partitionId, source, destination, oldReplicaIndex, newReplicaIndex, -1,
+        final String sourceUuid = getMemberUuid(source);
+        final String destinationUuid = getMemberUuid(destination);
+
+        return new MigrationInfo(partitionId, source, sourceUuid, destination, destinationUuid, oldReplicaIndex, newReplicaIndex, -1,
                 oldReplicaIndex);
     }
 
     private MigrationInfo createCopyMigration(final int partitionId, final int copyReplicaIndex, final Address destination) {
-        return new MigrationInfo(partitionId, null, destination, -1, -1, -1, copyReplicaIndex);
+        return new MigrationInfo(partitionId, null, null, destination, getMemberUuid(destination), -1, -1, -1, copyReplicaIndex);
     }
 
     private MigrationInfo createShiftUpMigration(final int partitionId, final int oldReplicaIndex, final int newReplicaIndex) {
         final InternalPartitionImpl partition = getPartition(instances[0], partitionId);
         final Address source = partition.getReplicaAddress(newReplicaIndex);
+        final String sourceUuid = getMemberUuid(source);
         final Address destination = partition.getReplicaAddress(oldReplicaIndex);
-        return new MigrationInfo(partitionId, source, destination, newReplicaIndex, -1, oldReplicaIndex, newReplicaIndex);
+        final String destinationUuid = getMemberUuid(destination);
+        return new MigrationInfo(partitionId, source, sourceUuid, destination, destinationUuid, newReplicaIndex, -1, oldReplicaIndex, newReplicaIndex);
+    }
+
+    private String getMemberUuid(Address address) {
+        return address != null ? getNodeEngineImpl(factory.getInstance(address)).getLocalMember().getUuid() : null;
     }
 
     private Address clearReplicaIndex(final int partitionId, final int replicaIndexToClear)


### PR DESCRIPTION
When a member is restarted with the same address, it will have a different uuid. 
Migration & promotion requests will contain source and destination member uuids. These uuids will be checked by executing member and process will fail if local uuid is not same.

Fixes #8005