### PR TITLE
Fix cluster state transaction when a member leaves during commit

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -517,7 +517,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                 }
 
                 final ClusterState clusterState = clusterStateManager.getState();
-                if (clusterState == ClusterState.FROZEN || clusterState == ClusterState.PASSIVE) {
+                if (clusterState != ClusterState.ACTIVE) {
                     if (logger.isFinestEnabled()) {
                         logger.finest(deadMember + " is dead, added to members left while cluster is " + clusterState + " state");
                     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
@@ -17,12 +17,15 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ClusterStateManager;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ExceptionAction;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.util.EmptyStatement;
@@ -67,6 +70,14 @@ public class ChangeClusterStateOperation extends AbstractOperation implements Al
         } else {
             super.logError(e);
         }
+    }
+
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+        return super.onInvocationException(throwable);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.test.AssertTask;
@@ -251,6 +252,81 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
                 assertClusterState(ClusterState.ACTIVE, instances[0], instances[1]);
             }
         });
+    }
+
+    @Test(timeout = 120000)
+    public void changeClusterState_shouldNotFail_whenNonInitiatorMemberDies_duringCommit() throws Exception {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        final HazelcastInstance[] instances = factory.newInstances();
+
+        final HazelcastInstance hz = instances[2];
+        TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
+
+        final Address address = getAddress(instances[0]);
+
+        TransactionOptions options = TransactionOptions.getDefault().setDurability(0);
+        when(transactionManagerService.newAllowedDuringPassiveStateTransaction(options)).thenAnswer(new TransactionAnswer() {
+            @Override
+            protected void afterPrepare() {
+                terminateInstance(instances[0]);
+            }
+        });
+
+        hz.getCluster().changeClusterState(ClusterState.FROZEN, options);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertClusterState(ClusterState.FROZEN, instances[2], instances[1]);
+            }
+        });
+
+        instances[0] = factory.newHazelcastInstance(address);
+
+        assertClusterSizeEventually(3, instances[0]);
+        assertClusterSizeEventually(3, instances[1]);
+        assertClusterSizeEventually(3, instances[2]);
+        assertClusterState(ClusterState.FROZEN, instances);
+    }
+
+    @Test(timeout = 120000)
+    public void changeClusterState_shouldFail_whenNonInitiatorMemberDies_beforePrepare() throws Exception {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        final HazelcastInstance[] instances = factory.newInstances();
+
+        final HazelcastInstance hz = instances[2];
+        TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
+
+        final Address address = getAddress(instances[0]);
+
+        TransactionOptions options = TransactionOptions.getDefault().setDurability(0);
+        when(transactionManagerService.newAllowedDuringPassiveStateTransaction(options)).thenAnswer(new TransactionAnswer() {
+            @Override
+            protected void beforePrepare() {
+                terminateInstance(instances[0]);
+            }
+        });
+
+        try {
+            hz.getCluster().changeClusterState(ClusterState.FROZEN, options);
+            fail("A member is terminated. Cannot commit the transaction!");
+        } catch (TargetNotMemberException ignored) {
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertClusterState(ClusterState.ACTIVE, instances[2], instances[1]);
+            }
+        });
+
+        instances[0] = factory.newHazelcastInstance(address);
+
+        assertClusterSizeEventually(3, instances[0]);
+        assertClusterSizeEventually(3, instances[1]);
+        assertClusterSizeEventually(3, instances[2]);
+        assertClusterState(ClusterState.ACTIVE, instances);
     }
 
     @Test


### PR DESCRIPTION
When a member leaves during commit of a cluster state tx, after prepare
is completed, tx should be completed successfully. We can assume it's left
after tx completed, because it will be added to the list of members which are
removed while cluster is not active and will be able to rejoin cluster.
Effectively there's no difference between leaving after commit vs during commit.