### PR TITLE
Adds Index Support For EntryProcessors With A Predicate

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -93,6 +93,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.IMapEvent;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.core.Member;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.MapPartitionLostEvent;
@@ -1071,7 +1072,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapEntrySetCodec.ResponseParameters resultParameters = MapEntrySetCodec.decodeResponse(response);
 
         InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(resultParameters.response.size());
-        SerializationService serializationService = getContext().getSerializationService();
+        InternalSerializationService serializationService
+                = ((InternalSerializationService) getContext().getSerializationService());
         for (Entry<Data, Data> row : resultParameters.response) {
             LazyMapEntry entry = new LazyMapEntry(row.getKey(), row.getValue(), serializationService);
             setBuilder.add(entry);
@@ -1128,7 +1130,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         MapEntriesWithPredicateCodec.ResponseParameters resultParameters = MapEntriesWithPredicateCodec.decodeResponse(response);
 
         InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(resultParameters.response.size());
-        SerializationService serializationService = getContext().getSerializationService();
+        InternalSerializationService serializationService
+                = ((InternalSerializationService) getContext().getSerializationService());
         for (Entry<Data, Data> row : resultParameters.response) {
             LazyMapEntry entry = new LazyMapEntry(row.getKey(), row.getValue(), serializationService);
             setBuilder.add(entry);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -266,7 +266,7 @@ public class MapContainer {
         this.evictor = evictor;
     }
 
-    Extractors getExtractors() {
+    public Extractors getExtractors() {
         return extractors;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -27,6 +27,7 @@ import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 
@@ -128,6 +129,8 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     MapQueryEngine getMapQueryEngine(String name);
 
+    QueryOptimizer getQueryOptimizer();
+
     LocalMapStatsProvider getLocalMapStatsProvider();
 
     MapOperationProvider getMapOperationProvider(String name);
@@ -137,4 +140,5 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     void incrementOperationStats(long startTime, LocalMapStatsImpl localMapStats, String mapName, Operation operation);
 
     void removeMapContainer(MapContainer mapContainer);
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -41,6 +41,7 @@ import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.query.impl.predicates.QueryOptimizer;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
@@ -101,6 +102,7 @@ class MapServiceContextImpl implements MapServiceContext {
     protected final LocalMapStatsProvider localMapStatsProvider;
     protected final MergePolicyProvider mergePolicyProvider;
     protected final MapQueryEngine mapQueryEngine;
+    protected final QueryOptimizer queryOptimizer;
     protected MapEventPublisher mapEventPublisher;
     protected MapService mapService;
     protected EventService eventService;
@@ -116,7 +118,8 @@ class MapServiceContextImpl implements MapServiceContext {
         this.localMapStatsProvider = createLocalMapStatsProvider();
         this.mergePolicyProvider = new MergePolicyProvider(nodeEngine);
         this.mapEventPublisher = createMapEventPublisherSupport();
-        this.mapQueryEngine = createMapQueryEngine();
+        this.queryOptimizer = newOptimizer(nodeEngine.getProperties());
+        this.mapQueryEngine = createMapQueryEngine(queryOptimizer);
         this.eventService = nodeEngine.getEventService();
         this.operationProviders = createOperationProviders();
     }
@@ -131,8 +134,8 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     // this method is overridden in another context.
-    MapQueryEngineImpl createMapQueryEngine() {
-        return new MapQueryEngineImpl(this, newOptimizer(nodeEngine.getProperties()));
+    MapQueryEngineImpl createMapQueryEngine(QueryOptimizer queryOptimizer) {
+        return new MapQueryEngineImpl(this, queryOptimizer);
     }
 
     // this method is overridden in another context.
@@ -357,6 +360,11 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public MapQueryEngine getMapQueryEngine(String mapName) {
         return mapQueryEngine;
+    }
+
+    @Override
+    public QueryOptimizer getQueryOptimizer() {
+        return queryOptimizer;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.MapContainer;
@@ -130,7 +131,9 @@ public class EntryBackupOperation extends MutatingKeyBasedMapOperation implement
     }
 
     private Map.Entry createMapEntry(Data key, Object value) {
-        return new LazyMapEntry(key, value, getNodeEngine().getSerializationService());
+        InternalSerializationService serializationService
+                = ((InternalSerializationService) getNodeEngine().getSerializationService());
+        return new LazyMapEntry(key, value, serializationService, mapContainer.getExtractors());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.LazyMapEntry;
@@ -131,7 +132,7 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
 
     @Override
     public boolean shouldBackup() {
-        return entryProcessor.getBackupProcessor() != null;
+        return mapContainer.getBackupCount() > 0 && entryProcessor.getBackupProcessor() != null;
     }
 
     @Override
@@ -196,7 +197,9 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
     }
 
     private Map.Entry createMapEntry(Data key, Object value) {
-        return new LazyMapEntry(key, value, getNodeEngine().getSerializationService());
+        InternalSerializationService serializationService
+                = ((InternalSerializationService) getNodeEngine().getSerializationService());
+        return new LazyMapEntry(key, value, serializationService, mapContainer.getExtractors());
     }
 
     private LocalMapStatsImpl getLocalMapStats() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -41,24 +41,27 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOpe
 
     @Override
     public void run() throws Exception {
-        final Set<Data> keys = this.keys;
-        for (Data dataKey : keys) {
-            if (keyNotOwnedByThisPartition(dataKey)) {
+        for (Data key : keys) {
+            if (!isKeyProcessable(key)) {
                 continue;
             }
-            final Object oldValue = recordStore.get(dataKey, true);
 
-            final Map.Entry entry = createMapEntry(dataKey, oldValue);
+            Object value = recordStore.get(key, true);
+
+            Map.Entry entry = createMapEntry(key, value);
+            if (!isEntryProcessable(entry)) {
+                continue;
+            }
 
             processBackup(entry);
 
-            if (noOp(entry, oldValue)) {
+            if (noOp(entry, value)) {
                 continue;
             }
-            if (entryRemovedBackup(entry, dataKey)) {
+            if (entryRemovedBackup(entry, key)) {
                 continue;
             }
-            entryAddedOrUpdatedBackup(entry, dataKey);
+            entryAddedOrUpdatedBackup(entry, key);
 
             evict();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateBackupOperation.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+public class MultipleEntryWithPredicateBackupOperation extends MultipleEntryBackupOperation {
+
+    private Predicate predicate;
+
+    public MultipleEntryWithPredicateBackupOperation() {
+    }
+
+    public MultipleEntryWithPredicateBackupOperation(String name, Set<Data> keys,
+                                                     EntryBackupProcessor backupProcessor, Predicate predicate) {
+        super(name, keys, backupProcessor);
+        this.predicate = checkNotNull(predicate, "predicate cannot be null");
+    }
+
+    @Override
+    protected boolean isEntryProcessable(Map.Entry entry) {
+        return super.isEntryProcessable(entry) && predicate.apply(entry);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+
+        out.writeObject(predicate);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+
+        predicate = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryWithPredicateOperation.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.spi.Operation;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+public class MultipleEntryWithPredicateOperation extends MultipleEntryOperation {
+
+    private Predicate predicate;
+
+    public MultipleEntryWithPredicateOperation() {
+    }
+
+    public MultipleEntryWithPredicateOperation(String name, Set<Data> keys, EntryProcessor entryProcessor,
+                                               Predicate predicate) {
+        super(name, keys, entryProcessor);
+        this.predicate = checkNotNull(predicate, "predicate cannot be null");
+    }
+
+    @Override
+    protected boolean isEntryProcessable(Map.Entry entry) {
+        return super.isEntryProcessable(entry) && predicate.apply(entry);
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        EntryBackupProcessor backupProcessor = entryProcessor.getBackupProcessor();
+        if (backupProcessor == null) {
+            return null;
+        }
+
+        MultipleEntryWithPredicateBackupOperation backupOperation
+                = new MultipleEntryWithPredicateBackupOperation(name, keys, backupProcessor, predicate);
+        backupOperation.setWanEventList(wanEventList);
+
+        return backupOperation;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+
+        out.writeObject(predicate);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+
+        predicate = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -95,7 +95,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
 
     @Override
     public boolean shouldBackup() {
-        return entryProcessor.getBackupProcessor() != null;
+        return mapContainer.getTotalBackupCount() > 0 && entryProcessor.getBackupProcessor() != null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
@@ -17,26 +17,128 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.predicates.QueryOptimizer;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
+import com.hazelcast.util.collection.InflatableSet;
+import com.hazelcast.util.collection.Int2ObjectHashMap;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-public class PartitionWideEntryWithPredicateOperationFactory implements OperationFactory {
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.util.CollectionUtil.isEmpty;
+import static com.hazelcast.util.CollectionUtil.toIntArray;
+
+public class PartitionWideEntryWithPredicateOperationFactory implements PartitionAwareOperationFactory {
+
     private String name;
     private EntryProcessor entryProcessor;
     private Predicate predicate;
 
+    private transient Set<Data> keySet;
+    private transient NodeEngine nodeEngine;
+    private transient boolean hasIndex;
+    private transient Map<Integer, List<Data>> partitionIdToKeys;
+
     public PartitionWideEntryWithPredicateOperationFactory() {
     }
 
-    public PartitionWideEntryWithPredicateOperationFactory(String name, EntryProcessor entryProcessor, Predicate predicate) {
+    public PartitionWideEntryWithPredicateOperationFactory(String name, EntryProcessor entryProcessor,
+                                                           Predicate predicate) {
         this.name = name;
         this.entryProcessor = entryProcessor;
         this.predicate = predicate;
+    }
+
+    @Override
+    public void init(NodeEngine nodeEngine) {
+        this.nodeEngine = nodeEngine;
+        queryIndex();
+    }
+
+    private void queryIndex() {
+        // Do not use index in this case, because it requires full-table-scan.
+        if (predicate == TruePredicate.INSTANCE) {
+            return;
+        }
+
+        // get indexes
+        MapService mapService = nodeEngine.getService(SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        Indexes indexes = mapServiceContext.getMapContainer(name).getIndexes();
+        // optimize predicate
+        QueryOptimizer queryOptimizer = mapServiceContext.getQueryOptimizer();
+        predicate = queryOptimizer.optimize(predicate, indexes);
+
+        Set<QueryableEntry> querySet = indexes.query(predicate);
+        if (querySet == null) {
+            return;
+        }
+
+        List<Data> keys = null;
+        for (QueryableEntry e : querySet) {
+            if (keys == null) {
+                keys = new ArrayList<Data>(querySet.size());
+            }
+            keys.add(e.getKeyData());
+        }
+
+        hasIndex = true;
+        keySet = keys == null ? Collections.<Data>emptySet() : InflatableSet.newBuilder(keys).build();
+    }
+
+    @Override
+    public Operation createPartitionOperation(int partition) {
+        if (hasIndex) {
+            List<Data> keys = partitionIdToKeys.get(partition);
+            InflatableSet<Data> keySet = InflatableSet.newBuilder(keys).build();
+            return new MultipleEntryWithPredicateOperation(name, keySet, entryProcessor, predicate);
+        }
+
+        return createOperation();
+    }
+
+    @Override
+    public int[] getPartitions() {
+        if (!hasIndex) {
+            return null;
+        }
+
+        partitionIdToKeys = getPartitionIdToKeysMap();
+        return toIntArray(partitionIdToKeys.keySet());
+    }
+
+    private Map<Integer, List<Data>> getPartitionIdToKeysMap() {
+        if (isEmpty(keySet)) {
+            return Collections.emptyMap();
+        }
+
+        Map<Integer, List<Data>> partitionToKeys = new Int2ObjectHashMap<List<Data>>();
+        for (Data key : keySet) {
+            int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
+            List<Data> keyList = partitionToKeys.get(partitionId);
+            if (keyList == null) {
+                keyList = new ArrayList<Data>();
+                partitionToKeys.put(partitionId, keyList);
+            }
+            keyList.add(key);
+        }
+        return partitionToKeys;
     }
 
     @Override
@@ -56,6 +158,5 @@ public class PartitionWideEntryWithPredicateOperationFactory implements Operatio
         name = in.readUTF();
         entryProcessor = in.readObject();
         predicate = in.readObject();
-
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -42,7 +42,7 @@ public interface MapQueryEngine {
 
     /**
      * Executes a query a specific local partition.
-     *
+     * <p>
      * todo: what happens when the partition is not local?
      *
      * @param mapName     map name.
@@ -54,9 +54,9 @@ public interface MapQueryEngine {
 
     /**
      * Query all local partitions.
-     *
+     * <p>
      * todo: we need better explanation of difference between this method and
-     *  {@link #queryLocalPartitions(String, Predicate, IterationType)}
+     * {@link #queryLocalPartitions(String, Predicate, IterationType)}
      *
      * @param mapName       map name.
      * @param predicate     except paging predicate.
@@ -67,15 +67,15 @@ public interface MapQueryEngine {
     /**
      * Queries all partitions. Paging predicates are not allowed.
      *
-     * @param mapName   map name.
-     * @param predicate except paging predicate.
+     * @param mapName       map name.
+     * @param predicate     except paging predicate.
      * @param iterationType the IterationType
      */
     QueryResult invokeQueryAllPartitions(String mapName, Predicate predicate, IterationType iterationType);
 
     /**
      * Query all local partitions with a paging predicate.
-     *
+     * <p>
      * todo: it would be better to have a single queryLocal... method and let the implementation figure out how to deal
      * with a regular predicate and a paging predicate. No need to have that in the interface. The problem is that currently
      * the signatures don't match up. This implementation detail should not be exposed through the interface.
@@ -89,7 +89,7 @@ public interface MapQueryEngine {
 
     /**
      * Queries all partitions with a paging predicate.
-     *
+     * <p>
      * todo: it would be better to have single queryAll method and let the implementation figure out how to deal
      * with a paging predicate. See comment in {@link #queryLocalPartitionsWithPagingPredicate}
      *

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -26,10 +26,10 @@ import com.hazelcast.query.impl.getters.Extractors;
  */
 public class CachedQueryEntry extends QueryableEntry {
 
-    private Data keyData;
-    private Object keyObject;
-    private Data valueData;
-    private Object valueObject;
+    protected Data keyData;
+    protected Object keyObject;
+    protected Data valueData;
+    protected Object valueObject;
 
     public CachedQueryEntry() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionAwareOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionAwareOperationFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl.operations;
+
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+
+/**
+ * Provides a way to instantiate partition specific operations in the {@link PartitionIteratingOperation}
+ */
+public interface PartitionAwareOperationFactory extends OperationFactory {
+
+    /**
+     * Initializes this factory.
+     *
+     * @param nodeEngine nodeEngine
+     */
+    void init(NodeEngine nodeEngine);
+
+    /**
+     * Create a partition-operation for the supplied partition-id
+     *
+     * @param partition id of partition
+     * @return new operation
+     */
+    Operation createPartitionOperation(int partition);
+
+    /**
+     * Created operations by this factory will be run on these partitions.
+     * Return null to preserve  default behaviour.
+     *
+     * @return null to preserve default behaviour or return all partition-ids for the operations of this factory.
+     */
+    int[] getPartitions();
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
@@ -27,23 +27,25 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 /**
  * Provides fast {@link Set} implementation for cases where items are known to not
  * contain duplicates.
- *
+ * <p>
  * It requires creation via {@link com.hazelcast.util.collection.InflatableSet.Builder}
- *
+ * <p>
  * The builder doesn't call equals/hash methods on initial data insertion, hence it avoids
  * performance penalty in the case these methods are expensive. It also means it does
  * not detect duplicates - it's the responsibility of the caller to make sure no duplicated
  * entries are inserted.
- *
+ * <p>
  * Once InflatableSet is constructed via {@link Builder#build()} then it acts as a regular set. It has
  * been designed to mimic {@link HashSet}. On new entry insertion or lookup via
  * {@link #contains(Object)} it inflates itself: The backing list is copied into
  * internal {@link HashSet}. This obviously costs time and space. We are making a bet the
  * Set won't be modified in most cases.
- *
+ * <p>
  * It's intended to be used in cases where the contract mandates us to return Set,
  * but we know our data does not contain duplicates. It performs best in cases
  * biased towards sequential iteration.
@@ -96,6 +98,10 @@ public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Se
 
     public static <T> Builder<T> newBuilder(int initialCapacity) {
         return new Builder<T>(initialCapacity);
+    }
+
+    public static <T> Builder<T> newBuilder(List<T> list) {
+        return new Builder<T>(list);
     }
 
     @Override
@@ -250,6 +256,10 @@ public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Se
 
         private Builder(int initialCapacity) {
             this.list = new ArrayList<T>(initialCapacity);
+        }
+
+        private Builder(List<T> list) {
+            this.list = checkNotNull(list, "list cannot be null");
         }
 
         public Builder add(T item) {

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/InflatableSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/InflatableSetTest.java
@@ -29,6 +29,11 @@ public class InflatableSetTest {
         InflatableSet.newBuilder(-1);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void whenNullListPassed_thenNullPointerException() {
+        InflatableSet.newBuilder(null);
+    }
+
     @Test
     public void serialization_whenInInitialLoadingAndEmpty() throws IOException, ClassNotFoundException {
         InflatableSet<Object> set = InflatableSet.newBuilder(0).build();


### PR DESCRIPTION
Entry-processor can select processable entries by using a predicate. Currently, this selection happens by doing a full-table-scan in a partition. Instead of full-table-scan, indexes can be used if they are available