### PR TITLE
Fixed possible division by zero in InternalPartitionServiceImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -53,11 +53,11 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionAwareService;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.partition.IPartitionLostEvent;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.FutureUtil.ExceptionHandler;
@@ -835,7 +835,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     public Map<Address, List<Integer>> getMemberPartitionsMap() {
         Collection<Member> dataMembers = node.getClusterService().getMembers(DATA_MEMBER_SELECTOR);
         int dataMembersSize = dataMembers.size();
-        int partitionsPerMember = (int) ceil((float) partitionCount / dataMembersSize);
+        int partitionsPerMember = (dataMembersSize > 0 ? (int) ceil((float) partitionCount / dataMembersSize) : 0);
 
         Map<Address, List<Integer>> memberPartitions = new HashMap<Address, List<Integer>>(dataMembersSize);
         for (int partitionId = 0; partitionId < partitionCount; partitionId++) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImplTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class InternalPartitionServiceImplTest extends HazelcastTestSupport {
@@ -126,6 +125,7 @@ public class InternalPartitionServiceImplTest extends HazelcastTestSupport {
     }
 
     private static class TestPartitionListener implements PartitionListener {
+
         private int eventCount;
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
@@ -43,8 +43,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class InternalPartitionServiceLiteMemberTest
-        extends HazelcastTestSupport {
+public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport {
 
     private final Config liteMemberConfig = new Config().setLiteMember(true);
 
@@ -147,8 +146,7 @@ public class InternalPartitionServiceLiteMemberTest
 
             assertTrueEventually(new AssertTask() {
                 @Override
-                public void run()
-                        throws Exception {
+                public void run() throws Exception {
                     for (int i = 0; i < partitionService.getPartitionCount(); i++) {
                         assertEquals(getNode(master).getThisAddress(), partitionService.getPartition(i).getOwnerOrNull());
                     }
@@ -219,13 +217,13 @@ public class InternalPartitionServiceLiteMemberTest
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 try {
                     final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(lite);
                     partitionService.getPartitionOwnerOrWait(0);
                     fail();
                 } catch (NoDataMemberInClusterException expected) {
+                    ignore(expected);
                 }
             }
         });
@@ -245,13 +243,13 @@ public class InternalPartitionServiceLiteMemberTest
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 try {
                     final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(lite);
                     partitionService.getPartitionOwnerOrWait(0);
                     fail();
                 } catch (NoDataMemberInClusterException expected) {
+                    ignore(expected);
                 }
             }
         });
@@ -468,8 +466,7 @@ public class InternalPartitionServiceLiteMemberTest
     private void assertMemberGroupsSizeEventually(final HazelcastInstance instance, final int memberGroupSize) {
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
                 assertEquals(memberGroupSize, partitionService.getMemberGroupsSize());
             }
@@ -535,8 +532,7 @@ public class InternalPartitionServiceLiteMemberTest
     private void assertMaxBackupCountEventually(final HazelcastInstance instance, final int maxBackupCount) {
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
+            public void run() throws Exception {
                 final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
                 assertEquals(maxBackupCount, partitionService.getMaxAllowedBackupCount());
             }
@@ -546,5 +542,4 @@ public class InternalPartitionServiceLiteMemberTest
     private InternalPartitionServiceImpl getInternalPartitionServiceImpl(HazelcastInstance instance) {
         return (InternalPartitionServiceImpl) getNode(instance).getPartitionService();
     }
-
 }


### PR DESCRIPTION
* Fixed possible division by zero in `InternalPartitionServiceImpl.getMemberPartitionsMap()`.
* Small cleanup of `InternalPartitionServiceImpl` test classes.

Thx @ahmetmircik for this finding :)

I first wanted to directly return the empty map, but actually the `getPartitionOwnerOrWait()` method throws a `NoDataMemberInClusterException` if there are no data members in the cluster. I didn't want to change that, so I just fixed the initial size if there are no data members, and let the method throw its exception (there is also a test for this in `InternalPartitionServiceLiteMemberTest`).