### PR TITLE
Deprecated ConfigReadonly classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
@@ -30,6 +30,8 @@ import java.util.Set;
  *
  * @param <K> type of the key
  * @param <V> type of the value
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.git ch
  */
 public class CacheConfigReadOnly<K, V> extends CacheConfig<K, V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfigReadOnly.java
@@ -23,6 +23,8 @@ import java.util.EventListener;
 /**
  * Read-Only Configuration for CachePartitionLostListener
  * @see CachePartitionLostListener
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class CachePartitionLostListenerConfigReadOnly
         extends CachePartitionLostListenerConfig {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfigReadOnly.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 /**
  * Readonly version of {@link com.hazelcast.config.CacheSimpleConfig}
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class CacheSimpleConfigReadOnly
         extends CacheSimpleConfig {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfigReadOnly.java
@@ -18,6 +18,8 @@ package com.hazelcast.config;
 
 /**
  * Readonly version of CacheSimpleEntryListenerConfig
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class CacheSimpleEntryListenerConfigReadOnly
         extends CacheSimpleEntryListenerConfig {

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfigReadOnly.java
@@ -21,6 +21,8 @@ import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 
 /**
  * Readonly version of {@link DiscoveryConfig}
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class DiscoveryConfigReadOnly
         extends DiscoveryConfig {

--- a/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfigReadOnly.java
@@ -22,6 +22,8 @@ import java.util.EventListener;
 
 /**
  * Configuration for EntryListener(Read Only)
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class EntryListenerConfigReadOnly extends EntryListenerConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
@@ -18,6 +18,8 @@ package com.hazelcast.config;
 
 /**
  * Read only version of {@link com.hazelcast.config.EvictionConfig}.
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class EvictionConfigReadOnly
         extends EvictionConfig {

--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfigReadOnly.java
@@ -18,6 +18,8 @@ package com.hazelcast.config;
 
 /**
  * Configuration for Executor(Read Only)
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class ExecutorConfigReadOnly extends ExecutorConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfigReadOnly.java
@@ -22,6 +22,8 @@ import java.util.EventListener;
 
 /**
  * Contains the configuration for an Item Listener(Read-only).
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class ItemListenerConfigReadOnly extends ItemListenerConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfigReadOnly.java
@@ -19,6 +19,8 @@ package com.hazelcast.config;
 import com.hazelcast.mapreduce.TopologyChangedStrategy;
 /**
  * Contains the configuration for an {@link com.hazelcast.mapreduce.JobTracker}.
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class JobTrackerConfigReadOnly
         extends JobTrackerConfig {

--- a/hazelcast/src/main/java/com/hazelcast/config/ListConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListConfigReadOnly.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 /**
  * Contains the configuration for an {@link com.hazelcast.core.IList} (read-only).
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class ListConfigReadOnly extends ListConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListenerConfigReadOnly.java
@@ -17,8 +17,11 @@
 package com.hazelcast.config;
 
 import java.util.EventListener;
+
 /**
  * Contains the configuration for a Listener.
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class ListenerConfigReadOnly extends ListenerConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MapAttributeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapAttributeConfigReadOnly.java
@@ -18,6 +18,8 @@ package com.hazelcast.config;
 
 /**
  * Contains the configuration for a extractor of Map.
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class MapAttributeConfigReadOnly extends MapAttributeConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfigReadOnly.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 /**
  * Contains the configuration for an {@link com.hazelcast.core.IMap} (read-only).
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class MapConfigReadOnly extends MapConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfigReadOnly.java
@@ -15,8 +15,11 @@
  */
 
 package com.hazelcast.config;
+
 /**
  * Contains the configuration for a index of Map.
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class MapIndexConfigReadOnly extends MapIndexConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MapPartitionLostListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapPartitionLostListenerConfigReadOnly.java
@@ -23,6 +23,8 @@ import java.util.EventListener;
 /**
  * Read-Only Configuration for MapPartitionLostListener
  * @see com.hazelcast.map.listener.MapPartitionLostListener
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class MapPartitionLostListenerConfigReadOnly
         extends MapPartitionLostListenerConfig {

--- a/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfigReadOnly.java
@@ -17,8 +17,11 @@
 package com.hazelcast.config;
 
 import java.util.Properties;
+
 /**
  * Contains the configuration for a Map Store (read-only).
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class MapStoreConfigReadOnly extends MapStoreConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
@@ -18,6 +18,8 @@ package com.hazelcast.config;
 
 /**
  * Contains the configuration for a size of Map.
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class MaxSizeConfigReadOnly extends MaxSizeConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
@@ -18,8 +18,11 @@ package com.hazelcast.config;
 
 import java.util.Collections;
 import java.util.Map;
+
 /**
  * Contains configuration for attribute of member (Read-Only).
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class MemberAttributeConfigReadOnly extends MemberAttributeConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfigReadOnly.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 /**
  * Contains the configuration for an {@link com.hazelcast.core.MultiMap}.
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class MultiMapConfigReadOnly extends MultiMapConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
@@ -15,8 +15,11 @@
  */
 
 package com.hazelcast.config;
+
 /**
  * Contains configuration for an NearCache(Read-Only).
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class NearCacheConfigReadOnly extends NearCacheConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfigReadOnly.java
@@ -17,8 +17,11 @@
 package com.hazelcast.config;
 
 import com.hazelcast.core.PartitioningStrategy;
+
 /**
  * Contains the configuration for strategy of partitioning
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class PartitioningStrategyConfigReadOnly extends PartitioningStrategyConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
@@ -22,6 +22,7 @@ import com.hazelcast.query.Predicate;
  * Contains the configuration for a Predicate.
  *
  * @since 3.5
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 class PredicateConfigReadOnly extends PredicateConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfigReadOnly.java
@@ -24,6 +24,7 @@ import java.util.List;
  * Read only {@code QueryCacheConfig}
  *
  * @since 3.5
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 class QueryCacheConfigReadOnly extends QueryCacheConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueConfigReadOnly.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 /**
  * Contains the configuration for an {@link com.hazelcast.core.IQueue}.
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class QueueConfigReadOnly extends QueueConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfigReadOnly.java
@@ -23,6 +23,8 @@ import java.util.Properties;
 
 /**
  * Contains the configuration for an {@link com.hazelcast.core.QueueStore}.
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class QueueStoreConfigReadOnly extends QueueStoreConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -258,7 +258,7 @@ public class ReliableTopicConfig {
 
     static class ReliableTopicConfigReadOnly extends ReliableTopicConfig {
 
-        public ReliableTopicConfigReadOnly(ReliableTopicConfig config) {
+        ReliableTopicConfigReadOnly(ReliableTopicConfig config) {
             super(config);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
@@ -19,6 +19,9 @@ package com.hazelcast.config;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
+/**
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
+ */
 class ReplicatedMapConfigReadOnly extends ReplicatedMapConfig {
 
     public ReplicatedMapConfigReadOnly(ReplicatedMapConfig replicatedMapConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfigReadOnly.java
@@ -15,10 +15,12 @@
  */
 
 package com.hazelcast.config;
+
 /**
  * Contains configuration for Semaphore(read only)
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
-
 public class SemaphoreConfigReadOnly extends SemaphoreConfig {
 
     public SemaphoreConfigReadOnly(SemaphoreConfig config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/SetConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SetConfigReadOnly.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 /**
  * Contains configuration for Set(read only)
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class SetConfigReadOnly extends SetConfig {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfigReadOnly.java
@@ -19,10 +19,12 @@ package com.hazelcast.config;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 /**
  * Configuration for topic(Read only)
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
-
 public class TopicConfigReadOnly extends TopicConfig {
 
     public TopicConfigReadOnly(TopicConfig config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRefReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRefReadOnly.java
@@ -18,6 +18,8 @@ package com.hazelcast.config;
 
 /**
  * Configuration for Wan target replication reference(read only)
+ *
+ * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
 public class WanReplicationRefReadOnly extends WanReplicationRef {
 


### PR DESCRIPTION
These classes should not be visible to the public since they are implementation details.
The simplest thing to do is to make these classes inner classes of the actual Config class like is
done with the ReliableTopicConfig.

Removing these classes reduces coupling and makes the config API easier to use since the size of this package is reduced considerably by removing non relevant classes.