### PR TITLE
Concurrent operation cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AbstractAtomicLongOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AbstractAtomicLongOperation.java
@@ -14,62 +14,44 @@
  * limitations under the License.
  */
 
-package com.hazelcast.concurrent.atomicreference.operations;
+package com.hazelcast.concurrent.atomiclong.operations;
 
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
+import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
+import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
+import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.io.IOException;
 
-public abstract class AtomicReferenceBaseOperation extends Operation
+public abstract class AbstractAtomicLongOperation extends AbstractOperation
         implements PartitionAwareOperation, IdentifiedDataSerializable {
 
     protected String name;
 
-    public AtomicReferenceBaseOperation() {
+    public AbstractAtomicLongOperation() {
     }
 
-    public AtomicReferenceBaseOperation(String name) {
+    public AbstractAtomicLongOperation(String name) {
         this.name = name;
+    }
+
+    public AtomicLongContainer getLongContainer() {
+        AtomicLongService service = getService();
+        return service.getLongContainer(name);
     }
 
     @Override
     public String getServiceName() {
-        return AtomicReferenceService.SERVICE_NAME;
-    }
-
-    public AtomicReferenceContainer getReferenceContainer() {
-        AtomicReferenceService service = getService();
-        return service.getReferenceContainer(name);
-    }
-
-    @Override
-    public void beforeRun() throws Exception {
-    }
-
-    @Override
-    public void afterRun() throws Exception {
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return true;
+        return AtomicLongService.SERVICE_NAME;
     }
 
     @Override
     public int getFactoryId() {
-        return AtomicReferenceDataSerializerHook.F_ID;
+        return AtomicLongDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AddBackupOperation.java
@@ -24,7 +24,7 @@ import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 
-public class AddBackupOperation extends AtomicLongBaseOperation implements BackupOperation {
+public class AddBackupOperation extends AbstractAtomicLongOperation implements BackupOperation {
 
     private long delta;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/ApplyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/ApplyOperation.java
@@ -24,7 +24,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 
-public class ApplyOperation<R> extends AtomicLongBaseOperation {
+public class ApplyOperation<R> extends AbstractAtomicLongOperation {
 
     private IFunction<Long, R> function;
     private R returnValue;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/AtomicLongBackupAwareOperation.java
@@ -18,7 +18,7 @@ package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.spi.BackupAwareOperation;
 
-public abstract class AtomicLongBackupAwareOperation extends AtomicLongBaseOperation
+public abstract class AtomicLongBackupAwareOperation extends AbstractAtomicLongOperation
         implements BackupAwareOperation {
 
     protected boolean shouldBackup = true;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.concurrent.atomiclong.operations;
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
 import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
 
-public class GetOperation extends AtomicLongBaseOperation {
+public class GetOperation extends AbstractAtomicLongOperation {
 
     private long returnValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/SetBackupOperation.java
@@ -24,7 +24,7 @@ import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 
-public class SetBackupOperation extends AtomicLongBaseOperation implements BackupOperation {
+public class SetBackupOperation extends AbstractAtomicLongOperation implements BackupOperation {
 
     private long newValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAtomicReferenceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AbstractAtomicReferenceOperation.java
@@ -14,67 +14,49 @@
  * limitations under the License.
  */
 
-package com.hazelcast.concurrent.atomiclong.operations;
+package com.hazelcast.concurrent.atomicreference.operations;
 
-import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
-import com.hazelcast.concurrent.atomiclong.AtomicLongService;
+import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
+import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
+import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.AbstractOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.io.IOException;
 
-public abstract class AtomicLongBaseOperation extends Operation
+public abstract class AbstractAtomicReferenceOperation extends AbstractOperation
         implements PartitionAwareOperation, IdentifiedDataSerializable {
 
     protected String name;
 
-    public AtomicLongBaseOperation() {
+    public AbstractAtomicReferenceOperation() {
     }
 
-    public AtomicLongBaseOperation(String name) {
+    public AbstractAtomicReferenceOperation(String name) {
         this.name = name;
-    }
-
-    public AtomicLongContainer getLongContainer() {
-        AtomicLongService service = getService();
-        return service.getLongContainer(name);
-    }
-
-    @Override
-    public void afterRun() throws Exception {
-    }
-
-    @Override
-    public void beforeRun() throws Exception {
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return true;
     }
 
     @Override
     public String getServiceName() {
-        return AtomicLongService.SERVICE_NAME;
+        return AtomicReferenceService.SERVICE_NAME;
+    }
+
+    public AtomicReferenceContainer getReferenceContainer() {
+        AtomicReferenceService service = getService();
+        return service.getReferenceContainer(name);
     }
 
     @Override
-    public int getFactoryId() {
-        return AtomicLongDataSerializerHook.F_ID;
+    public final int getFactoryId() {
+        return AtomicReferenceDataSerializerHook.F_ID;
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-       out.writeUTF(name);
+        out.writeUTF(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ApplyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ApplyOperation.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.NodeEngine;
 
 import java.io.IOException;
 
-public class ApplyOperation extends AtomicReferenceBaseOperation {
+public class ApplyOperation extends AbstractAtomicReferenceOperation {
 
     protected Data function;
     protected Data returnValue;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AtomicReferenceBackupAwareOperation.java
@@ -18,7 +18,7 @@ package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.spi.BackupAwareOperation;
 
-public abstract class AtomicReferenceBackupAwareOperation extends AtomicReferenceBaseOperation
+public abstract class AtomicReferenceBackupAwareOperation extends AbstractAtomicReferenceOperation
         implements BackupAwareOperation {
 
     protected boolean shouldBackup = true;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ContainsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/ContainsOperation.java
@@ -24,7 +24,7 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 
-public class ContainsOperation extends AtomicReferenceBaseOperation {
+public class ContainsOperation extends AbstractAtomicReferenceOperation {
 
     private boolean returnValue;
     private Data contains;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.concurrent.atomicreference.operations;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 
-public class GetOperation extends AtomicReferenceBaseOperation {
+public class GetOperation extends AbstractAtomicReferenceOperation {
 
     private Data returnValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/IsNullOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/IsNullOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.concurrent.atomicreference.operations;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 
-public class IsNullOperation extends AtomicReferenceBaseOperation {
+public class IsNullOperation extends AbstractAtomicReferenceOperation {
 
     private boolean returnValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/SetBackupOperation.java
@@ -25,7 +25,7 @@ import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 
-public class SetBackupOperation extends AtomicReferenceBaseOperation implements BackupOperation {
+public class SetBackupOperation extends AbstractAtomicReferenceOperation implements BackupOperation {
 
     private Data newValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AbstractCountDownLatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AbstractCountDownLatchOperation.java
@@ -16,19 +16,21 @@
 
 package com.hazelcast.concurrent.countdownlatch.operations;
 
+import com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializerHook;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
 import com.hazelcast.concurrent.countdownlatch.LatchKey;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
 
-abstract class BaseCountDownLatchOperation extends AbstractNamedOperation
-        implements PartitionAwareOperation {
+abstract class AbstractCountDownLatchOperation extends AbstractNamedOperation
+        implements PartitionAwareOperation, IdentifiedDataSerializable {
 
-    protected BaseCountDownLatchOperation() {
+    AbstractCountDownLatchOperation() {
     }
 
-    protected BaseCountDownLatchOperation(String name) {
+    AbstractCountDownLatchOperation(String name) {
         super(name);
     }
 
@@ -37,7 +39,12 @@ abstract class BaseCountDownLatchOperation extends AbstractNamedOperation
         return CountDownLatchService.SERVICE_NAME;
     }
 
-    protected WaitNotifyKey waitNotifyKey() {
+    @Override
+    public final int getFactoryId() {
+        return CountDownLatchDataSerializerHook.F_ID;
+    }
+
+    WaitNotifyKey waitNotifyKey() {
         return new LatchKey(name);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/AwaitOperation.java
@@ -18,11 +18,10 @@ package com.hazelcast.concurrent.countdownlatch.operations;
 
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializerHook;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public class AwaitOperation extends BaseCountDownLatchOperation implements BlockingOperation, IdentifiedDataSerializable {
+public class AwaitOperation extends AbstractCountDownLatchOperation implements BlockingOperation {
 
     public AwaitOperation() {
     }
@@ -55,11 +54,6 @@ public class AwaitOperation extends BaseCountDownLatchOperation implements Block
     @Override
     public void onWaitExpire() {
         sendResponse(false);
-    }
-
-    @Override
-    public int getFactoryId() {
-        return CountDownLatchDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BackupAwareCountDownLatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BackupAwareCountDownLatchOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 
-abstract class BackupAwareCountDownLatchOperation extends BaseCountDownLatchOperation
+abstract class BackupAwareCountDownLatchOperation extends AbstractCountDownLatchOperation
         implements BackupAwareOperation {
 
     protected BackupAwareCountDownLatchOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownLatchBackupOperation.java
@@ -20,13 +20,11 @@ import com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializerHook;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 
-public class CountDownLatchBackupOperation extends BaseCountDownLatchOperation
-        implements BackupOperation, IdentifiedDataSerializable {
+public class CountDownLatchBackupOperation extends AbstractCountDownLatchOperation implements BackupOperation {
 
     private int count;
 
@@ -47,11 +45,6 @@ public class CountDownLatchBackupOperation extends BaseCountDownLatchOperation
     @Override
     public Object getResponse() {
         return Boolean.TRUE;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return CountDownLatchDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/CountDownOperation.java
@@ -18,11 +18,10 @@ package com.hazelcast.concurrent.countdownlatch.operations;
 
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializerHook;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public class CountDownOperation extends BackupAwareCountDownLatchOperation implements Notifier, IdentifiedDataSerializable {
+public class CountDownOperation extends BackupAwareCountDownLatchOperation implements Notifier {
 
     private boolean shouldNotify;
 
@@ -54,11 +53,6 @@ public class CountDownOperation extends BackupAwareCountDownLatchOperation imple
     @Override
     public WaitNotifyKey getNotifiedKey() {
         return waitNotifyKey();
-    }
-
-    @Override
-    public int getFactoryId() {
-        return CountDownLatchDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/GetCountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/GetCountOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.countdownlatch.operations;
 
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializerHook;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class GetCountOperation extends BaseCountDownLatchOperation implements IdentifiedDataSerializable {
+public class GetCountOperation extends AbstractCountDownLatchOperation {
 
     private int count;
 
@@ -40,11 +39,6 @@ public class GetCountOperation extends BaseCountDownLatchOperation implements Id
     @Override
     public Object getResponse() {
         return count;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return CountDownLatchDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/SetCountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/SetCountOperation.java
@@ -20,11 +20,10 @@ import com.hazelcast.concurrent.countdownlatch.CountDownLatchDataSerializerHook;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
-public class SetCountOperation extends BackupAwareCountDownLatchOperation implements IdentifiedDataSerializable {
+public class SetCountOperation extends BackupAwareCountDownLatchOperation {
 
     private int count;
     private boolean response;
@@ -51,11 +50,6 @@ public class SetCountOperation extends BackupAwareCountDownLatchOperation implem
     @Override
     public boolean shouldBackup() {
         return response;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return CountDownLatchDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AbstractLockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AbstractLockOperation.java
@@ -29,7 +29,7 @@ import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.io.IOException;
 
-public abstract class BaseLockOperation extends AbstractOperation
+public abstract class AbstractLockOperation extends AbstractOperation
         implements PartitionAwareOperation, IdentifiedDataSerializable {
 
     public static final int ANY_THREAD = 0;
@@ -42,23 +42,23 @@ public abstract class BaseLockOperation extends AbstractOperation
     private transient boolean asyncBackup;
     private long referenceCallId;
 
-    public BaseLockOperation() {
+    public AbstractLockOperation() {
     }
 
-    protected BaseLockOperation(ObjectNamespace namespace, Data key, long threadId) {
+    protected AbstractLockOperation(ObjectNamespace namespace, Data key, long threadId) {
         this.namespace = namespace;
         this.key = key;
         this.threadId = threadId;
     }
 
-    protected BaseLockOperation(ObjectNamespace namespace, Data key, long threadId, long timeout) {
+    protected AbstractLockOperation(ObjectNamespace namespace, Data key, long threadId, long timeout) {
         this.namespace = namespace;
         this.key = key;
         this.threadId = threadId;
         setWaitTimeout(timeout);
     }
 
-    public BaseLockOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, long timeout) {
+    public AbstractLockOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, long timeout) {
         this.namespace = namespace;
         this.key = key;
         this.threadId = threadId;
@@ -122,7 +122,7 @@ public abstract class BaseLockOperation extends AbstractOperation
     }
 
     @Override
-    public int getFactoryId() {
+    public final int getFactoryId() {
         return LockDataSerializerHook.F_ID;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
 
-public class AwaitBackupOperation extends BaseLockOperation
+public class AwaitBackupOperation extends AbstractLockOperation
         implements BackupOperation {
 
     private String originalCaller;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -29,7 +29,7 @@ import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
 
-public class AwaitOperation extends BaseLockOperation
+public class AwaitOperation extends AbstractLockOperation
         implements BlockingOperation, BackupAwareOperation {
 
     private String conditionId;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
@@ -25,7 +25,7 @@ import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
 
-abstract class BaseSignalOperation extends BaseLockOperation {
+abstract class BaseSignalOperation extends AbstractLockOperation {
 
     protected boolean all;
     protected String conditionId;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
 
-public class BeforeAwaitBackupOperation extends BaseLockOperation implements BackupOperation {
+public class BeforeAwaitBackupOperation extends AbstractLockOperation implements BackupOperation {
 
     private String conditionId;
     private String originalCaller;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.WaitNotifyKey;
 
 import java.io.IOException;
 
-public class BeforeAwaitOperation extends BaseLockOperation implements Notifier, BackupAwareOperation {
+public class BeforeAwaitOperation extends AbstractLockOperation implements Notifier, BackupAwareOperation {
 
     private String conditionId;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetLockCountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetLockCountOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
 
-public class GetLockCountOperation extends BaseLockOperation {
+public class GetLockCountOperation extends AbstractLockOperation {
 
     public GetLockCountOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetRemainingLeaseTimeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetRemainingLeaseTimeOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
 
-public class GetRemainingLeaseTimeOperation extends BaseLockOperation {
+public class GetRemainingLeaseTimeOperation extends AbstractLockOperation {
 
     public GetRemainingLeaseTimeOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/IsLockedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/IsLockedOperation.java
@@ -21,7 +21,7 @@ import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
 
-public class IsLockedOperation extends BaseLockOperation {
+public class IsLockedOperation extends AbstractLockOperation {
 
     public IsLockedOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
 
-public class LockBackupOperation extends BaseLockOperation implements BackupOperation {
+public class LockBackupOperation extends AbstractLockOperation implements BackupOperation {
 
     private String originalCallerUuid;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public class LockOperation extends BaseLockOperation implements BlockingOperation, BackupAwareOperation {
+public class LockOperation extends AbstractLockOperation implements BlockingOperation, BackupAwareOperation {
 
     public LockOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
@@ -26,7 +26,7 @@ import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
 
-public class UnlockBackupOperation extends BaseLockOperation implements BackupOperation {
+public class UnlockBackupOperation extends AbstractLockOperation implements BackupOperation {
 
     private boolean force;
     private String originalCallerUuid;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
@@ -32,7 +32,9 @@ import com.hazelcast.spi.WaitNotifyKey;
 
 import java.io.IOException;
 
-public class UnlockOperation extends BaseLockOperation implements Notifier, BackupAwareOperation {
+import static java.lang.Boolean.TRUE;
+
+public class UnlockOperation extends AbstractLockOperation implements Notifier, BackupAwareOperation {
 
     private boolean force;
     private boolean shouldNotify;
@@ -101,7 +103,7 @@ public class UnlockOperation extends BaseLockOperation implements Notifier, Back
 
     @Override
     public boolean shouldBackup() {
-        return Boolean.TRUE.equals(response);
+        return TRUE.equals(response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
@@ -18,10 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class AcquireBackupOperation extends SemaphoreBackupOperation
-        implements IdentifiedDataSerializable {
+public class AcquireBackupOperation extends SemaphoreBackupOperation {
 
     public AcquireBackupOperation() {
     }
@@ -35,11 +33,6 @@ public class AcquireBackupOperation extends SemaphoreBackupOperation
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
         semaphoreContainer.acquire(permitCount, firstCaller);
         response = true;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
@@ -19,13 +19,13 @@ package com.hazelcast.concurrent.semaphore.operations;
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.concurrent.semaphore.SemaphoreWaitNotifyKey;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public class AcquireOperation extends SemaphoreBackupAwareOperation
-        implements BlockingOperation, IdentifiedDataSerializable {
+import static java.lang.Boolean.TRUE;
+
+public class AcquireOperation extends SemaphoreBackupAwareOperation implements BlockingOperation {
 
     public AcquireOperation() {
     }
@@ -59,17 +59,12 @@ public class AcquireOperation extends SemaphoreBackupAwareOperation
 
     @Override
     public boolean shouldBackup() {
-        return Boolean.TRUE.equals(response);
+        return TRUE.equals(response);
     }
 
     @Override
     public Operation getBackupOperation() {
         return new AcquireBackupOperation(name, permitCount, getCallerUuid());
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AvailableOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AvailableOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class AvailableOperation extends SemaphoreOperation implements IdentifiedDataSerializable {
+public class AvailableOperation extends SemaphoreOperation {
 
     public AvailableOperation() {
     }
@@ -33,11 +32,6 @@ public class AvailableOperation extends SemaphoreOperation implements Identified
     public void run() throws Exception {
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
         response = semaphoreContainer.getAvailable();
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class DrainBackupOperation extends SemaphoreBackupOperation implements IdentifiedDataSerializable {
+public class DrainBackupOperation extends SemaphoreBackupOperation {
 
     public DrainBackupOperation() {
     }
@@ -34,11 +33,6 @@ public class DrainBackupOperation extends SemaphoreBackupOperation implements Id
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
         semaphoreContainer.drain(firstCaller);
         response = true;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainOperation.java
@@ -18,10 +18,9 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
-public class DrainOperation extends SemaphoreBackupAwareOperation implements IdentifiedDataSerializable {
+public class DrainOperation extends SemaphoreBackupAwareOperation {
 
     public DrainOperation() {
     }
@@ -44,11 +43,6 @@ public class DrainOperation extends SemaphoreBackupAwareOperation implements Ide
     @Override
     public Operation getBackupOperation() {
         return new DrainBackupOperation(name, permitCount, getCallerUuid());
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class InitBackupOperation extends SemaphoreBackupOperation implements IdentifiedDataSerializable {
+public class InitBackupOperation extends SemaphoreBackupOperation {
 
     public InitBackupOperation() {
     }
@@ -34,11 +33,6 @@ public class InitBackupOperation extends SemaphoreBackupOperation implements Ide
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
         semaphoreContainer.init(permitCount);
         response = true;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/InitOperation.java
@@ -18,10 +18,11 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
-public class InitOperation extends SemaphoreBackupAwareOperation implements IdentifiedDataSerializable {
+import static java.lang.Boolean.TRUE;
+
+public class InitOperation extends SemaphoreBackupAwareOperation {
 
     public InitOperation() {
     }
@@ -38,17 +39,12 @@ public class InitOperation extends SemaphoreBackupAwareOperation implements Iden
 
     @Override
     public boolean shouldBackup() {
-        return Boolean.TRUE.equals(response);
+        return TRUE.equals(response);
     }
 
     @Override
     public Operation getBackupOperation() {
         return new InitBackupOperation(name, permitCount);
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class ReduceBackupOperation extends SemaphoreBackupOperation implements IdentifiedDataSerializable {
+public class ReduceBackupOperation extends SemaphoreBackupOperation {
 
     public ReduceBackupOperation() {
     }
@@ -34,11 +33,6 @@ public class ReduceBackupOperation extends SemaphoreBackupOperation implements I
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
         semaphoreContainer.reduce(permitCount);
         response = true;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReduceOperation.java
@@ -18,10 +18,11 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
-public class ReduceOperation extends SemaphoreBackupAwareOperation implements IdentifiedDataSerializable {
+import static java.lang.Boolean.TRUE;
+
+public class ReduceOperation extends SemaphoreBackupAwareOperation {
 
     public ReduceOperation() {
     }
@@ -38,17 +39,12 @@ public class ReduceOperation extends SemaphoreBackupAwareOperation implements Id
 
     @Override
     public boolean shouldBackup() {
-        return Boolean.TRUE.equals(response);
+        return TRUE.equals(response);
     }
 
     @Override
     public Operation getBackupOperation() {
         return new ReduceBackupOperation(name, permitCount);
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class ReleaseBackupOperation extends SemaphoreBackupOperation implements IdentifiedDataSerializable {
+public class ReleaseBackupOperation extends SemaphoreBackupOperation {
 
     public ReleaseBackupOperation() {
     }
@@ -34,11 +33,6 @@ public class ReleaseBackupOperation extends SemaphoreBackupOperation implements 
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
         semaphoreContainer.release(permitCount, firstCaller);
         response = true;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseOperation.java
@@ -19,12 +19,11 @@ package com.hazelcast.concurrent.semaphore.operations;
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.concurrent.semaphore.SemaphoreWaitNotifyKey;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public class ReleaseOperation extends SemaphoreBackupAwareOperation implements Notifier, IdentifiedDataSerializable {
+public class ReleaseOperation extends SemaphoreBackupAwareOperation implements Notifier {
 
     public ReleaseOperation() {
     }
@@ -58,11 +57,6 @@ public class ReleaseOperation extends SemaphoreBackupAwareOperation implements N
     @Override
     public Operation getBackupOperation() {
         return new ReleaseBackupOperation(name, permitCount, getCallerUuid());
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberBackupOperation.java
@@ -19,10 +19,8 @@ package com.hazelcast.concurrent.semaphore.operations;
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class SemaphoreDeadMemberBackupOperation extends SemaphoreBackupOperation
-        implements IdentifiedDataSerializable {
+public class SemaphoreDeadMemberBackupOperation extends SemaphoreBackupOperation {
 
     public SemaphoreDeadMemberBackupOperation() {
     }
@@ -38,11 +36,6 @@ public class SemaphoreDeadMemberBackupOperation extends SemaphoreBackupOperation
             SemaphoreContainer semaphoreContainer = service.getSemaphoreContainer(name);
             response = semaphoreContainer.memberRemoved(firstCaller);
         }
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberOperation.java
@@ -22,7 +22,6 @@ import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.concurrent.semaphore.SemaphoreWaitNotifyKey;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.Operation;
@@ -32,8 +31,7 @@ import com.hazelcast.spi.partition.IPartitionService;
 
 import java.io.IOException;
 
-public class SemaphoreDeadMemberOperation extends SemaphoreBackupAwareOperation
-        implements Notifier, IdentifiedDataSerializable {
+public class SemaphoreDeadMemberOperation extends SemaphoreBackupAwareOperation implements Notifier {
 
     private String firstCaller;
 
@@ -80,11 +78,6 @@ public class SemaphoreDeadMemberOperation extends SemaphoreBackupAwareOperation
     @Override
     public WaitNotifyKey getNotifiedKey() {
         return new SemaphoreWaitNotifyKey(name, "acquire");
-    }
-
-    @Override
-    public int getFactoryId() {
-        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreOperation.java
@@ -17,16 +17,18 @@
 package com.hazelcast.concurrent.semaphore.operations;
 
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
+import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
 
 import java.io.IOException;
 
 public abstract class SemaphoreOperation extends AbstractNamedOperation
-        implements PartitionAwareOperation {
+        implements PartitionAwareOperation, IdentifiedDataSerializable {
 
     protected int permitCount;
     protected transient Object response;
@@ -52,6 +54,11 @@ public abstract class SemaphoreOperation extends AbstractNamedOperation
     public SemaphoreContainer getSemaphoreContainer() {
         SemaphoreService service = getService();
         return service.getSemaphoreContainer(name);
+    }
+
+    @Override
+    public final int getFactoryId() {
+        return SemaphoreDataSerializerHook.F_ID;
     }
 
     @Override


### PR DESCRIPTION
Renamed 'Base' operation to 'Abstract' since that is the standard naming
strategy used for abstract classes.

Pulled IdentifiedDataSerializable into the Abstract class instead of repeating
it on the subclasses

Extending AbstractOperation instead of Operation to remove more duplication