### PR TITLE
OperationServiceImpl.thisAddress added

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -131,10 +131,12 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     private final AsyncResponseHandler asyncResponseHandler;
     private final InternalSerializationService serializationService;
     private final ResponseHandler responseHandler;
+    private final Address thisAddress;
 
     public OperationServiceImpl(NodeEngineImpl nodeEngine) {
         this.nodeEngine = nodeEngine;
         this.node = nodeEngine.getNode();
+        this.thisAddress = node.getThisAddress();
         this.logger = node.getLogger(OperationService.class);
         this.serializationService = (InternalSerializationService) nodeEngine.getSerializationService();
 
@@ -151,7 +153,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
                 logger, backpressureRegulator.newCallIdSequence(), concurrencyLevel);
 
         this.invocationMonitor = new InvocationMonitor(
-                nodeEngine, node.getThisAddress(), node.getHazelcastThreadGroup(), node.getProperties(),
+                nodeEngine, thisAddress, node.getHazelcastThreadGroup(), node.getProperties(),
                 invocationRegistry, logger, (InternalSerializationService) nodeEngine.getSerializationService(),
                 nodeEngine.getServiceManager());
 
@@ -168,7 +170,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
                 responseHandler);
 
         this.operationExecutor = new OperationExecutorImpl(
-                hazelcastProperties, node.loggingService, node.getThisAddress(), new OperationRunnerFactoryImpl(this),
+                hazelcastProperties, node.loggingService, thisAddress, new OperationRunnerFactoryImpl(this),
                 node.getHazelcastThreadGroup(), node.getNodeExtension());
 
         ExecutionService executionService = nodeEngine.getExecutionService();
@@ -386,7 +388,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     public boolean send(Operation op, Address target) {
         checkNotNull(target, "Target is required!");
 
-        if (nodeEngine.getThisAddress().equals(target)) {
+        if (thisAddress.equals(target)) {
             throw new IllegalArgumentException("Target is this node! -> " + target + ", op: " + op);
         }
 
@@ -407,7 +409,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     public boolean send(Response response, Address target) {
         checkNotNull(target, "Target is required!");
 
-        if (nodeEngine.getThisAddress().equals(target)) {
+        if (thisAddress.equals(target)) {
             throw new IllegalArgumentException("Target is this node! -> " + target + ", response: " + response);
         }
 


### PR DESCRIPTION
To reduce coupling to nodeengine, a thisAddress field is added to OperationService.
So during construction there is a dependency on Node for thisAddress, but once
constructed, the node is not needed to provide the thisAddress. This makes it
easier in the future get get rid of reliance on node/nodeengineiml