### PR TITLE
Inv: Renamed sync backup count to backup ack count

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -24,7 +24,7 @@ import com.hazelcast.spi.impl.eventservice.impl.EventEnvelope;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation.PartitionResponse;
-import com.hazelcast.spi.impl.operationservice.impl.responses.BackupResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
@@ -38,7 +38,7 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
 
     public static final int NORMAL_RESPONSE = 0;
     public static final int BACKUP = 1;
-    public static final int BACKUP_RESPONSE = 2;
+    public static final int BACKUP_ACK_RESPONSE = 2;
     public static final int PARTITION_ITERATOR = 3;
     public static final int PARTITION_RESPONSE = 4;
     public static final int PARALLEL_OPERATION_FACTORY = 5;
@@ -57,8 +57,8 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
                         return new NormalResponse();
                     case BACKUP:
                         return new Backup();
-                    case BACKUP_RESPONSE:
-                        return new BackupResponse();
+                    case BACKUP_ACK_RESPONSE:
+                        return new BackupAckResponse();
                     case PARTITION_ITERATOR:
                         return new PartitionIteratingOperation();
                     case PARTITION_RESPONSE:

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -248,13 +248,13 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
 
     private void handleResponse(Operation op) throws Exception {
         boolean returnsResponse = op.returnsResponse();
-        int syncBackupCount = sendBackup(op);
+        int backupAcks = sendBackup(op);
 
         if (!returnsResponse) {
             return;
         }
 
-        sendResponse(op, syncBackupCount);
+        sendResponse(op, backupAcks);
     }
 
     private int sendBackup(Operation op) throws Exception {
@@ -262,19 +262,19 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
             return 0;
         }
 
-        int syncBackupCount = 0;
+        int backupAcks = 0;
         BackupAwareOperation backupAwareOp = (BackupAwareOperation) op;
         if (backupAwareOp.shouldBackup()) {
-            syncBackupCount = operationService.operationBackupHandler.backup(backupAwareOp);
+            backupAcks = operationService.operationBackupHandler.backup(backupAwareOp);
         }
-        return syncBackupCount;
+        return backupAcks;
     }
 
-    private void sendResponse(Operation op, int syncBackupCount) {
+   private void sendResponse(Operation op, int backupAcks) {
         try {
             Object response = op.getResponse();
-            if (syncBackupCount > 0) {
-                response = new NormalResponse(response, op.getCallId(), syncBackupCount, op.isUrgent());
+            if (backupAcks > 0) {
+                response = new NormalResponse(response, op.getCallId(), backupAcks, op.isUrgent());
             }
             op.sendResponse(response);
         } catch (ResponseAlreadySentException e) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponseHandler.java
@@ -28,7 +28,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PacketHandler;
-import com.hazelcast.spi.impl.operationservice.impl.responses.BackupResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
@@ -84,9 +84,9 @@ public final class ResponseHandler implements PacketHandler, MetricsProvider {
                 notifyNormalResponse(
                         normalResponse.getCallId(),
                         normalResponse.getValue(),
-                        normalResponse.getBackupCount(),
+                        normalResponse.getBackupAcks(),
                         sender);
-            } else if (response instanceof BackupResponse) {
+            } else if (response instanceof BackupAckResponse) {
                 notifyBackupComplete(response.getCallId());
             } else if (response instanceof CallTimeoutResponse) {
                 notifyCallTimeout(response.getCallId(), sender);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -31,7 +31,7 @@ import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.spi.impl.operationservice.impl.responses.BackupResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.util.Clock;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -157,8 +157,8 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         if (nodeEngine.getThisAddress().equals(originalCaller)) {
             operationService.getResponseHandler().notifyBackupComplete(callId);
         } else {
-            BackupResponse backupResponse = new BackupResponse(callId, backupOp.isUrgent());
-            operationService.send(backupResponse, originalCaller);
+            BackupAckResponse backupAckResponse = new BackupAckResponse(callId, backupOp.isUrgent());
+            operationService.send(backupAckResponse, originalCaller);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupAckResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupAckResponse.java
@@ -16,31 +16,31 @@
 
 package com.hazelcast.spi.impl.operationservice.impl.responses;
 
-import com.hazelcast.spi.impl.SpiDataSerializerHook;
+import static com.hazelcast.spi.impl.SpiDataSerializerHook.BACKUP_ACK_RESPONSE;
 
 /**
  * The {Response} for a {@link com.hazelcast.spi.BackupOperation}. So when a operation like
  * Map.put is done, backup operations are send to the backup partitions. For the initial
  * Map.put to complete, the {@link com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse} needs to return,
- * but also the {@link BackupResponse} to make sure that the change
+ * but also the {@link BackupAckResponse} to make sure that the change
  * is written to the expected number of backups.
  */
-public final class BackupResponse extends Response {
+public final class BackupAckResponse extends Response {
 
-    public BackupResponse() {
+    public BackupAckResponse() {
     }
 
-    public BackupResponse(long callId, boolean urgent) {
+    public BackupAckResponse(long callId, boolean urgent) {
         super(callId, urgent);
     }
 
     @Override
     public int getId() {
-        return SpiDataSerializerHook.BACKUP_RESPONSE;
+        return BACKUP_ACK_RESPONSE;
     }
 
     @Override
     public String toString() {
-        return "BackupResponse{callId=" + callId + ", urgent=" + urgent + '}';
+        return "BackupAckResponse{callId=" + callId + ", urgent=" + urgent + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/CallTimeoutResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/CallTimeoutResponse.java
@@ -19,6 +19,8 @@ package com.hazelcast.spi.impl.operationservice.impl.responses;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 
+import static com.hazelcast.spi.impl.SpiDataSerializerHook.CALL_TIMEOUT_RESPONSE;
+
 /**
  * An response that indicates that the execution of a single call ran into a timeout.
  */
@@ -38,7 +40,7 @@ public class CallTimeoutResponse extends Response implements IdentifiedDataSeria
 
     @Override
     public int getId() {
-        return SpiDataSerializerHook.CALL_TIMEOUT_RESPONSE;
+        return CALL_TIMEOUT_RESPONSE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
@@ -18,9 +18,10 @@ package com.hazelcast.spi.impl.operationservice.impl.responses;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.impl.SpiDataSerializerHook;
 
 import java.io.IOException;
+
+import static com.hazelcast.spi.impl.SpiDataSerializerHook.ERROR_RESPONSE;
 
 public class ErrorResponse extends Response {
     private Throwable cause;
@@ -39,7 +40,7 @@ public class ErrorResponse extends Response {
 
     @Override
     public int getId() {
-        return SpiDataSerializerHook.ERROR_RESPONSE;
+        return ERROR_RESPONSE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
@@ -31,7 +31,7 @@ import java.io.IOException;
  * {@link NormalResponse} the result of a regular Operation result, e.g. Map.put
  * </li>
  * <li>
- * {@link BackupResponse} the result of a completed {@link com.hazelcast.spi.impl.operationservice.impl.operations.Backup}.
+ * {@link BackupAckResponse} the result of a completed {@link com.hazelcast.spi.impl.operationservice.impl.operations.Backup}.
  * </li>
  * </ol>
  */

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_DetectHeartbeatTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_DetectHeartbeatTimeoutTest.java
@@ -63,7 +63,7 @@ public class Invocation_DetectHeartbeatTimeoutTest extends HazelcastTestSupport 
 
         Invocation invocation = f.invocation;
         invocation.pendingResponse = "foo";
-        invocation.backupsExpected = 1;
+        invocation.backupsAcksExpected = 1;
 
         assertEquals(NO_TIMEOUT__RESPONSE_AVAILABLE, invocation.detectTimeout(SECONDS.toMillis(1)));
         assertFalse(f.isDone());


### PR DESCRIPTION
Acks are more standard. The ack count is the actual number of acknowledgments that need to be received before continuing with the next invocation.

Also the backupresponse writes a byte instead of an int for the backup-ack-acount since number of backups < 127. This shaves 3 bytes from each normal response.