### PR TITLE
MockConnectionManager & MockJoiner fixes 

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -40,7 +40,6 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.EmptyStatement;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -55,7 +54,6 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-@Ignore //https://github.com/hazelcast/hazelcast/issues/8026
 public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -62,7 +62,7 @@ public class TestHazelcastInstanceFactory {
 
     public TestHazelcastInstanceFactory() {
         this.count = 0;
-        this.registry = new TestNodeRegistry(addressMap.values());
+        this.registry = new TestNodeRegistry(Collections.unmodifiableCollection(addressMap.values()));
     }
 
     public TestHazelcastInstanceFactory(int initialPort, String... addresses) {
@@ -93,7 +93,7 @@ public class TestHazelcastInstanceFactory {
         for (Address address : addresses) {
             addressMap.put(ix++, address);
         }
-        this.registry = new TestNodeRegistry(addressMap.values());
+        this.registry = new TestNodeRegistry(Collections.unmodifiableCollection(addressMap.values()));
     }
 
     /**

--- a/hazelcast/src/test/resources/log4j.properties
+++ b/hazelcast/src/test/resources/log4j.properties
@@ -20,9 +20,11 @@ log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %5p |%X{test-name}| - [%c{1}] %t - %m%n
 
+log4j.logger.com.hazelcast.instance=debug
 log4j.logger.com.hazelcast.cluster=debug
 log4j.logger.com.hazelcast.internal.cluster=debug
 log4j.logger.com.hazelcast.internal.partition=debug
 log4j.logger.com.hazelcast.spi.hotrestart=info
+log4j.logger.com.hazelcast.test.mocknetwork=debug
 
 log4j.rootLogger=info, stdout


### PR DESCRIPTION
- MockConnectionManager should remove only cluster members while stopping
itself. Otherwise, async member removal task can lead to member split
just after cluster merge.

- MockJoiner should search for master only when there's no master candidate
or found candidate can not be connected.

- Also adding debug level logs for MockJoiner.

Fixes https://github.com/hazelcast/hazelcast/issues/8026