### PR TITLE
Fix proposal for CachePartitionEventData FindBugs issue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
@@ -130,7 +130,6 @@ public class CacheEventDataImpl
         }
 
         CacheEventDataImpl that = (CacheEventDataImpl) o;
-
         if (isOldValueAvailable != that.isOldValueAvailable) {
             return false;
         }
@@ -147,7 +146,6 @@ public class CacheEventDataImpl
             return false;
         }
         return dataOldValue != null ? dataOldValue.equals(that.dataOldValue) : that.dataOldValue == null;
-
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
@@ -58,21 +58,41 @@ public class CachePartitionEventData extends CacheEventDataImpl implements Cache
     }
 
     @Override
-    public boolean equals(Object o) {
-        return super.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
-    }
-
-    @Override
     public String toString() {
         return "CachePartitionEventData{"
                 + super.toString()
                 + ", partitionId=" + partitionId
                 + '}';
     }
-}
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CachePartitionEventData)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        CachePartitionEventData that = (CachePartitionEventData) o;
+        if (partitionId != that.partitionId) {
+            return false;
+        }
+        if (member != null ? !member.equals(that.member) : that.member != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + partitionId;
+        result = 31 * result + (member != null ? member.hashCode() : 0);
+        return result;
+    }
+}


### PR DESCRIPTION
@sancar just added `equals()` and `hashCode()` to `CacheEventDataImpl`. So FindBugs doesn't like `CachePartitionEventData` anymore, which extends `CacheEventDataImpl` and has two more fields.

I don't know those classes well, but this is what IDEA creates to extend `equals()` and `hashCode()` for the two additional fields.