### PR TITLE
Use return value from TestHazelcastInstanceFactory.initOrCreateConfig

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/DistributedMapperMapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/DistributedMapperMapReduceTest.java
@@ -23,8 +23,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.Repeat;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -116,7 +114,6 @@ public class DistributedMapperMapReduceTest
     }
 
     @Test(timeout = 30000)
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/4390
     public void testMapperReducerCollator() throws Exception {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(4);
         HazelcastInstance h1 = nodeFactory.newHazelcastInstance();

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -111,7 +111,7 @@ public class TestHazelcastInstanceFactory {
     public HazelcastInstance newHazelcastInstance(Config config) {
         String instanceName = config != null ? config.getInstanceName() : null;
         if (mockNetwork) {
-            init(config);
+            config = initOrCreateConfig(config);
             NodeContext nodeContext = registry.createNodeContext(pickAddress());
             return HazelcastInstanceManager.newHazelcastInstance(config, instanceName, nodeContext);
         }
@@ -136,7 +136,7 @@ public class TestHazelcastInstanceFactory {
     public HazelcastInstance newHazelcastInstance(Address address, Config config) {
         final String instanceName = config != null ? config.getInstanceName() : null;
         if (mockNetwork) {
-            init(config);
+            config = initOrCreateConfig(config);
             NodeContext nodeContext = registry.createNodeContext(address);
             return HazelcastInstanceManager.newHazelcastInstance(config, instanceName, nodeContext);
         }
@@ -256,7 +256,7 @@ public class TestHazelcastInstanceFactory {
         }
     }
 
-    private static Config init(Config config) {
+    private static Config initOrCreateConfig(Config config) {
         if (config == null) {
             config = new XmlConfigBuilder().build();
         }


### PR DESCRIPTION
When `null` config is passed to `TestHazelcastInstanceFactory.initOrCreateConfig()`,
it creates a new one returns it, otherwise initializes the config. But if returned
config is not used, a new default config is created while starting a new Hazelcast
instance and that causes failures on build system because multicast is enabled
in default config and that breaks isolation between tests.

Fixes many failures related to mock joiner. Fixes #7463