### PR TITLE
Simplify MockJoiner

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
@@ -21,13 +21,12 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.mocknetwork.MockConnectionManager;
+import com.hazelcast.test.mocknetwork.TestNodeRegistry;
 
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 public class FirewallingMockConnectionManager extends MockConnectionManager {
 
@@ -35,8 +34,8 @@ public class FirewallingMockConnectionManager extends MockConnectionManager {
 
     private volatile PacketFilter packetFilter;
 
-    public FirewallingMockConnectionManager(IOService ioService, ConcurrentMap<Address, NodeEngineImpl> nodes, Node node, Object joinerLock) {
-        super(ioService, nodes, node, joinerLock);
+    public FirewallingMockConnectionManager(IOService ioService, Node node, TestNodeRegistry registry) {
+        super(ioService, node, registry);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
@@ -36,7 +36,7 @@ public class MockConnection implements Connection {
     protected final Address localEndpoint;
     protected final NodeEngineImpl nodeEngine;
 
-    final Address remoteEndpoint;
+    private final Address remoteEndpoint;
 
     volatile Connection localConnection;
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoinerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoinerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.mocknetwork;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MockJoinerTest extends HazelcastTestSupport {
+
+    private int nodeCount = 5;
+
+    @Test
+    public void serialJoin() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = new HazelcastInstance[nodeCount];
+        for (int i = 0; i < nodeCount; i++) {
+            instances[i] = factory.newHazelcastInstance();
+        }
+
+        assertClusterSizeEventually(instances);
+    }
+
+    @Test
+    public void serialJoin_withNewInstances() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = factory.newInstances(new Config(), nodeCount);
+
+        assertClusterSizeEventually(instances);
+    }
+
+    @Test
+    public void parallelJoin() {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        final Collection<HazelcastInstance> instances = Collections.synchronizedCollection(new ArrayList<HazelcastInstance>());
+
+        final CountDownLatch latch = new CountDownLatch(nodeCount);
+
+        for (int i = 0; i < nodeCount; i++) {
+            new Thread() {
+                public void run() {
+                    HazelcastInstance hz = factory.newHazelcastInstance();
+                    instances.add(hz);
+                    latch.countDown();
+                }
+            }.start();
+        }
+
+        assertOpenEventually(latch);
+        assertEquals(nodeCount, instances.size());
+
+        for (HazelcastInstance instance : instances) {
+            assertClusterSizeEventually(nodeCount, instance);
+        }
+    }
+
+    @Test
+    public void restart_master() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance[] instances = factory.newInstances(new Config(), nodeCount);
+        assertClusterSizeEventually(instances);
+
+        Address address = getAddress(instances[0]);
+        instances[0].getLifecycleService().terminate();
+
+        instances[0] = factory.newHazelcastInstance(address, new Config());
+        assertClusterSizeEventually(instances);
+    }
+
+    @Test
+    public void restart_slave() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance[] instances = factory.newInstances(new Config(), nodeCount);
+        assertClusterSizeEventually(instances);
+
+        Address address = getAddress(instances[1]);
+        instances[1].getLifecycleService().terminate();
+
+        instances[1] = factory.newHazelcastInstance(address, new Config());
+        assertClusterSizeEventually(instances);
+    }
+
+    @Test
+    public void restart_multipleInParallel() {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        final HazelcastInstance[] instances = factory.newInstances(new Config(), nodeCount);
+        assertClusterSizeEventually(instances);
+
+        int restartCount = nodeCount / 2;
+        final CountDownLatch latch = new CountDownLatch(restartCount);
+
+        for (int i = 0; i < restartCount; i++) {
+            final int ix = i;
+            new Thread() {
+                public void run() {
+                    Address address = getAddress(instances[ix]);
+                    instances[ix].getLifecycleService().terminate();
+                    instances[ix] = factory.newHazelcastInstance(address, new Config());
+                    latch.countDown();
+                }
+            }.start();
+        }
+
+        assertOpenEventually(latch);
+        assertClusterSizeEventually(instances);
+    }
+
+    private void assertClusterSizeEventually(HazelcastInstance... instances) {
+        int size = instances.length;
+        for (HazelcastInstance instance : instances) {
+            assertClusterSizeEventually(size, instance);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -27,25 +27,17 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.NodeIOService;
 import com.hazelcast.nio.tcp.FirewallingMockConnectionManager;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.nio.channels.ServerSocketChannel;
-import java.util.Collection;
-import java.util.concurrent.ConcurrentMap;
 
 class MockNodeContext implements NodeContext {
 
-    private final Collection<Address> joinAddresses;
-    private final ConcurrentMap<Address, NodeEngineImpl> nodes;
+    private final TestNodeRegistry registry;
     private final Address thisAddress;
-    private final Object joinerLock;
 
-    public MockNodeContext(Collection<Address> addresses, ConcurrentMap<Address, NodeEngineImpl> nodes,
-            Address thisAddress, Object joinerLock) {
-        this.joinAddresses = addresses;
-        this.nodes = nodes;
+    MockNodeContext(TestNodeRegistry registry, Address thisAddress) {
+        this.registry = registry;
         this.thisAddress = thisAddress;
-        this.joinerLock = joinerLock;
     }
 
     @Override
@@ -58,11 +50,11 @@ class MockNodeContext implements NodeContext {
     }
 
     public Joiner createJoiner(Node node) {
-        return new MockJoiner(node, joinAddresses, nodes, joinerLock);
+        return new MockJoiner(node, registry);
     }
 
     public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
         NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
-        return new FirewallingMockConnectionManager(ioService, nodes, node, joinerLock);
+        return new FirewallingMockConnectionManager(ioService, node, registry);
     }
 }


### PR DESCRIPTION
Simplify MockJoiner mechanism to use present joiner system
as much as possible. Previous code was very complicated and difficult
to track problems.