### PR TITLE
Added the ConnectionListenable

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -20,14 +20,14 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.spi.impl.ConnectionHeartbeatListener;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.ConnectionListener;
+import com.hazelcast.nio.ConnectionListenable;
 
 import java.io.IOException;
 
 /**
  * Responsible for managing {@link com.hazelcast.client.connection.nio.ClientConnection} objects.
  */
-public interface ClientConnectionManager {
+public interface ClientConnectionManager extends ConnectionListenable {
 
     /**
      * Shutdown clientConnectionManager
@@ -88,8 +88,5 @@ public interface ClientConnectionManager {
      */
     void handleClientMessage(ClientMessage message, Connection connection);
 
-    void addConnectionListener(ConnectionListener connectionListener);
-
     void addConnectionHeartbeatListener(ConnectionHeartbeatListener connectionHeartbeatListener);
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionListenable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionListenable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio;
+
+import com.hazelcast.spi.annotation.PrivateApi;
+
+/**
+ * Provides connection listen capabilities.
+ */
+@PrivateApi
+public interface ConnectionListenable {
+
+    /**
+     * Registers a ConnectionListener.
+     *
+     * If the same listener is registered multiple times, it will be notified multiple times.
+     *
+     * @param listener the ConnectionListener to add.
+     * @throws NullPointerException if listener is null.
+     */
+    void addConnectionListener(ConnectionListener listener);
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
@@ -22,8 +22,7 @@ import com.hazelcast.spi.annotation.PrivateApi;
  * Responsible for managing {@link com.hazelcast.nio.Connection} objects.
  */
 @PrivateApi
-public interface ConnectionManager {
-
+public interface ConnectionManager extends ConnectionListenable {
 
     /**
      * Gets the number of client connections.
@@ -78,7 +77,7 @@ public interface ConnectionManager {
      * {@link #getConnection(Address)}.
      *
      * @param address the address to connect to.
-     * @param silent if logging should be done on debug level (silent=true) or on info level (silent=false).
+     * @param silent  if logging should be done on debug level (silent=true) or on info level (silent=false).
      * @return the existing connection.
      */
     Connection getOrConnect(Address address, boolean silent);
@@ -97,21 +96,11 @@ public interface ConnectionManager {
     void destroyConnection(Connection connection);
 
     /**
-     * Registers a ConnectionListener.
-     *
-     * If the same listener is registered multiple times, it will be notified multiple times.
-     *
-     * @param listener the ConnectionListener to add.
-     * @throws NullPointerException if listener is null.
-     */
-    void addConnectionListener(ConnectionListener listener);
-
-    /**
      * Transmits a packet to a certain connection.
      *
      * If this method is called with a null connection, the call returns false
      *
-     * @param packet The Packet to transmit.
+     * @param packet     The Packet to transmit.
      * @param connection The connection to where the Packet should be transmitted.
      * @return true if the transmit was a success, false if a failure. There is no guarantee that the packet is actually going
      * to be received since the Packet perhaps is stuck in some buffer. It just means that it is buffered somewhere.
@@ -128,8 +117,8 @@ public interface ConnectionManager {
      * @param packet The Packet to transmit.
      * @param target The address of the target machine where the Packet should be transmitted.
      * @return true if the transmit was a success, false if a failure.
-     * @see #transmit(com.hazelcast.nio.Packet, com.hazelcast.nio.Connection)
      * @throws NullPointerException if packet or target is null.
+     * @see #transmit(com.hazelcast.nio.Packet, com.hazelcast.nio.Connection)
      */
     boolean transmit(Packet packet, Address target);
 


### PR DESCRIPTION
For another PR the client/member connectionmanager needs have a single 'listen' interface
so I can listen to connection changes. Using the ConnectionListenable abstraction this is possible.