### PR TITLE
Address toString simplification

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -186,7 +186,7 @@ public final class Address implements IdentifiedDataSerializable {
 
     @Override
     public String toString() {
-        return "Address[" + getHost() + "]:" + port;
+        return '[' + host + "]:" + port;
     }
 
     private static InetAddress resolve(InetSocketAddress inetSocketAddress) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
@@ -58,7 +58,7 @@ public class DiscoveryJoinerTest {
         DiscoveryJoiner joiner = new DiscoveryJoiner(TestUtil.getNode(hz), service, true);
         doReturn(discoveryNodes).when(service).discoverNodes();
         Collection<Address> addresses = joiner.getPossibleAddresses();
-        assertEquals("[Address[127.0.0.1]:50001, Address[127.0.0.1]:50002]", addresses.toString());
+        assertEquals("[[127.0.0.1]:50001, [127.0.0.1]:50002]", addresses.toString());
     }
 
     @Test
@@ -66,6 +66,6 @@ public class DiscoveryJoinerTest {
         DiscoveryJoiner joiner = new DiscoveryJoiner(TestUtil.getNode(hz), service, false);
         doReturn(discoveryNodes).when(service).discoverNodes();
         Collection<Address> addresses = joiner.getPossibleAddresses();
-        assertEquals("[Address[127.0.0.2]:50001, Address[127.0.0.2]:50002]", addresses.toString());
+        assertEquals("[[127.0.0.2]:50001, [127.0.0.2]:50002]", addresses.toString());
     }
 }


### PR DESCRIPTION
Instead of Address[1.2.3.4]:5701, you get [1.2.3.4]:5701. So the 'Address' part has been removed.