### PR TITLE
Minor changes TcpIpConnection.toString

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -258,7 +258,11 @@ public final class TcpIpConnection implements Connection {
         Socket socket = socketChannel.socket();
         SocketAddress localSocketAddress = socket != null ? socket.getLocalSocketAddress() : null;
         SocketAddress remoteSocketAddress = socket != null ? socket.getRemoteSocketAddress() : null;
-        return "Connection [" + localSocketAddress + " -> " + remoteSocketAddress
-                + "], endpoint=" + endPoint + ", alive=" + alive + ", type=" + type;
+        return "Connection[id=" + connectionId
+                + ", " + localSocketAddress + "->" + remoteSocketAddress
+                + ", endpoint=" + endPoint
+                + ", alive=" + alive
+                + ", type=" + type
+                + "]";
     }
 }


### PR DESCRIPTION
including connectionid (useful for grepping)
all info between []

THe reason behind this change is that I'm using the connection toString in the metrics system and performance log. And currently it isn't that easy to grep on. Also the content of the string was a bit messy; some parts in [], other parts after.