### PR TITLE
Fixes the Diagnistic property names

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -213,7 +213,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     private MetricsRegistryImpl initMetricsRegistry() {
-        ProbeLevel probeLevel = properties.getEnum(GroupProperty.PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+        ProbeLevel probeLevel = properties.getEnum(Diagnostics.METRICS_LEVEL, ProbeLevel.class);
         return new MetricsRegistryImpl(loggingService.getLogger(MetricsRegistryImpl.class), probeLevel);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
@@ -20,7 +20,6 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
@@ -36,7 +35,7 @@ public class MetricsPlugin extends DiagnosticsPlugin {
      * The period in seconds the {@link MetricsPlugin} runs.
      *
      * The MetricsPlugin periodically writing the content of the MetricsRegistry to the logfile. For debugging purposes
-     * make sure the {@link GroupProperty#PERFORMANCE_METRICS_LEVEL} is set to debug.
+     * make sure the {@link Diagnostics#METRICS_LEVEL} is set to debug.
      *
      * This plugin is very cheap to use.
      *

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -75,7 +75,7 @@ import com.hazelcast.wan.WanReplicationService;
 import java.util.Collection;
 import java.util.LinkedList;
 
-import static com.hazelcast.spi.properties.GroupProperty.PERFORMANCE_METRICS_LEVEL;
+import static com.hazelcast.internal.diagnostics.Diagnostics.METRICS_LEVEL;
 import static java.lang.System.currentTimeMillis;
 
 /**
@@ -136,7 +136,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     private MetricsRegistryImpl newMetricRegistry(Node node) {
-        ProbeLevel probeLevel = node.getProperties().getEnum(PERFORMANCE_METRICS_LEVEL, ProbeLevel.class);
+        ProbeLevel probeLevel = node.getProperties().getEnum(METRICS_LEVEL, ProbeLevel.class);
         return new MetricsRegistryImpl(node.getLogger(MetricsRegistryImpl.class), probeLevel);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -19,7 +19,6 @@ package com.hazelcast.spi.properties;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
-import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.diagnostics.HealthMonitorLevel;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.query.QueryResultSizeLimiter;
@@ -115,15 +114,6 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.health.monitoring.threshold.memory.percentage", 70);
     public static final HazelcastProperty HEALTH_MONITORING_THRESHOLD_CPU_PERCENTAGE
             = new HazelcastProperty("hazelcast.health.monitoring.threshold.cpu.percentage", 70);
-
-    /**
-     * The minimum level for probes is MANDATORY, but it can be changed to INFO or DEBUG. A lower level will increase
-     * memory usage (probably just a few 100KB) and provides much greater detail on what is going on inside a HazelcastInstance.
-     * <p/>
-     * By default only mandatory probes are being tracked
-     */
-    public static final HazelcastProperty PERFORMANCE_METRICS_LEVEL
-            = new HazelcastProperty("hazelcast.performance.metric.level", ProbeLevel.MANDATORY.name());
 
     /**
      * The number of threads doing socket input and the number of threads doing socket output.

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
@@ -99,18 +99,36 @@ public class HazelcastProperties {
      * @return the value or <tt>null</tt> if nothing has been configured
      */
     public String getString(HazelcastProperty property) {
-        String configValue = properties.getProperty(property.getName());
-        if (configValue != null) {
-            return configValue;
+        String value = properties.getProperty(property.getName());
+        if (value != null) {
+            return value;
         }
-        String systemProperty = property.getSystemProperty();
-        if (systemProperty != null) {
-            return systemProperty;
+
+        value = property.getSystemProperty();
+        if (value != null) {
+            return value;
         }
 
         HazelcastProperty parent = property.getParent();
         if (parent != null) {
             return getString(parent);
+        }
+
+        String deprecatedName = property.getDeprecatedName();
+        if (deprecatedName != null) {
+            value = get(deprecatedName);
+            if (value == null) {
+                value = System.getProperty(deprecatedName);
+            }
+
+            if (value != null) {
+                // we don't have a logger available, and the Logging service is constructed after the Properties are created.
+                System.err.print("Don't use deprecated '" + deprecatedName + "' "
+                        + "but use '" + property.getName() + "' instead. "
+                        + "The former name will be removed in the next Hazelcast release.");
+
+                return value;
+            }
         }
 
         return property.getDefaultValue();

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperty.java
@@ -30,6 +30,7 @@ public final class HazelcastProperty {
     private final String defaultValue;
     private final TimeUnit timeUnit;
     private final HazelcastProperty parent;
+    private volatile String deprecatedName;
 
     public HazelcastProperty(String name) {
         this(name, (String) null);
@@ -76,6 +77,28 @@ public final class HazelcastProperty {
     }
 
     /**
+     * Sets the deprecated name of ths property. Useful if compatibility needs to be provided on property names.
+     *
+     * This method is thread-safe, but is expected to be called immediately after the HazelcastProperty is constructed.
+     *
+     * <code>
+     *     HazelcastProperty property = new HazelcastProperty("newname").setDeprecatedName("oldname");
+     * </code>
+     *
+     * @param deprecatedName the deprecated name of the property
+     * @return the updated {@link HazelcastProperty}
+     * @throws IllegalArgumentException if the deprecatedName is null or an empty string.
+     */
+    public HazelcastProperty setDeprecatedName(String deprecatedName) {
+        this.deprecatedName = checkHasText(deprecatedName, "a valid string should be provided");
+        return this;
+    }
+
+    public String getDeprecatedName() {
+        return deprecatedName;
+    }
+
+    /**
      * Returns the property name.
      *
      * @return the property name
@@ -116,7 +139,6 @@ public final class HazelcastProperty {
         return parent;
     }
 
-
     /**
      * Sets the environmental value of the property.
      *
@@ -131,16 +153,8 @@ public final class HazelcastProperty {
      *
      * @return the value of the property
      */
-
     public String getSystemProperty() {
         return System.getProperty(name);
-    }
-
-    /**
-     * Clears the environmental value of the property.
-     */
-    public String clearSystemProperty() {
-        return System.clearProperty(name);
     }
 
     @Override


### PR DESCRIPTION
The property names are now following `hazelcast.diagnostics` as prefix instead of `hazelcast.performance.monitor`

A change was made to the HazelcastProperty system to easily deal with deprecated names. 

So this PR introduces the new names, but keeps compatibility on the old names.

Also the metrics level configuration is making use of diagnostics prefix (+ keeping compatibility)