### PR TITLE
Node shutdown fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -479,13 +479,16 @@ public class Node {
             return;
         }
         logger.info("Node is already shutting down... Waiting for shutdown process to complete...");
-        while (state != NodeState.SHUT_DOWN) {
+        while (state != NodeState.SHUT_DOWN && shuttingDown.get()) {
             try {
                 Thread.sleep(THREAD_SLEEP_DURATION_MS);
             } catch (InterruptedException e) {
                 logger.warning("Interrupted while waiting for shutdown!");
                 return;
             }
+        }
+        if (state != NodeState.SHUT_DOWN) {
+            throw new IllegalStateException("Node failed to shutdown!");
         }
     }
 


### PR DESCRIPTION
- During graceful shutdown, there was a race between checking if that
node is master and reading master address field. If a node becomes master
in this race window, shutdown process fails with an exception:
`java.lang.IllegalArgumentException: Target is this node!...`

- When node shutdown fails, another thread waiting for shutdown to complete
hangs forever, because node-state never becomes `SHUT_DOWN`. Instead, it should
fail with an exception too.