### PR TITLE
Revert "Remove unused method in OperationExecutor"

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -154,6 +154,11 @@ public interface OperationExecutor extends PacketHandler {
     boolean isOperationThread();
 
     /**
+     * Interrupts the partition threads.
+     */
+    void interruptPartitionThreads();
+
+    /**
      * Starts this OperationExecutor
      */
     void start();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -352,6 +352,13 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
     }
 
     @Override
+    public void interruptPartitionThreads() {
+        for (PartitionOperationThread partitionThread : partitionThreads) {
+            partitionThread.interrupt();
+        }
+    }
+
+    @Override
     public void run(Operation operation) {
         checkNotNull(operation, "operation can't be null");
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
@@ -122,6 +122,57 @@ public class OperationExecutorImpl_BasicTest extends OperationExecutorImpl_Abstr
         awaitBarrier(barrier);
     }
 
+    @Test
+    public void test_interruptAllPartitionThreads() throws Exception {
+        initExecutor();
+
+        int threadCount = executor.getPartitionThreadCount();
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
+
+        executor.executeOnPartitionThreads(new Runnable() {
+            @Override
+            public void run() {
+                // current thread must be a PartitionOperationThread
+                if (Thread.currentThread() instanceof PartitionOperationThread) {
+                    try {
+                        Thread.sleep(Long.MAX_VALUE);
+                    } catch (InterruptedException ignored) {
+                    } finally {
+                        try {
+                            awaitBarrier(barrier);
+                        } catch (Exception ex) {
+                            ex.printStackTrace();
+                        }
+                    }
+                }
+            }
+        });
+
+        executor.interruptPartitionThreads();
+        awaitBarrier(barrier);
+    }
+
+    @Test
+    public void genericPriorityTaskIsPickedUpEvenWhenAllGenericThreadsBusy() {
+        initExecutor();
+
+        // lets keep the regular generic threads busy
+        for (int k = 0; k < executor.getGenericThreadCount() * 10; k++) {
+            executor.execute(new DummyOperation(GENERIC_PARTITION_ID).durationMs(20000000));
+        }
+
+        final CountDownLatch open = new CountDownLatch(1);
+        // then we schedule a priority task
+        executor.execute(new UrgentDummyOperation(GENERIC_PARTITION_ID) {
+            public void run() {
+                open.countDown();
+            }
+        });
+
+        // and verify it completes.
+        assertOpenEventually(open);
+    }
+
     private static void awaitBarrier(CyclicBarrier barrier) throws Exception {
         barrier.await(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
Method will stop being used only after [EE PR #884](https://github.com/hazelcast/hazelcast-enterprise/pull/884) is merged.
This reverts commit 7ac9408b17a8c7d4926691cbab264d2a01f28bca.