### PR TITLE
Improved serialize exception message

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -51,6 +51,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.EMPTY_
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createSerializerAdapter;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.getInterfaces;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.handleException;
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.handleSerializeException;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.indexForDefaultType;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.isNullData;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -139,7 +140,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
             serializer.write(out, obj);
             return out.toByteArray();
         } catch (Throwable e) {
-            throw handleException(e);
+            throw handleSerializeException(obj, e);
         } finally {
             pool.returnOutputBuffer(out);
         }
@@ -197,7 +198,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
             out.writeInt(serializer.getTypeId());
             serializer.write(out, obj);
         } catch (Throwable e) {
-            throw handleException(e);
+            throw handleSerializeException(obj, e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -61,6 +61,18 @@ public final class SerializationUtil {
         throw new HazelcastSerializationException(e);
     }
 
+    static RuntimeException handleSerializeException(Object rootObject, Throwable e) {
+        if (e instanceof OutOfMemoryError) {
+            OutOfMemoryErrorDispatcher.onOutOfMemory((OutOfMemoryError) e);
+            throw (Error) e;
+        }
+        if (e instanceof Error) {
+            throw (Error) e;
+        }
+        String clazz = rootObject == null ? "null" : rootObject.getClass().getName();
+        throw new HazelcastSerializationException("Failed to serialize '" + clazz + '\'', e);
+    }
+
     static SerializerAdapter createSerializerAdapter(Serializer serializer, InternalSerializationService serializationService) {
         final SerializerAdapter s;
         if (serializer instanceof StreamSerializer) {


### PR DESCRIPTION
Fix #6576

Serialize error has been improved to capture the class of the outer object.

The following program
```
public class Main {

    public static void main(String[] args){
        HazelcastInstance hz = Hazelcast.newHazelcastInstance();
        Foo key = new Foo();
        key.hz = hz;
        hz.getMap("foo").put(key, "foo");
    }

    public static class Foo implements Serializable {
        HazelcastInstance hz;
    }
}
```
Before the fix shows:

```
Exception in thread "main" com.hazelcast.nio.serialization.HazelcastSerializationException: java.io.NotSerializableException: com.hazelcast.instance.HazelcastInstanceProxy
	at com.hazelcast.internal.serialization.impl.SerializationUtil.handleException(SerializationUtil.java:61)
	at com.hazelcast.internal.serialization.impl.SerializationUtil.handleSerializeException(SerializationUtil.java:66)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:143)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toData(AbstractSerializationService.java:118)
	at com.hazelcast.map.impl.proxy.MapProxySupport.toData(MapProxySupport.java:958)
	at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:103)
	at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:95)
	at com.hazelcast.Main.main(Main.java:17)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:144)
Caused by: java.io.NotSerializableException: com.hazelcast.instance.HazelcastInstanceProxy
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at com.hazelcast.internal.serialization.impl.JavaDefaultSerializers$JavaSerializer.write(JavaDefaultSerializers.java:242)
	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.write(StreamSerializerAdapter.java:41)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:140)
	... 10 more
```

After the fix it shows:
```
Exception in thread "main" com.hazelcast.nio.serialization.HazelcastSerializationException: Failed to serialize 'com.hazelcast.Main$Foo'
	at com.hazelcast.internal.serialization.impl.SerializationUtil.handleSerializeException(SerializationUtil.java:73)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:143)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toData(AbstractSerializationService.java:118)
	at com.hazelcast.map.impl.proxy.MapProxySupport.toData(MapProxySupport.java:958)
	at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:103)
	at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:95)
	at com.hazelcast.Main.main(Main.java:17)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:144)
Caused by: java.io.NotSerializableException: com.hazelcast.instance.HazelcastInstanceProxy
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1184)
	at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1548)
	at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1509)
	at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1432)
	at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1178)
	at java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:348)
	at com.hazelcast.internal.serialization.impl.JavaDefaultSerializers$JavaSerializer.write(JavaDefaultSerializers.java:242)
	at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.write(StreamSerializerAdapter.java:41)
	at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:140)
	... 10 more
```

As one can see the classname of the outer object 'com.hazelcast.Main$Foo' is now mentioned in the exception message.