### PR TITLE
Multicast enabled by default in XML 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -193,9 +193,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
 
     @Override
     public Config build() {
-        Config config = new Config();
-        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
-        return build(config);
+        return build(new Config());
     }
 
     Config build(Config config) {

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
@@ -271,6 +271,7 @@ public class XmlConfigImportVariableReplacementTest {
         final String networkConfig =
                 "    <network>\n" +
                         "        <join>\n" +
+                        "            <multicast enabled=\"false\"/>\n" +
                         "            <tcp-ip enabled=\"true\"/>\n" +
                         "        </join>\n" +
                         "    </network>\n";


### PR DESCRIPTION
Multicast was explicitly disabled while parsing.

This is a inconsistency with the xsd; which  states that multicast is enabled by default.
It also is an inconsistency with the programmatic api, where multicast is enabled by default.

This fix resolves these inconsistencies. 

However it could be that xml-users that only configure tcp and have not explicitly disabled multicast, since it was disabled by default, now get an error because multicast needs to be explicitly disabled (you can't have multiple join mechanisms active).

Fix #945