### PR TITLE
Reduces loglevel of member leaving to info

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractHandler.java
@@ -118,7 +118,7 @@ public abstract class AbstractHandler implements MigratableHandler {
         sb.append(connection.getEndPoint());
         sb.append(", Cause:").append(e);
 
-        Level level = getLevel(e, connectionType);
+        Level level = getLevel(e);
 
         if (e instanceof IOException) {
             logger.log(level, sb.toString());
@@ -127,14 +127,9 @@ public abstract class AbstractHandler implements MigratableHandler {
         }
     }
 
-    private Level getLevel(Throwable e, ConnectionType connectionType) {
+    private Level getLevel(Throwable e) {
         if (ioService.isActive()) {
-            if (connectionType.isClient()) {
-                // in case of a client disconnecting, we don't want to pollute the log with warnings.
-                return e instanceof EOFException ? Level.INFO : Level.WARNING;
-            } else {
-                return Level.WARNING;
-            }
+            return e instanceof EOFException ? Level.INFO : Level.WARNING;
         } else {
             return Level.FINEST;
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/AbstractHandler.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.logging.Level;
 
@@ -54,11 +55,20 @@ public abstract class AbstractHandler {
         sb.append(" Closing socket to endpoint ");
         sb.append(connection.getEndPoint());
         sb.append(", Cause:").append(e);
-        Level level = connectionManager.getIoService().isActive() ? Level.WARNING : Level.FINEST;
+        Level level = getLevel(e);
+
         if (e instanceof IOException) {
             logger.log(level, sb.toString());
         } else {
             logger.log(level, sb.toString(), e);
+        }
+    }
+
+    private Level getLevel(Throwable e) {
+        if (ioService.isActive()) {
+            return e instanceof EOFException ? Level.INFO : Level.WARNING;
+        } else {
+            return Level.FINEST;
         }
     }
 }


### PR DESCRIPTION
Logging of spinning and nonblocking handlers is also alligned

Fix #4223