### PR TITLE
Resolved races on setting max in LocalMapStateImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsImpl.java
@@ -21,6 +21,8 @@ import com.hazelcast.monitor.NearCacheStats;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
+import static com.hazelcast.util.ConcurrencyUtil.setMax;
+
 /**
  * {@link CacheStatistics} implementation for {@link com.hazelcast.cache.ICache}.
  *
@@ -238,15 +240,7 @@ public class CacheStatisticsImpl
      * @param time time to set the cache last access time
      */
     public void setLastAccessTime(long time) {
-        for (;;) {
-            if (time > lastAccessTime) {
-                if (LAST_ACCESS_TIME.compareAndSet(this, lastAccessTime, time)) {
-                    break;
-                }
-            } else {
-                break;
-            }
-        }
+        setMax(this, LAST_ACCESS_TIME, time);
     }
 
     /**
@@ -255,15 +249,7 @@ public class CacheStatisticsImpl
      * @param time time to set the cache last update time
      */
     public void setLastUpdateTime(long time) {
-        for (;;) {
-            if (time > lastUpdateTime) {
-                if (LAST_UPDATE_TIME.compareAndSet(this, lastUpdateTime, time)) {
-                    break;
-                }
-            } else {
-                break;
-            }
-        }
+        setMax(this, LAST_UPDATE_TIME, time);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -24,6 +24,7 @@ import com.hazelcast.util.Clock;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
+import static com.hazelcast.util.ConcurrencyUtil.setMax;
 import static com.hazelcast.util.JsonUtil.getInt;
 import static com.hazelcast.util.JsonUtil.getLong;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
@@ -151,7 +152,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void setLastAccessTime(long lastAccessTime) {
-        LAST_ACCESS_TIME.set(this, Math.max(this.lastAccessTime, lastAccessTime));
+        setMax(this, LAST_ACCESS_TIME, lastAccessTime);
     }
 
     @Override
@@ -160,7 +161,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     public void setLastUpdateTime(long lastUpdateTime) {
-        LAST_UPDATE_TIME.set(this, Math.max(this.lastUpdateTime, lastUpdateTime));
+        setMax(this, LAST_UPDATE_TIME, lastUpdateTime);
     }
 
     @Override
@@ -200,16 +201,14 @@ public class LocalMapStatsImpl implements LocalMapStats {
         return putCount;
     }
 
+    public void incrementPuts(long latency) {
+        incrementPuts(1, latency);
+    }
+
     public void incrementPuts(long delta, long latency) {
         PUT_COUNT.addAndGet(this, delta);
         TOTAL_PUT_LATENCIES.addAndGet(this, latency);
-        MAX_PUT_LATENCY.set(this, Math.max(maxPutLatency, latency / delta));
-    }
-
-    public void incrementPuts(long latency) {
-        PUT_COUNT.incrementAndGet(this);
-        TOTAL_PUT_LATENCIES.addAndGet(this, latency);
-        MAX_PUT_LATENCY.set(this, Math.max(maxPutLatency, latency));
+        setMax(this, MAX_PUT_LATENCY, latency);
     }
 
     @Override
@@ -220,7 +219,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     public void incrementGets(long latency) {
         GET_COUNT.incrementAndGet(this);
         TOTAL_GET_LATENCIES.addAndGet(this, latency);
-        MAX_GET_LATENCY.set(this, Math.max(maxGetLatency, latency));
+        setMax(this, MAX_GET_LATENCY, latency);
     }
 
     @Override
@@ -231,7 +230,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     public void incrementRemoves(long latency) {
         REMOVE_COUNT.incrementAndGet(this);
         TOTAL_REMOVE_LATENCIES.addAndGet(this, latency);
-        MAX_REMOVE_LATENCY.set(this, Math.max(maxRemoveLatency, latency));
+        setMax(this, MAX_REMOVE_LATENCY, latency);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.util.Clock;
 
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
+import static com.hazelcast.util.ConcurrencyUtil.setMax;
 import static com.hazelcast.util.JsonUtil.getLong;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
@@ -144,8 +145,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     public void setLastAccessTime(long lastAccessTime) {
-        long max = Math.max(this.lastAccessTime, lastAccessTime);
-        LAST_ACCESS_TIME.set(this, max);
+        setMax(this, LAST_ACCESS_TIME, lastAccessTime);
     }
 
     @Override
@@ -154,8 +154,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     }
 
     public void setLastUpdateTime(long lastUpdateTime) {
-        long max = Math.max(this.lastUpdateTime, lastUpdateTime);
-        LAST_UPDATE_TIME.set(this, max);
+        setMax(this, LAST_UPDATE_TIME, lastUpdateTime);
     }
 
     @Override
@@ -198,7 +197,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     public void incrementPuts(long latency) {
         PUT_COUNT.incrementAndGet(this);
         TOTAL_PUT_LATENCIES.addAndGet(this, latency);
-        MAX_PUT_LATENCY.set(this, Math.max(maxPutLatency, latency));
+        setMax(this, MAX_PUT_LATENCY, latency);
     }
 
     @Override
@@ -209,7 +208,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     public void incrementGets(long latency) {
         GET_COUNT.incrementAndGet(this);
         TOTAL_GET_LATENCIES.addAndGet(this, latency);
-        MAX_GET_LATENCY.set(this, Math.max(maxGetLatency, latency));
+        setMax(this, MAX_GET_LATENCY, latency);
     }
 
     @Override
@@ -220,7 +219,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     public void incrementRemoves(long latency) {
         REMOVE_COUNT.incrementAndGet(this);
         TOTAL_REMOVE_LATENCIES.addAndGet(this, latency);
-        MAX_REMOVE_LATENCY.set(this, Math.max(maxRemoveLatency, latency));
+        setMax(this, MAX_REMOVE_LATENCY, latency);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalTopicStatsImpl.java
@@ -76,8 +76,8 @@ public class LocalTopicStatsImpl implements LocalTopicStats {
     @Override
     public void fromJson(JsonObject json) {
         creationTime = getLong(json, "creationTime", -1L);
-        TOTAL_PUBLISHES.set(this, getLong(json, "totalPublishes", -1L));
-        TOTAL_RECEIVED_MESSAGES.set(this, getLong(json, "totalReceivedMessages", -1L));
+        totalPublishes = getLong(json, "totalPublishes", -1L);
+        totalReceivedMessages = getLong(json, "totalReceivedMessages", -1L);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/util/ConcurrencyUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ConcurrencyUtilTest.java
@@ -1,0 +1,39 @@
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConcurrencyUtilTest {
+
+    @Test
+    public void setMax() {
+        setMax(10, 9);
+        setMax(10, 10);
+        setMax(10, 11);
+    }
+
+    public void setMax(long current, long update) {
+        LongValue longValue = new LongValue();
+        longValue.value = current;
+
+        ConcurrencyUtil.setMax(longValue, LongValue.UPDATER, update);
+
+        long max = Math.max(current, update);
+        assertEquals(max, longValue.value);
+    }
+
+    private final static class LongValue {
+        final static AtomicLongFieldUpdater UPDATER = AtomicLongFieldUpdater.newUpdater(LongValue.class, "value");
+        volatile long value;
+    }
+}


### PR DESCRIPTION
Fix #8128

The same problem was also fixed at LocalReplicatedMapStatsImpl

CacheStatisticsImpl got a cleanup by removing duplicate code for the 'max' functionality.