### PR TITLE
Cluster management REST URLs are changed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -26,9 +26,9 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String URI_CLUSTER_MANAGEMENT_BASE_URL = "/hazelcast/rest/management/cluster";
     public static final String URI_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/state";
     public static final String URI_CHANGE_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/changeState";
-    public static final String URI_SHUTDOWN_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/shutdown";
+    public static final String URI_SHUTDOWN_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/clusterShutdown";
     public static final String URI_FORCESTART_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/forceStart";
-    public static final String URI_KILLNODE_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/shutdownMember";
+    public static final String URI_KILLNODE_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/memberShutdown";
     public static final String URI_CLUSTER_NODES_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/nodes";
     public static final String URI_MANCENTER_CHANGE_URL = "/hazelcast/rest/mancenter/changeurl";
 

--- a/hazelcast/src/main/resources/cluster.sh
+++ b/hazelcast/src/main/resources/cluster.sh
@@ -172,7 +172,7 @@ if [ "$OPERATION" = "shutdown" ]; then
     echo "You are shutting down the cluster. Please make sure you provide valid user/pass."
     echo "Shutting down from member on ip ${ADDRESS} on port ${PORT}"
 
-    request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/shutdown"
+    request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/clusterShutdown"
     response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -138,7 +138,7 @@ public class HTTPCommunicator {
 
     public int shutdownCluster(String groupName, String groupPassword) throws IOException {
 
-        String url = address + "management/cluster/shutdown";
+        String url = address + "management/cluster/clusterShutdown";
         /** set up the http connection parameters */
         HttpURLConnection urlConnection = (HttpURLConnection) (new URL(url)).openConnection();
         urlConnection.setRequestMethod("POST");
@@ -161,7 +161,7 @@ public class HTTPCommunicator {
 
     public String killMember(String groupName, String groupPassword) throws IOException {
 
-        String url = address + "management/cluster/shutdownMember";
+        String url = address + "management/cluster/memberShutdown";
         return doPost(url, groupName, groupPassword);
     }
 


### PR DESCRIPTION
Since we check the URLs via `startsWith()`, it caused lots of trouble before.

@bilalyasar please check if this affects the CLI implementation. 