### PR TITLE
Fixed configuration error in CacheCreationTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheCreationTest.java
@@ -43,13 +43,14 @@ import java.util.concurrent.Executors;
 @Category(SlowTest.class)
 public class CacheCreationTest {
 
-    static Config hzConfig;
     private static final int THREAD_COUNT = 4;
+
+    private static Config hzConfig;
 
     @BeforeClass
     public static void init() throws Exception {
-        final URL configUrl1 = CacheCreationTest.class.getClassLoader().getResource("test-hazelcast-real-jcache.xml");
-        XmlConfigBuilder configBuilder = new XmlConfigBuilder(configUrl1.getFile());
+        final URL configUrl = CacheCreationTest.class.getClassLoader().getResource("test-hazelcast-real-jcache.xml");
+        XmlConfigBuilder configBuilder = new XmlConfigBuilder(configUrl.getFile());
         hzConfig = configBuilder.build();
     }
 
@@ -92,12 +93,12 @@ public class CacheCreationTest {
 
         final CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
         for (int i = 0; i < THREAD_COUNT; i++) {
-            final int finalI = i;
+            final String cacheName = "xmlCache" + i;
             executorService.execute(new Runnable() {
                 @Override
                 public void run() {
                     HazelcastServerCachingProvider cachingProvider = createCachingProvider(hzConfig);
-                    Cache<Object, Object> cache = cachingProvider.getCacheManager().getCache("xmlCache" + finalI);
+                    Cache<Object, Object> cache = cachingProvider.getCacheManager().getCache(cacheName);
                     cache.get(1);
                     latch.countDown();
                 }
@@ -109,8 +110,6 @@ public class CacheCreationTest {
 
     private HazelcastServerCachingProvider createCachingProvider(Config hzConfig) {
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(hzConfig);
-        HazelcastServerCachingProvider cachingProvider =
-                HazelcastServerCachingProvider.createCachingProvider(hazelcastInstance);
-        return cachingProvider;
+        return HazelcastServerCachingProvider.createCachingProvider(hazelcastInstance);
     }
 }

--- a/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
@@ -26,6 +26,7 @@
 
     <network>
         <join>
+            <multicast enabled="false"/>
             <tcp-ip enabled="true">
                 <member>127.0.0.1</member>
             </tcp-ip>


### PR DESCRIPTION
Fixed "InvalidConfigurationException: TCP/IP and Multicast join can't be enabled at the same time" in `CacheCreationTest`.

```
com.hazelcast.config.InvalidConfigurationException: TCP/IP and Multicast join can't be enabled at the same time

	at com.hazelcast.config.JoinConfig.verify(JoinConfig.java:111)
	at com.hazelcast.config.XmlConfigBuilder.handleJoin(XmlConfigBuilder.java:673)
	at com.hazelcast.config.XmlConfigBuilder.handleNetwork(XmlConfigBuilder.java:521)
	at com.hazelcast.config.XmlConfigBuilder.handleXmlNode(XmlConfigBuilder.java:278)
	at com.hazelcast.config.XmlConfigBuilder.handleConfig(XmlConfigBuilder.java:265)
	at com.hazelcast.config.XmlConfigBuilder.parseAndBuildConfig(XmlConfigBuilder.java:221)
	at com.hazelcast.config.XmlConfigBuilder.build(XmlConfigBuilder.java:203)
	at com.hazelcast.config.XmlConfigBuilder.build(XmlConfigBuilder.java:196)
	at com.hazelcast.cache.CacheCreationTest.init(CacheCreationTest.java:53)
        (...)
```

This test is a slow test, so the PR builder will not run it. I ran it locally to check the fix and the exception is not thrown anymore.