### PR TITLE
disabled multicast at test-hazelcast-real-jcache.xml

### DIFF
--- a/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-real-jcache.xml
@@ -29,6 +29,8 @@
             <tcp-ip enabled="true">
                 <member>127.0.0.1</member>
             </tcp-ip>
+            <multicast enabled="false">
+            </multicast>
         </join>
     </network>
 


### PR DESCRIPTION
After https://github.com/hazelcast/hazelcast/pull/8123, sonar and nightly builds failed with:
```
com.hazelcast.config.InvalidConfigurationException: TCP/IP and Multicast join can't be enabled at the same time
	at com.hazelcast.config.JoinConfig.verify(JoinConfig.java:111)
	at com.hazelcast.config.XmlConfigBuilder.handleJoin(XmlConfigBuilder.java:673)
	at com.hazelcast.config.XmlConfigBuilder.handleNetwork(XmlConfigBuilder.java:521)
	at com.hazelcast.config.XmlConfigBuilder.handleXmlNode(XmlConfigBuilder.java:278)
	at com.hazelcast.config.XmlConfigBuilder.handleConfig(XmlConfigBuilder.java:265)
	at com.hazelcast.config.XmlConfigBuilder.parseAndBuildConfig(XmlConfigBuilder.java:221)
	at com.hazelcast.config.XmlConfigBuilder.build(XmlConfigBuilder.java:203)
	at com.hazelcast.config.XmlConfigBuilder.build(XmlConfigBuilder.java:196)
	at com.hazelcast.cache.CacheCreationTest.init(CacheCreationTest.java:53)
```

https://hazelcast-l337.ci.cloudbees.com/view/Official%20Builds/job/Hazelcast-3.x-nightly/com.hazelcast$hazelcast/947/testReport/junit/com.hazelcast.cache/CacheCreationTest/com_hazelcast_cache_CacheCreationTest/