### PR TITLE
Disable stale read on partition migration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -342,6 +342,8 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.partition.migration.timeout", 300, SECONDS);
     public static final HazelcastProperty PARTITION_MIGRATION_ZIP_ENABLED
             = new HazelcastProperty("hazelcast.partition.migration.zip.enabled", true);
+    public static final HazelcastProperty DISABLE_STALE_READ_ON_PARTITION_MIGRATION
+            = new HazelcastProperty("hazelcast.partition.migration.stale.read.disabled", false);
 
     public static final HazelcastProperty PARTITION_TABLE_SEND_INTERVAL
             = new HazelcastProperty("hazelcast.partition.table.send.interval", 15, SECONDS);

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
@@ -1,0 +1,97 @@
+package com.hazelcast.internal.partition;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.impl.InternalPartitionImpl;
+import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ExceptionAction;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.InvocationBuilder;
+import com.hazelcast.spi.ReadonlyOperation;
+import com.hazelcast.spi.exception.PartitionMigratingException;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class StaleReadDuringMigrationTest extends HazelcastTestSupport {
+
+    @Test
+    public void testReadOperationFailsWhenStaleReadDisabledDuringMigration()
+            throws ExecutionException, InterruptedException {
+        final Config config = new Config();
+        config.setProperty(GroupProperty.DISABLE_STALE_READ_ON_PARTITION_MIGRATION.getName(), "true");
+
+        final InternalCompletableFuture<Boolean> future = invokeOperation(config);
+        try {
+            future.get();
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof PartitionMigratingException);
+        }
+    }
+
+    @Test
+    public void testReadOperationSucceedsWhenStaleReadEnabledDuringMigration()
+            throws ExecutionException, InterruptedException {
+        final InternalCompletableFuture<Boolean> future = invokeOperation(new Config());
+
+        assertTrue(future.get());
+    }
+
+    private InternalCompletableFuture<Boolean> invokeOperation(final Config config) {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
+        final HazelcastInstance instance = factory.newHazelcastInstance(config);
+        warmUpPartitions(instance);
+
+        final int partitionId = 0;
+        final InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) getPartitionService(instance);
+        final InternalPartitionImpl partition = (InternalPartitionImpl) partitionService.getPartition(partitionId);
+        partition.setMigrating(true);
+
+        final InternalOperationService operationService = getOperationService(instance);
+        final InvocationBuilder invocationBuilder = operationService
+                .createInvocationBuilder(InternalPartitionService.SERVICE_NAME, new DummyOperation(), partitionId);
+        return invocationBuilder.invoke();
+    }
+
+    private static class DummyOperation extends AbstractOperation implements ReadonlyOperation {
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        public boolean returnsResponse() {
+            return true;
+        }
+
+        @Override
+        public Object getResponse() {
+            return true;
+        }
+
+        @Override
+        public ExceptionAction onInvocationException(Throwable throwable) {
+            if (throwable instanceof PartitionMigratingException) {
+                return ExceptionAction.THROW_EXCEPTION;
+            }
+            return super.onInvocationException(throwable);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Currently, we allow read operations to be performed while a partition is being migrated. It can lead to stale reads on the following scenario:

Lets say Node A is owner of a partition which will be migrated to Node B. When migration starts, mutating operations are blocked but read operations are allowed on Node A.
After Node B (migration destination) commits the migration, it can start performing mutations but Node A (migration source) continues to allow read operations on itself until it commits the migration.

With this flag (`hazelcast.partition.migration.stale.read.disabled`), one can disable stale read possibility on migrations. By default, it is set to false and current behavior is preserved.