### PR TITLE
Multiple IAtomicReference issues fixed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterAndGetOperation.java
@@ -37,12 +37,16 @@ public class AlterAndGetOperation extends AbstractAlterOperation {
         IFunction f = nodeEngine.toObject(function);
         AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
 
-        Object input = nodeEngine.toObject(atomicReferenceContainer.get());
+        Data originalData = atomicReferenceContainer.get();
+        Object input = nodeEngine.toObject(originalData);
         //noinspection unchecked
         Object output = f.apply(input);
-        shouldBackup = true;
-        backup = nodeEngine.toData(output);
-        atomicReferenceContainer.set(backup);
+        Data serializedOutput = nodeEngine.toData(output);
+        shouldBackup = !isEquals(originalData, serializedOutput);
+        if (shouldBackup) {
+            backup = serializedOutput;
+            atomicReferenceContainer.set(backup);
+        }
         response = output;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/AlterOperation.java
@@ -37,12 +37,14 @@ public class AlterOperation extends AbstractAlterOperation {
         IFunction f = nodeEngine.toObject(function);
         AtomicReferenceContainer reference = getReferenceContainer();
 
-        Object input = nodeEngine.toObject(reference.get());
+        Data originalData = reference.get();
+        Object input = nodeEngine.toObject(originalData);
         //noinspection unchecked
         Object output = f.apply(input);
-        shouldBackup = !isEquals(input, output);
+        Data serializedOutput = nodeEngine.toData(output);
+        shouldBackup = !isEquals(originalData, serializedOutput);
         if (shouldBackup) {
-            backup = nodeEngine.toData(output);
+            backup = serializedOutput;
             reference.set(backup);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndAlterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetAndAlterOperation.java
@@ -37,14 +37,15 @@ public class GetAndAlterOperation extends AbstractAlterOperation {
         IFunction f = nodeEngine.toObject(function);
         AtomicReferenceContainer atomicReferenceContainer = getReferenceContainer();
 
+        response = atomicReferenceContainer.get();
         Object input = nodeEngine.toObject(atomicReferenceContainer.get());
-        response = input;
         //noinspection unchecked
         Object output = f.apply(input);
-        shouldBackup = !isEquals(input, output);
+        Data serializedOutput = nodeEngine.toData(output);
+        shouldBackup = !isEquals(response, serializedOutput);
         if (shouldBackup) {
-            backup = nodeEngine.toData(output);
-            atomicReferenceContainer.set(backup);
+            atomicReferenceContainer.set(serializedOutput);
+            backup = serializedOutput;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
@@ -325,9 +325,33 @@ public abstract class AtomicReferenceAbstractTest extends HazelcastTestSupport {
     public void getAndAlter_when_same_reference() {
         BitSet bitSet = new BitSet();
         IAtomicReference<BitSet> ref2 = newInstance();
+
+        ref2.set(bitSet);
+        assertEquals(bitSet, ref2.getAndAlter(new FailingFunctionAlter()));
+
+        bitSet.set(100);
+        assertEquals(bitSet, ref2.get());
+    }
+
+    @Test
+    public void alterAndGet_when_same_reference() {
+        BitSet bitSet = new BitSet();
+        IAtomicReference<BitSet> ref2 = newInstance();
+
         ref2.set(bitSet);
         bitSet.set(100);
+
         assertEquals(bitSet, ref2.alterAndGet(new FailingFunctionAlter()));
+        assertEquals(bitSet, ref2.get());
+    }
+
+    @Test
+    public void alter_when_same_reference() {
+        BitSet bitSet = new BitSet();
+        IAtomicReference<BitSet> ref2 = newInstance();
+        ref2.set(bitSet);
+        bitSet.set(100);
+        ref2.alter(new FailingFunctionAlter());
         assertEquals(bitSet, ref2.get());
     }
 


### PR DESCRIPTION
1. getAndAlter test was testing alterAndGet method
2. AlterAndGetOperation optimized - sen backup only when (serialized) new value is different from the original value
3. AlterOperation fixed - use serialized values to make a decision whether to persist change - otherwise a change is lost when the function mutates the original object instead of creating a backup
4. GetAndAlterOperation fixed - the same issues as with AlterOperation

Fixes #8149