### PR TITLE
Reduced binary size of map.get/contains/entryview operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.map.impl.operation.ContainsKeyOperation;
 import com.hazelcast.map.impl.operation.EvictBackupOperation;
 import com.hazelcast.map.impl.operation.GetOperation;
 import com.hazelcast.map.impl.operation.PutBackupOperation;
@@ -43,20 +44,16 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int REMOVE = 2;
     public static final int PUT_BACKUP = 3;
     public static final int REMOVE_BACKUP = 4;
-    //public static final int DATA_RECORD = 5;
-    //public static final int OBJECT_RECORD = 6;
-    //public static final int CACHED_RECORD = 7;
-    public static final int KEY_SET = 8;
-    public static final int VALUES = 9;
-    public static final int MAP_ENTRIES = 10;
-    public static final int ENTRY_VIEW = 11;
-    //public static final int MAP_STATS = 12;
-    public static final int QUERY_RESULT_ROW = 13;
-    //public static final int QUERY_RESULT_SET = 14;
-    public static final int QUERY_RESULT = 15;
-    public static final int EVICT_BACKUP = 16;
+    public static final int KEY_SET = 5;
+    public static final int VALUES = 6;
+    public static final int MAP_ENTRIES = 7;
+    public static final int ENTRY_VIEW = 8;
+    public static final int QUERY_RESULT_ROW = 9;
+    public static final int QUERY_RESULT = 10;
+    public static final int EVICT_BACKUP = 11;
+    public static final int CONTAINS_KEY = 12;
 
-    private static final int LEN = EVICT_BACKUP + 1;
+    private static final int LEN = CONTAINS_KEY + 1;
 
     @Override
     public int getFactoryId() {
@@ -117,11 +114,6 @@ public final class MapDataSerializerHook implements DataSerializerHook {
                 return (IdentifiedDataSerializable) EntryViews.createSimpleEntryView();
             }
         };
-//        constructors[MAP_STATS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-//            public IdentifiedDataSerializable createNew(Integer arg) {
-//                return new LocalMapStatsImpl();
-//            }
-//        };
         constructors[QUERY_RESULT_ROW] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new QueryResultRow();
@@ -130,6 +122,11 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[QUERY_RESULT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new QueryResult();
+            }
+        };
+        constructors[CONTAINS_KEY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new ContainsKeyOperation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -25,11 +25,10 @@ import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
 
-public abstract class BasePutOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
+public abstract class BasePutOperation extends LockAwareOperation implements BackupAwareOperation {
 
     protected transient Data dataOldValue;
     protected transient EntryEventType eventType;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -20,10 +20,9 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
 
-public abstract class BaseRemoveOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
+public abstract class BaseRemoveOperation extends LockAwareOperation implements BackupAwareOperation {
 
     protected transient Data dataOldValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -18,26 +18,39 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.DefaultObjectNamespace;
-import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public class ContainsKeyOperation extends KeyBasedMapOperation implements ReadonlyOperation, BlockingOperation {
+public class ContainsKeyOperation extends ReadonlyKeyBasedMapOperation implements BlockingOperation, IdentifiedDataSerializable {
 
-    private boolean containsKey;
+    private transient boolean containsKey;
 
     public ContainsKeyOperation() {
     }
 
     public ContainsKeyOperation(String name, Data dataKey) {
-        super(name, dataKey);
+        this.name = name;
+        this.dataKey = dataKey;
     }
 
+    @Override
     public void run() {
         containsKey = recordStore.containsKey(dataKey);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.CONTAINS_KEY;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
@@ -29,7 +29,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
 
 import java.io.IOException;
@@ -37,7 +36,7 @@ import java.util.Map;
 
 import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
 
-public class EntryBackupOperation extends KeyBasedMapOperation implements BackupOperation, MutatingOperation {
+public class EntryBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
 
     protected transient Object oldValue;
     private EntryBackupProcessor entryProcessor;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBackupOperation.java
@@ -22,13 +22,12 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 
-public class EvictBackupOperation extends KeyBasedMapOperation implements BackupOperation, MutatingOperation,
-        IdentifiedDataSerializable {
+public class EvictBackupOperation extends MutatingKeyBasedMapOperation
+        implements BackupOperation, IdentifiedDataSerializable {
 
     protected boolean unlockKey;
     protected boolean disableWanReplicationEvent;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetEntryViewOperation.java
@@ -25,10 +25,9 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.DefaultObjectNamespace;
-import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public class GetEntryViewOperation extends KeyBasedMapOperation implements ReadonlyOperation, BlockingOperation {
+public class GetEntryViewOperation extends ReadonlyKeyBasedMapOperation implements BlockingOperation {
 
     private EntryView<Data, Data> result;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -24,11 +24,10 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.DefaultObjectNamespace;
-import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public final class GetOperation extends KeyBasedMapOperation
-        implements IdentifiedDataSerializable, BlockingOperation, ReadonlyOperation {
+public final class GetOperation extends ReadonlyKeyBasedMapOperation
+        implements IdentifiedDataSerializable, BlockingOperation {
 
     private Data result;
 
@@ -37,6 +36,8 @@ public final class GetOperation extends KeyBasedMapOperation
 
     public GetOperation(String name, Data dataKey) {
         super(name, dataKey);
+
+        this.dataKey = dataKey;
     }
 
     @Override
@@ -68,7 +69,7 @@ public final class GetOperation extends KeyBasedMapOperation
     }
 
     @Override
-    public Object getResponse() {
+    public Data getResponse() {
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
@@ -23,7 +23,7 @@ import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.WaitNotifyKey;
 
-public abstract class LockAwareOperation extends KeyBasedMapOperation implements BlockingOperation {
+public abstract class LockAwareOperation extends MutatingKeyBasedMapOperation implements BlockingOperation {
 
     protected LockAwareOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
@@ -20,41 +20,42 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.NamedOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 
-public abstract class KeyBasedMapOperation extends MapOperation implements PartitionAwareOperation, NamedOperation {
+public abstract class MutatingKeyBasedMapOperation extends MapOperation
+        implements PartitionAwareOperation, MutatingOperation {
 
     protected Data dataKey;
     protected long threadId;
     protected Data dataValue;
     protected long ttl = DEFAULT_TTL;
 
-    public KeyBasedMapOperation() {
+    public MutatingKeyBasedMapOperation() {
     }
 
-    public KeyBasedMapOperation(String name, Data dataKey) {
+    public MutatingKeyBasedMapOperation(String name, Data dataKey) {
         super(name);
         this.dataKey = dataKey;
     }
 
-    protected KeyBasedMapOperation(String name, Data dataKey, Data dataValue) {
+    protected MutatingKeyBasedMapOperation(String name, Data dataKey, Data dataValue) {
         super(name);
         this.dataKey = dataKey;
         this.dataValue = dataValue;
     }
 
-    protected KeyBasedMapOperation(String name, Data dataKey, long ttl) {
+    protected MutatingKeyBasedMapOperation(String name, Data dataKey, long ttl) {
         super(name);
         this.dataKey = dataKey;
         this.ttl = ttl;
     }
 
-    protected KeyBasedMapOperation(String name, Data dataKey, Data dataValue, long ttl) {
+    protected MutatingKeyBasedMapOperation(String name, Data dataKey, Data dataValue, long ttl) {
         super(name);
         this.dataKey = dataKey;
         this.dataValue = dataValue;
@@ -113,13 +114,5 @@ public abstract class KeyBasedMapOperation extends MapOperation implements Parti
         threadId = in.readLong();
         dataValue = in.readData();
         ttl = in.readLong();
-    }
-
-
-    @Override
-    protected void toString(StringBuilder sb) {
-        super.toString(sb);
-
-        sb.append(", name=").append(name);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -29,12 +29,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public final class PutBackupOperation extends KeyBasedMapOperation implements BackupOperation,
-        IdentifiedDataSerializable, MutatingOperation {
+public final class PutBackupOperation extends MutatingKeyBasedMapOperation
+        implements BackupOperation, IdentifiedDataSerializable {
 
     // todo unlockKey is a logic just used in transactional put operations.
     // todo It complicates here there should be another Operation for that logic. e.g. TxnSetBackup

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
@@ -22,12 +22,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 
-public class RemoveBackupOperation extends KeyBasedMapOperation implements BackupOperation, MutatingOperation,
+public class RemoveBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation,
         IdentifiedDataSerializable {
 
     protected boolean unlockKey;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map.impl.tx;
 
-import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -29,7 +29,7 @@ import java.io.IOException;
 /**
  *  An operation to prepare transaction by locking the key on key backup owner.
  */
-public class TxnPrepareBackupOperation extends KeyBasedMapOperation implements BackupOperation, MutatingOperation {
+public class TxnPrepareBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation, MutatingOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
     private String lockOwner;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -17,7 +17,7 @@
 package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -31,7 +31,7 @@ import java.io.IOException;
 /**
  * An operation to prepare transaction by locking the key on the key owner.
  */
-public class TxnPrepareOperation extends KeyBasedMapOperation implements BackupAwareOperation, MutatingOperation {
+public class TxnPrepareOperation extends MutatingKeyBasedMapOperation implements BackupAwareOperation, MutatingOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map.impl.tx;
 
-import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -28,7 +28,7 @@ import java.io.IOException;
 /**
  * An operation to rollback transaction by unlocking the key on key backup owner.
  */
-public class TxnRollbackBackupOperation extends KeyBasedMapOperation implements BackupOperation {
+public class TxnRollbackBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
 
     private String lockOwner;
     private long lockThreadId;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.tx;
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -35,7 +35,7 @@ import java.io.IOException;
 /**
  * An operation to rollback transaction by unlocking the key on key owner.
  */
-public class TxnRollbackOperation extends KeyBasedMapOperation implements BackupAwareOperation, Notifier {
+public class TxnRollbackOperation extends MutatingKeyBasedMapOperation implements BackupAwareOperation, Notifier {
 
     private String ownerUuid;
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.impl.operation.BaseRemoveOperation;
-import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
+import com.hazelcast.map.impl.operation.MutatingKeyBasedMapOperation;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -129,7 +129,7 @@ public class MapRemoveFailingBackupTest extends HazelcastTestSupport {
         }
     }
 
-    private static class ExceptionThrowingRemoveBackupOperation extends KeyBasedMapOperation {
+    private static class ExceptionThrowingRemoveBackupOperation extends MutatingKeyBasedMapOperation {
         private ExceptionThrowingRemoveBackupOperation() {
         }
 


### PR DESCRIPTION
Shaves 12 bytes of. TTL and data-value isn't needed. This is done by
making 2 class hierarchies.

1: ReadonlyKeyBasedMapOperation without ttl/data-value
2: MutatingKeyBasedMapOperation with ttl/data-value

No enterprise changes required