### PR TITLE
Shutdown nodes via LifecycleService on cluster shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -894,7 +894,9 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         }
 
         logger.info("Number of other nodes remaining: " + getSize(NON_LOCAL_MEMBER_SELECTOR) + ". Shutting down itself.");
-        node.shutdown(false);
+
+        final HazelcastInstanceImpl hazelcastInstance = node.hazelcastInstance;
+        hazelcastInstance.getLifecycleService().shutdown();
     }
 
     public void initialClusterState(ClusterState clusterState) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ShutdownNodeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ShutdownNodeOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
@@ -43,7 +44,8 @@ public class ShutdownNodeOperation
                 new Thread(new Runnable() {
                     @Override
                     public void run() {
-                        nodeEngine.getNode().shutdown(false);
+                        final Node node = nodeEngine.getNode();
+                        node.hazelcastInstance.getLifecycleService().shutdown();
                     }
                 }).start();
             } else {


### PR DESCRIPTION
... so that lifecycle listeners are invoked properly on cluster shutdown

Fixes #8070 