### PR TITLE
[DONT MERGE] caller uuid now UUID instead of String

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientImpl.java
@@ -20,23 +20,31 @@ import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientType;
 
 import java.net.InetSocketAddress;
+import java.util.UUID;
 
 /**
  * Default {@link com.hazelcast.core.Client} implementation.
  */
 public class ClientImpl implements Client {
 
-    private final String uuid;
+    private final String uuidString;
     private final InetSocketAddress socketAddress;
+    private final UUID uuid;
 
     public ClientImpl(String uuid, InetSocketAddress socketAddress) {
-        this.uuid = uuid;
+        this.uuidString = uuid;
+        this.uuid = UUID.fromString(uuidString);
         this.socketAddress = socketAddress;
     }
 
     @Override
-    public String getUuid() {
+    public UUID getUUID() {
         return uuid;
+    }
+
+    @Override
+    public String getUuid() {
+        return uuidString;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -55,6 +55,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -280,7 +281,7 @@ public abstract class AbstractCacheService
     }
 
     @Override
-    public void deleteCache(String name, String callerUuid, boolean destroy) {
+    public void deleteCache(String name, UUID callerUuid, boolean destroy) {
         CacheConfig config = deleteCacheConfig(name);
         if (destroy) {
             destroySegments(name);
@@ -663,7 +664,7 @@ public abstract class AbstractCacheService
      * @param sourceUuid an id that represents the source for invalidation event
      */
     @Override
-    public void sendInvalidationEvent(String name, Data key, String sourceUuid) {
+    public void sendInvalidationEvent(String name, Data key, UUID sourceUuid) {
         cacheEventHandler.sendInvalidationEvent(name, key, sourceUuid);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -137,7 +138,7 @@ class CacheEventHandler {
         eventService.publishEvent(ICacheService.SERVICE_NAME, candidates, eventSet, orderKey);
     }
 
-    void sendInvalidationEvent(String name, Data key, String sourceUuid) {
+    void sendInvalidationEvent(String name, Data key, UUID sourceUuid) {
         if (key == null) {
             sendSingleInvalidationEvent(name, null, sourceUuid);
         } else {
@@ -155,7 +156,7 @@ class CacheEventHandler {
         }
     }
 
-    private void sendSingleInvalidationEvent(String name, Data key, String sourceUuid) {
+    private void sendSingleInvalidationEvent(String name, Data key, UUID sourceUuid) {
         EventService eventService = nodeEngine.getEventService();
         Collection<EventRegistration> registrations = eventService.getRegistrations(ICacheService.SERVICE_NAME, name);
         if (!registrations.isEmpty()) {
@@ -165,7 +166,7 @@ class CacheEventHandler {
         }
     }
 
-    private void sendBatchInvalidationEvent(String name, Data key, String sourceUuid) {
+    private void sendBatchInvalidationEvent(String name, Data key, UUID sourceUuid) {
         EventService eventService = nodeEngine.getEventService();
         Collection<EventRegistration> registrations = eventService.getRegistrations(ICacheService.SERVICE_NAME, name);
         if (registrations.isEmpty()) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -25,6 +25,7 @@ import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.processor.EntryProcessor;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * {@link ICacheRecordStore} is the core contract providing internal functionality to
@@ -78,7 +79,7 @@ public interface ICacheRecordStore {
      * @param caller  uuid of the calling node or client.
      * @return the stored {@link CacheRecord}  (added as new record or updated). <code>null</code> if record has expired.
      */
-    CacheRecord put(Data key, Object value, ExpiryPolicy expiryPolicy, String caller, int completionId);
+    CacheRecord put(Data key, Object value, ExpiryPolicy expiryPolicy, UUID caller, int completionId);
 
     /**
      * Associates the specified value with the specified key in this cache,
@@ -100,7 +101,7 @@ public interface ICacheRecordStore {
      * @return the value associated with the key at the start of the operation or
      *         null if none was associated.
      */
-    Object getAndPut(Data key, Object value, ExpiryPolicy expiryPolicy, String caller, int completionId);
+    Object getAndPut(Data key, Object value, ExpiryPolicy expiryPolicy, UUID caller, int completionId);
 
     /**
      * Removes the mapping for a key from this cache if it is present.
@@ -122,7 +123,7 @@ public interface ICacheRecordStore {
      * @param caller  uuid of the calling node or client.
      * @return true if a value was set..
      */
-    boolean putIfAbsent(Data key, Object value, ExpiryPolicy expiryPolicy, String caller, int completionId);
+    boolean putIfAbsent(Data key, Object value, ExpiryPolicy expiryPolicy, UUID caller, int completionId);
 
     /**
      * Atomically removes the entry for a key only if it is currently mapped to some
@@ -144,7 +145,7 @@ public interface ICacheRecordStore {
      * @param caller  uuid of the calling node or client.
      * @return the value if one existed or null if no mapping existed for this key.
      */
-    Object getAndRemove(Data key, String caller, int completionId);
+    Object getAndRemove(Data key, UUID caller, int completionId);
 
     /**
      * Removes the mapping for a key from this cache if it is present.
@@ -164,7 +165,7 @@ public interface ICacheRecordStore {
      * @param caller  uuid of the calling node or client.
      * @return returns false if there was no matching key.
      */
-    boolean remove(Data key, String caller, int completionId);
+    boolean remove(Data key, UUID caller, int completionId);
 
     /**
      * Atomically removes the mapping for a key only if currently mapped to the
@@ -186,7 +187,7 @@ public interface ICacheRecordStore {
      * @param caller  uuid of the calling node or client.
      * @return returns false if there was no matching key.
      */
-    boolean remove(Data key, Object value, String caller, int completionId);
+    boolean remove(Data key, Object value, UUID caller, int completionId);
 
     /**
      * Atomically replaces the entry for a key only if currently mapped to some
@@ -208,7 +209,7 @@ public interface ICacheRecordStore {
      * @param caller  uuid of the calling node or client.
      * @return <tt>true</tt> if the value was replaced.
      */
-    boolean replace(Data key, Object value, ExpiryPolicy expiryPolicy, String caller, int completionId);
+    boolean replace(Data key, Object value, ExpiryPolicy expiryPolicy, UUID caller, int completionId);
 
     /**
      * Atomically replaces the entry for a key only if currently mapped to a
@@ -232,7 +233,7 @@ public interface ICacheRecordStore {
      * @param caller  uuid of the calling node or client.
      * @return <tt>true</tt> if the value was replaced.
      */
-    boolean replace(Data key, Object oldValue, Object newValue, ExpiryPolicy expiryPolicy, String caller, int completionId);
+    boolean replace(Data key, Object oldValue, Object newValue, ExpiryPolicy expiryPolicy, UUID caller, int completionId);
 
     /**
      * Atomically replaces the value for a given key if and only if there is a
@@ -257,7 +258,7 @@ public interface ICacheRecordStore {
      * @return the previous value associated with the specified key, or
      *         <tt>null</tt> if there was no mapping for the key.
      */
-    Object getAndReplace(Data key, Object value, ExpiryPolicy expiryPolicy, String caller, int completionId);
+    Object getAndReplace(Data key, Object value, ExpiryPolicy expiryPolicy, UUID caller, int completionId);
 
     /**
      * Determines if this store contains an entry for the specified key.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
 
 import java.util.Collection;
+import java.util.UUID;
 
 public interface ICacheService
         extends ManagedService,
@@ -64,7 +65,7 @@ public interface ICacheService
 
     CacheContext getOrCreateCacheContext(String name);
 
-    void deleteCache(String name, String callerUuid, boolean destroy);
+    void deleteCache(String name, UUID callerUuid, boolean destroy);
 
     void deleteCacheStat(String name);
 
@@ -95,7 +96,7 @@ public interface ICacheService
 
     String addInvalidationListener(String name, CacheEventListener listener, boolean localOnly);
 
-    void sendInvalidationEvent(String name, Data key, String sourceUuid);
+    void sendInvalidationEvent(String name, Data key, UUID sourceUuid);
 
     boolean isWanReplicationEnabled(String cacheName);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheInvalidationMessage.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public abstract class CacheInvalidationMessage implements IdentifiedDataSerializable {
 
@@ -43,7 +44,7 @@ public abstract class CacheInvalidationMessage implements IdentifiedDataSerializ
         return null;
     }
 
-    public String getSourceUuid() {
+    public UUID getSourceUuid() {
         return null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheSingleInvalidationMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheSingleInvalidationMessage.java
@@ -22,17 +22,18 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class CacheSingleInvalidationMessage extends CacheInvalidationMessage {
 
     private Data key;
-    private String sourceUuid;
+    private UUID sourceUuid;
 
     public CacheSingleInvalidationMessage() {
 
     }
 
-    public CacheSingleInvalidationMessage(String name, Data key, String sourceUuid) {
+    public CacheSingleInvalidationMessage(String name, Data key, UUID sourceUuid) {
         super(name);
         this.key = key;
         this.sourceUuid = sourceUuid;
@@ -43,7 +44,7 @@ public class CacheSingleInvalidationMessage extends CacheInvalidationMessage {
         return key;
     }
 
-    public String getSourceUuid() {
+    public UUID getSourceUuid() {
         return sourceUuid;
     }
 
@@ -56,7 +57,7 @@ public class CacheSingleInvalidationMessage extends CacheInvalidationMessage {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
-        out.writeUTF(sourceUuid);
+        out.writeUUID(sourceUuid);
         boolean hasKey = key != null;
         out.writeBoolean(hasKey);
         if (hasKey) {
@@ -67,7 +68,7 @@ public class CacheSingleInvalidationMessage extends CacheInvalidationMessage {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
-        sourceUuid = in.readUTF();
+        sourceUuid = in.readUUID();
         if (in.readBoolean()) {
             key = in.readData();
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheDestroyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheDestroyOperation.java
@@ -29,13 +29,14 @@ import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * <p>
  * Destroys the cache on the cluster or on a single node by calling
- * {@link ICacheService#deleteCache(String, String, boolean)}.
+ * {@link ICacheService#deleteCache(String, UUID, boolean)} .
  * </p>
- * @see ICacheService#deleteCache(String, String, boolean)
+ * @see ICacheService#deleteCache(String, UUID, boolean)
  */
 public class CacheDestroyOperation
         extends AbstractNamedOperation
@@ -64,12 +65,12 @@ public class CacheDestroyOperation
         }
     }
 
-    private void destroyCacheOnAllMembers(String name, String callerUuid) {
+    private void destroyCacheOnAllMembers(String name, UUID callerUuid) {
         NodeEngine nodeEngine = getNodeEngine();
         OperationService operationService = nodeEngine.getOperationService();
         Collection<Member> members = nodeEngine.getClusterService().getMembers();
         for (Member member : members) {
-            if (!member.localMember() && !member.getUuid().equals(callerUuid)) {
+            if (!member.localMember() && !member.getUUID().equals(callerUuid)) {
                 CacheDestroyOperation op = new CacheDestroyOperation(name, true);
                 operationService.invokeOnTarget(ICacheService.SERVICE_NAME, op, member.getAddress());
             }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllOperation.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class CachePutAllOperation
         extends AbstractNamedOperation
@@ -75,7 +76,7 @@ public class CachePutAllOperation
     public void run()
             throws Exception {
         int partitionId = getPartitionId();
-        String callerUuid = getCallerUuid();
+        UUID callerUuid = getCallerUuid();
         ICacheService service = getService();
         cache = service.getOrCreateRecordStore(name, partitionId);
         backupRecords = new HashMap<Data, CacheRecord>(entries.size());

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEvent.java
@@ -21,19 +21,22 @@ import com.hazelcast.core.ClientType;
 import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.net.InetSocketAddress;
+import java.util.UUID;
 
 /**
  * Event used for notification of client connection and disconnection
+ *
+ * //todo: this is bad modelling. An event is not a client.
  */
 @PrivateApi
 public class ClientEvent implements Client {
 
-    private final String uuid;
+    private final UUID uuid;
     private final ClientEventType eventType;
     private final InetSocketAddress address;
     private final ClientType clientType;
 
-    public ClientEvent(String uuid, ClientEventType eventType, InetSocketAddress address, ClientType clientType) {
+    public ClientEvent(UUID uuid, ClientEventType eventType, InetSocketAddress address, ClientType clientType) {
         this.uuid = uuid;
         this.eventType = eventType;
         this.address = address;
@@ -42,6 +45,11 @@ public class ClientEvent implements Client {
 
     @Override
     public String getUuid() {
+        return uuid.toString();
+    }
+
+    @Override
+    public UUID getUUID() {
         return uuid;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -34,6 +34,7 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -52,6 +53,9 @@ public final class ClientEndpointImpl implements ClientEndpoint {
 
     private LoginContext loginContext;
     private ClientPrincipal principal;
+
+    private String uuidString;
+    private UUID uuid;
     private boolean firstConnection;
     private Credentials credentials;
     private volatile boolean authenticated;
@@ -74,7 +78,12 @@ public final class ClientEndpointImpl implements ClientEndpoint {
 
     @Override
     public String getUuid() {
-        return principal != null ? principal.getUuid() : null;
+        return uuidString;
+    }
+
+    @Override
+    public UUID getUUID() {
+        return uuid;
     }
 
     @Override
@@ -99,6 +108,10 @@ public final class ClientEndpointImpl implements ClientEndpoint {
     @Override
     public void authenticated(ClientPrincipal principal, Credentials credentials, boolean firstConnection) {
         this.principal = principal;
+        if (principal != null) {
+            uuid = UUID.fromString(principal.getUuid());
+            uuidString = principal.getOwnerUuid();
+        }
         this.firstConnection = firstConnection;
         this.credentials = credentials;
         this.authenticated = true;
@@ -107,6 +120,10 @@ public final class ClientEndpointImpl implements ClientEndpoint {
     @Override
     public void authenticated(ClientPrincipal principal) {
         this.principal = principal;
+        if (principal != null) {
+            uuid = UUID.fromString(principal.getUuid());
+            uuidString = principal.getOwnerUuid();
+        }
         this.authenticated = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -139,7 +139,7 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
                 }
             }, DESTROY_ENDPOINT_DELAY_MS, TimeUnit.MILLISECONDS);
         }
-        ClientEvent event = new ClientEvent(endpoint.getUuid(),
+        ClientEvent event = new ClientEvent(endpoint.getUUID(),
                 ClientEventType.DISCONNECTED,
                 endpoint.getSocketAddress(),
                 endpoint.getClientType());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -235,7 +235,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
             Address address = new Address(conn.getRemoteSocketAddress());
             ((TcpIpConnection) conn).setEndPoint(address);
         }
-        ClientEvent event = new ClientEvent(endpoint.getUuid(),
+        ClientEvent event = new ClientEvent(endpoint.getUUID(),
                 ClientEventType.CONNECTED,
                 endpoint.getSocketAddress(),
                 endpoint.getClientType());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
@@ -41,7 +41,7 @@ public class ClientReAuthOperation extends AbstractOperation implements UrgentSy
     @Override
     public void run() throws Exception {
         ClientEngineImpl service = getService();
-        String memberUuid = getCallerUuid();
+        String memberUuid = getCallerUuid().toString();
         ClientEngineImpl engine = getService();
         Set<ClientEndpoint> endpoints = engine.getEndpointManager().getEndpoints(clientUuid);
         for (ClientEndpoint endpoint : endpoints) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/OperationFactoryWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/OperationFactoryWrapper.java
@@ -22,16 +22,17 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public final class OperationFactoryWrapper implements OperationFactory {
 
     private OperationFactory opFactory;
-    private String uuid;
+    private UUID uuid;
 
     public OperationFactoryWrapper() {
     }
 
-    public OperationFactoryWrapper(OperationFactory opFactory, String uuid) {
+    public OperationFactoryWrapper(OperationFactory opFactory, UUID uuid) {
         this.opFactory = opFactory;
         this.uuid = uuid;
     }
@@ -45,13 +46,13 @@ public final class OperationFactoryWrapper implements OperationFactory {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(uuid);
+        out.writeUUID(uuid);
         out.writeObject(opFactory);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        uuid = in.readUTF();
+        uuid = in.readUUID();
         opFactory = in.readObject();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAllPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAllPartitionsMessageTask.java
@@ -35,7 +35,7 @@ public abstract class AbstractAllPartitionsMessageTask<P> extends AbstractMessag
     @Override
     protected void processMessage() throws Exception {
         ClientEndpoint endpoint = getEndpoint();
-        OperationFactory operationFactory = new OperationFactoryWrapper(createOperationFactory(), endpoint.getUuid());
+        OperationFactory operationFactory = new OperationFactoryWrapper(createOperationFactory(), endpoint.getUUID());
         final InternalOperationService operationService = nodeEngine.getOperationService();
         Map<Integer, Object> map = operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
         sendResponse(reduce(map));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractInvocationMessageTask.java
@@ -34,7 +34,7 @@ public abstract class AbstractInvocationMessageTask<P> extends AbstractMessageTa
     protected void processMessage() {
         final ClientEndpoint endpoint = getEndpoint();
         Operation op = prepareOperation();
-        op.setCallerUuid(endpoint.getUuid());
+        op.setCallerUuid(endpoint.getUUID());
 
         InvocationBuilder builder = getInvocationBuilder(op)
                 .setExecutionCallback(this)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiPartitionMessageTask.java
@@ -36,7 +36,7 @@ public abstract class AbstractMultiPartitionMessageTask<P> extends AbstractCalla
     @Override
     protected Object call() throws Exception {
         ClientEndpoint endpoint = getEndpoint();
-        OperationFactory operationFactory = new OperationFactoryWrapper(createOperationFactory(), endpoint.getUuid());
+        OperationFactory operationFactory = new OperationFactoryWrapper(createOperationFactory(), endpoint.getUUID());
 
         final InternalOperationService operationService = nodeEngine.getOperationService();
         Map<Integer, Object> map = operationService.invokeOnPartitions(getServiceName(), operationFactory, getPartitions());

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMultiTargetMessageTask.java
@@ -56,7 +56,7 @@ public abstract class AbstractMultiTargetMessageTask<P> extends AbstractMessageT
         MultiTargetCallback callback = new MultiTargetCallback(targets);
         for (Address target : targets) {
             Operation op = operationFactory.createOperation();
-            op.setCallerUuid(endpoint.getUuid());
+            op.setCallerUuid(endpoint.getUUID());
             InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, target)
                     .setTryCount(TRY_COUNT)
                     .setResultDeserialized(false)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractPartitionMessageTask.java
@@ -60,7 +60,7 @@ public abstract class AbstractPartitionMessageTask<P>
     public final void processMessage() {
         beforeProcess();
         Operation op = prepareOperation();
-        op.setCallerUuid(endpoint.getUuid());
+        op.setCallerUuid(endpoint.getUUID());
         ICompletableFuture f = nodeEngine.getOperationService()
                 .createInvocationBuilder(getServiceName(), op, getPartitionId())
                 .setResultDeserialized(false)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -40,6 +40,7 @@ import javax.security.auth.login.LoginException;
 import java.security.Permission;
 import java.util.Collection;
 import java.util.Set;
+import java.util.UUID;
 import java.util.logging.Level;
 
 /**
@@ -155,9 +156,9 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractCallableM
     private ClientMessage handleAuthenticated() {
         if (isOwnerConnection()) {
             final String uuid = getUuid();
-            final String localMemberUUID = clientEngine.getLocalMember().getUuid();
+            final UUID localMemberUUID = clientEngine.getLocalMember().getUUID();
 
-            principal = new ClientPrincipal(uuid, localMemberUUID);
+            principal = new ClientPrincipal(uuid, localMemberUUID.toString());
             reAuthLocal();
             Collection<Member> members = nodeEngine.getClusterService().getMembers();
             for (Member member : members) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddInvalidationListenerTask.java
@@ -35,6 +35,7 @@ import com.hazelcast.spi.NotifiableEventListener;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class CacheAddInvalidationListenerTask
         extends AbstractCallableMessageTask<CacheAddInvalidationListenerCodec.RequestParameters> {
@@ -72,7 +73,7 @@ public class CacheAddInvalidationListenerTask
                 return;
             }
             if (eventObject instanceof CacheInvalidationMessage) {
-                String targetUuid = endpoint.getUuid();
+                UUID targetUuid = endpoint.getUUID();
                 if (eventObject instanceof CacheSingleInvalidationMessage) {
                     CacheSingleInvalidationMessage message = (CacheSingleInvalidationMessage) eventObject;
                     if (!targetUuid.equals(message.getSourceUuid())) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
@@ -60,7 +60,7 @@ public class ExecutorServiceSubmitToAddressMessageTask
         }
 
         MemberCallableTaskOperation op = new MemberCallableTaskOperation(parameters.name, parameters.uuid, callableData);
-        op.setCallerUuid(endpoint.getUuid());
+        op.setCallerUuid(endpoint.getUUID());
         return op;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAClearRemoteTransactionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transaction/XAClearRemoteTransactionMessageTask.java
@@ -60,7 +60,7 @@ public class XAClearRemoteTransactionMessageTask
 
         Data xidData = serializationService.toData(parameters.xid);
         Operation op = new ClearRemoteTransactionOperation(xidData);
-        op.setCallerUuid(endpoint.getUuid());
+        op.setCallerUuid(endpoint.getUUID());
         int partitionId = partitionService.getPartitionId(xidData);
 
         InvocationBuilder builder = operationService.createInvocationBuilder(getServiceName(), op, partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
@@ -74,7 +74,7 @@ public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data
         operation.setServiceName(SERVICE_NAME);
         operation.setPartitionId(partitionId);
         OperationAccessor.setCallerAddress(operation, nodeEngine.getThisAddress());
-        operation.setCallerUuid(nodeEngine.getLocalMember().getUuid());
+        operation.setCallerUuid(nodeEngine.getLocalMember().getUUID());
         operation.setOperationResponseHandler(unlockResponseHandler);
         operation.setValidateTarget(false);
         operation.setAsyncBackup(true);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
@@ -18,15 +18,17 @@ package com.hazelcast.concurrent.lock;
 
 import com.hazelcast.nio.serialization.Data;
 
+import java.util.UUID;
+
 public interface LockResource {
 
     Data getKey();
 
     boolean isLocked();
 
-    boolean isLockedBy(String owner, long threadId);
+    boolean isLockedBy(UUID owner, long threadId);
 
-    String getOwner();
+    UUID getOwner();
 
     boolean isTransactional();
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -19,20 +19,21 @@ package com.hazelcast.concurrent.lock;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Set;
+import java.util.UUID;
 
 public interface LockStore {
 
-    boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime);
+    boolean lock(Data key, UUID caller, long threadId, long referenceId, long leaseTime);
 
-    boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime, boolean blockReads);
+    boolean txnLock(Data key, UUID caller, long threadId, long referenceId, long leaseTime, boolean blockReads);
 
-    boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime);
+    boolean extendLeaseTime(Data key, UUID caller, long threadId, long leaseTime);
 
-    boolean unlock(Data key, String caller, long threadId, long referenceId);
+    boolean unlock(Data key, UUID caller, long threadId, long referenceId);
 
     boolean isLocked(Data key);
 
-    boolean isLockedBy(Data key, String caller, long threadId);
+    boolean isLockedBy(Data key, UUID caller, long threadId);
 
     int getLockCount(Data key);
 
@@ -40,7 +41,7 @@ public interface LockStore {
 
     long getRemainingLeaseTime(Data key);
 
-    boolean canAcquireLock(Data key, String caller, long threadId);
+    boolean canAcquireLock(Data key, UUID caller, long threadId);
 
     boolean shouldBlockReads(Data key);
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -65,7 +66,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
+    public boolean lock(Data key, UUID caller, long threadId, long referenceId, long leaseTime) {
         leaseTime = getLeaseTime(leaseTime);
         LockResourceImpl lock = getLock(key);
         return lock.lock(caller, threadId, referenceId, leaseTime, false, false);
@@ -84,13 +85,13 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime, boolean blockReads) {
+    public boolean txnLock(Data key, UUID caller, long threadId, long referenceId, long leaseTime, boolean blockReads) {
         LockResourceImpl lock = getLock(key);
         return lock.lock(caller, threadId, referenceId, leaseTime, true, blockReads);
     }
 
     @Override
-    public boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime) {
+    public boolean extendLeaseTime(Data key, UUID caller, long threadId, long leaseTime) {
         LockResourceImpl lock = locks.get(key);
         if (lock == null) {
             return false;
@@ -109,7 +110,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean isLockedBy(Data key, String caller, long threadId) {
+    public boolean isLockedBy(Data key, UUID caller, long threadId) {
         LockResource lock = locks.get(key);
         if (lock == null) {
             return false;
@@ -143,7 +144,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean canAcquireLock(Data key, String caller, long threadId) {
+    public boolean canAcquireLock(Data key, UUID caller, long threadId) {
         LockResourceImpl lock = locks.get(key);
         if (lock == null) {
             return true;
@@ -159,7 +160,7 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
     }
 
     @Override
-    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
+    public boolean unlock(Data key, UUID caller, long threadId, long referenceId) {
         LockResourceImpl lock = locks.get(key);
         if (lock == null) {
             return false;
@@ -258,17 +259,17 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
         return backupCount + asyncBackupCount;
     }
 
-    public boolean addAwait(Data key, String conditionId, String caller, long threadId) {
+    public boolean addAwait(Data key, String conditionId, UUID caller, long threadId) {
         LockResourceImpl lock = getLock(key);
         return lock.addAwait(conditionId, caller, threadId);
     }
 
-    public boolean removeAwait(Data key, String conditionId, String caller, long threadId) {
+    public boolean removeAwait(Data key, String conditionId, UUID caller, long threadId) {
         LockResourceImpl lock = getLock(key);
         return lock.removeAwait(conditionId, caller, threadId);
     }
 
-    public boolean startAwaiting(Data key, String conditionId, String caller, long threadId) {
+    public boolean startAwaiting(Data key, String conditionId, UUID caller, long threadId) {
         LockResourceImpl lock = getLock(key);
         return lock.startAwaiting(conditionId, caller, threadId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
@@ -21,6 +21,7 @@ import com.hazelcast.spi.ObjectNamespace;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.UUID;
 
 public final class LockStoreProxy implements LockStore {
 
@@ -33,25 +34,25 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
+    public boolean lock(Data key, UUID caller, long threadId, long referenceId, long leaseTime) {
         LockStore lockStore = getLockStoreOrNull();
         return lockStore != null && lockStore.lock(key, caller, threadId, referenceId, leaseTime);
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime, boolean blockReads) {
+    public boolean txnLock(Data key, UUID caller, long threadId, long referenceId, long leaseTime, boolean blockReads) {
         LockStore lockStore = getLockStoreOrNull();
         return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, leaseTime, blockReads);
     }
 
     @Override
-    public boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime) {
+    public boolean extendLeaseTime(Data key, UUID caller, long threadId, long leaseTime) {
         LockStore lockStore = getLockStoreOrNull();
         return lockStore != null && lockStore.extendLeaseTime(key, caller, threadId, leaseTime);
     }
 
     @Override
-    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
+    public boolean unlock(Data key, UUID caller, long threadId, long referenceId) {
         LockStore lockStore = getLockStoreOrNull();
         return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
@@ -63,7 +64,7 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean isLockedBy(Data key, String caller, long threadId) {
+    public boolean isLockedBy(Data key, UUID caller, long threadId) {
         LockStore lockStore = getLockStoreOrNull();
         return lockStore != null && lockStore.isLockedBy(key, caller, threadId);
     }
@@ -96,7 +97,7 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
-    public boolean canAcquireLock(Data key, String caller, long threadId) {
+    public boolean canAcquireLock(Data key, UUID caller, long threadId) {
         LockStore lockStore = getLockStoreOrNull();
         return lockStore != null && lockStore.canAcquireLock(key, caller, threadId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -26,18 +26,19 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class AwaitBackupOperation extends AbstractLockOperation
         implements BackupOperation {
 
-    private String originalCaller;
+    private UUID originalCaller;
     private String conditionId;
 
     public AwaitBackupOperation() {
     }
 
     public AwaitBackupOperation(ObjectNamespace namespace, Data key, long threadId,
-                                String conditionId, String originalCaller) {
+                                String conditionId, UUID originalCaller) {
         super(namespace, key, threadId);
         this.conditionId = conditionId;
         this.originalCaller = originalCaller;
@@ -61,14 +62,14 @@ public class AwaitBackupOperation extends AbstractLockOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(originalCaller);
+        out.writeUUID(originalCaller);
         out.writeUTF(conditionId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        originalCaller = in.readUTF();
+        originalCaller = in.readUUID();
         conditionId = in.readUTF();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
@@ -25,17 +25,18 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class BeforeAwaitBackupOperation extends AbstractLockOperation implements BackupOperation {
 
     private String conditionId;
-    private String originalCaller;
+    private UUID originalCaller;
 
     public BeforeAwaitBackupOperation() {
     }
 
     public BeforeAwaitBackupOperation(ObjectNamespace namespace, Data key, long threadId,
-                                      String conditionId, String originalCaller) {
+                                      String conditionId, UUID originalCaller) {
         super(namespace, key, threadId);
         this.conditionId = conditionId;
         this.originalCaller = originalCaller;
@@ -57,14 +58,14 @@ public class BeforeAwaitBackupOperation extends AbstractLockOperation implements
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(originalCaller);
+        out.writeUUID(originalCaller);
         out.writeUTF(conditionId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        originalCaller = in.readUTF();
+        originalCaller = in.readUUID();
         conditionId = in.readUTF();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -25,15 +25,16 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class LockBackupOperation extends AbstractLockOperation implements BackupOperation {
 
-    private String originalCallerUuid;
+    private UUID originalCallerUuid;
 
     public LockBackupOperation() {
     }
 
-    public LockBackupOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, String originalCallerUuid) {
+    public LockBackupOperation(ObjectNamespace namespace, Data key, long threadId, long leaseTime, UUID originalCallerUuid) {
         super(namespace, key, threadId);
         this.leaseTime = leaseTime;
         this.originalCallerUuid = originalCallerUuid;
@@ -53,12 +54,12 @@ public class LockBackupOperation extends AbstractLockOperation implements Backup
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(originalCallerUuid);
+        out.writeUUID(originalCallerUuid);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        originalCallerUuid = in.readUTF();
+        originalCallerUuid = in.readUUID();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
@@ -25,17 +25,18 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class UnlockBackupOperation extends AbstractLockOperation implements BackupOperation {
 
     private boolean force;
-    private String originalCallerUuid;
+    private UUID originalCallerUuid;
 
     public UnlockBackupOperation() {
     }
 
     public UnlockBackupOperation(
-            ObjectNamespace namespace, Data key, long threadId, String originalCallerUuid, boolean force) {
+            ObjectNamespace namespace, Data key, long threadId, UUID originalCallerUuid, boolean force) {
         super(namespace, key, threadId);
         this.force = force;
         this.originalCallerUuid = originalCallerUuid;
@@ -63,14 +64,14 @@ public class UnlockBackupOperation extends AbstractLockOperation implements Back
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(originalCallerUuid);
+        out.writeUUID(originalCallerUuid);
         out.writeBoolean(force);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        originalCallerUuid = in.readUTF();
+        originalCallerUuid = in.readUUID();
         force = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -97,7 +98,7 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
 
     @Override
     public void memberRemoved(MembershipServiceEvent event) {
-        String caller = event.getMember().getUuid();
+        UUID caller = event.getMember().getUUID();
         onOwnerDisconnected(caller);
     }
 
@@ -105,7 +106,7 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
     }
 
-    private void onOwnerDisconnected(final String caller) {
+    private void onOwnerDisconnected(final UUID caller) {
         IPartitionService partitionService = nodeEngine.getPartitionService();
         OperationService operationService = nodeEngine.getOperationService();
 
@@ -189,6 +190,6 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
 
     @Override
     public void clientDisconnected(String clientUuid) {
-        onOwnerDisconnected(clientUuid);
+        onOwnerDisconnected(UUID.fromString(clientUuid));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
@@ -19,12 +19,14 @@ package com.hazelcast.concurrent.semaphore.operations;
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 
+import java.util.UUID;
+
 public class AcquireBackupOperation extends SemaphoreBackupOperation {
 
     public AcquireBackupOperation() {
     }
 
-    public AcquireBackupOperation(String name, int permitCount, String firstCaller) {
+    public AcquireBackupOperation(String name, int permitCount, UUID firstCaller) {
         super(name, permitCount, firstCaller);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/DrainBackupOperation.java
@@ -19,12 +19,14 @@ package com.hazelcast.concurrent.semaphore.operations;
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 
+import java.util.UUID;
+
 public class DrainBackupOperation extends SemaphoreBackupOperation {
 
     public DrainBackupOperation() {
     }
 
-    public DrainBackupOperation(String name, int permitCount, String firstCaller) {
+    public DrainBackupOperation(String name, int permitCount, UUID firstCaller) {
         super(name, permitCount, firstCaller);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
@@ -19,12 +19,14 @@ package com.hazelcast.concurrent.semaphore.operations;
 import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 
+import java.util.UUID;
+
 public class ReleaseBackupOperation extends SemaphoreBackupOperation {
 
     public ReleaseBackupOperation() {
     }
 
-    public ReleaseBackupOperation(String name, int permitCount, String firstCaller) {
+    public ReleaseBackupOperation(String name, int permitCount, UUID firstCaller) {
         super(name, permitCount, firstCaller);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreBackupOperation.java
@@ -21,15 +21,16 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public abstract class SemaphoreBackupOperation extends SemaphoreOperation implements BackupOperation {
 
-    protected String firstCaller;
+    protected UUID firstCaller;
 
     protected SemaphoreBackupOperation() {
     }
 
-    protected SemaphoreBackupOperation(String name, int permitCount, String firstCaller) {
+    protected SemaphoreBackupOperation(String name, int permitCount, UUID firstCaller) {
         super(name, permitCount);
         this.firstCaller = firstCaller;
     }
@@ -37,12 +38,12 @@ public abstract class SemaphoreBackupOperation extends SemaphoreOperation implem
     @Override
     public void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(firstCaller);
+        out.writeUUID(firstCaller);
     }
 
     @Override
     public void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        firstCaller = in.readUTF();
+        firstCaller = in.readUUID();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberBackupOperation.java
@@ -20,12 +20,14 @@ import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 
+import java.util.UUID;
+
 public class SemaphoreDeadMemberBackupOperation extends SemaphoreBackupOperation {
 
     public SemaphoreDeadMemberBackupOperation() {
     }
 
-    public SemaphoreDeadMemberBackupOperation(String name, String firstCaller) {
+    public SemaphoreDeadMemberBackupOperation(String name, UUID firstCaller) {
         super(name, -1, firstCaller);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberOperation.java
@@ -30,15 +30,16 @@ import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.partition.IPartitionService;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class SemaphoreDeadMemberOperation extends SemaphoreBackupAwareOperation implements Notifier {
 
-    private String firstCaller;
+    private UUID firstCaller;
 
     public SemaphoreDeadMemberOperation() {
     }
 
-    public SemaphoreDeadMemberOperation(String name, String firstCaller) {
+    public SemaphoreDeadMemberOperation(String name, UUID firstCaller) {
         super(name, -1);
         this.firstCaller = firstCaller;
     }
@@ -88,12 +89,12 @@ public class SemaphoreDeadMemberOperation extends SemaphoreBackupAwareOperation 
     @Override
     public void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(firstCaller);
+        out.writeUUID(firstCaller);
     }
 
     @Override
     public void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        firstCaller = in.readUTF();
+        firstCaller = in.readUUID();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/Client.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Client.java
@@ -17,6 +17,7 @@
 package com.hazelcast.core;
 
 import java.net.InetSocketAddress;
+import java.util.UUID;
 
 /**
  * The Client interface allows to get information about
@@ -33,6 +34,8 @@ public interface Client extends Endpoint {
      * @return a unique uuid for this client
      */
     String getUuid();
+
+    UUID getUUID();
 
     /**
      * Returns the socket address of this client.

--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Cluster member interface. The default implementation
@@ -78,6 +79,8 @@ public interface Member extends DataSerializable, Endpoint {
      * @return the UUID of this member.
      */
     String getUuid();
+
+    UUID getUUID();
 
     /**
      * Returns configured attributes for this member.<br/>

--- a/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
@@ -32,6 +32,7 @@ import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @PrivateApi
@@ -40,6 +41,7 @@ public abstract class AbstractMember implements Member {
     protected final Map<String, Object> attributes = new ConcurrentHashMap<String, Object>();
     protected Address address;
     protected String uuid;
+    protected UUID uuidObject;
     protected boolean liteMember;
 
     protected AbstractMember() {
@@ -113,11 +115,17 @@ public abstract class AbstractMember implements Member {
 
     void setUuid(String uuid) {
         this.uuid = uuid;
+        this.uuidObject = UUID.fromString(uuid);
     }
 
     @Override
     public String getUuid() {
         return uuid;
+    }
+
+    @Override
+    public UUID getUUID() {
+        return uuidObject;
     }
 
     @Override
@@ -152,6 +160,7 @@ public abstract class AbstractMember implements Member {
         address = new Address();
         address.readData(in);
         uuid = in.readUTF();
+        uuidObject = UUID.fromString(uuid);
         liteMember = in.readBoolean();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
@@ -40,8 +40,8 @@ public abstract class AbstractMember implements Member {
 
     protected final Map<String, Object> attributes = new ConcurrentHashMap<String, Object>();
     protected Address address;
-    protected String uuid;
-    protected UUID uuidObject;
+    protected String uuidString;
+    protected UUID uuid;
     protected boolean liteMember;
 
     protected AbstractMember() {
@@ -61,7 +61,9 @@ public abstract class AbstractMember implements Member {
 
     protected AbstractMember(Address address, String uuid, Map<String, Object> attributes, boolean liteMember) {
         this.address = address;
-        this.uuid = uuid;
+        this.uuidString = uuid;
+        this.uuid = UUID.fromString(uuidString);
+
         if (attributes != null) {
             this.attributes.putAll(attributes);
         }
@@ -70,6 +72,7 @@ public abstract class AbstractMember implements Member {
 
     protected AbstractMember(AbstractMember member) {
         this.address = member.address;
+        this.uuidString = member.uuidString;
         this.uuid = member.uuid;
         this.attributes.putAll(member.attributes);
         this.liteMember = member.liteMember;
@@ -114,18 +117,18 @@ public abstract class AbstractMember implements Member {
     }
 
     void setUuid(String uuid) {
-        this.uuid = uuid;
-        this.uuidObject = UUID.fromString(uuid);
+        this.uuidString = uuid;
+        this.uuid = UUID.fromString(uuid);
     }
 
     @Override
     public String getUuid() {
-        return uuid;
+        return uuidString;
     }
 
     @Override
     public UUID getUUID() {
-        return uuidObject;
+        return uuid;
     }
 
     @Override
@@ -159,8 +162,8 @@ public abstract class AbstractMember implements Member {
     public void readData(ObjectDataInput in) throws IOException {
         address = new Address();
         address.readData(in);
-        uuid = in.readUTF();
-        uuidObject = UUID.fromString(uuid);
+        uuidString = in.readUTF();
+        uuid = UUID.fromString(uuidString);
         liteMember = in.readBoolean();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
@@ -173,7 +176,7 @@ public abstract class AbstractMember implements Member {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         address.writeData(out);
-        out.writeUTF(uuid);
+        out.writeUTF(uuidString);
         out.writeBoolean(liteMember);
         Map<String, Object> attributes = new HashMap<String, Object>(this.attributes);
         out.writeInt(attributes.size());
@@ -190,7 +193,7 @@ public abstract class AbstractMember implements Member {
         sb.append("]");
         sb.append(":");
         sb.append(address.getPort());
-        sb.append(" - ").append(uuid);
+        sb.append(" - ").append(uuidString);
         if (localMember()) {
             sb.append(" this");
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -31,6 +31,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static com.hazelcast.cluster.MemberAttributeOperationType.PUT;
 import static com.hazelcast.cluster.MemberAttributeOperationType.REMOVE;
@@ -210,7 +211,7 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
     private void invokeOnAllMembers(Operation operation) {
         NodeEngineImpl nodeEngine = instance.node.nodeEngine;
         OperationService os = nodeEngine.getOperationService();
-        String uuid = nodeEngine.getLocalMember().getUuid();
+        UUID uuid = nodeEngine.getLocalMember().getUUID();
         operation.setCallerUuid(uuid).setNodeEngine(nodeEngine);
         try {
             for (Member member : nodeEngine.getClusterService().getMembers()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberAttributeChangedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberAttributeChangedOperation.java
@@ -43,7 +43,7 @@ public class MemberAttributeChangedOperation extends AbstractClusterOperation {
     @Override
     public void run() throws Exception {
         final ClusterServiceImpl cs = getService();
-        cs.updateMemberAttribute(getCallerUuid(), operationType, key, value);
+        cs.updateMemberAttribute(getCallerUuid().toString(), operationType, key, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -25,6 +25,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
+import java.util.UUID;
 
 import static com.hazelcast.nio.Bits.CHAR_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
@@ -58,6 +59,18 @@ class ByteArrayObjectDataInput extends InputStream implements BufferObjectDataIn
         this.service = service;
         this.pos = offset;
         this.bigEndian = byteOrder == ByteOrder.BIG_ENDIAN;
+    }
+
+    @Override
+    public UUID readUUID() throws IOException {
+        long mostSignificantBits = readLong();
+        long leastSignificantBits = readLong();
+
+        if (mostSignificantBits == 0 && leastSignificantBits == 0) {
+            return null;
+        }
+
+        return new UUID(mostSignificantBits, leastSignificantBits);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.serialization.Data;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteOrder;
+import java.util.UUID;
 
 import static com.hazelcast.nio.Bits.CHAR_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
@@ -31,7 +32,9 @@ import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
 
-class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectDataOutput {
+public class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectDataOutput {
+
+    private static final UUID NULL_UUID = new UUID(0, 0);
 
     final int initialSize;
 
@@ -48,6 +51,16 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
         this.buffer = new byte[size];
         this.service = service;
         isBigEndian = byteOrder == ByteOrder.BIG_ENDIAN;
+    }
+
+    @Override
+    public void writeUUID(UUID uuid) throws IOException {
+        if (uuid == null) {
+            uuid = NULL_UUID;
+        }
+
+        writeLong(uuid.getMostSignificantBits());
+        writeLong(uuid.getLeastSignificantBits());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -21,8 +21,13 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.util.UUID;
 
 final class EmptyObjectDataOutput implements ObjectDataOutput {
+
+    @Override
+    public void writeUUID(UUID uuid) throws IOException {
+    }
 
     @Override
     public void writeObject(Object object) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -26,6 +26,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
+import java.util.UUID;
 
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 
@@ -39,6 +40,17 @@ public class ObjectDataInputStream extends InputStream implements ObjectDataInpu
         this.serializationService = serializationService;
         this.dataInput = new DataInputStream(in);
         this.byteOrder = serializationService.getByteOrder();
+    }
+
+    @Override
+    public UUID readUUID() throws IOException {
+        long mostSignificantBits = readLong();
+        long leastSignificantBits = readLong();
+        if (mostSignificantBits == 0 && leastSignificantBits == 0) {
+            return null;
+        }
+
+        return new UUID(mostSignificantBits, leastSignificantBits);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -26,9 +26,11 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteOrder;
+import java.util.UUID;
 
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 
+@SuppressWarnings("checkstyle:methodcount")
 public class ObjectDataOutputStream extends OutputStream implements ObjectDataOutput, Closeable {
 
     private final InternalSerializationService serializationService;
@@ -39,6 +41,11 @@ public class ObjectDataOutputStream extends OutputStream implements ObjectDataOu
         this.serializationService = serializationService;
         this.dataOut = new DataOutputStream(outputStream);
         this.byteOrder = serializationService.getByteOrder();
+    }
+
+    @Override
+    public void writeUUID(UUID uuid) throws IOException {
+
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
@@ -201,7 +201,7 @@ public class ExpirationManager {
         final ClearExpiredOperation clearExpiredOperation = new ClearExpiredOperation(expirationPercentage);
         clearExpiredOperation
                 .setNodeEngine(nodeEngine)
-                .setCallerUuid(nodeEngine.getLocalMember().getUuid())
+                .setCallerUuid(nodeEngine.getLocalMember().getUUID())
                 .setPartitionId(partitionId)
                 .setValidateTarget(false)
                 .setService(mapServiceContext.getService());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
@@ -371,7 +371,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
         operation.setServiceName(SERVICE_NAME)
                 .setNodeEngine(nodeEngine)
                 .setPartitionId(partitionId)
-                .setCallerUuid(nodeEngine.getLocalMember().getUuid())
+                .setCallerUuid(nodeEngine.getLocalMember().getUUID())
                 .setOperationResponseHandler(createEmptyResponseHandler());
 
         operationService.executeOperation(operation);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchInvalidator.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -84,17 +85,17 @@ public class BatchInvalidator extends AbstractNearCacheInvalidator {
     }
 
     @Override
-    public void invalidate(String mapName, Data key, String sourceUuid) {
+    public void invalidate(String mapName, Data key, UUID sourceUuid) {
         invalidateInternal(mapName, key, null, sourceUuid);
     }
 
     @Override
-    public void invalidate(String mapName, List<Data> keys, String sourceUuid) {
+    public void invalidate(String mapName, List<Data> keys, UUID sourceUuid) {
         invalidateInternal(mapName, null, keys, sourceUuid);
     }
 
     @Override
-    public void clear(String mapName, boolean owner, String sourceUuid) {
+    public void clear(String mapName, boolean owner, UUID sourceUuid) {
         if (owner) {
             // only send invalidation event to clients, server near-caches are cleared by ClearOperation.
             invalidateClient(new CleaningNearCacheInvalidation(mapName, sourceUuid));
@@ -103,7 +104,7 @@ public class BatchInvalidator extends AbstractNearCacheInvalidator {
         clearLocal(mapName);
     }
 
-    private void invalidateInternal(String mapName, Data key, List<Data> keys, String sourceUuid) {
+    private void invalidateInternal(String mapName, Data key, List<Data> keys, UUID sourceUuid) {
         accumulateOrInvalidate(mapName, key, keys, sourceUuid);
         invalidateLocal(mapName, key, keys);
     }
@@ -133,7 +134,7 @@ public class BatchInvalidator extends AbstractNearCacheInvalidator {
         invalidationQueues.clear();
     }
 
-    public void accumulateOrInvalidate(String mapName, Data key, List<Data> keys, String sourceUuid) {
+    public void accumulateOrInvalidate(String mapName, Data key, List<Data> keys, UUID sourceUuid) {
         if (!mapServiceContext.getMapContainer(mapName).isInvalidationEnabled()) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/CleaningNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/CleaningNearCacheInvalidation.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.map.impl.nearcache;
 
+import java.util.UUID;
+
 /**
  * Used when invalidating client near-caches.
  * When a client near-cache invalidation listener receives this data, it clears its near-cache.
@@ -25,7 +27,7 @@ public class CleaningNearCacheInvalidation extends Invalidation {
     public CleaningNearCacheInvalidation() {
     }
 
-    public CleaningNearCacheInvalidation(String mapName, String sourceUuid) {
+    public CleaningNearCacheInvalidation(String mapName, UUID sourceUuid) {
         super(mapName, sourceUuid);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/Invalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/Invalidation.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * Root interface for near-cache invalidation data.
@@ -31,12 +32,12 @@ import java.io.IOException;
 public abstract class Invalidation implements IMapEvent, DataSerializable {
 
     private String mapName;
-    private String sourceUuid;
+    private UUID sourceUuid;
 
     public Invalidation() {
     }
 
-    public Invalidation(String mapName, String sourceUuid) {
+    public Invalidation(String mapName, UUID sourceUuid) {
         this.mapName = mapName;
         this.sourceUuid = sourceUuid;
     }
@@ -46,7 +47,7 @@ public abstract class Invalidation implements IMapEvent, DataSerializable {
         return mapName;
     }
 
-    public String getSourceUuid() {
+    public UUID getSourceUuid() {
         return sourceUuid;
     }
 
@@ -63,12 +64,12 @@ public abstract class Invalidation implements IMapEvent, DataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(mapName);
-        out.writeUTF(sourceUuid);
+        out.writeUUID(sourceUuid);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         mapName = in.readUTF();
-        sourceUuid = in.readUTF();
+        sourceUuid = in.readUUID();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ManagedService;
 
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Responsible for local and remote near-cache invalidation.
@@ -37,7 +38,7 @@ public interface NearCacheInvalidator {
      * @param key        key of the entry to be removed from near-cache.
      * @param sourceUuid caller uuid
      */
-    void invalidate(String mapName, Data key, String sourceUuid);
+    void invalidate(String mapName, Data key, UUID sourceUuid);
 
     /**
      * Invalidates local and remote near-caches.
@@ -47,7 +48,7 @@ public interface NearCacheInvalidator {
      * @param keys       keys of the entries to be removed from near-cache.
      * @param sourceUuid caller uuid
      */
-    void invalidate(String mapName, List<Data> keys, String sourceUuid);
+    void invalidate(String mapName, List<Data> keys, UUID sourceUuid);
 
 
     /**
@@ -58,7 +59,7 @@ public interface NearCacheInvalidator {
      * @param owner      <code>true</code> if this method is called from partition owner, otherwise <code>false</code>.
      * @param sourceUuid caller uuid
      */
-    void clear(String mapName, boolean owner, String sourceUuid);
+    void clear(String mapName, boolean owner, UUID sourceUuid);
 
     /**
      * Removes supplied maps invalidation queue and flushes its content.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NonStopInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NonStopInvalidator.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.Operation;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 import static com.hazelcast.core.EntryEventType.INVALIDATION;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
@@ -40,17 +41,17 @@ public class NonStopInvalidator extends AbstractNearCacheInvalidator {
     }
 
     @Override
-    public void invalidate(String mapName, Data key, String sourceUuid) {
+    public void invalidate(String mapName, Data key, UUID sourceUuid) {
         invalidateInternal(mapName, key, null, sourceUuid);
     }
 
     @Override
-    public void invalidate(String mapName, List<Data> keys, String sourceUuid) {
+    public void invalidate(String mapName, List<Data> keys, UUID sourceUuid) {
         invalidateInternal(mapName, null, keys, sourceUuid);
     }
 
     @Override
-    public void clear(String mapName, boolean owner, String sourceUuid) {
+    public void clear(String mapName, boolean owner, UUID sourceUuid) {
         if (owner) {
             // only send invalidation event to clients, server near-caches are cleared by ClearOperation.
             invalidateClient(mapName, null, null, sourceUuid);
@@ -74,13 +75,13 @@ public class NonStopInvalidator extends AbstractNearCacheInvalidator {
         // nop.
     }
 
-    private void invalidateInternal(String mapName, Data key, List<Data> keys, String sourceUuid) {
+    private void invalidateInternal(String mapName, Data key, List<Data> keys, UUID sourceUuid) {
         invalidateMember(mapName, key, keys, sourceUuid);
         invalidateClient(mapName, key, keys, sourceUuid);
         invalidateLocal(mapName, key, keys);
     }
 
-    protected void invalidateClient(String mapName, Data key, List<Data> keys, String sourceUuid) {
+    protected void invalidateClient(String mapName, Data key, List<Data> keys, UUID sourceUuid) {
         if (!hasInvalidationListener(mapName)) {
             return;
         }
@@ -99,7 +100,7 @@ public class NonStopInvalidator extends AbstractNearCacheInvalidator {
         }
     }
 
-    private static Invalidation newInvalidation(String mapName, Data key, List<Data> keys, String sourceUuid) {
+    private static Invalidation newInvalidation(String mapName, Data key, List<Data> keys, UUID sourceUuid) {
         if (key != null) {
             return new SingleNearCacheInvalidation(mapName, key, sourceUuid);
         }
@@ -117,7 +118,7 @@ public class NonStopInvalidator extends AbstractNearCacheInvalidator {
         return new CleaningNearCacheInvalidation(mapName, sourceUuid);
     }
 
-    protected void invalidateMember(String mapName, Data key, List<Data> keys, String sourceUuid) {
+    protected void invalidateMember(String mapName, Data key, List<Data> keys, UUID sourceUuid) {
         if (!isMemberNearCacheInvalidationEnabled(mapName)) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/SingleNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/SingleNearCacheInvalidation.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class SingleNearCacheInvalidation extends Invalidation {
 
@@ -29,7 +30,7 @@ public class SingleNearCacheInvalidation extends Invalidation {
     public SingleNearCacheInvalidation() {
     }
 
-    public SingleNearCacheInvalidation(String mapName, Data key, String sourceUuid) {
+    public SingleNearCacheInvalidation(String mapName, Data key, UUID sourceUuid) {
         super(mapName, sourceUuid);
         this.key = key;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -29,6 +29,7 @@ import com.hazelcast.spi.OperationFactory;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Creates map operations.
@@ -170,7 +171,7 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createTxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, String
+    public MapOperation createTxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, UUID
             ownerUuid, boolean shouldLoad, boolean blockReads) {
         return new TxnLockAndGetOperation(name, dataKey, timeout, ttl, ownerUuid, shouldLoad, blockReads);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.OperationFactory;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Provides {@link com.hazelcast.config.InMemoryFormat InMemoryFormat} specific
@@ -77,7 +78,7 @@ public interface MapOperationProvider {
 
     MapOperation createTxnDeleteOperation(String name, Data dataKey, long version);
 
-    MapOperation createTxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, String ownerUuid,
+    MapOperation createTxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, UUID ownerUuid,
                                               boolean shouldLoad, boolean blockReads);
 
     MapOperation createTxnSetOperation(String name, Data dataKey, Data value, long version, long ttl);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.OperationFactory;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Base class which basically delegates all method calls to underlying {@link MapOperationProvider}
@@ -150,7 +151,7 @@ public abstract class MapOperationProviderDelegator implements MapOperationProvi
 
     @Override
     public MapOperation createTxnLockAndGetOperation(String name, Data dataKey, long timeout,
-                                                     long ttl, String ownerUuid, boolean shouldLoad, boolean blockReads) {
+                                                     long ttl, UUID ownerUuid, boolean shouldLoad, boolean blockReads) {
         return getDelegate().createTxnLockAndGetOperation(name, dataKey, timeout, ttl, ownerUuid, shouldLoad, blockReads);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
@@ -238,7 +238,7 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
         });
         operation.setPartitionId(partitionId);
         OperationAccessor.setCallerAddress(operation, nodeEngine.getThisAddress());
-        operation.setCallerUuid(nodeEngine.getLocalMember().getUuid());
+        operation.setCallerUuid(nodeEngine.getLocalMember().getUUID());
         operation.setServiceName(MapService.SERVICE_NAME);
         return operation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -54,6 +54,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 
@@ -332,19 +333,19 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl, boolean blockReads) {
+    public boolean txnLock(Data key, UUID caller, long threadId, long referenceId, long ttl, boolean blockReads) {
         checkIfLoaded();
         return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl, blockReads);
     }
 
     @Override
-    public boolean extendLock(Data key, String caller, long threadId, long ttl) {
+    public boolean extendLock(Data key, UUID caller, long threadId, long ttl) {
         checkIfLoaded();
         return lockStore != null && lockStore.extendLeaseTime(key, caller, threadId, ttl);
     }
 
     @Override
-    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
+    public boolean unlock(Data key, UUID caller, long threadId, long referenceId) {
         checkIfLoaded();
         return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
@@ -365,7 +366,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public boolean canAcquireLock(Data key, String caller, long threadId) {
+    public boolean canAcquireLock(Data key, UUID caller, long threadId) {
         return lockStore == null || lockStore.canAcquireLock(key, caller, threadId);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.exception.RetryableHazelcastException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Defines a record-store.
@@ -204,17 +205,17 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
 
     int size();
 
-    boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl, boolean blockReads);
+    boolean txnLock(Data key, UUID caller, long threadId, long referenceId, long ttl, boolean blockReads);
 
-    boolean extendLock(Data key, String caller, long threadId, long ttl);
+    boolean extendLock(Data key, UUID caller, long threadId, long ttl);
 
-    boolean unlock(Data key, String caller, long threadId, long referenceId);
+    boolean unlock(Data key, UUID caller, long threadId, long referenceId);
 
     boolean isLocked(Data key);
 
     boolean isTransactionallyLocked(Data key);
 
-    boolean canAcquireLock(Data key, String caller, long threadId);
+    boolean canAcquireLock(Data key, UUID caller, long threadId);
 
     String getLockOwnerInfo(Data key);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
@@ -25,6 +25,7 @@ import com.hazelcast.transaction.impl.TransactionLogRecord;
 import com.hazelcast.util.ThreadUtil;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * Represents an operation on the map in the transaction log.
@@ -35,13 +36,13 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
     private String name;
     private Data key;
     private long threadId = ThreadUtil.getThreadId();
-    private String ownerUuid;
+    private UUID ownerUuid;
     private Operation op;
 
     public MapTransactionLogRecord() {
     }
 
-    public MapTransactionLogRecord(String name, Data key, int partitionId, Operation op, long version, String ownerUuid) {
+    public MapTransactionLogRecord(String name, Data key, int partitionId, Operation op, long version, UUID ownerUuid) {
         this.name = name;
         this.key = key;
         if (!(op instanceof MapTxnOperation)) {
@@ -85,7 +86,7 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
             out.writeData(key);
         }
         out.writeLong(threadId);
-        out.writeUTF(ownerUuid);
+        out.writeUUID(ownerUuid);
         out.writeObject(op);
     }
 
@@ -98,7 +99,7 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
             key = in.readData();
         }
         threadId = in.readLong();
-        ownerUuid = in.readUTF();
+        ownerUuid = in.readUUID();
         op = in.readObject();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTxnOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTxnOperation.java
@@ -18,6 +18,8 @@ package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.spi.Notifier;
 
+import java.util.UUID;
+
 /**
  * Transactional operation interface for {@link com.hazelcast.core.IMap}
  */
@@ -29,6 +31,6 @@ public interface MapTxnOperation extends Notifier {
 
     void setThreadId(long threadId);
 
-    void setOwnerUuid(String ownerUuid);
+    void setOwnerUuid(UUID ownerUuid);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnDeleteOperation.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * Transactional delete operation
@@ -35,7 +36,7 @@ public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOpe
 
     private long version;
     private boolean successful;
-    private String ownerUuid;
+    private UUID ownerUuid;
 
     public TxnDeleteOperation() {
     }
@@ -102,7 +103,7 @@ public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOpe
     }
 
     @Override
-    public void setOwnerUuid(String ownerUuid) {
+    public void setOwnerUuid(UUID ownerUuid) {
         this.ownerUuid = ownerUuid;
     }
 
@@ -119,13 +120,13 @@ public class TxnDeleteOperation extends BaseRemoveOperation implements MapTxnOpe
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(version);
-        out.writeUTF(ownerUuid);
+        out.writeUUID(ownerUuid);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         version = in.readLong();
-        ownerUuid = in.readUTF();
+        ownerUuid = in.readUUID();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * Transactional lock and get operation.
@@ -32,14 +33,14 @@ import java.io.IOException;
 public class TxnLockAndGetOperation extends LockAwareOperation implements MutatingOperation {
 
     private VersionedValue response;
-    private String ownerUuid;
+    private UUID ownerUuid;
     private boolean shouldLoad;
     private boolean blockReads;
 
     public TxnLockAndGetOperation() {
     }
 
-    public TxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, String ownerUuid,
+    public TxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, UUID ownerUuid,
                                   boolean shouldLoad, boolean blockReads) {
         super(name, dataKey, ttl);
         this.ownerUuid = ownerUuid;
@@ -78,7 +79,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(ownerUuid);
+        out.writeUUID(ownerUuid);
         out.writeBoolean(shouldLoad);
         out.writeBoolean(blockReads);
     }
@@ -86,7 +87,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        ownerUuid = in.readUTF();
+        ownerUuid = in.readUUID();
         shouldLoad = in.readBoolean();
         blockReads = in.readBoolean();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareBackupOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  *  An operation to prepare transaction by locking the key on key backup owner.
@@ -32,10 +33,10 @@ import java.io.IOException;
 public class TxnPrepareBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation, MutatingOperation {
 
     private static final long LOCK_TTL_MILLIS = 10000L;
-    private String lockOwner;
+    private UUID lockOwner;
     private long lockThreadId;
 
-    protected TxnPrepareBackupOperation(String name, Data dataKey, String lockOwner, long lockThreadId) {
+    protected TxnPrepareBackupOperation(String name, Data dataKey, UUID lockOwner, long lockThreadId) {
         super(name, dataKey);
         this.lockOwner = lockOwner;
         this.lockThreadId = lockThreadId;
@@ -60,14 +61,14 @@ public class TxnPrepareBackupOperation extends MutatingKeyBasedMapOperation impl
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(lockOwner);
+        out.writeUUID(lockOwner);
         out.writeLong(lockThreadId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        lockOwner = in.readUTF();
+        lockOwner = in.readUUID();
         lockThreadId = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnPrepareOperation.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * An operation to prepare transaction by locking the key on the key owner.
@@ -35,9 +36,9 @@ public class TxnPrepareOperation extends MutatingKeyBasedMapOperation implements
 
     private static final long LOCK_TTL_MILLIS = 10000L;
 
-    private String ownerUuid;
+    private UUID ownerUuid;
 
-    protected TxnPrepareOperation(int partitionId, String name, Data dataKey, String ownerUuid) {
+    protected TxnPrepareOperation(int partitionId, String name, Data dataKey, UUID ownerUuid) {
         super(name, dataKey);
         setPartitionId(partitionId);
         this.ownerUuid = ownerUuid;
@@ -98,13 +99,13 @@ public class TxnPrepareOperation extends MutatingKeyBasedMapOperation implements
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(ownerUuid);
+        out.writeUUID(ownerUuid);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        ownerUuid = in.readUTF();
+        ownerUuid = in.readUUID();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackBackupOperation.java
@@ -24,16 +24,17 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * An operation to rollback transaction by unlocking the key on key backup owner.
  */
 public class TxnRollbackBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
 
-    private String lockOwner;
+    private UUID lockOwner;
     private long lockThreadId;
 
-    protected TxnRollbackBackupOperation(String name, Data dataKey, String lockOwner, long lockThreadId) {
+    protected TxnRollbackBackupOperation(String name, Data dataKey, UUID lockOwner, long lockThreadId) {
         super(name, dataKey);
         this.lockOwner = lockOwner;
         this.lockThreadId = lockThreadId;
@@ -58,14 +59,14 @@ public class TxnRollbackBackupOperation extends MutatingKeyBasedMapOperation imp
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(lockOwner);
+        out.writeUUID(lockOwner);
         out.writeLong(lockThreadId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        lockOwner = in.readUTF();
+        lockOwner = in.readUUID();
         lockThreadId = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnRollbackOperation.java
@@ -31,15 +31,16 @@ import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * An operation to rollback transaction by unlocking the key on key owner.
  */
 public class TxnRollbackOperation extends MutatingKeyBasedMapOperation implements BackupAwareOperation, Notifier {
 
-    private String ownerUuid;
+    private UUID ownerUuid;
 
-    protected TxnRollbackOperation(int partitionId, String name, Data dataKey, String ownerUuid) {
+    protected TxnRollbackOperation(int partitionId, String name, Data dataKey, UUID ownerUuid) {
         super(name, dataKey);
         setPartitionId(partitionId);
         this.ownerUuid = ownerUuid;
@@ -106,12 +107,12 @@ public class TxnRollbackOperation extends MutatingKeyBasedMapOperation implement
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(ownerUuid);
+        out.writeUUID(ownerUuid);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        ownerUuid = in.readUTF();
+        ownerUuid = in.readUUID();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * An operation to unlock and set (key,value) on the partition .
@@ -40,7 +41,7 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
 
     private long version;
     private transient boolean shouldBackup;
-    private String ownerUuid;
+    private UUID ownerUuid;
 
     public TxnSetOperation() {
     }
@@ -96,7 +97,7 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
     }
 
     @Override
-    public void setOwnerUuid(String ownerUuid) {
+    public void setOwnerUuid(UUID ownerUuid) {
         this.ownerUuid = ownerUuid;
     }
 
@@ -133,13 +134,13 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(version);
-        out.writeUTF(ownerUuid);
+        out.writeUUID(ownerUuid);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         version = in.readLong();
-        ownerUuid = in.readUTF();
+        ownerUuid = in.readUUID();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
@@ -23,19 +23,20 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * An operation to unlock key on the backup owner.
  */
 public class TxnUnlockBackupOperation extends MutatingKeyBasedMapOperation implements BackupOperation {
 
-    private String ownerUuid;
+    private UUID ownerUuid;
 
 
     public TxnUnlockBackupOperation() {
     }
 
-    public TxnUnlockBackupOperation(String name, Data dataKey, String ownerUuid) {
+    public TxnUnlockBackupOperation(String name, Data dataKey, UUID ownerUuid) {
         super(name, dataKey, -1);
         this.ownerUuid = ownerUuid;
     }
@@ -53,12 +54,12 @@ public class TxnUnlockBackupOperation extends MutatingKeyBasedMapOperation imple
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(ownerUuid);
+        out.writeUUID(ownerUuid);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        ownerUuid = in.readUTF();
+        ownerUuid = in.readUUID();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 /**
  * An operation to unlock key on the partition owner.
@@ -33,7 +34,7 @@ import java.io.IOException;
 public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOperation, BackupAwareOperation {
 
     private long version;
-    private String ownerUuid;
+    private UUID ownerUuid;
 
     public TxnUnlockOperation() {
     }
@@ -105,7 +106,7 @@ public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOper
     }
 
     @Override
-    public void setOwnerUuid(String ownerUuid) {
+    public void setOwnerUuid(UUID ownerUuid) {
         this.ownerUuid = ownerUuid;
     }
 
@@ -123,13 +124,13 @@ public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOper
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(version);
-        out.writeUTF(ownerUuid);
+        out.writeUUID(ownerUuid);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         version = in.readLong();
-        ownerUuid = in.readUTF();
+        ownerUuid = in.readUUID();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
@@ -176,7 +176,7 @@ public final class MapReduceUtil {
                 if (nodeEngine.getThisAddress().equals(member.getAddress())) {
                     // Locally we can call the operation directly
                     operation.setNodeEngine(nodeEngine);
-                    operation.setCallerUuid(nodeEngine.getLocalMember().getUuid());
+                    operation.setCallerUuid(nodeEngine.getLocalMember().getUUID());
                     operation.setService(mapReduceService);
                     operation.run();
 
@@ -227,7 +227,7 @@ public final class MapReduceUtil {
             if (cs.getThisAddress().equals(address)) {
                 // Locally we can call the operation directly
                 operation.setNodeEngine(nodeEngine);
-                operation.setCallerUuid(nodeEngine.getLocalMember().getUuid());
+                operation.setCallerUuid(nodeEngine.getLocalMember().getUUID());
                 operation.setService(mapReduceService);
                 operation.run();
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MemberAssigningJobProcessInformationImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MemberAssigningJobProcessInformationImpl.java
@@ -19,6 +19,8 @@ package com.hazelcast.mapreduce.impl.task;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.nio.Address;
 
+import java.util.UUID;
+
 import static com.hazelcast.mapreduce.JobPartitionState.State.WAITING;
 import static com.hazelcast.mapreduce.impl.MapReduceUtil.stateChange;
 
@@ -34,7 +36,7 @@ public class MemberAssigningJobProcessInformationImpl
         super(partitionCount, supervisor);
     }
 
-    public int assignMemberId(Address address, String memberUuid, JobTaskConfiguration configuration) {
+    public int assignMemberId(Address address, UUID memberUuid, JobTaskConfiguration configuration) {
         JobPartitionState[] partitionStates = getPartitionStates();
         for (int i = 0; i < partitionStates.length; i++) {
             JobPartitionState partitionState = partitionStates[i];

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.hazelcast.util.Clock.currentTimeMillis;
 
@@ -61,7 +62,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         this.creationTime = currentTimeMillis();
     }
 
-    public boolean canAcquireLock(Data dataKey, String caller, long threadId) {
+    public boolean canAcquireLock(Data dataKey, UUID caller, long threadId) {
         return lockStore != null && lockStore.canAcquireLock(dataKey, caller, threadId);
     }
 
@@ -73,11 +74,11 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         return lockStore != null && lockStore.shouldBlockReads(key);
     }
 
-    public boolean txnLock(Data key, String caller, long threadId, long referenceId, long ttl, boolean blockReads) {
+    public boolean txnLock(Data key, UUID caller, long threadId, long referenceId, long ttl, boolean blockReads) {
         return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, ttl, blockReads);
     }
 
-    public boolean unlock(Data key, String caller, long threadId, long referenceId) {
+    public boolean unlock(Data key, UUID caller, long threadId, long referenceId) {
         return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
 
@@ -85,7 +86,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         return lockStore != null && lockStore.forceUnlock(key);
     }
 
-    public boolean extendLock(Data key, String caller, long threadId, long ttl) {
+    public boolean extendLock(Data key, UUID caller, long threadId, long ttl) {
         return lockStore != null && lockStore.extendLeaseTime(key, caller, threadId, ttl);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitBackupOperation.java
@@ -27,16 +27,17 @@ import com.hazelcast.spi.Operation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class TxnCommitBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation {
 
     List<Operation> opList;
-    String caller;
+    UUID caller;
 
     public TxnCommitBackupOperation() {
     }
 
-    public TxnCommitBackupOperation(String name, Data dataKey, List<Operation> opList, String caller, long threadId) {
+    public TxnCommitBackupOperation(String name, Data dataKey, List<Operation> opList, UUID caller, long threadId) {
         super(name, dataKey);
         this.opList = opList;
         this.caller = caller;
@@ -63,7 +64,7 @@ public class TxnCommitBackupOperation extends MultiMapKeyBasedOperation implemen
         for (Operation op : opList) {
             out.writeObject(op);
         }
-        out.writeUTF(caller);
+        out.writeUUID(caller);
     }
 
     @Override
@@ -74,7 +75,7 @@ public class TxnCommitBackupOperation extends MultiMapKeyBasedOperation implemen
         for (int i = 0; i < size; i++) {
             opList.add((Operation) in.readObject());
         }
-        caller = in.readUTF();
+        caller = in.readUUID();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
@@ -26,17 +26,18 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class TxnPrepareBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation {
 
     private static final long LOCK_EXTENSION_TIME_IN_MILLIS = 10000L;
-    String caller;
+    UUID caller;
     long ttl;
 
     public TxnPrepareBackupOperation() {
     }
 
-    public TxnPrepareBackupOperation(String name, Data dataKey, String caller, long threadId) {
+    public TxnPrepareBackupOperation(String name, Data dataKey, UUID caller, long threadId) {
         super(name, dataKey);
         this.caller = caller;
         this.threadId = threadId;
@@ -55,14 +56,14 @@ public class TxnPrepareBackupOperation extends MultiMapKeyBasedOperation impleme
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(caller);
+        out.writeUUID(caller);
         out.writeLong(ttl);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        caller = in.readUTF();
+        caller = in.readUUID();
         ttl = in.readLong();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
@@ -26,15 +26,16 @@ import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class TxnRollbackBackupOperation extends MultiMapKeyBasedOperation implements BackupOperation {
 
-    String caller;
+    UUID caller;
 
     public TxnRollbackBackupOperation() {
     }
 
-    public TxnRollbackBackupOperation(String name, Data dataKey, String caller, long threadId) {
+    public TxnRollbackBackupOperation(String name, Data dataKey, UUID caller, long threadId) {
         super(name, dataKey);
         this.caller = caller;
         this.threadId = threadId;
@@ -53,13 +54,13 @@ public class TxnRollbackBackupOperation extends MultiMapKeyBasedOperation implem
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(caller);
+        out.writeUUID(caller);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        caller = in.readUTF();
+        caller = in.readUUID();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -21,11 +21,14 @@ import com.hazelcast.nio.serialization.Data;
 import java.io.DataInput;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.util.UUID;
 
 /**
  * Provides serialization methods for arrays of primitive types
  */
 public interface ObjectDataInput extends DataInput {
+
+    UUID readUUID() throws IOException;
 
     /**
      * @return the byte array read

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -21,11 +21,18 @@ import com.hazelcast.nio.serialization.Data;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.util.UUID;
 
 /**
  * Provides serialization methods for arrays by extending DataOutput
  */
 public interface ObjectDataOutput extends DataOutput {
+
+    /**
+     * @param uuid UUID to be written
+     * @throws IOException
+     */
+    void writeUUID(UUID uuid) throws IOException;
 
     /**
      * @param bytes byte array to be written

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.properties.GroupProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.logging.Level;
 
 import static com.hazelcast.util.EmptyStatement.ignore;
@@ -71,7 +72,7 @@ public abstract class Operation implements DataSerializable {
     private long invocationTime = -1;
     private long callTimeout = Long.MAX_VALUE;
     private long waitTimeout = -1;
-    private String callerUuid;
+    private UUID callerUuid;
 
     // injected
     private transient NodeEngine nodeEngine;
@@ -361,11 +362,11 @@ public abstract class Operation implements DataSerializable {
         return onException(throwable);
     }
 
-    public String getCallerUuid() {
+    public UUID getCallerUuid() {
         return callerUuid;
     }
 
-    public Operation setCallerUuid(String callerUuid) {
+    public Operation setCallerUuid(UUID callerUuid) {
         this.callerUuid = callerUuid;
         setFlag(callerUuid != null, BITMASK_CALLER_UUID_SET);
         return this;
@@ -473,7 +474,7 @@ public abstract class Operation implements DataSerializable {
         }
 
         if (isFlagSet(BITMASK_CALLER_UUID_SET)) {
-            out.writeUTF(callerUuid);
+            out.writeUUID(callerUuid);
         }
 
         writeInternal(out);
@@ -514,7 +515,7 @@ public abstract class Operation implements DataSerializable {
         }
 
         if (isFlagSet(BITMASK_CALLER_UUID_SET)) {
-            callerUuid = in.readUTF();
+            callerUuid = in.readUUID();
         }
 
         readInternal(in);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -52,6 +52,7 @@ import com.hazelcast.util.Clock;
 import com.hazelcast.util.executor.ManagedExecutorService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.logging.Level;
@@ -662,7 +663,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         final long defaultCallTimeoutMillis;
         final InvocationRegistry invocationRegistry;
         final InvocationMonitor invocationMonitor;
-        final String localMemberUuid;
+        final UUID localMemberUuid;
         final ILogger logger;
         final Node node;
         final NodeEngine nodeEngine;
@@ -682,7 +683,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
                        long defaultCallTimeoutMillis,
                        InvocationRegistry invocationRegistry,
                        InvocationMonitor invocationMonitor,
-                       String localMemberUuid,
+                       UUID localMemberUuid,
                        ILogger logger,
                        Node node,
                        NodeEngine nodeEngine,

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -248,7 +248,7 @@ final class OperationBackupHandler {
 
         backup.setPartitionId(op.getPartitionId())
                 .setReplicaIndex(replicaIndex)
-                .setCallerUuid(nodeEngine.getLocalMember().getUuid());
+                .setCallerUuid(nodeEngine.getLocalMember().getUUID());
         setCallId(backup, op.getCallId());
 
         return backup;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -440,7 +440,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         }
         MemberImpl callerMember = node.clusterService.getMember(caller);
         if (callerMember != null) {
-            op.setCallerUuid(callerMember.getUuid());
+            op.setCallerUuid(callerMember.getUUID());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -436,7 +436,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
                 nodeEngine.getProperties().getMillis(OPERATION_CALL_TIMEOUT_MILLIS),
                 invocationRegistry,
                 invocationMonitor,
-                nodeEngine.getLocalMember().getUuid(),
+                nodeEngine.getLocalMember().getUUID(),
                 nodeEngine.getLogger(Invocation.class),
                 node,
                 nodeEngine,

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/AllowedDuringPassiveStateTransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/AllowedDuringPassiveStateTransactionImpl.java
@@ -28,19 +28,20 @@ import com.hazelcast.transaction.impl.operations.RollbackAllowedDuringPassiveSta
 import com.hazelcast.transaction.impl.operations.RollbackTxBackupLogOperation;
 
 import java.util.List;
+import java.util.UUID;
 
 public class AllowedDuringPassiveStateTransactionImpl
         extends TransactionImpl {
 
     public AllowedDuringPassiveStateTransactionImpl(TransactionManagerServiceImpl transactionManagerService,
-                                                    NodeEngine nodeEngine, TransactionOptions options, String txOwnerUuid) {
+                                                    NodeEngine nodeEngine, TransactionOptions options, UUID txOwnerUuid) {
         super(transactionManagerService, nodeEngine, options, txOwnerUuid);
     }
 
     // used by tx backups
     AllowedDuringPassiveStateTransactionImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngine nodeEngine,
                                              String txnId, List<TransactionLogRecord> transactionLog, long timeoutMillis,
-                                             long startTime, String txOwnerUuid) {
+                                             long startTime, UUID txOwnerUuid) {
         super(transactionManagerService, nodeEngine, txnId, transactionLog, timeoutMillis, startTime, txOwnerUuid);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/Transaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/Transaction.java
@@ -19,6 +19,8 @@ package com.hazelcast.transaction.impl;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions.TransactionType;
 
+import java.util.UUID;
+
 public interface Transaction {
 
     void begin() throws IllegalStateException;
@@ -41,7 +43,7 @@ public interface Transaction {
 
     TransactionLogRecord get(Object key);
 
-    String getOwnerUuid();
+    UUID getOwnerUuid();
 
     boolean isOriginatedFromClient();
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
@@ -40,6 +40,7 @@ import com.hazelcast.transaction.impl.xa.XAService;
 import javax.transaction.xa.XAResource;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static com.hazelcast.transaction.impl.Transaction.State.ACTIVE;
 
@@ -51,7 +52,7 @@ final class TransactionContextImpl implements TransactionContext {
             = new HashMap<TransactionalObjectKey, TransactionalObject>(2);
 
     TransactionContextImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngineImpl nodeEngine,
-                           TransactionOptions options, String ownerUuid, boolean originatedFromClient) {
+                           TransactionOptions options, UUID ownerUuid, boolean originatedFromClient) {
         this.nodeEngine = nodeEngine;
         this.transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, ownerUuid, originatedFromClient);
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -34,6 +34,7 @@ import com.hazelcast.transaction.impl.operations.RollbackTxBackupLogOperation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
@@ -79,7 +80,7 @@ public class TransactionImpl implements Transaction {
     private final TransactionType transactionType;
     private final boolean checkThreadAccess;
     private final ILogger logger;
-    private final String txOwnerUuid;
+    private final UUID txOwnerUuid;
     private final TransactionLog transactionLog;
     private Long threadId;
     private long timeoutMillis;
@@ -90,12 +91,12 @@ public class TransactionImpl implements Transaction {
     private boolean originatedFromClient;
 
     public TransactionImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngine nodeEngine,
-                           TransactionOptions options, String txOwnerUuid) {
+                           TransactionOptions options, UUID txOwnerUuid) {
         this(transactionManagerService, nodeEngine, options, txOwnerUuid, false);
     }
 
     public TransactionImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngine nodeEngine,
-                           TransactionOptions options, String txOwnerUuid, boolean originatedFromClient) {
+                           TransactionOptions options, UUID txOwnerUuid, boolean originatedFromClient) {
         this.transactionLog = new TransactionLog();
         this.transactionManagerService = transactionManagerService;
         this.nodeEngine = nodeEngine;
@@ -103,7 +104,7 @@ public class TransactionImpl implements Transaction {
         this.timeoutMillis = options.getTimeoutMillis();
         this.transactionType = options.getTransactionType() == LOCAL ? ONE_PHASE : options.getTransactionType();
         this.durability = transactionType == ONE_PHASE ? 0 : options.getDurability();
-        this.txOwnerUuid = txOwnerUuid == null ? nodeEngine.getLocalMember().getUuid() : txOwnerUuid;
+        this.txOwnerUuid = txOwnerUuid == null ? nodeEngine.getLocalMember().getUUID() : txOwnerUuid;
         this.checkThreadAccess = txOwnerUuid == null;
 
         this.logger = nodeEngine.getLogger(getClass());
@@ -115,7 +116,7 @@ public class TransactionImpl implements Transaction {
     // used by tx backups
     TransactionImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngine nodeEngine,
                     String txnId, List<TransactionLogRecord> transactionLog, long timeoutMillis,
-                    long startTime, String txOwnerUuid) {
+                    long startTime, UUID txOwnerUuid) {
         this.transactionLog = new TransactionLog(transactionLog);
         this.transactionManagerService = transactionManagerService;
         this.nodeEngine = nodeEngine;
@@ -143,7 +144,7 @@ public class TransactionImpl implements Transaction {
     }
 
     @Override
-    public String getOwnerUuid() {
+    public UUID getOwnerUuid() {
         return txOwnerUuid;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -19,6 +19,8 @@ package com.hazelcast.transaction.impl.operations;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 
+import java.util.UUID;
+
 import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.CREATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
 
 public final class CreateAllowedDuringPassiveStateTxBackupLogOperation
@@ -28,7 +30,7 @@ public final class CreateAllowedDuringPassiveStateTxBackupLogOperation
     public CreateAllowedDuringPassiveStateTxBackupLogOperation() {
     }
 
-    public CreateAllowedDuringPassiveStateTxBackupLogOperation(String callerUuid, String txnId) {
+    public CreateAllowedDuringPassiveStateTxBackupLogOperation(UUID callerUuid, String txnId) {
         super(callerUuid, txnId);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/CreateTxBackupLogOperation.java
@@ -24,19 +24,20 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.CREATE_TX_BACKUP_LOG;
 
 public class CreateTxBackupLogOperation extends AbstractTxOperation {
 
-    private String callerUuid;
+    private UUID callerUuid;
     private String txnId;
 
     public CreateTxBackupLogOperation() {
     }
 
-    public CreateTxBackupLogOperation(String callerUuid, String txnId) {
+    public CreateTxBackupLogOperation(UUID callerUuid, String txnId) {
         this.callerUuid = callerUuid;
         this.txnId = txnId;
     }
@@ -66,7 +67,7 @@ public class CreateTxBackupLogOperation extends AbstractTxOperation {
     }
 
     @Override
-    public String getCallerUuid() {
+    public UUID getCallerUuid() {
         return callerUuid;
     }
 
@@ -76,13 +77,13 @@ public class CreateTxBackupLogOperation extends AbstractTxOperation {
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(callerUuid);
+        out.writeUUID(callerUuid);
         out.writeUTF(txnId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        callerUuid = in.readUTF();
+        callerUuid = in.readUUID();
         txnId = in.readUTF();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateAllowedDuringPassiveStateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateAllowedDuringPassiveStateTxBackupLogOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
 
 import java.util.List;
+import java.util.UUID;
 
 import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.REPLICATE_ALLOWED_DURING_PASSIVE_STATE_TX_BACKUP_LOG;
 
@@ -30,7 +31,7 @@ public final class ReplicateAllowedDuringPassiveStateTxBackupLogOperation
     public ReplicateAllowedDuringPassiveStateTxBackupLogOperation() {
     }
 
-    public ReplicateAllowedDuringPassiveStateTxBackupLogOperation(List<TransactionLogRecord> logs, String callerUuid,
+    public ReplicateAllowedDuringPassiveStateTxBackupLogOperation(List<TransactionLogRecord> logs, UUID callerUuid,
                                                                   String txnId, long timeoutMillis, long startTime) {
         super(logs, callerUuid, txnId, timeoutMillis, startTime);
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxBackupLogOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/operations/ReplicateTxBackupLogOperation.java
@@ -27,6 +27,7 @@ import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 import static com.hazelcast.transaction.impl.TransactionDataSerializerHook.REPLICATE_TX_BACKUP_LOG;
@@ -40,7 +41,7 @@ public class ReplicateTxBackupLogOperation extends AbstractTxOperation {
 
     // todo: probably we don't want to use linked list.
     private final List<TransactionLogRecord> records = new LinkedList<TransactionLogRecord>();
-    private String callerUuid;
+    private UUID callerUuid;
     private String txnId;
     private long timeoutMillis;
     private long startTime;
@@ -48,7 +49,7 @@ public class ReplicateTxBackupLogOperation extends AbstractTxOperation {
     public ReplicateTxBackupLogOperation() {
     }
 
-    public ReplicateTxBackupLogOperation(List<TransactionLogRecord> logs, String callerUuid, String txnId,
+    public ReplicateTxBackupLogOperation(List<TransactionLogRecord> logs, UUID callerUuid, String txnId,
                                          long timeoutMillis, long startTime) {
         records.addAll(logs);
         this.callerUuid = callerUuid;
@@ -83,7 +84,7 @@ public class ReplicateTxBackupLogOperation extends AbstractTxOperation {
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(callerUuid);
+        out.writeUUID(callerUuid);
         out.writeUTF(txnId);
         out.writeLong(timeoutMillis);
         out.writeLong(startTime);
@@ -98,7 +99,7 @@ public class ReplicateTxBackupLogOperation extends AbstractTxOperation {
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        callerUuid = in.readUTF();
+        callerUuid = in.readUUID();
         txnId = in.readUTF();
         timeoutMillis = in.readLong();
         startTime = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAService.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -83,7 +84,7 @@ public class XAService implements ManagedService, RemoteService, MigrationAwareS
     }
 
     public TransactionContext newXATransactionContext(Xid xid, String ownerUuid, int timeout, boolean originatedFromClient) {
-        return new XATransactionContextImpl(nodeEngine, xid, ownerUuid, timeout, originatedFromClient);
+        return new XATransactionContextImpl(nodeEngine, xid, UUID.fromString(ownerUuid), timeout, originatedFromClient);
     }
 
     public void putTransaction(XATransaction transaction) {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransaction.java
@@ -37,6 +37,7 @@ import com.hazelcast.util.UuidUtil;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.Xid;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
@@ -76,7 +77,7 @@ public final class XATransaction implements Transaction {
     private final long timeoutMillis;
     private final String txnId;
     private final SerializableXID xid;
-    private final String txOwnerUuid;
+    private final UUID txOwnerUuid;
     private final TransactionLog transactionLog;
 
     private State state = NO_TXN;
@@ -84,13 +85,13 @@ public final class XATransaction implements Transaction {
 
     private boolean originatedFromClient;
 
-    public XATransaction(NodeEngine nodeEngine, Xid xid, String txOwnerUuid, int timeout, boolean originatedFromClient) {
+    public XATransaction(NodeEngine nodeEngine, Xid xid, UUID txOwnerUuid, int timeout, boolean originatedFromClient) {
         this.nodeEngine = nodeEngine;
         this.transactionLog = new TransactionLog();
         this.timeoutMillis = SECONDS.toMillis(timeout);
         this.txnId = UuidUtil.newUnsecureUuidString();
         this.xid = new SerializableXID(xid.getFormatId(), xid.getGlobalTransactionId(), xid.getBranchQualifier());
-        this.txOwnerUuid = txOwnerUuid == null ? nodeEngine.getLocalMember().getUuid() : txOwnerUuid;
+        this.txOwnerUuid = txOwnerUuid == null ? nodeEngine.getLocalMember().getUUID() : txOwnerUuid;
 
         ILogger logger = nodeEngine.getLogger(getClass());
         this.commitExceptionHandler = logAllExceptions(logger, "Error during commit!", Level.WARNING);
@@ -100,7 +101,7 @@ public final class XATransaction implements Transaction {
     }
 
     public XATransaction(NodeEngine nodeEngine, List<TransactionLogRecord> logs,
-                         String txnId, SerializableXID xid, String txOwnerUuid, long timeoutMillis, long startTime) {
+                         String txnId, SerializableXID xid, UUID txOwnerUuid, long timeoutMillis, long startTime) {
         this.nodeEngine = nodeEngine;
         this.transactionLog = new TransactionLog(logs);
         this.timeoutMillis = timeoutMillis;
@@ -260,7 +261,7 @@ public final class XATransaction implements Transaction {
     }
 
     @Override
-    public String getOwnerUuid() {
+    public UUID getOwnerUuid() {
         return txOwnerUuid;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
@@ -39,6 +39,7 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class XATransactionContextImpl implements TransactionContext {
 
@@ -47,7 +48,7 @@ public class XATransactionContextImpl implements TransactionContext {
     private final Map<TransactionalObjectKey, TransactionalObject> txnObjectMap
             = new HashMap<TransactionalObjectKey, TransactionalObject>(2);
 
-    public XATransactionContextImpl(NodeEngineImpl nodeEngine, Xid xid, String txOwnerUuid,
+    public XATransactionContextImpl(NodeEngineImpl nodeEngine, Xid xid, UUID txOwnerUuid,
                                     int timeout, boolean originatedFromClient) {
         this.nodeEngine = nodeEngine;
         this.transaction = new XATransaction(nodeEngine, xid, txOwnerUuid, timeout, originatedFromClient);

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionDTO.java
@@ -24,11 +24,12 @@ import com.hazelcast.transaction.impl.TransactionLogRecord;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class XATransactionDTO implements DataSerializable {
     private String txnId;
     private SerializableXID xid;
-    private String ownerUuid;
+    private UUID ownerUuid;
     private long timeoutMilis;
     private long startTime;
     private List<TransactionLogRecord> records;
@@ -45,7 +46,7 @@ public class XATransactionDTO implements DataSerializable {
         records = xaTransaction.getTransactionRecords();
     }
 
-    public XATransactionDTO(String txnId, SerializableXID xid, String ownerUuid, long timeoutMilis,
+    public XATransactionDTO(String txnId, SerializableXID xid, UUID ownerUuid, long timeoutMilis,
                             long startTime, List<TransactionLogRecord> records) {
         this.txnId = txnId;
         this.xid = xid;
@@ -63,7 +64,7 @@ public class XATransactionDTO implements DataSerializable {
         return xid;
     }
 
-    public String getOwnerUuid() {
+    public UUID getOwnerUuid() {
         return ownerUuid;
     }
 
@@ -83,7 +84,7 @@ public class XATransactionDTO implements DataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(txnId);
         out.writeObject(xid);
-        out.writeUTF(ownerUuid);
+        out.writeUUID(ownerUuid);
         out.writeLong(timeoutMilis);
         out.writeLong(startTime);
         int len = records.size();
@@ -99,7 +100,7 @@ public class XATransactionDTO implements DataSerializable {
     public void readData(ObjectDataInput in) throws IOException {
         txnId = in.readUTF();
         xid = in.readObject();
-        ownerUuid = in.readUTF();
+        ownerUuid = in.readUUID();
         timeoutMilis = in.readLong();
         startTime = in.readLong();
         int size = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionBackupOperation.java
@@ -28,6 +28,7 @@ import com.hazelcast.transaction.impl.xa.XATransaction;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 public class PutRemoteTransactionBackupOperation extends AbstractXAOperation implements BackupOperation {
 
@@ -35,7 +36,7 @@ public class PutRemoteTransactionBackupOperation extends AbstractXAOperation imp
 
     private SerializableXID xid;
     private String txnId;
-    private String txOwnerUuid;
+    private UUID txOwnerUuid;
     private long timeoutMillis;
     private long startTime;
 
@@ -43,7 +44,7 @@ public class PutRemoteTransactionBackupOperation extends AbstractXAOperation imp
     }
 
     public PutRemoteTransactionBackupOperation(List<TransactionLogRecord> logs, String txnId, SerializableXID xid,
-                                               String txOwnerUuid, long timeoutMillis, long startTime) {
+                                               UUID txOwnerUuid, long timeoutMillis, long startTime) {
         records.addAll(logs);
         this.txnId = txnId;
         this.xid = xid;
@@ -70,7 +71,7 @@ public class PutRemoteTransactionBackupOperation extends AbstractXAOperation imp
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(txnId);
         out.writeObject(xid);
-        out.writeUTF(txOwnerUuid);
+        out.writeUUID(txOwnerUuid);
         out.writeLong(timeoutMillis);
         out.writeLong(startTime);
         int len = records.size();
@@ -86,7 +87,7 @@ public class PutRemoteTransactionBackupOperation extends AbstractXAOperation imp
     protected void readInternal(ObjectDataInput in) throws IOException {
         txnId = in.readUTF();
         xid = in.readObject();
-        txOwnerUuid = in.readUTF();
+        txOwnerUuid = in.readUUID();
         timeoutMillis = in.readLong();
         startTime = in.readLong();
         int len = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/PutRemoteTransactionOperation.java
@@ -29,6 +29,7 @@ import com.hazelcast.transaction.impl.xa.XATransaction;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 public class PutRemoteTransactionOperation extends AbstractXAOperation implements BackupAwareOperation {
 
@@ -36,7 +37,7 @@ public class PutRemoteTransactionOperation extends AbstractXAOperation implement
 
     private SerializableXID xid;
     private String txnId;
-    private String txOwnerUuid;
+    private UUID txOwnerUuid;
     private long timeoutMillis;
     private long startTime;
 
@@ -44,7 +45,7 @@ public class PutRemoteTransactionOperation extends AbstractXAOperation implement
     }
 
     public PutRemoteTransactionOperation(List<TransactionLogRecord> logs, String txnId, SerializableXID xid,
-                                         String txOwnerUuid, long timeoutMillis, long startTime) {
+                                         UUID txOwnerUuid, long timeoutMillis, long startTime) {
         records.addAll(logs);
         this.txnId = txnId;
         this.xid = xid;
@@ -86,7 +87,7 @@ public class PutRemoteTransactionOperation extends AbstractXAOperation implement
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(txnId);
         out.writeObject(xid);
-        out.writeUTF(txOwnerUuid);
+        out.writeUUID(txOwnerUuid);
         out.writeLong(timeoutMillis);
         out.writeLong(startTime);
         int len = records.size();
@@ -102,7 +103,7 @@ public class PutRemoteTransactionOperation extends AbstractXAOperation implement
     protected void readInternal(ObjectDataInput in) throws IOException {
         txnId = in.readUTF();
         xid = in.readObject();
-        txOwnerUuid = in.readUTF();
+        txOwnerUuid = in.readUUID();
         timeoutMillis = in.readLong();
         startTime = in.readLong();
         int len = in.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/Main.java
+++ b/hazelcast/src/test/java/com/hazelcast/Main.java
@@ -1,0 +1,53 @@
+package com.hazelcast;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.ByteArrayObjectDataOutput;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastTestSupport;
+import sun.misc.UUDecoder;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Created by alarmnummer on 5/13/16.
+ */
+public class Main {
+
+    public static void main(String[] args){
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance();
+        InternalSerializationService serializationService = HazelcastTestSupport.getSerializationService(hz);
+
+        Foo foo = new Foo();
+        foo.uuidString = hz.getCluster().getLocalMember().getUuid();
+        foo.uuid = UUID.randomUUID();
+
+        serializationService.toBytes(foo);
+    }
+
+    static class Foo implements DataSerializable {
+        private String uuidString;
+        private UUID uuid;
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            ByteArrayObjectDataOutput bos = (ByteArrayObjectDataOutput)out;
+            int before = bos.position();
+            out.writeUTF(uuidString);
+            int after = bos.position();
+
+            System.out.println("size:"+(after-before));
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
@@ -31,6 +31,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collection;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
@@ -57,7 +58,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     private LockStoreImpl lockStore;
 
     private Data key = new HeapData();
-    private String callerId = "called";
+    private UUID callerId = UUID.randomUUID();
     private long threadId = 1;
     private long referenceId = 1;
     private long leaseTime = Long.MAX_VALUE;
@@ -175,7 +176,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     @Test
     public void testIsLockedBy_whenLockedByDifferentCallerAndSameThread_thenReturnFalse() {
         lockAndIncreaseReferenceId();
-        String differentCaller = callerId + "different";
+        UUID differentCaller = UUID.randomUUID();
         boolean lockedBy = lockStore.isLockedBy(key, differentCaller, threadId);
         assertFalse(lockedBy);
     }
@@ -184,7 +185,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     public void testIsLockedBy_whenLockedByDifferentCallerAndDifferentThread_thenReturnFalse() {
         lockAndIncreaseReferenceId();
         long differentThreadId = threadId + 1;
-        String differentCaller = callerId + "different";
+        UUID differentCaller = UUID.randomUUID();
         boolean lockedBy = lockStore.isLockedBy(key, differentCaller, differentThreadId);
         assertFalse(lockedBy);
     }
@@ -226,7 +227,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     @Test
     public void testCanAquireLock_whenLockedBySameThreadAndDifferentCaller_thenReturnFalse() {
         lockAndIncreaseReferenceId();
-        String differentCaller = callerId + "different";
+        UUID differentCaller = UUID.randomUUID();
         boolean canAcquire = lockStore.canAcquireLock(key, differentCaller, threadId);
         assertFalse(canAcquire);
     }
@@ -243,7 +244,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     public void testCanAcquireLock_whenLockedByDifferentThreadAndDifferentCaller_thenReturnFalse() {
         lockAndIncreaseReferenceId();
         long differentThreadId = threadId + 1;
-        String differentCaller = callerId + "different";
+        UUID differentCaller = UUID.randomUUID();
         boolean canAcquire = lockStore.canAcquireLock(key, differentCaller, differentThreadId);
         assertFalse(canAcquire);
     }
@@ -253,7 +254,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
         lockAndIncreaseReferenceId();
         unlockAndIncreaseReferenceId();
         long differentThreadId = threadId + 1;
-        String differentCaller = callerId + "different";
+        UUID differentCaller = UUID.randomUUID();
         boolean canAcquire = lockStore.canAcquireLock(key, differentCaller, differentThreadId);
         assertTrue(canAcquire);
     }
@@ -341,7 +342,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     @Test
     public void testUnlock_whenLockedByDifferentCallerAndSameThreadId_thenReturnFalse() {
         lockAndIncreaseReferenceId();
-        callerId += "different";
+        callerId = UUID.randomUUID();
         boolean unlocked = unlockAndIncreaseReferenceId();
         assertFalse(unlocked);
     }
@@ -367,7 +368,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     public void testUnlock_whenLockedByDifferentCallerAndDifferentThreadId_thenReturnFalse() {
         lockAndIncreaseReferenceId();
         threadId++;
-        callerId += "different";
+        callerId = UUID.randomUUID();
         boolean unlocked = unlockAndIncreaseReferenceId();
         assertFalse(unlocked);
     }
@@ -389,7 +390,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     @Test
     public void testTxnLock_whenLockedByDifferentCallerAndSameThreadId_thenReturnFalse() {
         txnLockAndIncreaseReferenceId();
-        callerId += "different";
+        callerId = UUID.randomUUID();
         boolean locked = txnLockAndIncreaseReferenceId();
         assertFalse(locked);
     }

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.UUID;
 
 public class SimpleMemberImpl implements Member {
 
@@ -43,6 +44,11 @@ public class SimpleMemberImpl implements Member {
         this.uuid = uuid;
         this.address = address;
         this.liteMember = liteMember;
+    }
+
+    @Override
+    public UUID getUUID() {
+        return UUID.fromString(uuid);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -60,6 +60,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -735,7 +736,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         }
 
         @Override
-        public String getOwnerUuid() {
+        public UUID getOwnerUuid() {
             return tx.getOwnerUuid();
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutputTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 
 import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.UUID;
 
 import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
@@ -293,6 +294,28 @@ public class ByteArrayObjectDataOutputTest {
     public void testWriteObject() throws Exception {
         out.writeObject("TEST");
         verify(mockSerializationService).writeObject(out, "TEST");
+    }
+
+
+    @Test
+    public void testWriteUUID_whenNull() throws Exception {
+        out.writeUUID(null);
+        long most = Bits.readLongB(out.buffer, 0);
+        long least = Bits.readLongB(out.buffer, Bits.LONG_SIZE_IN_BYTES);
+
+        assertEquals(0, most);
+        assertEquals(0, least);
+    }
+
+    @Test
+    public void testWriteUUID_whenNotNull() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        out.writeUUID(uuid);
+        long most = Bits.readLongB(out.buffer, 0);
+        long least = Bits.readLongB(out.buffer, Bits.LONG_SIZE_IN_BYTES);
+
+        assertEquals(uuid.getMostSignificantBits(), most);
+        assertEquals(uuid.getLeastSignificantBits(), least);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -176,7 +176,7 @@ public class SerializationTest
     public void test_callid_on_correct_stream_position() throws Exception {
         InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
         CancellationOperation operation = new CancellationOperation(UuidUtil.newUnsecureUuidString(), true);
-        operation.setCallerUuid(UuidUtil.newUnsecureUuidString());
+        operation.setCallerUuid(UuidUtil.newUnsecureUUID());
         OperationAccessor.setCallId(operation, 12345);
 
         Data data = serializationService.toData(operation);

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
@@ -7,6 +7,7 @@ import com.hazelcast.nio.BufferObjectDataOutput;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.UuidUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -14,6 +15,7 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -128,11 +130,10 @@ public class OperationSerializationTest extends HazelcastTestSupport {
     @Test
     public void test_callerUuid() {
         test_callerUuid(null, false);
-        test_callerUuid("", true);
-        test_callerUuid("foofbar", true);
+        test_callerUuid(UuidUtil.newUnsecureUUID(), true);
     }
 
-    public void test_callerUuid(String callerUuid, boolean callerUuidSet) {
+    public void test_callerUuid(UUID callerUuid, boolean callerUuidSet) {
         Operation op = new DummyOperation();
         op.setCallerUuid(callerUuid);
         assertEquals(callerUuid, op.getCallerUuid());

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionContextImpl_backupLogsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionContextImpl_backupLogsTest.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
+
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -31,7 +33,7 @@ public class TransactionContextImpl_backupLogsTest extends HazelcastTestSupport 
 
     private TransactionManagerServiceImpl localTxManager;
     private TransactionManagerServiceImpl remoteTxManager;
-    private String ownerUuid;
+    private UUID ownerUuid;
     private HazelcastInstance localHz;
     private NodeEngineImpl localNodeEngine;
 
@@ -42,7 +44,7 @@ public class TransactionContextImpl_backupLogsTest extends HazelcastTestSupport 
         localNodeEngine = getNodeEngineImpl(localHz);
         localTxManager = getTransactionManagerService(cluster[0]);
         remoteTxManager = getTransactionManagerService(cluster[1]);
-        ownerUuid = UuidUtil.newUnsecureUuidString();
+        ownerUuid = UUID.randomUUID();
     }
 
     private TransactionManagerServiceImpl getTransactionManagerService(HazelcastInstance hz) {

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImplTest.java
@@ -9,10 +9,13 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.util.UuidUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.UUID;
 
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static java.lang.String.format;
@@ -50,20 +53,20 @@ public class TransactionImplTest extends HazelcastTestSupport {
 
     @Test
     public void getTimeoutMillis() throws Exception {
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         assertEquals(options.getTimeoutMillis(), tx.getTimeoutMillis());
     }
 
     @Test
     public void testToString() throws Exception {
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         assertEquals(format("Transaction{txnId='%s', state=%s, txType=%s, timeoutMillis=%s}",
                 tx.getTxnId(), tx.getState(), options.getTransactionType(), options.getTimeoutMillis()), tx.toString());
     }
 
     @Test
     public void getOwnerUUID() throws Exception {
-        String ownerUUID = "dummy-uuid";
+        UUID ownerUUID = UuidUtil.newSecureUUID();
         TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, ownerUUID);
         assertEquals(ownerUUID, tx.getOwnerUuid());
     }

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_OnePhaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_OnePhaseTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
+
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_PHASE;
 import static com.hazelcast.transaction.impl.Transaction.State.ROLLED_BACK;
 import static org.junit.Assert.assertEquals;
@@ -60,7 +62,7 @@ public class TransactionImpl_OnePhaseTest extends HazelcastTestSupport {
 
     @Test
     public void requiresPrepare() throws Exception {
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UUID.randomUUID());
         tx.begin();
 
         assertFalse(tx.requiresPrepare());
@@ -70,7 +72,7 @@ public class TransactionImpl_OnePhaseTest extends HazelcastTestSupport {
 
     @Test(expected = TransactionNotActiveException.class)
     public void prepare_whenNotActive() throws Exception {
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UUID.randomUUID());
         tx.begin();
         tx.rollback();
 
@@ -81,7 +83,7 @@ public class TransactionImpl_OnePhaseTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalStateException.class)
     public void commit_whenNotActive() {
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options,UUID.randomUUID());
         tx.begin();
         tx.rollback();
 
@@ -90,7 +92,7 @@ public class TransactionImpl_OnePhaseTest extends HazelcastTestSupport {
 
     @Test(expected = TransactionException.class)
     public void commit_ThrowsExceptionDuringCommit() throws Exception {
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UUID.randomUUID());
         tx.begin();
         tx.add(new MockTransactionLogRecord().failCommit());
         tx.commit();
@@ -100,7 +102,7 @@ public class TransactionImpl_OnePhaseTest extends HazelcastTestSupport {
 
     @Test
     public void rollback_whenEmpty() throws Exception {
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UUID.randomUUID());
         tx.begin();
         tx.rollback();
 
@@ -109,7 +111,7 @@ public class TransactionImpl_OnePhaseTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalStateException.class)
     public void rollback_whenNotActive() throws Exception {
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UUID.randomUUID());
         tx.begin();
         tx.rollback();
 
@@ -118,7 +120,7 @@ public class TransactionImpl_OnePhaseTest extends HazelcastTestSupport {
 
     @Test
     public void rollback_whenRollingBackCommitFailedTransaction() {
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UUID.randomUUID());
         tx.begin();
         tx.add(new MockTransactionLogRecord().failCommit());
         try {

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
@@ -15,6 +15,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.UUID;
+
 import static com.hazelcast.transaction.TransactionOptions.TransactionType.TWO_PHASE;
 import static com.hazelcast.transaction.impl.Transaction.State.COMMITTED;
 import static com.hazelcast.transaction.impl.Transaction.State.COMMITTING;
@@ -36,7 +38,7 @@ public class TransactionImpl_TwoPhaseIntegrationTest extends HazelcastTestSuppor
     private TransactionManagerServiceImpl localTxService;
     private TransactionManagerServiceImpl remoteTxService;
     private NodeEngineImpl localNodeEngine;
-    private String txOwner;
+    private UUID txOwner;
 
     @Before
     public void setup() {
@@ -45,7 +47,7 @@ public class TransactionImpl_TwoPhaseIntegrationTest extends HazelcastTestSuppor
         localNodeEngine = getNodeEngineImpl(cluster[0]);
         localTxService = getTransactionManagerService(cluster[0]);
         remoteTxService = getTransactionManagerService(cluster[1]);
-        txOwner = UuidUtil.newUnsecureUuidString();
+        txOwner = UuidUtil.newUnsecureUUID();
     }
 
     private void assertPrepared(TransactionImpl tx) {
@@ -297,7 +299,7 @@ public class TransactionImpl_TwoPhaseIntegrationTest extends HazelcastTestSuppor
 
     @Test
     public void prepare_whenMultipleItemsAndDurabilityOne_thenRemoveBackupLog() {
-        final String txOwner = localNodeEngine.getLocalMember().getUuid();
+        final UUID txOwner = localNodeEngine.getLocalMember().getUUID();
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(1);
         final TransactionImpl tx = new TransactionImpl(localTxService, localNodeEngine, options, txOwner);
         tx.begin();

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseTest.java
@@ -11,6 +11,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.util.UuidUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -70,7 +71,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
 
         // other independent transaction in same thread
         // should behave identically
-        tx = new TransactionImpl(txManagerService, nodeEngine, options, "123");
+        tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         try {
             tx.begin();
             fail("Transaction expected to fail");
@@ -98,7 +99,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
 
     public void assertRequiresPrepare(int recordCount, boolean expected) throws Exception {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         tx.begin();
         for (int k = 0; k < recordCount; k++) {
             tx.add(new MockTransactionLogRecord());
@@ -114,7 +115,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
     @Test(expected = TransactionException.class)
     public void prepare_whenThrowsExceptionDuringPrepare() throws Exception {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         tx.begin();
         tx.add(new MockTransactionLogRecord().failPrepare());
 
@@ -126,7 +127,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
     @Test(expected = IllegalStateException.class)
     public void commit_whenNotActive() {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options,UuidUtil.newSecureUUID());
         tx.begin();
         tx.rollback();
 
@@ -136,7 +137,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
     @Test(expected = IllegalStateException.class)
     public void commit_whenNotPreparedAndMoreThanOneTransactionLogRecord() {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         tx.begin();
         tx.add(new MockTransactionLogRecord());
         tx.add(new MockTransactionLogRecord());
@@ -148,7 +149,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
     @Test
     public void commit_whenOneTransactionLogRecord_thenCommit() {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         tx.begin();
         tx.add(new MockTransactionLogRecord());
 
@@ -160,7 +161,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
     @Test
     public void commit_whenThrowsExceptionDuringCommit() throws Exception {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         tx.begin();
         tx.add(new MockTransactionLogRecord().failCommit());
         tx.prepare();
@@ -179,7 +180,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
     @Test
     public void rollback() {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         tx.begin();
 
         tx.rollback();
@@ -190,7 +191,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
     @Test(expected = IllegalStateException.class)
     public void rollback_whenAlreadyRolledBack() {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         tx.begin();
         tx.rollback();
 
@@ -200,7 +201,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
     @Test
     public void rollback_whenFailureDuringRollback() {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         tx.begin();
         tx.add(new MockTransactionLogRecord().failRollback());
 
@@ -210,7 +211,7 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
     @Test
     public void rollback_whenRollingBackCommitFailedTransaction() {
         TransactionOptions options = new TransactionOptions().setTransactionType(TWO_PHASE).setDurability(0);
-        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, "dummy-uuid");
+        TransactionImpl tx = new TransactionImpl(txManagerService, nodeEngine, options, UuidUtil.newSecureUUID());
         tx.begin();
         tx.add(new MockTransactionLogRecord().failCommit());
         try {

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionManagerServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionManagerServiceImplTest.java
@@ -7,6 +7,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl.TxBackupLog;
+import com.hazelcast.util.UuidUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -14,6 +15,7 @@ import org.junit.runner.RunWith;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.UUID;
 
 import static com.hazelcast.transaction.impl.Transaction.State.ACTIVE;
 import static com.hazelcast.transaction.impl.Transaction.State.COMMITTING;
@@ -40,7 +42,7 @@ public class TransactionManagerServiceImplTest extends HazelcastTestSupport {
 
     @Test
     public void createBackupLog_whenNotCreated() {
-        String callerUuid = "somecaller";
+        UUID callerUuid = UuidUtil.newSecureUUID();
         String txId = "tx1";
         txService.createBackupLog(callerUuid, txId);
 
@@ -49,7 +51,7 @@ public class TransactionManagerServiceImplTest extends HazelcastTestSupport {
 
     @Test(expected = TransactionException.class)
     public void createBackupLog_whenAlreadyExist() {
-        String callerUuid = "somecaller";
+        UUID callerUuid = UuidUtil.newSecureUUID();
         String txId = "tx1";
         txService.createBackupLog(callerUuid, txId);
 
@@ -61,12 +63,12 @@ public class TransactionManagerServiceImplTest extends HazelcastTestSupport {
     @Test(expected = TransactionException.class)
     public void replicaBackupLog_whenNotExist_thenTransactionException() {
         List<TransactionLogRecord> records = new LinkedList<TransactionLogRecord>();
-        txService.replicaBackupLog(records, "notexist", "notexist", 1, 1);
+        txService.replicaBackupLog(records, UuidUtil.newSecureUUID(), "notexist", 1, 1);
     }
 
     @Test
     public void replicaBackupLog_whenExist() {
-        String callerUuid = "somecaller";
+        UUID callerUuid = UuidUtil.newSecureUUID();
         String txId = "tx1";
         txService.createBackupLog(callerUuid, txId);
 
@@ -78,7 +80,7 @@ public class TransactionManagerServiceImplTest extends HazelcastTestSupport {
 
     @Test(expected = TransactionException.class)
     public void replicaBackupLog_whenNotActive() {
-        String callerUuid = "somecaller";
+        UUID callerUuid = UuidUtil.newSecureUUID();
         String txId = "tx1";
         txService.createBackupLog(callerUuid, txId);
         txService.txBackupLogs.get(txId).state = ROLLED_BACK;
@@ -97,7 +99,7 @@ public class TransactionManagerServiceImplTest extends HazelcastTestSupport {
 
     @Test
     public void rollbackBackupLog_whenExist() {
-        String callerUuid = "somecaller";
+        UUID callerUuid = UuidUtil.newSecureUUID();
         String txId = "tx1";
         txService.createBackupLog(callerUuid, txId);
 
@@ -115,7 +117,7 @@ public class TransactionManagerServiceImplTest extends HazelcastTestSupport {
 
     @Test
     public void purgeBackupLog_whenExist_thenRemoved() {
-        String callerUuid = "somecaller";
+        UUID callerUuid = UuidUtil.newSecureUUID();
         String txId = "tx1";
         txService.createBackupLog(callerUuid, txId);
 

--- a/hazelcast/src/test/java/com/hazelcast/util/CollectionTxnUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/CollectionTxnUtilTest.java
@@ -39,6 +39,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -55,7 +56,7 @@ public class CollectionTxnUtilTest extends HazelcastTestSupport {
 
     private String serviceName;
 
-    private String callerUuid;
+    private UUID callerUuid;
 
     private int partitionId;
 
@@ -68,7 +69,7 @@ public class CollectionTxnUtilTest extends HazelcastTestSupport {
         serviceName = randomString();
         when(nodeEngine.getService(serviceName)).thenReturn(remoteService);
 
-        callerUuid = randomString();
+        callerUuid = UuidUtil.newUnsecureUUID();
         partitionId = RandomPicker.getInt(271);
         operationList = new ArrayList<Operation>(10);
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
The Operation.callerUUID is now a UUID instead of String. It has the following advantages:
* it reduces the payload by 24 bytes. The utf encoding is very inefficient and the UUID can be encoded in 16 bytes.
* litter reduction: for a String you need the string object + char array, for a UUID you only need a UUD object. So that is 1 instance per invocation less.