### PR TITLE
Remove calleruuid from Backup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -60,11 +59,6 @@ public abstract class MutatingKeyBasedMapOperation extends MapOperation
         this.dataKey = dataKey;
         this.dataValue = dataValue;
         this.ttl = ttl;
-    }
-
-    @Override
-    public String getServiceName() {
-        return MapService.SERVICE_NAME;
     }
 
     public final Data getKey() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -247,8 +247,7 @@ final class OperationBackupHandler {
         }
 
         backup.setPartitionId(op.getPartitionId())
-                .setReplicaIndex(replicaIndex)
-                .setCallerUuid(nodeEngine.getLocalMember().getUuid());
+                .setReplicaIndex(replicaIndex);
         setCallId(backup, op.getCallId());
 
         return backup;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_CallerUuidTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_CallerUuidTest.java
@@ -1,0 +1,83 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A unit test that verifies that there is no need to explicitly pass the callerUuid.
+ *
+ * See the following PR for more detail:
+ * https://github.com/hazelcast/hazelcast/pull/8173
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Backup_CallerUuidTest extends HazelcastTestSupport {
+
+    private HazelcastInstance hz;
+    private final static AtomicReference CALLER_UUID = new AtomicReference();
+
+    @Before
+    public void setup() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        warmUpPartitions(cluster);
+        hz = cluster[0];
+    }
+
+    @Test
+    public void test() {
+        InternalCompletableFuture f = getOperationService(hz).invokeOnPartition(new DummyUpdateOperation()
+                .setPartitionId(getPartitionId(hz)));
+        assertCompletesEventually(f);
+
+        assertEquals(CALLER_UUID.get(), hz.getCluster().getLocalMember().getUuid());
+    }
+
+    private static class DummyUpdateOperation extends AbstractOperation implements BackupAwareOperation {
+        @Override
+        public boolean shouldBackup() {
+            return true;
+        }
+
+        @Override
+        public int getSyncBackupCount() {
+            return 1;
+        }
+
+        @Override
+        public int getAsyncBackupCount() {
+            return 0;
+        }
+
+        @Override
+        public Operation getBackupOperation() {
+            return new DummyBackupOperation();
+        }
+
+        @Override
+        public void run() throws Exception {
+        }
+    }
+
+    private static class DummyBackupOperation extends AbstractOperation implements BackupOperation {
+        @Override
+        public void run() throws Exception {
+            CALLER_UUID.set(getCallerUuid());
+        }
+    }
+}


### PR DESCRIPTION
This shaves 40 bytes from a BackupOperation and removed 2 object instances per invocation (String/char-array).

There is no point in setting the callerUuid since on the executing side of the Backup operation, the callerUuid will be determined (if missing) based on the caller address. 