### PR TITLE
Backup target operation never converted to data

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -60,11 +59,6 @@ public abstract class MutatingKeyBasedMapOperation extends MapOperation
         this.dataKey = dataKey;
         this.dataValue = dataValue;
         this.ttl = ttl;
-    }
-
-    @Override
-    public String getServiceName() {
-        return MapService.SERVICE_NAME;
     }
 
     public final Data getKey() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -20,10 +20,8 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 
 import static com.hazelcast.internal.partition.InternalPartition.MAX_BACKUP_COUNT;
@@ -37,13 +35,11 @@ final class OperationBackupHandler {
 
     private final Node node;
     private final OperationServiceImpl operationService;
-    private final NodeEngineImpl nodeEngine;
     private final BackpressureRegulator backpressureRegulator;
 
     OperationBackupHandler(OperationServiceImpl operationService) {
         this.operationService = operationService;
         this.node = operationService.node;
-        this.nodeEngine = operationService.nodeEngine;
         this.backpressureRegulator = operationService.backpressureRegulator;
     }
 
@@ -149,55 +145,18 @@ final class OperationBackupHandler {
 
     private int makeBackups(BackupAwareOperation backupAwareOp, int partitionId, long[] replicaVersions,
                             int syncBackups, int asyncBackups) {
-        int sendSyncBackups;
         int totalBackups = syncBackups + asyncBackups;
 
         InternalPartitionService partitionService = node.getPartitionService();
         InternalPartition partition = partitionService.getPartition(partitionId);
 
-        if (totalBackups == 1) {
-            sendSyncBackups = sendSingleBackup(backupAwareOp, partition, replicaVersions, syncBackups);
-        } else {
-            sendSyncBackups = sendMultipleBackups(backupAwareOp, partition, replicaVersions, syncBackups, totalBackups);
-        }
-        return sendSyncBackups;
+        return sendBackups(backupAwareOp, partition, replicaVersions, syncBackups, totalBackups);
     }
 
-    private int sendSingleBackup(BackupAwareOperation backupAwareOp, InternalPartition partition,
-                                 long[] replicaVersions, int syncBackups) {
-        // Since there is only one replica, replica index is `1`
-        Address target = partition.getReplicaAddress(1);
-        if (target != null) {
-            // Since there is only one backup, backup operation is sent to only one node.
-            // If backup operation is converted to `Data`, there will be these operations as below:
-            //      - a temporary memory allocation (byte[]) for `Data`
-            //      - serialize backup operation to allocated memory
-            //      - copy the temporary allocated memory (backup operation data) to output while serializing `Backup`
-            // In this flow, there are two redundant operations (allocating temporary memory and copying it to output).
-            // So in this case (there is only one backup), we don't convert backup operation to `Data` as temporary
-            // before `Backup` is serialized but backup operation is already serialized directly into output
-            // without any unnecessary memory allocation and copy when it is used as object inside `Backup`.
-            Operation backupOp = getBackupOperation(backupAwareOp);
-
-            assertNoBackupOnPrimaryMember(partition, target);
-
-            boolean isSyncBackup = syncBackups == 1;
-
-            Backup backup = newBackup(backupAwareOp, backupOp, replicaVersions, 1, isSyncBackup);
-            operationService.send(backup, target);
-
-            if (isSyncBackup) {
-                return 1;
-            }
-        }
-        return 0;
-    }
-
-    private int sendMultipleBackups(BackupAwareOperation backupAwareOp, InternalPartition partition,
-                                    long[] replicaVersions, int syncBackups, int totalBackups) {
+    private int sendBackups(BackupAwareOperation backupAwareOp, InternalPartition partition,
+                            long[] replicaVersions, int syncBackups, int totalBackups) {
         int sendSyncBackups = 0;
         Operation backupOp = getBackupOperation(backupAwareOp);
-        Data backupOpData = nodeEngine.getSerializationService().toData(backupOp);
 
         for (int replicaIndex = 1; replicaIndex <= totalBackups; replicaIndex++) {
             Address target = partition.getReplicaAddress(replicaIndex);
@@ -210,7 +169,7 @@ final class OperationBackupHandler {
 
             boolean isSyncBackup = replicaIndex <= syncBackups;
 
-            Backup backup = newBackup(backupAwareOp, backupOpData, replicaVersions, replicaIndex, isSyncBackup);
+            Backup backup = newBackup(backupAwareOp, backupOp, replicaVersions, replicaIndex, isSyncBackup);
             operationService.send(backup, target);
 
             if (isSyncBackup) {
@@ -234,22 +193,14 @@ final class OperationBackupHandler {
         return backupOp;
     }
 
-    private Backup newBackup(BackupAwareOperation backupAwareOp, Object backupOp, long[] replicaVersions,
-            int replicaIndex, boolean respondBack) {
+    private Backup newBackup(BackupAwareOperation backupAwareOp, Operation backupOp, long[] replicaVersions,
+                             int replicaIndex, boolean respondBack) {
         Operation op = (Operation) backupAwareOp;
-        Backup backup;
-        if (backupOp instanceof Operation) {
-            backup = new Backup((Operation) backupOp, op.getCallerAddress(), replicaVersions, respondBack);
-        } else if (backupOp instanceof Data) {
-            backup = new Backup((Data) backupOp, op.getCallerAddress(), replicaVersions, respondBack);
-        } else {
-            throw new IllegalArgumentException("Only 'Data' or 'Operation' typed backup operation is supported!");
-        }
+        Backup backup = new Backup(backupOp, op.getCallerAddress(), replicaVersions, respondBack);
 
         backup.setPartitionId(op.getPartitionId())
                 .setReplicaIndex(replicaIndex);
         setCallId(backup, op.getCallId());
-
         return backup;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -247,8 +247,7 @@ final class OperationBackupHandler {
         }
 
         backup.setPartitionId(op.getPartitionId())
-                .setReplicaIndex(replicaIndex)
-                .setCallerUuid(nodeEngine.getLocalMember().getUuid());
+                .setReplicaIndex(replicaIndex);
         setCallId(backup, op.getCallId());
 
         return backup;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -22,7 +22,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.NodeEngine;
@@ -49,7 +48,6 @@ public final class Backup extends Operation implements BackupOperation, Identifi
     private boolean sync;
 
     private Operation backupOp;
-    private Data backupOpData;
 
     private transient boolean valid = true;
 
@@ -65,18 +63,6 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         if (sync && originalCaller == null) {
             throw new IllegalArgumentException("Sync backup requires original caller address, Backup operation: "
                     + backupOp);
-        }
-    }
-
-    @SuppressFBWarnings("EI_EXPOSE_REP")
-    public Backup(Data backupOpData, Address originalCaller, long[] replicaVersions, boolean sync) {
-        this.backupOpData = backupOpData;
-        this.originalCaller = originalCaller;
-        this.sync = sync;
-        this.replicaVersions = replicaVersions;
-        if (sync && originalCaller == null) {
-            throw new IllegalArgumentException("Sync backup requires original caller address, Backup operation data: "
-                    + backupOpData);
         }
     }
 
@@ -108,7 +94,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         }
     }
 
-    private void ensureBackupOperationInitialized() {
+    private void initBackupOp() {
         if (backupOp.getNodeEngine() == null) {
             backupOp.setNodeEngine(getNodeEngine());
             backupOp.setPartitionId(getPartitionId());
@@ -130,17 +116,11 @@ public final class Backup extends Operation implements BackupOperation, Identifi
 
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
 
-        if (backupOp == null && backupOpData != null) {
-            backupOp = nodeEngine.getSerializationService().toObject(backupOpData);
-        }
+        initBackupOp();
 
-        if (backupOp != null) {
-            ensureBackupOperationInitialized();
-
-            backupOp.beforeRun();
-            backupOp.run();
-            backupOp.afterRun();
-        }
+        backupOp.beforeRun();
+        backupOp.run();
+        backupOp.afterRun();
 
         InternalPartitionService partitionService = nodeEngine.getPartitionService();
         partitionService.updatePartitionReplicaVersions(getPartitionId(), replicaVersions, getReplicaIndex());
@@ -186,7 +166,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
                 // Be sure that backup operation is initialized.
                 // If there is an exception before `run` (for example caller is not valid anymore),
                 // backup operation is initialized. So, we are initializing it here ourselves.
-                ensureBackupOperationInitialized();
+                initBackupOp();
                 backupOp.onExecutionFailure(e);
             } catch (Throwable t) {
                 getLogger().warning("While calling operation.onFailure(). op: " + backupOp, t);
@@ -200,7 +180,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
             // Be sure that backup operation is initialized.
             // If there is an exception before `run` (for example caller is not valid anymore),
             // backup operation is initialized. So, we are initializing it here ourselves.
-            ensureBackupOperationInitialized();
+            initBackupOp();
             backupOp.logError(e);
         } else {
             ReplicaErrorLogger.log(e, getLogger());
@@ -219,13 +199,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        if (backupOpData != null) {
-            out.writeBoolean(true);
-            out.writeData(backupOpData);
-        } else {
-            out.writeBoolean(false);
-            out.writeObject(backupOp);
-        }
+        out.writeObject(backupOp);
 
         if (originalCaller != null) {
             out.writeBoolean(true);
@@ -251,11 +225,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        if (in.readBoolean()) {
-            backupOpData = in.readData();
-        } else {
-            backupOp = in.readObject();
-        }
+        backupOp = in.readObject();
 
         if (in.readBoolean()) {
             originalCaller = new Address();
@@ -276,7 +246,6 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         super.toString(sb);
 
         sb.append(", backupOp=").append(backupOp);
-        sb.append(", backupOpData=").append(backupOpData);
         sb.append(", originalCaller=").append(originalCaller);
         sb.append(", version=").append(Arrays.toString(replicaVersions));
         sb.append(", sync=").append(sync);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_CallerUuidTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_CallerUuidTest.java
@@ -1,0 +1,83 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A unit test that verifies that there is no need to explicitly pass the callerUuid.
+ *
+ * See the following PR for more detail:
+ * https://github.com/hazelcast/hazelcast/pull/8173
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Backup_CallerUuidTest extends HazelcastTestSupport {
+
+    private HazelcastInstance hz;
+    private final static AtomicReference CALLER_UUID = new AtomicReference();
+
+    @Before
+    public void setup() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        warmUpPartitions(cluster);
+        hz = cluster[0];
+    }
+
+    @Test
+    public void test() {
+        InternalCompletableFuture f = getOperationService(hz).invokeOnPartition(new DummyUpdateOperation()
+                .setPartitionId(getPartitionId(hz)));
+        assertCompletesEventually(f);
+
+        assertEquals(CALLER_UUID.get(), hz.getCluster().getLocalMember().getUuid());
+    }
+
+    private static class DummyUpdateOperation extends AbstractOperation implements BackupAwareOperation {
+        @Override
+        public boolean shouldBackup() {
+            return true;
+        }
+
+        @Override
+        public int getSyncBackupCount() {
+            return 1;
+        }
+
+        @Override
+        public int getAsyncBackupCount() {
+            return 0;
+        }
+
+        @Override
+        public Operation getBackupOperation() {
+            return new DummyBackupOperation();
+        }
+
+        @Override
+        public void run() throws Exception {
+        }
+    }
+
+    private static class DummyBackupOperation extends AbstractOperation implements BackupOperation {
+        @Override
+        public void run() throws Exception {
+            CALLER_UUID.set(getCallerUuid());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Backup_Test.java
@@ -1,0 +1,77 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Backup_Test extends HazelcastTestSupport {
+
+    private HazelcastInstance hz;
+    private final static AtomicInteger BACKUP_COMPLETED_COUNT = new AtomicInteger();
+
+    @Before
+    public void setup() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(3).newInstances();
+        warmUpPartitions(cluster);
+        hz = cluster[0];
+    }
+
+    @Test
+    public void test() {
+        InternalCompletableFuture f = getOperationService(hz).invokeOnPartition(new DummyUpdateOperation()
+                .setPartitionId(getPartitionId(hz)));
+        assertCompletesEventually(f);
+
+        assertEquals(BACKUP_COMPLETED_COUNT.get(), 2);
+    }
+
+    private static class DummyUpdateOperation extends AbstractOperation implements BackupAwareOperation {
+        @Override
+        public boolean shouldBackup() {
+            return true;
+        }
+
+        @Override
+        public int getSyncBackupCount() {
+            return 2;
+        }
+
+        @Override
+        public int getAsyncBackupCount() {
+            return 0;
+        }
+
+        @Override
+        public Operation getBackupOperation() {
+            return new DummyBackupOperation();
+        }
+
+        @Override
+        public void run() throws Exception {
+        }
+    }
+
+    private static class DummyBackupOperation extends AbstractOperation implements BackupOperation {
+        @Override
+        public void run() throws Exception {
+            BACKUP_COMPLETED_COUNT.incrementAndGet();
+        }
+    }
+}


### PR DESCRIPTION
The target operation in the Backup should never be converted to Data. Before this fix, only in case of a single backup the conversion was skipped, but in case of multiple Backups the the target operation is first converted to Data and then stuffed in the Backup.

This is not only wasteful on the sending side, also the receiving side needs to deserialize first to data, and then needs to deserialize to the actual object. 

This fix solves this by never converting to data. No more litter, less complexity, and one byte backup size reduction since a 'is data' flag doesn't need to be set anymore.

There can not be accidental sharing of the target operation because a Backup operation always needs to be send to another member and therefor it is serialized/deserialized so the target always is cloned.
