### PR TITLE
[DONT MERGE] Reduced size DataSerializalbe on stream

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.Disposable;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.spi.serialization.SerializationService;
 
@@ -40,6 +41,10 @@ public interface InternalSerializationService extends SerializationService, Disp
     void writeObject(ObjectDataOutput out, Object obj);
 
     <T> T readObject(ObjectDataInput in);
+
+    void writeDataSerializable(ObjectDataOutput out, DataSerializable obj);
+
+    <T extends DataSerializable> T readDataSerializable(ObjectDataInput in);
 
     void disposeData(Data data);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -598,6 +599,11 @@ class ByteArrayObjectDataInput extends InputStream implements BufferObjectDataIn
     @Override
     public final Object readObject() throws EOFException {
         return service.readObject(this);
+    }
+
+    @Override
+    public <E extends DataSerializable> E readDataSerializable() throws IOException {
+        return service.readDataSerializable(this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.BufferObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -31,7 +32,7 @@ import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
 
-class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectDataOutput {
+public class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectDataOutput {
 
     final int initialSize;
 
@@ -369,6 +370,11 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
     @Override
     public void writeObject(Object object) throws IOException {
         service.writeObject(this, object);
+    }
+
+    @Override
+    public void writeDataSerializable(DataSerializable object) throws IOException {
+        service.writeDataSerializable(this, object);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -109,16 +109,8 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
             // BasicOperationService::extractOperationCallId
             if (identified) {
                 factoryId = in.readInt();
-                final DataSerializableFactory dsf = factories.get(factoryId);
-                if (dsf == null) {
-                    throw new HazelcastSerializationException("No DataSerializerFactory registered for namespace: " + factoryId);
-                }
                 id = in.readInt();
-                ds = dsf.create(id);
-                if (ds == null) {
-                    throw new HazelcastSerializationException(dsf
-                            + " is not be able to create an instance for id: " + id + " on factoryId: " + factoryId);
-                }
+                ds = create(factoryId, id);
                 // TODO: @mm - we can check if DS class is final.
             } else {
                 className = in.readUTF();
@@ -129,6 +121,19 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
         } catch (Exception e) {
             throw rethrowReadException(id, factoryId, className, e);
         }
+    }
+
+    public DataSerializable create(int factoryId, int id) {
+        DataSerializableFactory dsf = factories.get(factoryId);
+        if (dsf == null) {
+            throw new HazelcastSerializationException("No DataSerializerFactory registered for namespace: " + factoryId);
+        }
+        DataSerializable ds = dsf.create(id);
+        if (ds == null) {
+            throw new HazelcastSerializationException(dsf
+                    + " is not be able to create an instance for id: " + id + " on factoryId: " + factoryId);
+        }
+        return ds;
     }
 
     private IOException rethrowReadException(int id, int factoryId, String className, Exception e) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -26,6 +27,10 @@ final class EmptyObjectDataOutput implements ObjectDataOutput {
 
     @Override
     public void writeObject(Object object) throws IOException {
+    }
+
+    @Override
+    public void writeDataSerializable(DataSerializable object) throws IOException {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.Closeable;
 import java.io.DataInputStream;
@@ -332,6 +333,11 @@ public class ObjectDataInputStream extends InputStream implements ObjectDataInpu
     @Override
     public Object readObject() throws IOException {
         return serializationService.readObject(this);
+    }
+
+    @Override
+    public <E extends DataSerializable> E readDataSerializable() throws IOException {
+        return serializationService.readDataSerializable(this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.Closeable;
 import java.io.DataOutputStream;
@@ -29,6 +30,7 @@ import java.nio.ByteOrder;
 
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 
+@SuppressWarnings("checkstyle:methodcount")
 public class ObjectDataOutputStream extends OutputStream implements ObjectDataOutput, Closeable {
 
     private final InternalSerializationService serializationService;
@@ -248,6 +250,11 @@ public class ObjectDataOutputStream extends OutputStream implements ObjectDataOu
     @Override
     public void writeObject(Object object) throws IOException {
         serializationService.writeObject(this, object);
+    }
+
+    @Override
+    public void writeDataSerializable(DataSerializable object) throws IOException {
+        serializationService.writeDataSerializable(this, object);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.DataInput;
 import java.io.IOException;
@@ -87,6 +88,13 @@ public interface ObjectDataInput extends DataInput {
      * @throws IOException if it reaches end of file before finish reading
      */
     <T> T readObject() throws IOException;
+
+    /**
+     * @param <T> type of the DataSerializable to read
+     * @return object read
+     * @throws IOException if it reaches end of file before finish reading
+     */
+    <T extends DataSerializable> T readDataSerializable() throws IOException;
 
     /**
      * @return data read

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.DataOutput;
 import java.io.IOException;
@@ -86,6 +87,12 @@ public interface ObjectDataOutput extends DataOutput {
      * @throws IOException
      */
     void writeObject(Object object) throws IOException;
+
+    /**
+     * @param object object to be written
+     * @throws IOException
+     */
+    void writeDataSerializable(DataSerializable object) throws IOException;
 
     /**
      * @param data data to be written

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -283,7 +283,7 @@ public abstract class Operation implements DataSerializable {
         operationResponseHandler.sendResponse(this, value);
     }
 
-     /**
+    /**
      * Gets the time in milliseconds since this invocation started.
      *
      * For more information, see {@link ClusterClock#getClusterTime()}.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -224,7 +224,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
             out.writeData(backupOpData);
         } else {
             out.writeBoolean(false);
-            out.writeObject(backupOp);
+            out.writeDataSerializable(backupOp);
         }
 
         if (originalCaller != null) {
@@ -254,7 +254,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         if (in.readBoolean()) {
             backupOpData = in.readData();
         } else {
-            backupOp = in.readObject();
+            backupOp = in.readDataSerializable();
         }
 
         if (in.readBoolean()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -156,7 +156,7 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
 
-        out.writeObject(operationFactory);
+        out.writeDataSerializable(operationFactory);
         out.writeIntArray(partitions);
     }
 
@@ -164,7 +164,7 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
 
-        operationFactory = in.readObject();
+        operationFactory = in.readDataSerializable();
         partitions = in.readIntArray();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/Main.java
+++ b/hazelcast/src/test/java/com/hazelcast/Main.java
@@ -1,0 +1,22 @@
+package com.hazelcast;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastTestSupport;
+
+/**
+ * Created by alarmnummer on 5/13/16.
+ */
+public class Main extends HazelcastTestSupport {
+
+    public static void main(String[] args) {
+        setLoggingLog4j();
+        HazelcastInstance hz1= Hazelcast.newHazelcastInstance();
+        HazelcastInstance hz2= Hazelcast.newHazelcastInstance();
+
+        IAtomicLong l = hz1.getAtomicLong("x");
+        l.set(1);
+    }
+}


### PR DESCRIPTION
New methods were added to the ObjectDataInput and ObjectDataOutput for writing a DataSerializable directly. Apart from having a cheaper lookup process compared to Object, the way the data is written is more efficient than a regular DataSerializable and removes 10 bytes from the stream.

This is being used in Backup to write the Operation, so therefor the serialized size of the Backup is down 10 bytes.