### PR TITLE
Added more partition group strategy options.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -28,7 +28,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * <p/>
  * Hazelcast will always place partitions on different partition groups so as to provide redundancy.
  * There are three partition group schemes defined in {@link MemberGroupType}: PER_MEMBER, HOST_AWARE
- * and CUSTOM.
+ * CUSTOM, ZONE_AWARE, SPI.
  * <p/>
  * In all cases a partition will never be created on the same group. If there are more partitions defined than
  * there are partition groups, then only those partitions, up to the number of partition groups, will be created.
@@ -82,6 +82,22 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * You can define as many <code>member-group</code>s as you want. Hazelcast will always store backups in a different
  * member-group to the primary partition.
  * <p/>
+ * <code>
+ *     <pre>
+ * &lt;partition-group enabled="true" group-type="ZONE_AWARE"/&gt;
+ * </pre>
+ * </code>
+ * <h1>Zone Aware Partition Groups</h1>
+ * In this scheme, groups are allocated according to the metadata provided by Discovery SPI Partitions are not
+ * written to the same group. This is very useful for ensuring partitions are written to availability
+ * zones or different racks without providing the IP addresses to the config ahead.
+ * <code>
+ *     <pre>
+ * &lt;partition-group enabled="true" group-type="SPI"/&gt;
+ * </pre>
+ * </code>
+ * <h1>SPI Aware Partition Groups</h1>
+ * In this scheme, groups are allocated according to the implementation provided by Discovery SPI.
  * <h2>Overlapping Groups</h2>
  * Care should be taken when selecting overlapping groups, e.g.
  * <code>
@@ -129,7 +145,12 @@ public class PartitionGroupConfig {
          * only one zone is available, backups will be created in the
          * same zone.
          */
-        ZONE_AWARE
+        ZONE_AWARE,
+        /**
+         * MemberGroup implementation will be provided
+         * by the user via Discovery SPI
+         */
+        SPI
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -583,6 +583,10 @@ public class Node {
         return nodeExtension;
     }
 
+    public DiscoveryService getDiscoveryService() {
+        return discoveryService;
+    }
+
     public class NodeShutdownHookThread extends Thread {
 
         NodeShutdownHookThread(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -86,7 +86,8 @@ public class PartitionStateManager {
             this.partitions[i] = new InternalPartitionImpl(i, listener, thisAddress);
         }
 
-        memberGroupFactory = MemberGroupFactoryFactory.newMemberGroupFactory(node.getConfig().getPartitionGroupConfig());
+        memberGroupFactory = MemberGroupFactoryFactory.newMemberGroupFactory(node.getConfig().getPartitionGroupConfig(),
+                node.getDiscoveryService());
         partitionStateGenerator = new PartitionStateGeneratorImpl();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroupFactoryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/MemberGroupFactoryFactory.java
@@ -17,13 +17,15 @@
 package com.hazelcast.partition.membergroup;
 
 import com.hazelcast.config.PartitionGroupConfig;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
 public final class MemberGroupFactoryFactory {
 
     private MemberGroupFactoryFactory() {
     }
 
-    public static MemberGroupFactory newMemberGroupFactory(PartitionGroupConfig partitionGroupConfig) {
+    public static MemberGroupFactory newMemberGroupFactory(PartitionGroupConfig partitionGroupConfig,
+                                                           DiscoveryService discoveryService) {
         PartitionGroupConfig.MemberGroupType memberGroupType;
 
         if (partitionGroupConfig == null || !partitionGroupConfig.isEnabled()) {
@@ -39,6 +41,10 @@ public final class MemberGroupFactoryFactory {
                 return new ConfigMemberGroupFactory(partitionGroupConfig.getMemberGroupConfigs());
             case PER_MEMBER:
                 return new SingleMemberGroupFactory();
+            case ZONE_AWARE:
+                return new ZoneAwareMemberGroupFactory();
+            case SPI:
+                return new SPIAwareMemberGroupFactory(discoveryService);
             default:
                 throw new RuntimeException("Unknown MemberGroupType:" + memberGroupType);
         }

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SPIAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/SPIAwareMemberGroupFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.partition.membergroup;
+
+
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.properties.ValidationException;
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.partition.impl.PartitionStateManager;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryService;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+/**
+ * SPIAwareMemberGroupFactory is responsible for providing custom MemberGroups
+ * implemented by the user in {@link DiscoveryStrategy#getPartitionGroupStrategy()}
+ * to the {@link PartitionStateManager}.
+ *
+ * @since 3.7
+ */
+
+public class SPIAwareMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
+
+    private final DiscoveryService discoveryService;
+
+    public SPIAwareMemberGroupFactory(DiscoveryService discoveryService) {
+         this.discoveryService = discoveryService;
+    }
+
+    @Override
+    protected Set<MemberGroup> createInternalMemberGroups(Collection<? extends Member> allMembers) {
+        Set<MemberGroup> memberGroups = new HashSet<MemberGroup>();
+
+        for (Member member : allMembers) {
+            try {
+                if (member.localMember()) {
+                    DefaultDiscoveryService defaultDiscoveryService = (DefaultDiscoveryService) discoveryService;
+                    // If no discovery strategy is found fail-fast
+                    if (!defaultDiscoveryService.getDiscoveryStrategies().iterator().hasNext()) {
+                        throw new RuntimeException("Could not load any Discovery Strategy, please "
+                                + "check service definitions under META_INF.services folder. ");
+                    } else {
+                        for (DiscoveryStrategy discoveryStrategy : defaultDiscoveryService.getDiscoveryStrategies()) {
+                            checkNotNull(discoveryStrategy.getPartitionGroupStrategy());
+                            Iterable<MemberGroup> spiGroupsIterator =
+                                    discoveryStrategy.getPartitionGroupStrategy().getMemberGroups();
+                            for (MemberGroup group : spiGroupsIterator) {
+                                memberGroups.add(group);
+                            }
+                            return memberGroups;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                if (e instanceof ValidationException) {
+                    throw new InvalidConfigurationException("Invalid configuration", e);
+                } else {
+                    throw new RuntimeException("Failed to configure discovery strategies", e);
+                }
+            }
+        }
+
+        return memberGroups;
+    }
+
+    private DiscoveryStrategy buildDiscoveryStrategy(DiscoveryStrategyFactory factory,
+                                                     ILogger logger) {
+        /* We are building a new discovery strategy with null property and config
+        * because we are creating the discovery strategy to call getMemberGroups() impl
+        */
+        return factory.newDiscoveryStrategy(null, logger, new HashMap<String, Comparable>());
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ZoneAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ZoneAwareMemberGroupFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.partition.membergroup;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.partitiongroup.PartitionGroupMetaData;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * ZoneAwareMemberGroupFactory is responsible for MemberGroups
+ * creation according to the host metadata provided by
+ * {@link DiscoveryStrategy#discoverLocalMetadata()}
+ * @since 3.7
+ */
+
+public class ZoneAwareMemberGroupFactory extends BackupSafeMemberGroupFactory implements MemberGroupFactory {
+
+    @Override
+    protected Set<MemberGroup> createInternalMemberGroups(Collection<? extends Member> allMembers) {
+        Map<String, MemberGroup> groups = new HashMap<String, MemberGroup>();
+        for (Member member : allMembers) {
+
+            final String zoneInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE);
+            final String rackInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK);
+            final String hostInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST);
+
+            if (zoneInfo == null && rackInfo == null && hostInfo == null) {
+                throw new IllegalArgumentException("Not enough metadata information is provided. "
+                        + "At least one of availability zone, rack or host information must be provided "
+                        + "with ZONE_AWARE partition group.");
+            }
+
+            if (zoneInfo != null) {
+                MemberGroup group = groups.get(zoneInfo);
+                if (group == null) {
+                    group = new DefaultMemberGroup();
+                    groups.put(zoneInfo, group);
+                }
+                group.addMember(member);
+            } else {
+                if (rackInfo != null) {
+                    MemberGroup group = groups.get(rackInfo);
+                    if (group == null) {
+                        group = new DefaultMemberGroup();
+                        groups.put(rackInfo, group);
+                    }
+                    group.addMember(member);
+                } else {
+                    if (hostInfo != null) {
+                        MemberGroup group = groups.get(hostInfo);
+                        if (group == null) {
+                            group = new DefaultMemberGroup();
+                            groups.put(hostInfo, group);
+                        }
+                        group.addMember(member);
+                    }
+                }
+            }
+        }
+        return new HashSet<MemberGroup>(groups.values());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -100,6 +100,10 @@ public class DefaultDiscoveryService
         }
     }
 
+    public Iterable<DiscoveryStrategy> getDiscoveryStrategies() {
+        return discoveryStrategies;
+    }
+
     private NodeFilter getNodeFilter(DiscoveryServiceSettings settings) {
         DiscoveryConfig discoveryConfig = settings.getDiscoveryConfig();
         ClassLoader configClassLoader = settings.getConfigClassLoader();

--- a/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partitiongroup/PartitionGroupStrategy.java
@@ -35,9 +35,5 @@ import com.hazelcast.spi.discovery.AbstractDiscoveryStrategy;
  */
 public interface PartitionGroupStrategy {
 
-    /**
-     * TODO Has probably to be changed :)
-     */
     Iterable<MemberGroup> getMemberGroups();
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.partitiongroup.PartitionGroupMetaData;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -30,6 +31,54 @@ public class MemberGroupFactoryTest {
         assertEquals("Member Groups: " + String.valueOf(memberGroups), 8, memberGroups.size());
         for (MemberGroup memberGroup : memberGroups) {
             assertEquals("Member Group: " + String.valueOf(memberGroup), 2, memberGroup.size());
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testZoneAwareMemberGroupFactoryThrowsIllegalArgumentExceptionWhenNoMetadataIsProvided() throws Exception {
+        MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
+        Collection<Member> members = createMembersWithNoMetadata();
+        Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
+
+        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
+        for (MemberGroup memberGroup : memberGroups) {
+            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
+        }
+    }
+
+    @Test
+    public void testZoneMetadataAwareMemberGroupFactoryCreateMemberGroups() throws Exception {
+        MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
+        Collection<Member> members = createMembersWithZoneAwareMetadata();
+        Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
+
+        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
+        for (MemberGroup memberGroup : memberGroups) {
+            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
+        }
+    }
+
+    @Test
+    public void testRackMetadataAwareMemberGroupFactoryCreateMemberGroups() throws Exception {
+        MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
+        Collection<Member> members = createMembersWithRackAwareMetadata();
+        Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
+
+        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
+        for (MemberGroup memberGroup : memberGroups) {
+            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
+        }
+    }
+
+    @Test
+    public void testHostMetadataAwareMemberGroupFactoryCreateMemberGroups() throws Exception {
+        MemberGroupFactory groupFactory = new ZoneAwareMemberGroupFactory();
+        Collection<Member> members = createMembersWithHostAwareMetadata();
+        Collection<MemberGroup> memberGroups = groupFactory.createMemberGroups(members);
+
+        assertEquals("Member Groups: " + String.valueOf(memberGroups), 3, memberGroups.size());
+        for (MemberGroup memberGroup : memberGroups) {
+            assertEquals("Member Group: " + String.valueOf(memberGroup), 1, memberGroup.size());
         }
     }
 
@@ -65,6 +114,69 @@ public class MemberGroupFactoryTest {
         members.add(new MemberImpl(new Address("www.hazelcast.org", fakeAddress, 5702), false));
         members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5701), false));
         members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5702), false));
+        return members;
+    }
+
+    private Collection<Member> createMembersWithZoneAwareMetadata() throws UnknownHostException {
+        Collection<Member> members = new HashSet<Member>();
+        InetAddress fakeAddress = InetAddress.getLocalHost();
+        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), true);
+        member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "us-east-1");
+
+        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), true);
+        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "us-west-1");
+
+        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), true);
+        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "eu-central-1");
+
+        members.add(member1);
+        members.add(member2);
+        members.add(member3);
+        return members;
+    }
+
+    private Collection<Member> createMembersWithRackAwareMetadata() throws UnknownHostException {
+        Collection<Member> members = new HashSet<Member>();
+        InetAddress fakeAddress = InetAddress.getLocalHost();
+        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), true);
+        member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-1");
+
+        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), true);
+        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-2");
+
+        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), true);
+        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-3");
+
+        members.add(member1);
+        members.add(member2);
+        members.add(member3);
+        return members;
+    }
+
+    private Collection<Member> createMembersWithHostAwareMetadata() throws UnknownHostException {
+        Collection<Member> members = new HashSet<Member>();
+        InetAddress fakeAddress = InetAddress.getLocalHost();
+        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), true);
+        member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-1");
+
+        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), true);
+        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-2");
+
+        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), true);
+        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-3");
+
+        members.add(member1);
+        members.add(member2);
+        members.add(member3);
+        return members;
+    }
+
+    private Collection<Member> createMembersWithNoMetadata() throws UnknownHostException {
+        Collection<Member> members = new HashSet<Member>();
+        InetAddress fakeAddress = InetAddress.getLocalHost();
+        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), false));
+        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5702), false));
+        members.add(new MemberImpl(new Address("192.168.3.101", fakeAddress, 5701), false));
         return members;
     }
 

--- a/src/main/java/com/hazelcast/spi/partitiongroup/package-info.java
+++ b/src/main/java/com/hazelcast/spi/partitiongroup/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the basic SPI for the Partition Group SPI to define
+ * or configure how Hazelcast will configure and distribute backups in the
+ * cluster. The basic idea is to make sure that backups are stored on independent
+ * systems such as different physical hosts or zones.
+ */
+package com.hazelcast.spi.partitiongroup;

--- a/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+
+  <network>
+    <join>
+      <multicast enabled="false"/>
+      <tcp-ip enabled="false" />
+      <aws enabled="false"/>
+      <discovery-strategies>
+        <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.DiscoverySpiTest$MetadataProvidingDiscoveryStrategy">
+          <properties>
+            <property name="key-string">foo</property>
+            <property name="key-int">123</property>
+            <property name="key-boolean">true</property>
+          </properties>
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+  </network>
+
+</hazelcast>


### PR DESCRIPTION
Added `ZoneAwareMemberGroupFactory` and `SPIAwareMemberGroupFactory`.

- `ZoneAwareMemberGroupFactory`  is responsible for creation of partition groups based on metadata provided by Discovery SPI.

-  `SPIAwareMemberGroupFactory`. is responsible calling custom member group impl provided by
 `discoveryStrategy.getPartitionGroupStrategy().getMemberGroups()` method