### PR TITLE
Makes use of total-backup-count(sync+async backups) instead of backup…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -532,7 +532,7 @@ public abstract class AbstractCacheService
         final int partitionId = partitionLostEvent.getPartitionId();
         for (CacheConfig config : getCacheConfigs()) {
             final String cacheName = config.getName();
-            if (config.getBackupCount() <= partitionLostEvent.getLostReplicaIndex()) {
+            if (config.getTotalBackupCount() <= partitionLostEvent.getLostReplicaIndex()) {
                 publishCachePartitionLostEvent(cacheName, partitionId);
             }
         }


### PR DESCRIPTION
…-count(since it is only sync backup count) to fire partition-lost-event