### PR TITLE
Makes use of total-backup-count(sync+async backups) instead of backup…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -593,8 +593,8 @@ public abstract class AbstractCacheService
     public void onPartitionLost(IPartitionLostEvent partitionLostEvent) {
         int partitionId = partitionLostEvent.getPartitionId();
         for (CacheConfig config : getCacheConfigs()) {
-            String cacheName = config.getName();
-            if (config.getBackupCount() <= partitionLostEvent.getLostReplicaIndex()) {
+            final String cacheName = config.getName();
+            if (config.getTotalBackupCount() <= partitionLostEvent.getLostReplicaIndex()) {
                 publishCachePartitionLostEvent(cacheName, partitionId);
             }
         }


### PR DESCRIPTION
…-count(since it is only sync backup count) to fire partition-lost-event

forward port of https://github.com/hazelcast/hazelcast/pull/8188