### PR TITLE
Introduced Partition Iterator to Cache and Map

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCachePartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCachePartitionIterator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.hazelcast.client.cache.impl;
+
+import com.hazelcast.client.spi.ClientContext;
+
+public class ClientCachePartitionIterator<K, V> extends ClientClusterWideIterator<K, V> {
+
+    public ClientCachePartitionIterator(ClientCacheProxy<K, V> cacheProxy, ClientContext context, int fetchSize,
+                                        int partitionId, boolean prefetchValues) {
+        super(cacheProxy, context, fetchSize, partitionId, prefetchValues);
+    }
+
+    @Override
+    protected boolean advance() {
+        if (lastTableIndex < 0) {
+            lastTableIndex = Integer.MAX_VALUE;
+            return false;
+        }
+        result = fetch();
+        if (result != null && result.size() > 0) {
+            index = 0;
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -43,7 +43,14 @@ import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.ExceptionUtil;
-
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
@@ -53,14 +60,6 @@ import javax.cache.integration.CompletionListener;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
 
@@ -329,9 +328,9 @@ public class ClientCacheProxy<K, V>
         }
         CacheEventListenerAdaptor<K, V> adaptor =
                 new CacheEventListenerAdaptor<K, V>(this,
-                                                    cacheEntryListenerConfiguration,
-                                                    clientContext.getSerializationService(),
-                                                    clientContext.getHazelcastInstance());
+                        cacheEntryListenerConfiguration,
+                        clientContext.getSerializationService(),
+                        clientContext.getHazelcastInstance());
         EventHandler handler = createHandler(adaptor);
         String regId = clientContext.getListenerService().registerListener(createCacheEntryListenerCodec(), handler);
         if (regId != null) {
@@ -406,13 +405,18 @@ public class ClientCacheProxy<K, V>
     @Override
     public Iterator<Entry<K, V>> iterator() {
         ensureOpen();
-        return new ClientClusterWideIterator<K, V>(this, clientContext);
+        return new ClientClusterWideIterator<K, V>(this, clientContext, false);
     }
 
     @Override
     public Iterator<Entry<K, V>> iterator(int fetchSize) {
         ensureOpen();
-        return new ClientClusterWideIterator<K, V>(this, clientContext, fetchSize);
+        return new ClientClusterWideIterator<K, V>(this, clientContext, fetchSize, false);
+    }
+
+    public Iterator<Entry<K, V>> iterator(int fetchSize, int partitionId, boolean prefetchValues) {
+        ensureOpen();
+        return new ClientCachePartitionIterator<K, V>(this, clientContext, fetchSize, partitionId, prefetchValues);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl;
+
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapFetchEntriesCodec;
+import com.hazelcast.client.impl.protocol.codec.MapFetchKeysCodec;
+import com.hazelcast.client.proxy.ClientMapProxy;
+import com.hazelcast.client.spi.ClientContext;
+import com.hazelcast.client.spi.impl.ClientInvocation;
+import com.hazelcast.client.spi.impl.ClientInvocationFuture;
+import com.hazelcast.map.impl.iterator.AbstractMapPartitionIterator;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.ExceptionUtil;
+import java.util.List;
+
+public class ClientMapPartitionIterator<K, V> extends AbstractMapPartitionIterator<K, V> {
+
+    private final ClientMapProxy<K, V> mapProxy;
+    private final ClientContext context;
+
+    public ClientMapPartitionIterator(ClientMapProxy<K, V> mapProxy, ClientContext context, int fetchSize,
+                                      int partitionId, boolean prefetchValues) {
+        super(mapProxy, fetchSize, partitionId, prefetchValues);
+        this.mapProxy = mapProxy;
+        this.context = context;
+    }
+
+    @Override
+    protected List fetch() {
+        HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) context.getHazelcastInstance();
+        if (prefetchValues) {
+            ClientMessage request = MapFetchEntriesCodec.encodeRequest(mapProxy.getName(), partitionId, lastTableIndex,
+                    fetchSize);
+            ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionId);
+            try {
+                ClientInvocationFuture f = clientInvocation.invoke();
+                MapFetchEntriesCodec.ResponseParameters responseParameters = MapFetchEntriesCodec.decodeResponse(f.get());
+                setLastTableIndex(responseParameters.entries, responseParameters.tableIndex);
+                return responseParameters.entries;
+            } catch (Exception e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+        } else {
+            ClientMessage request = MapFetchKeysCodec.encodeRequest(mapProxy.getName(), partitionId,
+                    lastTableIndex, fetchSize);
+            ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionId);
+            try {
+                ClientInvocationFuture f = clientInvocation.invoke();
+                MapFetchKeysCodec.ResponseParameters responseParameters = MapFetchKeysCodec.decodeResponse(f.get());
+                setLastTableIndex(responseParameters.keys, responseParameters.tableIndex);
+                return responseParameters.keys;
+            } catch (Exception e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+        }
+    }
+
+    @Override
+    protected SerializationService getSerializationService() {
+        return context.getSerializationService();
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -73,6 +73,7 @@ import com.hazelcast.client.impl.protocol.codec.MapUnlockCodec;
 import com.hazelcast.client.impl.protocol.codec.MapValuesCodec;
 import com.hazelcast.client.impl.protocol.codec.MapValuesWithPagingPredicateCodec;
 import com.hazelcast.client.impl.protocol.codec.MapValuesWithPredicateCodec;
+import com.hazelcast.client.map.impl.ClientMapPartitionIterator;
 import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.ClientProxy;
@@ -128,11 +129,11 @@ import com.hazelcast.util.MapUtil;
 import com.hazelcast.util.Preconditions;
 import com.hazelcast.util.ThreadUtil;
 import com.hazelcast.util.collection.InflatableSet;
-
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1422,6 +1423,10 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         invoke(request);
 
         clearNearCachesOnLiteMembers();
+    }
+
+    public Iterator<Entry<K, V>> iterator(int fetchSize, int partitionId, boolean prefetchValues) {
+        return new ClientMapPartitionIterator<K, V>(this, getContext(), fetchSize, partitionId, prefetchValues);
     }
 
     private void clearNearCachesOnLiteMembers() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionIteratorTest.java
@@ -1,0 +1,120 @@
+package com.hazelcast.client.cache;
+
+import com.hazelcast.client.cache.impl.ClientCacheProxy;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Arrays;
+import java.util.Iterator;
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientCachePartitionIteratorTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public boolean prefetchValues;
+
+    @Parameterized.Parameters(name = "prefetchValues:{0}")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
+    }
+
+    private TestHazelcastFactory factory;
+    private CachingProvider cachingProvider;
+    private HazelcastInstance server;
+
+    @Before
+    public void init() {
+        factory = new TestHazelcastFactory();
+        server = factory.newHazelcastInstance();
+        cachingProvider = createCachingProvider();
+    }
+
+    @After
+    public void teardown() {
+        factory.terminateAll();
+    }
+
+    protected CachingProvider createCachingProvider() {
+        HazelcastInstance client = factory.newHazelcastClient();
+        return HazelcastClientCachingProvider.createCachingProvider(client);
+    }
+
+    private <K, V> ClientCacheProxy<K, V> getCacheProxy() {
+        String cacheName = randomString();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+        CacheConfig<K, V> config = new CacheConfig<K, V>();
+        config.getEvictionConfig().setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT).setSize(10000000);
+        return (ClientCacheProxy<K, V>) cacheManager.createCache(cacheName, config);
+
+    }
+
+    @Test
+    public void testIterator_HasNext_Returns_False_On_EmptyPartition() throws Exception {
+        ClientCacheProxy<Integer, Integer> cache = getCacheProxy();
+        Iterator<Cache.Entry<Integer, Integer>> iterator = cache.iterator(10, 1, prefetchValues);
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testIterator_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
+        ClientCacheProxy<String, String> cache = getCacheProxy();
+
+        String key = generateKeyForPartition(server, 1);
+        String value = randomString();
+        cache.put(key, value);
+
+        Iterator<Cache.Entry<String, String>> iterator = cache.iterator(10, 1, prefetchValues);
+        assertTrue(iterator.hasNext());
+    }
+
+    @Test
+    public void testIterator_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
+        ClientCacheProxy<String, String> cache = getCacheProxy();
+
+        String key = generateKeyForPartition(server, 1);
+        String value = randomString();
+        cache.put(key, value);
+
+        Iterator<Cache.Entry<String, String>> iterator = cache.iterator(10, 1, prefetchValues);
+        Cache.Entry entry = iterator.next();
+        assertEquals(value, entry.getValue());
+    }
+
+    @Test
+    public void testIterator_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
+        ClientCacheProxy<String, String> cache = getCacheProxy();
+        String value = randomString();
+        int count = 1000;
+        for (int i = 0; i < count; i++) {
+            String key = generateKeyForPartition(server, 42);
+            cache.put(key, value);
+        }
+        Iterator<Cache.Entry<String, String>> iterator = cache.iterator(10, 42, prefetchValues);
+        for (int i = 0; i < count; i++) {
+            Cache.Entry entry = iterator.next();
+            assertEquals(value, entry.getValue());
+
+        }
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapPartitionIteratorTest.java
@@ -1,0 +1,108 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.proxy.ClientMapProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMapPartitionIteratorTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public boolean prefetchValues;
+
+    @Parameterized.Parameters(name = "prefetchValues:{0}")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
+    }
+
+    private TestHazelcastFactory factory;
+    private HazelcastInstance server;
+    private HazelcastInstance client;
+
+    @Before
+    public void init() {
+        Config config = getConfig();
+        factory = new TestHazelcastFactory();
+        server = factory.newHazelcastInstance(config);
+        client = factory.newHazelcastClient();
+    }
+
+    @After
+    public void teardown() {
+        factory.terminateAll();
+    }
+
+    private <K, V> ClientMapProxy<K, V> getMapProxy() {
+        String mapName = randomString();
+        return (ClientMapProxy<K, V>) client.getMap(mapName);
+    }
+
+    @Test
+    public void testIterator_HasNext_Returns_False_On_EmptyPartition() throws Exception {
+        ClientMapProxy<Integer, Integer> map = getMapProxy();
+        Iterator<Map.Entry<Integer, Integer>> iterator = map.iterator(10, 1, prefetchValues);
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testIterator_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
+        ClientMapProxy<String, String> map = getMapProxy();
+
+        String key = generateKeyForPartition(server, 1);
+        String value = randomString();
+        map.put(key, value);
+
+        Iterator<Map.Entry<String, String>> iterator = map.iterator(10, 1, prefetchValues);
+        assertTrue(iterator.hasNext());
+    }
+
+    @Test
+    public void testIterator_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
+        ClientMapProxy<String, String> map = getMapProxy();
+
+        String key = generateKeyForPartition(server, 1);
+        String value = randomString();
+        map.put(key, value);
+
+        Iterator<Map.Entry<String, String>> iterator = map.iterator(10, 1, prefetchValues);
+        Map.Entry entry = iterator.next();
+        assertEquals(value, entry.getValue());
+    }
+
+    @Test
+    public void testIterator_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
+        ClientMapProxy<String, String> map = getMapProxy();
+        String value = randomString();
+        int count = 1000;
+        for (int i = 0; i < count; i++) {
+            String key = generateKeyForPartition(server, 42);
+            map.put(key, value);
+        }
+        Iterator<Map.Entry<String, String>> iterator = map.iterator(10, 42, prefetchValues);
+        for (int i = 0; i < count; i++) {
+            Map.Entry entry = iterator.next();
+            assertEquals(value, entry.getValue());
+
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -69,9 +69,6 @@ import static com.hazelcast.cache.impl.CacheEventContextUtil.createCacheUpdatedE
 import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLETION;
 import static com.hazelcast.cache.impl.record.CacheRecordFactory.isExpiredAt;
 
-/**
- * @author sozal 14/10/14
- */
 public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extends SampleableCacheRecordMap<Data, R>>
         implements ICacheRecordStore, EvictionListener<Data, R> {
 
@@ -198,13 +195,20 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     protected abstract CRM createRecordCacheMap();
+
     protected abstract CacheEntryProcessorEntry createCacheEntryProcessorEntry(Data key, R record,
                                                                                long now, int completionId);
+
     protected abstract R createRecord(Object value, long creationTime, long expiryTime);
+
     protected abstract Data valueToData(Object value);
+
     protected abstract Object dataToValue(Data data);
+
     protected abstract Object recordToValue(R record);
+
     protected abstract Data recordToData(R record);
+
     protected abstract Data toHeapData(Object obj);
 
     protected MaxSizeChecker createCacheMaxSizeChecker(int size, EvictionConfig.MaxSizePolicy maxSizePolicy) {
@@ -323,13 +327,13 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         onProcessExpiredEntry(key, removedRecord, removedRecord.getExpirationTime(), now, source, origin);
         if (isEventsEnabled()) {
             publishEvent(createCacheExpiredEvent(keyEventData, recordEventData,
-                         CacheRecord.TIME_NOT_AVAILABLE, origin, IGNORE_COMPLETION));
+                    CacheRecord.TIME_NOT_AVAILABLE, origin, IGNORE_COMPLETION));
         }
         return true;
     }
 
     protected R processExpiredEntry(Data key, R record, long expiryTime, long now, String source) {
-        return processExpiredEntry(key, record, expiryTime, now, source,  null);
+        return processExpiredEntry(key, record, expiryTime, now, source, null);
     }
 
     protected R processExpiredEntry(Data key, R record, long expiryTime, long now, String source, String origin) {
@@ -345,7 +349,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         onProcessExpiredEntry(key, removedRecord, expiryTime, now, source, origin);
         if (isEventsEnabled()) {
             publishEvent(createCacheExpiredEvent(keyEventData, recordEventData, CacheRecord.TIME_NOT_AVAILABLE,
-                                                 origin, IGNORE_COMPLETION));
+                    origin, IGNORE_COMPLETION));
         }
         return null;
     }
@@ -412,7 +416,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                 if (isEventsEnabled()) {
                     CacheEventContext cacheEventContext =
                             createBaseEventContext(CacheEventType.EXPIRATION_TIME_UPDATED, toEventData(key),
-                                                   toEventData(record.getValue()), expiryTime, null, IGNORE_COMPLETION);
+                                    toEventData(record.getValue()), expiryTime, null, IGNORE_COMPLETION);
                     cacheEventContext.setAccessHit(record.getAccessHit());
                     publishEvent(cacheEventContext);
                 }
@@ -449,8 +453,8 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             if (eventsBatchingEnabled) {
                 CacheEventDataImpl cacheEventData =
                         new CacheEventDataImpl(name, cacheEventContext.getEventType(), cacheEventContext.getDataKey(),
-                                               cacheEventContext.getDataValue(), cacheEventContext.getDataOldValue(),
-                                               cacheEventContext.isOldValueAvailable());
+                                cacheEventContext.getDataValue(), cacheEventContext.getDataOldValue(),
+                                cacheEventContext.isOldValueAvailable());
                 Set<CacheEventData> cacheEventDataSet = batchEvent.remove(cacheEventContext.getEventType());
                 if (cacheEventDataSet == null) {
                     cacheEventDataSet = new HashSet<CacheEventData>();
@@ -494,7 +498,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         R record = createRecord(value, expirationTime);
         if (isEventsEnabled()) {
             publishEvent(createCacheCreatedEvent(toEventData(keyData), toEventData(value),
-                                                 expirationTime, null, completionId));
+                    expirationTime, null, completionId));
         }
         return record;
     }
@@ -510,7 +514,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             doPutRecord(key, record);
         } catch (Throwable error) {
             onCreateRecordError(key, value, expiryTime, now, disableWriteThrough,
-                                completionId, origin, record, error);
+                    completionId, origin, record, error);
             throw ExceptionUtil.rethrow(error);
         }
         try {
@@ -522,12 +526,12 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             records.remove(key);
             // Disposing key/value/record should be handled inside `onCreateRecordWithExpiryError`.
             onCreateRecordError(key, value, expiryTime, now, disableWriteThrough,
-                                completionId, origin, record, error);
+                    completionId, origin, record, error);
             throw ExceptionUtil.rethrow(error);
         }
         if (isEventsEnabled()) {
             publishEvent(createCacheCreatedEvent(toEventData(key), toEventData(value),
-                                                 expiryTime, origin, completionId));
+                    expiryTime, origin, completionId));
         }
         return record;
     }
@@ -539,7 +543,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         }
         if (isEventsEnabled()) {
             publishEvent(createCacheCompleteEvent(toEventData(key), CacheRecord.TIME_NOT_AVAILABLE,
-                                                  origin, completionId));
+                    origin, completionId));
         }
         return null;
     }
@@ -629,9 +633,9 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
                 if (isEventsEnabled()) {
                     publishEvent(createCacheUpdatedEvent(eventDataKey, eventDataValue, eventDataOldValue,
-                                                         record.getCreationTime(), record.getExpirationTime(),
-                                                         record.getLastAccessTime(), record.getAccessHit(),
-                                                         origin, completionId));
+                            record.getCreationTime(), record.getExpirationTime(),
+                            record.getLastAccessTime(), record.getAccessHit(),
+                            origin, completionId));
                 }
             }
         } catch (Throwable error) {
@@ -654,25 +658,25 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     protected boolean updateRecordWithExpiry(Data key, Object value, R record, long expiryTime,
                                              long now, boolean disableWriteThrough, int completionId) {
         return updateRecordWithExpiry(key, value, record, expiryTime, now, disableWriteThrough,
-                                      completionId, SOURCE_NOT_AVAILABLE);
+                completionId, SOURCE_NOT_AVAILABLE);
     }
 
     protected boolean updateRecordWithExpiry(Data key, Object value, R record, long expiryTime,
                                              long now, boolean disableWriteThrough, int completionId, String source) {
         return updateRecordWithExpiry(key, value, record, expiryTime, now,
-                                      disableWriteThrough, completionId, source, null);
+                disableWriteThrough, completionId, source, null);
     }
 
     protected boolean updateRecordWithExpiry(Data key, Object value, R record, ExpiryPolicy expiryPolicy,
                                              long now, boolean disableWriteThrough, int completionId) {
         return updateRecordWithExpiry(key, value, record, expiryPolicy, now,
-                                      disableWriteThrough, completionId, SOURCE_NOT_AVAILABLE);
+                disableWriteThrough, completionId, SOURCE_NOT_AVAILABLE);
     }
 
     protected boolean updateRecordWithExpiry(Data key, Object value, R record, ExpiryPolicy expiryPolicy,
                                              long now, boolean disableWriteThrough, int completionId, String source) {
         return updateRecordWithExpiry(key, value, record, expiryPolicy, now,
-                                      disableWriteThrough, completionId, source, null);
+                disableWriteThrough, completionId, source, null);
     }
 
     protected boolean updateRecordWithExpiry(Data key, Object value, R record, ExpiryPolicy expiryPolicy, long now,
@@ -688,7 +692,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             EmptyStatement.ignore(e);
         }
         return updateRecordWithExpiry(key, value, record, expiryTime, now,
-                                      disableWriteThrough, completionId, source, origin);
+                disableWriteThrough, completionId, source, origin);
     }
 
     protected void onDeleteRecord(Data key, R record, Data dataValue, boolean deleted) {
@@ -723,7 +727,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             onDeleteRecord(key, record, dataValue, record != null);
             if (isEventsEnabled()) {
                 publishEvent(createCacheRemovedEvent(eventDataKey, eventDataValue,
-                                                     CacheRecord.TIME_NOT_AVAILABLE, origin, completionId));
+                        CacheRecord.TIME_NOT_AVAILABLE, origin, completionId));
             }
             return record != null;
         } catch (Throwable error) {
@@ -906,7 +910,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         Object value = null;
         R record = records.get(key);
         boolean isExpired = processExpiredEntry(key, record, now);
-
         try {
             if (recordNotExistOrExpired(record, isExpired)) {
                 if (isStatisticsEnabled()) {
@@ -966,7 +969,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         Object oldValue = null;
         R record = records.get(key);
         boolean isExpired = processExpiredEntry(key, record, now, source);
-
         try {
             // Check that new entry is not already expired, in which case it should
             // not be added to the cache or listeners called or writers called.
@@ -979,10 +981,10 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                     oldValue = toValue(record);
                 }
                 isSaveSucceed = updateRecordWithExpiry(key, value, record, expiryPolicy,
-                                                       now, disableWriteThrough, completionId, source);
+                        now, disableWriteThrough, completionId, source);
             }
             onPut(key, value, expiryPolicy, source, getValue, disableWriteThrough,
-                  record, oldValue, isExpired, isOnNewPut, isSaveSucceed);
+                    record, oldValue, isExpired, isOnNewPut, isSaveSucceed);
             updateGetAndPutStat(isSaveSucceed, getValue, oldValue == null, start);
             if (getValue) {
                 return oldValue;
@@ -991,7 +993,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             }
         } catch (Throwable error) {
             onPutError(key, value, expiryPolicy, source, getValue, disableWriteThrough,
-                       record, oldValue, isOnNewPut, error);
+                    record, oldValue, isOnNewPut, error);
             throw ExceptionUtil.rethrow(error);
         }
     }
@@ -1027,11 +1029,10 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         boolean saved = false;
         R record = records.get(key);
         boolean isExpired = processExpiredEntry(key, record, now, source);
-
         try {
             if (record == null || isExpired) {
                 saved = createRecordWithExpiry(key, value, expiryPolicy, now,
-                                               disableWriteThrough, completionId) != null;
+                        disableWriteThrough, completionId) != null;
             } else {
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), completionId));
@@ -1071,7 +1072,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         boolean replaced = false;
         R record = records.get(key);
         boolean isExpired = record != null && record.isExpiredAt(now);
-
         try {
             if (recordNotExistOrExpired(record, isExpired)) {
                 if (isEventsEnabled()) {
@@ -1107,14 +1107,13 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         boolean replaced = false;
         R record = records.get(key);
         boolean isExpired = record != null && record.isExpiredAt(now);
-
         try {
             if (record != null && !isExpired) {
                 isHit = true;
                 Object currentValue = toStorageValue(record);
                 if (compare(currentValue, toStorageValue(oldValue))) {
                     replaced = updateRecordWithExpiry(key, newValue, record, expiryPolicy,
-                                                      now, false, completionId, source);
+                            now, false, completionId, source);
                 } else {
                     onRecordAccess(key, record, expiryPolicy, now);
                 }
@@ -1129,7 +1128,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             return replaced;
         } catch (Throwable error) {
             onReplaceError(key, oldValue, newValue, expiryPolicy, source, false,
-                           record, isExpired, replaced, error);
+                    record, isExpired, replaced, error);
             throw ExceptionUtil.rethrow(error);
         }
     }
@@ -1142,7 +1141,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         boolean replaced = false;
         R record = records.get(key);
         boolean isExpired = record != null && record.isExpiredAt(now);
-
         try {
             Object obj = toValue(record);
             if (recordNotExistOrExpired(record, isExpired)) {
@@ -1191,12 +1189,11 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
         R record = records.get(key);
         boolean removed = false;
-
         try {
             if (recordNotExistOrExpired(record, now)) {
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), CacheRecord.TIME_NOT_AVAILABLE,
-                                                          origin, completionId));
+                            origin, completionId));
                 }
             } else {
                 removed = deleteRecord(key, completionId, source, origin);
@@ -1243,7 +1240,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             if (!removed) {
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), CacheRecord.TIME_NOT_AVAILABLE,
-                                                          origin, completionId));
+                            origin, completionId));
                 }
             }
             onRemove(key, value, source, false, record, removed);
@@ -1287,7 +1284,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                 obj = null;
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), CacheRecord.TIME_NOT_AVAILABLE,
-                                                          origin, completionId));
+                            origin, completionId));
                 }
             } else {
                 obj = toValue(record);
@@ -1389,8 +1386,13 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     @Override
-    public CacheKeyIteratorResult iterator(int tableIndex, int size) {
-        return records.fetchNext(tableIndex, size);
+    public CacheKeyIterationResult fetchKeys(int tableIndex, int size) {
+        return records.fetchKeys(tableIndex, size);
+    }
+
+    @Override
+    public CacheEntryIterationResult fetchEntries(int tableIndex, int size) {
+        return records.fetchEntries(tableIndex, size);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -26,6 +26,7 @@ import com.hazelcast.cache.impl.operation.CacheClearOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheContainsKeyOperation;
 import com.hazelcast.cache.impl.operation.CacheCreateConfigOperation;
 import com.hazelcast.cache.impl.operation.CacheDestroyOperation;
+import com.hazelcast.cache.impl.operation.CacheEntryIteratorOperation;
 import com.hazelcast.cache.impl.operation.CacheEntryProcessorOperation;
 import com.hazelcast.cache.impl.operation.CacheGetAllOperation;
 import com.hazelcast.cache.impl.operation.CacheGetAllOperationFactory;
@@ -112,8 +113,10 @@ public final class CacheDataSerializerHook
     public static final short MERGE = 38;
     public static final short INVALIDATION_MESSAGE = 39;
     public static final short BATCH_INVALIDATION_MESSAGE = 40;
+    public static final short ENTRY_ITERATOR = 41;
+    public static final short ENTRY_ITERATION_RESULT = 42;
 
-    private static final int LEN = 41;
+    private static final int LEN = 43;
 
     public int getFactoryId() {
         return F_ID;
@@ -224,7 +227,7 @@ public final class CacheDataSerializerHook
         };
         constructors[KEY_ITERATION_RESULT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
-                return new CacheKeyIteratorResult();
+                return new CacheKeyIterationResult();
             }
         };
         constructors[ENTRY_PROCESSOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
@@ -322,6 +325,16 @@ public final class CacheDataSerializerHook
         constructors[BATCH_INVALIDATION_MESSAGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new CacheBatchInvalidationMessage();
+            }
+        };
+        constructors[ENTRY_ITERATOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheEntryIteratorOperation();
+            }
+        };
+        constructors[ENTRY_ITERATION_RESULT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheEntryIterationResult();
             }
         };
         return new ArrayDataSerializableFactory(constructors);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryIterationResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryIterationResult.java
@@ -20,30 +20,30 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-
 import java.io.IOException;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
- * <p>Response data object returned by {@link com.hazelcast.cache.impl.operation.CacheKeyIteratorOperation }.</p>
- * This result wrapper is used in {@link AbstractClusterWideIterator}'s subclasses to return a collection of keys
+ * <p>Response data object returned by {@link com.hazelcast.cache.impl.operation.CacheEntryIteratorOperation }.</p>
+ * This result wrapper is used in {@link AbstractClusterWideIterator}'s subclasses to return a collection of entries
  * and the last tableIndex processed.
  *
  * @see AbstractClusterWideIterator
- * @see com.hazelcast.cache.impl.operation.CacheKeyIteratorOperation
+ * @see com.hazelcast.cache.impl.operation.CacheEntryIteratorOperation
  */
-public class CacheKeyIteratorResult
-        implements IdentifiedDataSerializable {
+public class CacheEntryIterationResult implements IdentifiedDataSerializable {
 
     private int tableIndex;
-    private List<Data> keys;
+    private List<Map.Entry<Data, Data>> entries;
 
-    public CacheKeyIteratorResult() {
+    public CacheEntryIterationResult() {
     }
 
-    public CacheKeyIteratorResult(List<Data> keys, int tableIndex) {
-        this.keys = keys;
+    public CacheEntryIterationResult(List<Map.Entry<Data, Data>> entries, int tableIndex) {
+        this.entries = entries;
         this.tableIndex = tableIndex;
     }
 
@@ -51,8 +51,8 @@ public class CacheKeyIteratorResult
         return tableIndex;
     }
 
-    public List<Data> getKeys() {
-        return keys;
+    public List<Map.Entry<Data, Data>> getEntries() {
+        return entries;
     }
 
     @Override
@@ -62,19 +62,19 @@ public class CacheKeyIteratorResult
 
     @Override
     public int getId() {
-        return CacheDataSerializerHook.KEY_ITERATION_RESULT;
+        return CacheDataSerializerHook.ENTRY_ITERATION_RESULT;
     }
 
     @Override
     public void writeData(ObjectDataOutput out)
             throws IOException {
         out.writeInt(tableIndex);
-        int size = keys.size();
+        int size = entries.size();
         out.writeInt(size);
-        for (Data o : keys) {
-            out.writeData(o);
+        for (Map.Entry<Data, Data> entry : entries) {
+            out.writeData(entry.getKey());
+            out.writeData(entry.getValue());
         }
-
     }
 
     @Override
@@ -82,23 +82,21 @@ public class CacheKeyIteratorResult
             throws IOException {
         tableIndex = in.readInt();
         int size = in.readInt();
-        keys = new ArrayList<Data>(size);
+        entries = new ArrayList<Map.Entry<Data, Data>>(size);
         for (int i = 0; i < size; i++) {
-            Data data = in.readData();
-            keys.add(data);
+            Data key = in.readData();
+            Data value = in.readData();
+            entries.add(new AbstractMap.SimpleEntry<Data, Data>(key, value));
         }
     }
 
     @Override
     public String toString() {
-        return "CacheKeyIteratorResult{tableIndex=" + tableIndex + '}';
+        return "CacheEntryIteratorResult{tableIndex=" + tableIndex + '}';
     }
 
     public int getCount() {
-        return keys != null ? keys.size() : 0;
+        return entries != null ? entries.size() : 0;
     }
 
-    public Data getKey(int index) {
-        return keys != null ? keys.get(index) : null;
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheKeyIterationResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheKeyIterationResult.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>Response data object returned by {@link com.hazelcast.cache.impl.operation.CacheKeyIteratorOperation }.</p>
+ * This result wrapper is used in {@link AbstractClusterWideIterator}'s subclasses to return a collection of keys
+ * and the last tableIndex processed.
+ *
+ * @see AbstractClusterWideIterator
+ * @see com.hazelcast.cache.impl.operation.CacheKeyIteratorOperation
+ */
+public class CacheKeyIterationResult implements IdentifiedDataSerializable {
+
+    private int tableIndex;
+    private List<Data> keys;
+
+    public CacheKeyIterationResult() {
+    }
+
+    public CacheKeyIterationResult(List<Data> keys, int tableIndex) {
+        this.keys = keys;
+        this.tableIndex = tableIndex;
+    }
+
+    public int getTableIndex() {
+        return tableIndex;
+    }
+
+    public List<Data> getKeys() {
+        return keys;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.KEY_ITERATION_RESULT;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out)
+            throws IOException {
+        out.writeInt(tableIndex);
+        int size = keys.size();
+        out.writeInt(size);
+        for (Data o : keys) {
+            out.writeData(o);
+        }
+
+    }
+
+    @Override
+    public void readData(ObjectDataInput in)
+            throws IOException {
+        tableIndex = in.readInt();
+        int size = in.readInt();
+        keys = new ArrayList<Data>(size);
+        for (int i = 0; i < size; i++) {
+            Data data = in.readData();
+            keys.add(data);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "CacheKeyIteratorResult{tableIndex=" + tableIndex + '}';
+    }
+
+    public int getCount() {
+        return keys != null ? keys.size() : 0;
+    }
+
+    public Data getKey(int index) {
+        return keys != null ? keys.get(index) : null;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
@@ -53,6 +53,8 @@ public interface CacheOperationProvider {
 
     Operation createKeyIteratorOperation(int lastTableIndex, int fetchSize);
 
+    Operation createEntryIteratorOperation(int lastTableIndex, int fetchSize);
+
     OperationFactory createGetAllOperationFactory(Set<Data> keySet, ExpiryPolicy policy);
 
     OperationFactory createLoadAllOperationFactory(Set<Data> keySet, boolean replaceExistingValues);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionIterator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+public class CachePartitionIterator<K, V> extends ClusterWideIterator<K, V> {
+
+    public CachePartitionIterator(CacheProxy<K, V> cache, int fetchSize, int partitionId, boolean prefetchValues) {
+        super(cache, fetchSize, partitionId, prefetchValues);
+    }
+
+    @Override
+    protected boolean advance() {
+        if (lastTableIndex < 0) {
+            lastTableIndex = Integer.MAX_VALUE;
+            return false;
+        }
+        result = fetch();
+        if (result != null && result.size() > 0) {
+            index = 0;
+            return true;
+        }
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -31,15 +31,6 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.ExceptionUtil;
-
-import javax.cache.CacheException;
-import javax.cache.configuration.CacheEntryListenerConfiguration;
-import javax.cache.configuration.Configuration;
-import javax.cache.expiry.ExpiryPolicy;
-import javax.cache.integration.CompletionListener;
-import javax.cache.processor.EntryProcessor;
-import javax.cache.processor.EntryProcessorException;
-import javax.cache.processor.EntryProcessorResult;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -48,6 +39,14 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
+import javax.cache.CacheException;
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.configuration.Configuration;
+import javax.cache.expiry.ExpiryPolicy;
+import javax.cache.integration.CompletionListener;
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.EntryProcessorResult;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -281,9 +280,9 @@ public class CacheProxy<K, V>
         final ICacheService service = getService();
         final CacheEventListenerAdaptor<K, V> entryListener =
                 new CacheEventListenerAdaptor<K, V>(this,
-                                                    cacheEntryListenerConfiguration,
-                                                    getNodeEngine().getSerializationService(),
-                                                    getNodeEngine().getHazelcastInstance());
+                        cacheEntryListenerConfiguration,
+                        getNodeEngine().getSerializationService(),
+                        getNodeEngine().getHazelcastInstance());
         final String regId =
                 service.registerListener(getDistributedObjectName(), entryListener, entryListener, false);
         if (regId != null) {
@@ -328,13 +327,18 @@ public class CacheProxy<K, V>
     @Override
     public Iterator<Entry<K, V>> iterator() {
         ensureOpen();
-        return new ClusterWideIterator<K, V>(this);
+        return new ClusterWideIterator<K, V>(this, false);
     }
 
     @Override
     public Iterator<Entry<K, V>> iterator(int fetchSize) {
         ensureOpen();
-        return new ClusterWideIterator<K, V>(this, fetchSize);
+        return new ClusterWideIterator<K, V>(this, fetchSize, false);
+    }
+
+    public Iterator<Entry<K, V>> iterator(int fetchSize, int partitionId, boolean prefetchValues) {
+        ensureOpen();
+        return new CachePartitionIterator<K, V>(this, fetchSize, partitionId, prefetchValues);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.impl.operation.CacheClearOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheContainsKeyOperation;
+import com.hazelcast.cache.impl.operation.CacheEntryIteratorOperation;
 import com.hazelcast.cache.impl.operation.CacheEntryProcessorOperation;
 import com.hazelcast.cache.impl.operation.CacheGetAllOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheGetAndRemoveOperation;
@@ -108,6 +109,11 @@ public class DefaultOperationProvider implements CacheOperationProvider {
     @Override
     public Operation createKeyIteratorOperation(int lastTableIndex, int fetchSize) {
         return new CacheKeyIteratorOperation(nameWithPrefix, lastTableIndex, fetchSize);
+    }
+
+    @Override
+    public Operation createEntryIteratorOperation(int lastTableIndex, int fetchSize) {
+        return new CacheEntryIteratorOperation(nameWithPrefix, lastTableIndex, fetchSize);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -41,6 +41,7 @@ import java.util.Set;
  *
  * @see com.hazelcast.cache.impl.CacheRecordStore
  */
+@SuppressWarnings("checkstyle:methodcount")
 public interface ICacheRecordStore {
 
     int UNIT_PERCENTAGE = 100;
@@ -384,9 +385,17 @@ public interface ICacheRecordStore {
      * Starting from the provided table index, a set of keys are returned with a maximum size of <code>size</code>
      * @param tableIndex initial table index.
      * @param size maximum key set size.
-     * @return {@link CacheKeyIteratorResult} which wraps keys and last tableIndex.
+     * @return {@link CacheKeyIterationResult} which wraps keys and last tableIndex.
      */
-    CacheKeyIteratorResult iterator(int tableIndex, int size);
+    CacheKeyIterationResult fetchKeys(int tableIndex, int size);
+
+    /**
+     * Starting from the provided table index, a set of entries are returned with a maximum size of <code>size</code>
+     * @param tableIndex initial table index.
+     * @param size maximum entry set size.
+     * @return {@link CacheEntryIterationResult} which wraps entries and last tableIndex.
+     */
+    CacheEntryIterationResult fetchEntries(int tableIndex, int size);
 
     /**
      * Invokes an {@link EntryProcessor} against the {@link javax.cache.Cache.Entry} specified by

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryIteratorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheEntryIteratorOperation.java
@@ -17,33 +17,31 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
-import com.hazelcast.cache.impl.CacheKeyIterationResult;
+import com.hazelcast.cache.impl.CacheEntryIterationResult;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.ReadonlyOperation;
-
 import java.io.IOException;
 
 /**
  * <p>Provides iterator functionality for ICache.</p>
  * <p>
- * Initializes and grabs a number of keys defined by <code>size</code> parameter from the
+ * Initializes and grabs a number of entries defined by <code>size</code> parameter from the
  * {@link com.hazelcast.cache.impl.ICacheRecordStore} with the last table index.
  * </p>
- * @see com.hazelcast.cache.impl.ICacheRecordStore#fetchKeys(int, int)
+ *
+ * @see com.hazelcast.cache.impl.ICacheRecordStore#fetchEntries(int, int) (int, int)
  */
-public class CacheKeyIteratorOperation
-        extends AbstractCacheOperation
-        implements ReadonlyOperation {
+public class CacheEntryIteratorOperation extends AbstractCacheOperation implements ReadonlyOperation {
 
     private int tableIndex;
     private int size;
 
-    public CacheKeyIteratorOperation() {
+    public CacheEntryIteratorOperation() {
     }
 
-    public CacheKeyIteratorOperation(String name, int tableIndex, int size) {
+    public CacheEntryIteratorOperation(String name, int tableIndex, int size) {
         super(name, new HeapData());
         this.tableIndex = tableIndex;
         this.size = size;
@@ -51,13 +49,13 @@ public class CacheKeyIteratorOperation
 
     @Override
     public int getId() {
-        return CacheDataSerializerHook.KEY_ITERATOR;
+        return CacheDataSerializerHook.ENTRY_ITERATOR;
     }
 
     @Override
     public void run()
             throws Exception {
-        final CacheKeyIterationResult iterator = this.cache.fetchKeys(tableIndex, size);
+        final CacheEntryIterationResult iterator = this.cache.fetchEntries(tableIndex, size);
         response = iterator;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -18,16 +18,18 @@ package com.hazelcast.cache.impl.record;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.impl.CacheContext;
-import com.hazelcast.cache.impl.CacheKeyIteratorResult;
+import com.hazelcast.cache.impl.CacheEntryIterationResult;
+import com.hazelcast.cache.impl.CacheKeyIterationResult;
 import com.hazelcast.internal.eviction.Evictable;
 import com.hazelcast.internal.eviction.EvictionCandidate;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
-
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class CacheRecordHashMap
         extends SampleableConcurrentHashMap<Data, CacheRecord>
@@ -170,15 +172,28 @@ public class CacheRecordHashMap
     }
 
     @Override
-    public CacheKeyIteratorResult fetchNext(int nextTableIndex, int size) {
-        List<Data> keys = new ArrayList<Data>();
-        int tableIndex = fetch(nextTableIndex, size, keys);
-        return new CacheKeyIteratorResult(keys, tableIndex);
+    public CacheKeyIterationResult fetchKeys(int nextTableIndex, int size) {
+        List<Data> keys = new ArrayList<Data>(size);
+        int tableIndex = fetchKeys(nextTableIndex, size, keys);
+        return new CacheKeyIterationResult(keys, tableIndex);
+    }
+
+    @Override
+    public CacheEntryIterationResult fetchEntries(int nextTableIndex, int size) {
+        List<Map.Entry<Data, CacheRecord>> entries = new ArrayList<Map.Entry<Data, CacheRecord>>(size);
+        int newTableIndex = fetchEntries(nextTableIndex, size, entries);
+        List<Map.Entry<Data, Data>> entriesData = new ArrayList<Map.Entry<Data, Data>>(entries.size());
+        for (Map.Entry<Data, CacheRecord> entry : entries) {
+            CacheRecord record = entry.getValue();
+            Data dataValue = serializationService.toData(record.getValue());
+            entriesData.add(new AbstractMap.SimpleEntry<Data, Data>(entry.getKey(), dataValue));
+        }
+        return new CacheEntryIterationResult(entriesData, newTableIndex);
     }
 
     @Override
     public <C extends EvictionCandidate<Data, CacheRecord>> int evict(Iterable<C> evictionCandidates,
-            EvictionListener<Data, CacheRecord> evictionListener) {
+                                                                      EvictionListener<Data, CacheRecord> evictionListener) {
         if (evictionCandidates == null) {
             return 0;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordMap.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.cache.impl.record;
 
-import com.hazelcast.cache.impl.CacheKeyIteratorResult;
+import com.hazelcast.cache.impl.CacheEntryIterationResult;
+import com.hazelcast.cache.impl.CacheKeyIterationResult;
 import com.hazelcast.internal.eviction.EvictableStore;
 import com.hazelcast.nio.serialization.Data;
-
 import java.util.Map;
 
 /**
@@ -43,9 +43,18 @@ public interface CacheRecordMap<K extends Data, V extends CacheRecord>
      * Fetches keys in bulk as specified <tt>size</tt> at most.
      *
      * @param nextTableIndex starting point for fetching
-     * @param size maximum bulk size to fetch the keys
-     * @return the {@link CacheKeyIteratorResult} instance contains fetched keys
+     * @param size           maximum bulk size to fetch the keys
+     * @return the {@link CacheKeyIterationResult} instance contains fetched keys
      */
-    CacheKeyIteratorResult fetchNext(int nextTableIndex, int size);
+    CacheKeyIterationResult fetchKeys(int nextTableIndex, int size);
+
+    /**
+     * Fetches entries in bulk as specified <tt>size</tt> at most.
+     *
+     * @param nextTableIndex starting point for fetching
+     * @param size           maximum bulk size to fetch the entries
+     * @return the {@link CacheEntryIterationResult} instance contains fetched keys
+     */
+    CacheEntryIterationResult fetchEntries(int nextTableIndex, int size);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -320,6 +320,12 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
                 return new com.hazelcast.client.impl.protocol.task.cache.CacheSizeMessageTask(clientMessage, node, connection);
             }
         };
+        factories[com.hazelcast.client.impl.protocol.codec.CacheIterateEntriesCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new com.hazelcast.client.impl.protocol.task.cache.CacheIterateEntriesMessageTask(clientMessage, node, connection);
+            }
+        };
+
 //endregion
 //region ----------  REGISTRATION FOR com.hazelcast.client.impl.protocol.task.mapreduce
         factories[com.hazelcast.client.impl.protocol.codec.MapReduceJobProcessInformationCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
@@ -1444,6 +1450,16 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         factories[com.hazelcast.client.impl.protocol.codec.MapKeySetCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new com.hazelcast.client.impl.protocol.task.map.MapKeySetMessageTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.MapFetchKeysCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new com.hazelcast.client.impl.protocol.task.map.MapFetchKeysMessageTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.MapFetchEntriesCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new com.hazelcast.client.impl.protocol.task.map.MapFetchEntriesMessageTask(clientMessage, node, connection);
             }
         };
 //endregion

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateEntriesMessageTask.java
@@ -16,48 +16,48 @@
 
 package com.hazelcast.client.impl.protocol.task.cache;
 
-import com.hazelcast.cache.impl.CacheKeyIterationResult;
+import com.hazelcast.cache.impl.CacheEntryIterationResult;
 import com.hazelcast.cache.impl.CacheOperationProvider;
-import com.hazelcast.cache.impl.operation.CacheKeyIteratorOperation;
+import com.hazelcast.cache.impl.operation.CacheEntryIteratorOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.codec.CacheIterateCodec;
+import com.hazelcast.client.impl.protocol.codec.CacheIterateEntriesCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
-
 import java.util.Collections;
+import java.util.Map;
 
 /**
- * This client request  specifically calls {@link CacheKeyIteratorOperation} on the server side.
+ * This client request  specifically calls {@link CacheEntryIteratorOperation} on the server side.
  *
- * @see CacheKeyIteratorOperation
+ * @see CacheEntryIteratorOperation
  */
-public class CacheIterateMessageTask
-        extends AbstractCacheMessageTask<CacheIterateCodec.RequestParameters> {
+public class CacheIterateEntriesMessageTask
+        extends AbstractCacheMessageTask<CacheIterateEntriesCodec.RequestParameters> {
 
-    public CacheIterateMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+    public CacheIterateEntriesMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
     protected Operation prepareOperation() {
         CacheOperationProvider operationProvider = getOperationProvider(parameters.name);
-        return operationProvider.createKeyIteratorOperation(parameters.tableIndex, parameters.batch);
+        return operationProvider.createEntryIteratorOperation(parameters.tableIndex, parameters.batch);
     }
 
     @Override
-    protected CacheIterateCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return CacheIterateCodec.decodeRequest(clientMessage);
+    protected CacheIterateEntriesCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return CacheIterateEntriesCodec.decodeRequest(clientMessage);
     }
 
     @Override
     protected ClientMessage encodeResponse(Object response) {
         if (response == null) {
-            return CacheIterateCodec.encodeResponse(0, Collections.<Data>emptyList());
+            return CacheIterateEntriesCodec.encodeResponse(0, Collections.<Map.Entry<Data, Data>>emptyList());
         }
-        CacheKeyIterationResult keyIteratorResult = (CacheKeyIterationResult) response;
-        return CacheIterateCodec.encodeResponse(keyIteratorResult.getTableIndex(), keyIteratorResult.getKeys());
+        CacheEntryIterationResult iteratorResult = (CacheEntryIterationResult) response;
+        return CacheIterateEntriesCodec.encodeResponse(iteratorResult.getTableIndex(), iteratorResult.getEntries());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.map;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapFetchEntriesCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
+import com.hazelcast.map.impl.operation.MapOperationProvider;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.Operation;
+import java.security.Permission;
+import java.util.Collections;
+import java.util.Map;
+
+public class MapFetchEntriesMessageTask extends AbstractMapPartitionMessageTask<MapFetchEntriesCodec.RequestParameters> {
+    public MapFetchEntriesMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
+        return operationProvider.createFetchEntriesOperation(parameters.name, parameters.tableIndex, parameters.batch);
+    }
+
+    @Override
+    protected MapFetchEntriesCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return MapFetchEntriesCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        if (response == null) {
+            return MapFetchEntriesCodec.encodeResponse(0, Collections.<Map.Entry<Data, Data>>emptyList());
+        }
+        MapEntriesWithCursor mapEntriesWithCursor = (MapEntriesWithCursor) response;
+        return MapFetchEntriesCodec.encodeResponse(mapEntriesWithCursor.getNextTableIndexToReadFrom(),
+                mapEntriesWithCursor.getEntries());
+    }
+
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return null;
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "iterator";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[0];
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchKeysMessageTask.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.map;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapFetchKeysCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
+import com.hazelcast.map.impl.operation.MapOperationProvider;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.Operation;
+import java.security.Permission;
+import java.util.Collections;
+
+public class MapFetchKeysMessageTask extends AbstractMapPartitionMessageTask<MapFetchKeysCodec.RequestParameters> {
+    public MapFetchKeysMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
+        return operationProvider.createFetchKeysOperation(parameters.name, parameters.tableIndex, parameters.batch);
+    }
+
+    @Override
+    protected MapFetchKeysCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return MapFetchKeysCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        if (response == null) {
+            return MapFetchKeysCodec.encodeResponse(0, Collections.<Data>emptyList());
+        }
+        MapKeysWithCursor mapKeysWithCursor = (MapKeysWithCursor) response;
+        return MapFetchKeysCodec.encodeResponse(mapKeysWithCursor.getNextTableIndexToReadFrom(), mapKeysWithCursor.getKeys());
+    }
+
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return null;
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "iterator";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[0];
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -19,6 +19,8 @@ package com.hazelcast.map.impl;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
+import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
 import com.hazelcast.map.impl.operation.ContainsKeyOperation;
 import com.hazelcast.map.impl.operation.EvictBackupOperation;
 import com.hazelcast.map.impl.operation.GetOperation;
@@ -54,8 +56,10 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int EVICT_BACKUP = 11;
     public static final int CONTAINS_KEY = 12;
     public static final int PUT_ALL_PER_MEMBER = 13;
+    public static final int KEYS_WITH_CURSOR = 14;
+    public static final int ENTRIES_WITH_CURSOR = 15;
 
-    private static final int LEN = PUT_ALL_PER_MEMBER + 1;
+    private static final int LEN = ENTRIES_WITH_CURSOR + 1;
 
     @Override
     public int getFactoryId() {
@@ -134,6 +138,16 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[PUT_ALL_PER_MEMBER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new PutAllPerMemberOperation();
+            }
+        };
+        constructors[KEYS_WITH_CURSOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapKeysWithCursor();
+            }
+        };
+        constructors[ENTRIES_WITH_CURSOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapEntriesWithCursor();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractMapPartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractMapPartitionIterator.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.iterator;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.map.impl.LazyMapEntry;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+public abstract class AbstractMapPartitionIterator<K, V> implements Iterator<Map.Entry<K, V>> {
+
+    protected IMap<K, V> map;
+    protected final int fetchSize;
+    protected final int partitionId;
+    protected boolean prefetchValues;
+
+    /**
+     * The table is segment table of hash map, which is an array that stores the actual records.
+     * This field is used to mark where the latest entry is read.
+     * <p>
+     * The iteration will start from highest index available to the table.
+     * It will be converted to array size on the server side.
+     */
+    protected int lastTableIndex = Integer.MAX_VALUE;
+
+    protected int index;
+    protected int currentIndex = -1;
+
+    protected List result;
+
+    public AbstractMapPartitionIterator(IMap<K, V> map, int fetchSize, int partitionId, boolean prefetchValues) {
+        this.map = map;
+        this.fetchSize = fetchSize;
+        this.partitionId = partitionId;
+        this.prefetchValues = prefetchValues;
+    }
+
+    public boolean hasNext() {
+        return (result != null && index < result.size()) || advance();
+    }
+
+    public Map.Entry<K, V> next() {
+        while (hasNext()) {
+            currentIndex = index;
+            index++;
+            final Data keyData = getKey(currentIndex);
+            final Object value = getValue(currentIndex, keyData);
+            if (value != null) {
+                return new LazyMapEntry(keyData, value, (InternalSerializationService) getSerializationService());
+            }
+        }
+        throw new NoSuchElementException();
+    }
+
+    public void remove() {
+        if (result == null || currentIndex < 0) {
+            throw new IllegalStateException("Iterator.next() must be called before remove()!");
+        }
+        Data keyData = getKey(currentIndex);
+        map.remove(keyData);
+        currentIndex = -1;
+    }
+
+
+    protected boolean advance() {
+        if (lastTableIndex < 0) {
+            lastTableIndex = Integer.MAX_VALUE;
+            return false;
+        }
+        result = fetch();
+        if (result != null && result.size() > 0) {
+            index = 0;
+            return true;
+        }
+        return false;
+    }
+
+    private Data getKey(int index) {
+        if (result != null) {
+            if (prefetchValues) {
+                Map.Entry<Data, Data> entry = (Map.Entry<Data, Data>) result.get(index);
+                return entry.getKey();
+            } else {
+                return (Data) result.get(index);
+            }
+        }
+        return null;
+    }
+
+    private Object getValue(int index, Data keyData) {
+        if (result != null) {
+            if (prefetchValues) {
+                Map.Entry<Data, Data> entry = (Map.Entry<Data, Data>) result.get(index);
+                return entry.getValue();
+            } else {
+                return map.get(keyData);
+            }
+        }
+        return null;
+    }
+
+    protected void setLastTableIndex(List response, int lastTableIndex) {
+        if (response != null && response.size() > 0) {
+            this.lastTableIndex = lastTableIndex;
+        }
+    }
+
+    protected abstract List fetch();
+
+    protected abstract SerializationService getSerializationService();
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapEntriesWithCursor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.iterator;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class MapEntriesWithCursor implements IdentifiedDataSerializable {
+
+    private List<Map.Entry<Data, Data>> entries;
+    private int nextTableIndexToReadFrom;
+
+    public MapEntriesWithCursor() {
+    }
+
+    public MapEntriesWithCursor(List<Map.Entry<Data, Data>> entries, int nextTableIndexToReadFrom) {
+        this.entries = entries;
+        this.nextTableIndexToReadFrom = nextTableIndexToReadFrom;
+    }
+
+    public List<Map.Entry<Data, Data>> getEntries() {
+        return entries;
+    }
+
+    public int getNextTableIndexToReadFrom() {
+        return nextTableIndexToReadFrom;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.ENTRIES_WITH_CURSOR;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(nextTableIndexToReadFrom);
+        int size = entries.size();
+        out.writeInt(size);
+        for (Map.Entry<Data, Data> entry : entries) {
+            out.writeData(entry.getKey());
+            out.writeData(entry.getValue());
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        nextTableIndexToReadFrom = in.readInt();
+        int size = in.readInt();
+        entries = new ArrayList<Map.Entry<Data, Data>>(size);
+        for (int i = 0; i < size; i++) {
+            Data key = in.readData();
+            Data value = in.readData();
+            entries.add(new AbstractMap.SimpleEntry<Data, Data>(key, value));
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapKeysWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapKeysWithCursor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.iterator;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MapKeysWithCursor implements IdentifiedDataSerializable {
+
+    private int nextTableIndexToReadFrom;
+    private List<Data> keys;
+
+    public MapKeysWithCursor() {
+    }
+
+    public MapKeysWithCursor(List<Data> keys, int nextTableIndexToReadFrom) {
+        this.keys = keys;
+        this.nextTableIndexToReadFrom = nextTableIndexToReadFrom;
+    }
+
+    public int getNextTableIndexToReadFrom() {
+        return nextTableIndexToReadFrom;
+    }
+
+    public List<Data> getKeys() {
+        return keys;
+    }
+
+    public int getCount() {
+        return keys != null ? keys.size() : 0;
+    }
+
+    public Data getKey(int index) {
+        return keys != null ? keys.get(index) : null;
+    }
+
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(nextTableIndexToReadFrom);
+        int size = keys.size();
+        out.writeInt(size);
+        for (Data o : keys) {
+            out.writeData(o);
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        nextTableIndexToReadFrom = in.readInt();
+        int size = in.readInt();
+        keys = new ArrayList<Data>(size);
+        for (int i = 0; i < size; i++) {
+            Data data = in.readData();
+            keys.add(data);
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.KEYS_WITH_CURSOR;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapPartitionIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapPartitionIterator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.iterator;
+
+import com.hazelcast.map.impl.operation.MapOperation;
+import com.hazelcast.map.impl.operation.MapOperationProvider;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.serialization.SerializationService;
+import java.util.List;
+
+public class MapPartitionIterator<K, V> extends AbstractMapPartitionIterator<K, V> {
+
+    private final MapProxyImpl<K, V> mapProxy;
+
+    public MapPartitionIterator(MapProxyImpl<K, V> mapProxy, int fetchSize, int partitionId, boolean prefetchValues) {
+        super(mapProxy, fetchSize, partitionId, prefetchValues);
+        this.mapProxy = mapProxy;
+        advance();
+    }
+
+    protected List fetch() {
+        String name = mapProxy.getName();
+        String serviceName = mapProxy.getServiceName();
+        MapOperationProvider operationProvider = mapProxy.getOperationProvider();
+        OperationService operationService = mapProxy.getOperationService();
+        if (prefetchValues) {
+            MapOperation operation = operationProvider.createFetchEntriesOperation(name, lastTableIndex, fetchSize);
+            InternalCompletableFuture<MapEntriesWithCursor> future = operationService
+                    .invokeOnPartition(serviceName, operation, partitionId);
+            MapEntriesWithCursor mapEntriesWithCursor = future.join();
+            setLastTableIndex(mapEntriesWithCursor.getEntries(), mapEntriesWithCursor.getNextTableIndexToReadFrom());
+            return mapEntriesWithCursor.getEntries();
+        } else {
+            MapOperation operation = operationProvider.createFetchKeysOperation(name, lastTableIndex, fetchSize);
+            InternalCompletableFuture<MapKeysWithCursor> future = operationService
+                    .invokeOnPartition(serviceName, operation, partitionId);
+            MapKeysWithCursor mapKeysWithCursor = future.join();
+            setLastTableIndex(mapKeysWithCursor.getKeys(), mapKeysWithCursor.getNextTableIndexToReadFrom());
+            return mapKeysWithCursor.getKeys();
+        }
+    }
+
+    @Override
+    protected SerializationService getSerializationService() {
+        return mapProxy.getNodeEngine().getSerializationService();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -233,4 +233,15 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     public MapOperation createPutFromLoadAllOperation(String name, List<Data> keyValueSequence) {
         return new PutFromLoadAllOperation(name, keyValueSequence);
     }
+
+    @Override
+    public MapOperation createFetchKeysOperation(String name, int lastTableIndex, int fetchSize) {
+        return new MapFetchKeysOperation(name, lastTableIndex, fetchSize);
+    }
+
+    @Override
+    public MapOperation createFetchEntriesOperation(String name, int lastTableIndex, int fetchSize) {
+        return new MapFetchEntriesOperation(name, lastTableIndex, fetchSize);
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.ReadonlyOperation;
+import java.io.IOException;
+
+public class MapFetchEntriesOperation extends MapOperation implements ReadonlyOperation {
+
+    private int fetchSize;
+    private int lastTableIndex;
+    private transient MapEntriesWithCursor response;
+
+    public MapFetchEntriesOperation() {
+    }
+
+    public MapFetchEntriesOperation(String name, int lastTableIndex, int fetchSize) {
+        super(name);
+        this.lastTableIndex = lastTableIndex;
+        this.fetchSize = fetchSize;
+    }
+
+    @Override
+    public void run() throws Exception {
+        response = recordStore.fetchEntries(lastTableIndex, fetchSize);
+    }
+
+    @Override
+    public Object getResponse() {
+        return response;
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        fetchSize = in.readInt();
+        lastTableIndex = in.readInt();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(fetchSize);
+        out.writeInt(lastTableIndex);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchKeysOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchKeysOperation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.ReadonlyOperation;
+import java.io.IOException;
+
+public class MapFetchKeysOperation extends MapOperation implements ReadonlyOperation {
+
+    private int fetchSize;
+    private int lastTableIndex;
+    private transient MapKeysWithCursor response;
+
+    public MapFetchKeysOperation() {
+    }
+
+    public MapFetchKeysOperation(String name, int lastTableIndex, int fetchSize) {
+        super(name);
+        this.lastTableIndex = lastTableIndex;
+        this.fetchSize = fetchSize;
+    }
+
+    @Override
+    public void run() throws Exception {
+        response = recordStore.fetchKeys(lastTableIndex, fetchSize);
+    }
+
+    @Override
+    public Object getResponse() {
+        return response;
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        fetchSize = in.readInt();
+        lastTableIndex = in.readInt();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(fetchSize);
+        out.writeInt(lastTableIndex);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -23,7 +23,6 @@ import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.OperationFactory;
-
 import java.util.List;
 import java.util.Set;
 
@@ -91,6 +90,9 @@ public interface MapOperationProvider {
 
     MapOperation createLoadMapOperation(String name, boolean replaceExistingValues);
 
+    MapOperation createFetchKeysOperation(String name, int lastTableIndex, int fetchSize);
+
+    MapOperation createFetchEntriesOperation(String name, int lastTableIndex, int fetchSize);
 
     OperationFactory createPartitionWideEntryOperationFactory(String name, EntryProcessor entryProcessor);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -23,7 +23,6 @@ import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.OperationFactory;
-
 import java.util.List;
 import java.util.Set;
 
@@ -233,4 +232,15 @@ public abstract class MapOperationProviderDelegator implements MapOperationProvi
     public MapOperation createLoadMapOperation(String name, boolean replaceExistingValues) {
         return getDelegate().createLoadMapOperation(name, replaceExistingValues);
     }
+
+    @Override
+    public MapOperation createFetchKeysOperation(String name, int lastTableIndex, int fetchSize) {
+        return getDelegate().createFetchKeysOperation(name, lastTableIndex, fetchSize);
+    }
+
+    @Override
+    public MapOperation createFetchEntriesOperation(String name, int lastTableIndex, int fetchSize) {
+        return getDelegate().createFetchEntriesOperation(name, lastTableIndex, fetchSize);
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -28,6 +28,7 @@ import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.SimpleEntryView;
+import com.hazelcast.map.impl.iterator.MapPartitionIterator;
 import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultCollection;
@@ -55,10 +56,10 @@ import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.MapUtil;
 import com.hazelcast.util.executor.DelegatingFuture;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -788,6 +789,10 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
             throw (Throwable) returnObj;
         }
         return returnObj;
+    }
+
+    public Iterator<Entry<K, V>> iterator(int fetchSize, int partitionId, boolean prefetchValues) {
+        return new MapPartitionIterator<K, V>(this, fetchSize, partitionId, prefetchValues);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -1195,6 +1195,10 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         this.operationProvider = operationProvider;
     }
 
+    public MapOperationProvider getOperationProvider() {
+        return operationProvider;
+    }
+
     public int getTotalBackupCount() {
         return mapConfig.getBackupCount() + mapConfig.getAsyncBackupCount();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -28,6 +28,8 @@ import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapKeyLoader;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
+import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.mapstore.writebehind.WriteBehindQueue;
 import com.hazelcast.map.impl.mapstore.writebehind.WriteBehindStore;
@@ -44,7 +46,6 @@ import com.hazelcast.util.Clock;
 import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.FutureUtil;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -257,6 +258,16 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public Iterator<Record> iterator(long now, boolean backup) {
         return new ReadOnlyRecordIterator(storage.values(), now, backup);
+    }
+
+    @Override
+    public MapKeysWithCursor fetchKeys(int tableIndex, int size) {
+        return storage.fetchKeys(tableIndex, size);
+    }
+
+    @Override
+    public MapEntriesWithCursor fetchEntries(int tableIndex, int size) {
+        return storage.fetchEntries(tableIndex, size, serializationService);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -21,6 +21,8 @@ import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
+import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
 import com.hazelcast.map.impl.mapstore.MapDataStore;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordFactory;
@@ -187,6 +189,20 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
      * @return read only iterator for map values.
      */
     Iterator<Record> iterator(long now, boolean backup);
+
+    /**
+     * Fetches specified number of keys from provided tableIndex.
+     *
+     * @return {@link MapKeysWithCursor} which is a holder for keys and next index to read from.
+     */
+    MapKeysWithCursor fetchKeys(int tableIndex, int size);
+
+    /**
+     * Fetches specified number of entries from provided tableIndex.
+     *
+     * @return {@link MapEntriesWithCursor} which is a holder for entries and next index to read from.
+     */
+    MapEntriesWithCursor fetchEntries(int tableIndex, int size);
 
     /**
      * Iterates over record store entries but first waits map store to load.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
@@ -18,6 +18,9 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.map.impl.SizeEstimator;
 
+import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
+import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
+import com.hazelcast.spi.serialization.SerializationService;
 import java.util.Collection;
 
 /**
@@ -62,4 +65,9 @@ public interface Storage<K, R> {
      * @return sampled entries.
      */
     Iterable<LazyEntryViewFromRecord> getRandomSamples(int sampleCount);
+
+    MapKeysWithCursor fetchKeys(int tableIndex, int size);
+
+    MapEntriesWithCursor fetchEntries(int tableIndex, int size, SerializationService serializationService);
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -18,13 +18,18 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.map.impl.SizeEstimator;
+import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
+import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
 import com.hazelcast.map.impl.record.AbstractRecord;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
-
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 import static com.hazelcast.map.impl.SizeEstimators.createMapSizeEstimator;
 
@@ -146,6 +151,26 @@ public class StorageImpl<R extends Record> implements Storage<Data, R> {
     @Override
     public Iterable<LazyEntryViewFromRecord> getRandomSamples(int sampleCount) {
         return records.getRandomSamples(sampleCount);
+    }
+
+    @Override
+    public MapKeysWithCursor fetchKeys(int tableIndex, int size) {
+        List<Data> keys = new ArrayList<Data>(size);
+        int newTableIndex = records.fetchKeys(tableIndex, size, keys);
+        return new MapKeysWithCursor(keys, newTableIndex);
+    }
+
+    @Override
+    public MapEntriesWithCursor fetchEntries(int tableIndex, int size, SerializationService serializationService) {
+        List<Map.Entry<Data, R>> entries = new ArrayList<Map.Entry<Data, R>>(size);
+        int newTableIndex = records.fetchEntries(tableIndex, size, entries);
+        List<Map.Entry<Data, Data>> entriesData = new ArrayList<Map.Entry<Data, Data>>(entries.size());
+        for (Map.Entry<Data, R> entry : entries) {
+            R record = entry.getValue();
+            Data dataValue = serializationService.toData(record.getValue());
+            entriesData.add(new AbstractMap.SimpleEntry<Data, Data>(entry.getKey(), dataValue));
+        }
+        return new MapEntriesWithCursor(entriesData, newTableIndex);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
@@ -17,12 +17,12 @@
 package com.hazelcast.util;
 
 import com.hazelcast.internal.eviction.Expirable;
-import com.hazelcast.nio.serialization.Data;
-
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Random;
 
@@ -53,7 +53,7 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
     }
 
     public SampleableConcurrentHashMap(int initialCapacity, float loadFactor, int concurrencyLevel,
-            ReferenceType keyType, ReferenceType valueType, EnumSet<Option> options) {
+                                       ReferenceType keyType, ReferenceType valueType, EnumSet<Option> options) {
         super(initialCapacity, loadFactor, concurrencyLevel, keyType, valueType, options);
     }
 
@@ -67,7 +67,7 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
      *
      * @return the next index (checkpoint) for later fetches
      */
-    public int fetch(int tableIndex, int size, List<Data> keys) {
+    public int fetchKeys(int tableIndex, int size, List<K> keys) {
         final long now = Clock.currentTimeMillis();
         final Segment<K, V> segment = segments[0];
         final HashEntry<K, V>[] currentTable = segment.table;
@@ -84,7 +84,44 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
                 if (nextEntry.key() != null) {
                     final V value = nextEntry.value();
                     if (isValidForFetching(value, now)) {
-                        keys.add((Data) nextEntry.key());
+                        keys.add(nextEntry.key());
+                        counter++;
+                    }
+                }
+                nextEntry = nextEntry.next;
+            }
+        }
+        return nextTableIndex;
+    }
+
+    /**
+     * Fetches entries from given <code>tableIndex</code> as <code>size</code>
+     * and puts them into <code>entries</code> list.
+     *
+     * @param tableIndex           Index (checkpoint) for starting point of fetch operation
+     * @param size                 Count of how many entries will be fetched
+     * @param entries              List that fetched entries will be put into
+     * @return the next index (checkpoint) for later fetches
+     */
+    public int fetchEntries(int tableIndex, int size, List<Map.Entry<K, V>> entries) {
+        final long now = Clock.currentTimeMillis();
+        final Segment<K, V> segment = segments[0];
+        final HashEntry<K, V>[] currentTable = segment.table;
+        int nextTableIndex;
+        if (tableIndex >= 0 && tableIndex < segment.table.length) {
+            nextTableIndex = tableIndex;
+        } else {
+            nextTableIndex = currentTable.length - 1;
+        }
+        int counter = 0;
+        while (nextTableIndex >= 0 && counter < size) {
+            HashEntry<K, V> nextEntry = currentTable[nextTableIndex--];
+            while (nextEntry != null) {
+                if (nextEntry.key() != null) {
+                    final V value = nextEntry.value();
+                    if (isValidForFetching(value, now)) {
+                        K key = nextEntry.key();
+                        entries.add(new AbstractMap.SimpleEntry<K, V>(key, value));
                         counter++;
                     }
                 }
@@ -156,7 +193,6 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
      * Gets and returns samples as <code>sampleCount</code>.
      *
      * @param sampleCount Count of samples
-     *
      * @return the sampled {@link SamplingEntry} list
      */
     public <E extends SamplingEntry> Iterable<E> getRandomSamples(int sampleCount) {

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -657,7 +657,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
             while (remaining > 0 && nextTableIndex > 0) {
                 int size = (remaining > fetchSize ? fetchSize : remaining);
                 List<Data> keys = new ArrayList<Data>(size);
-                nextTableIndex = map.fetch(nextTableIndex, size, keys);
+                nextTableIndex = map.fetchKeys(nextTableIndex, size, keys);
                 remaining -= keys.size();
                 total += keys.size();
             }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorMigrationTest.java
@@ -1,0 +1,121 @@
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.CacheProxy;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CachePartitionIteratorMigrationTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public boolean prefetchValues;
+
+    @Parameterized.Parameters(name = "prefetchValues:{0}")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
+    }
+
+    protected CachingProvider createCachingProvider(HazelcastInstance server) {
+        return HazelcastServerCachingProvider.createCachingProvider(server);
+    }
+
+    private <K, V> CacheProxy<K, V> getCacheProxy(CachingProvider cachingProvider) {
+        String cacheName = randomString();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+        CacheConfig<K, V> config = new CacheConfig<K, V>();
+        config.getEvictionConfig().setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT).setSize(10000000);
+        return (CacheProxy<K, V>) cacheManager.createCache(cacheName, config);
+
+    }
+
+    @Test
+    public void testIterator_DoesNotReturn_DuplicateEntry_When_Rehashing_Happens() throws Exception {
+        HazelcastInstance instance = createHazelcastInstance();
+        CacheProxy<String, String> proxy = getCacheProxy(createCachingProvider(instance));
+        HashSet<String> readKeys = new HashSet<String>();
+
+        String value = "initialValue";
+        putValuesToPartition(instance, proxy, value, 1, 100);
+        Iterator<Cache.Entry<String, String>> iterator = proxy.iterator(10, 1, prefetchValues);
+        assertUniques(readKeys, iterator, 50);
+        // force rehashing
+        putValuesToPartition(instance, proxy, randomString(), 1, 150);
+        assertUniques(readKeys, iterator);
+
+    }
+
+    @Test
+    public void testIterator_DoesNotReturn_DuplicateEntry_When_Migration_Happens() throws Exception {
+        Config config = new Config();
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "2");
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        CacheProxy<String, String> proxy = getCacheProxy(createCachingProvider(instance));
+
+        HashSet<String> readKeysP1 = new HashSet<String>();
+        HashSet<String> readKeysP2 = new HashSet<String>();
+
+        String value = "value";
+        putValuesToPartition(instance, proxy, value, 0, 100);
+        putValuesToPartition(instance, proxy, value, 1, 100);
+
+        Iterator<Cache.Entry<String, String>> iteratorP1 = proxy.iterator(10, 0, prefetchValues);
+        Iterator<Cache.Entry<String, String>> iteratorP2 = proxy.iterator(10, 1, prefetchValues);
+        assertUniques(readKeysP1, iteratorP1, 50);
+        assertUniques(readKeysP2, iteratorP2, 50);
+        // force migration
+        factory.newHazelcastInstance(config);
+        // force rehashing
+        putValuesToPartition(instance, proxy, randomString(), 0, 150);
+        putValuesToPartition(instance, proxy, randomString(), 1, 150);
+        assertUniques(readKeysP1, iteratorP1);
+        assertUniques(readKeysP2, iteratorP2);
+    }
+
+    private void assertUniques(HashSet<String> readKeys, Iterator<Cache.Entry<String, String>> iterator) {
+        while (iterator.hasNext()) {
+            Cache.Entry<String, String> entry = iterator.next();
+            boolean unique = readKeys.add(entry.getKey());
+            Assert.assertTrue(unique);
+        }
+    }
+
+    private void assertUniques(HashSet<String> readKeys, Iterator<Cache.Entry<String, String>> iterator, int numberOfItemsToRead) {
+        int count = 0;
+        while (iterator.hasNext() && count++ < numberOfItemsToRead) {
+            Cache.Entry<String, String> entry = iterator.next();
+            boolean unique = readKeys.add(entry.getKey());
+            Assert.assertTrue(unique);
+        }
+    }
+
+    private void putValuesToPartition(HazelcastInstance instance, CacheProxy<String, String> proxy, String value, int partitionId, int count) {
+        for (int i = 0; i < count; i++) {
+            String key = generateKeyForPartition(instance, partitionId);
+            proxy.put(key, value);
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionIteratorTest.java
@@ -1,0 +1,110 @@
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.CacheProxy;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Arrays;
+import java.util.Iterator;
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CachePartitionIteratorTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public boolean prefetchValues;
+
+    @Parameterized.Parameters(name = "prefetchValues:{0}")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
+    }
+
+    private CachingProvider cachingProvider;
+    private HazelcastInstance server;
+
+    @Before
+    public void init() {
+        server = createHazelcastInstance();
+        cachingProvider = createCachingProvider();
+    }
+
+    protected CachingProvider createCachingProvider() {
+        return HazelcastServerCachingProvider.createCachingProvider(server);
+    }
+
+    private <K, V> CacheProxy<K, V> getCacheProxy() {
+        String cacheName = randomString();
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+        CacheConfig<K, V> config = new CacheConfig<K, V>();
+        config.getEvictionConfig().setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT).setSize(10000000);
+        return (CacheProxy<K, V>) cacheManager.createCache(cacheName, config);
+
+    }
+
+    @Test
+    public void testIterator_HasNext_Returns_False_On_EmptyPartition() throws Exception {
+        CacheProxy<Integer, Integer> cache = getCacheProxy();
+        Iterator<Cache.Entry<Integer, Integer>> iterator = cache.iterator(10, 1, prefetchValues);
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testIterator_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
+        CacheProxy<String, String> cache = getCacheProxy();
+
+        String key = generateKeyForPartition(server, 1);
+        String value = randomString();
+        cache.put(key, value);
+
+        Iterator<Cache.Entry<String, String>> iterator = cache.iterator(10, 1, prefetchValues);
+        assertTrue(iterator.hasNext());
+    }
+
+    @Test
+    public void testIterator_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
+        CacheProxy<String, String> cache = getCacheProxy();
+
+        String key = generateKeyForPartition(server, 1);
+        String value = randomString();
+        cache.put(key, value);
+
+        Iterator<Cache.Entry<String, String>> iterator = cache.iterator(10, 1, prefetchValues);
+        Cache.Entry entry = iterator.next();
+        assertEquals(value, entry.getValue());
+    }
+
+    @Test
+    public void testIterator_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
+        CacheProxy<String, String> cache = getCacheProxy();
+        String value = randomString();
+        int count = 1000;
+        for (int i = 0; i < count; i++) {
+            String key = generateKeyForPartition(server, 42);
+            cache.put(key, value);
+        }
+        Iterator<Cache.Entry<String, String>> iterator = cache.iterator(10, 42, prefetchValues);
+        for (int i = 0; i < count; i++) {
+            Cache.Entry entry = iterator.next();
+            assertEquals(value, entry.getValue());
+
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPartitionIteratorTest.java
@@ -1,0 +1,161 @@
+package com.hazelcast.map;
+
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapPartitionIteratorTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public boolean prefetchValues;
+
+    @Parameterized.Parameters(name = "prefetchValues:{0}")
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
+    }
+
+    @Test
+    public void testIterator_HasNext_Returns_False_On_EmptyPartition() throws Exception {
+        HazelcastInstance instance = createHazelcastInstance();
+        MapProxyImpl<Object, Object> proxy = (MapProxyImpl<Object, Object>) instance.getMap(randomMapName());
+
+        Iterator<Map.Entry<Object, Object>> iterator = proxy.iterator(10, 1, prefetchValues);
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testIterator_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
+        HazelcastInstance instance = createHazelcastInstance();
+        MapProxyImpl<Object, Object> proxy = (MapProxyImpl<Object, Object>) instance.getMap(randomMapName());
+
+        String key = generateKeyForPartition(instance, 1);
+        String value = randomString();
+        proxy.put(key, value);
+
+        Iterator<Map.Entry<Object, Object>> iterator = proxy.iterator(10, 1, prefetchValues);
+        assertTrue(iterator.hasNext());
+    }
+
+    @Test
+    public void testIterator_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
+        HazelcastInstance instance = createHazelcastInstance();
+        MapProxyImpl<Object, Object> proxy = (MapProxyImpl<Object, Object>) instance.getMap(randomMapName());
+
+        String key = generateKeyForPartition(instance, 1);
+        String value = randomString();
+        proxy.put(key, value);
+
+        Iterator<Map.Entry<Object, Object>> iterator = proxy.iterator(10, 1, prefetchValues);
+        Map.Entry entry = iterator.next();
+        assertEquals(value, entry.getValue());
+    }
+
+    @Test
+    public void testIterator_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
+        HazelcastInstance instance = createHazelcastInstance();
+        MapProxyImpl<Object, Object> proxy = (MapProxyImpl<Object, Object>) instance.getMap(randomMapName());
+
+        String value = randomString();
+        for (int i = 0; i < 100; i++) {
+            String key = generateKeyForPartition(instance, 1);
+            proxy.put(key, value);
+        }
+        Iterator<Map.Entry<Object, Object>> iterator = proxy.iterator(10, 1, prefetchValues);
+        for (int i = 0; i < 100; i++) {
+            Map.Entry entry = iterator.next();
+            assertEquals(value, entry.getValue());
+
+        }
+    }
+
+    @Test
+    public void testIterator_DoesNotReturn_DuplicateEntry_When_Rehashing_Happens() throws Exception {
+        HazelcastInstance instance = createHazelcastInstance();
+        MapProxyImpl<String, String> proxy = (MapProxyImpl<String, String>) instance.<String, String>getMap(randomMapName());
+        HashSet<String> readKeys = new HashSet<String>();
+
+        String value = "initialValue";
+        putValuesToPartition(instance, proxy, value, 1, 100);
+        Iterator<Map.Entry<String, String>> iterator = proxy.iterator(10, 1, prefetchValues);
+        assertUniques(readKeys, iterator, 50);
+        // force rehashing
+        putValuesToPartition(instance, proxy, randomString(), 1, 150);
+        assertUniques(readKeys, iterator);
+
+    }
+
+    @Test
+    public void testIterator_DoesNotReturn_DuplicateEntry_When_Migration_Happens() throws Exception {
+        Config config = new Config();
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "2");
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        MapProxyImpl<String, String> proxy = (MapProxyImpl<String, String>) instance.<String, String>getMap(randomMapName());
+
+        HashSet<String> readKeysP1 = new HashSet<String>();
+        HashSet<String> readKeysP2 = new HashSet<String>();
+
+        String value = "value";
+        putValuesToPartition(instance, proxy, value, 0, 100);
+        putValuesToPartition(instance, proxy, value, 1, 100);
+
+        Iterator<Map.Entry<String, String>> iteratorP1 = proxy.iterator(10, 0, prefetchValues);
+        Iterator<Map.Entry<String, String>> iteratorP2 = proxy.iterator(10, 1, prefetchValues);
+        assertUniques(readKeysP1, iteratorP1, 50);
+        assertUniques(readKeysP2, iteratorP2, 50);
+        // force migration
+        factory.newHazelcastInstance(config);
+        // force rehashing
+        putValuesToPartition(instance, proxy, randomString(), 0, 150);
+        putValuesToPartition(instance, proxy, randomString(), 1, 150);
+        assertUniques(readKeysP1, iteratorP1);
+        assertUniques(readKeysP2, iteratorP2);
+    }
+
+    private void assertUniques(HashSet<String> readKeys, Iterator<Map.Entry<String, String>> iterator) {
+        while (iterator.hasNext()) {
+            Map.Entry<String, String> entry = iterator.next();
+            boolean unique = readKeys.add(entry.getKey());
+            Assert.assertTrue(unique);
+        }
+    }
+
+    private void assertUniques(HashSet<String> readKeys, Iterator<Map.Entry<String, String>> iterator, int numberOfItemsToRead) {
+        int count = 0;
+        while (iterator.hasNext() && count++ < numberOfItemsToRead) {
+            Map.Entry<String, String> entry = iterator.next();
+            boolean unique = readKeys.add(entry.getKey());
+            Assert.assertTrue(unique);
+        }
+    }
+
+    private void putValuesToPartition(HazelcastInstance instance, MapProxyImpl<String, String> proxy, String value, int partitionId, int count) {
+        for (int i = 0; i < count; i++) {
+            String key = generateKeyForPartition(instance, partitionId);
+            proxy.put(key, value);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.0.0</client.protocol.version>
+        <client.protocol.version>1.1.0</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
This PR introduces capability of iterating entries of the single partition to the Cache and Map.

Motivation behind this change to provide ability to load map & cache entries to Apache Spark, partition by partition. 

The iterator will retrieve the keys in batch, and based on the configuration it will either pull values one by one for more recent values or pull the values in batch for better performance.

Client protocol counterpart: https://github.com/hazelcast/hazelcast-client-protocol/pull/7
Enterprise counterpart : https://github.com/hazelcast/hazelcast-enterprise/pull/901
