### PR TITLE
IMap.putAll() performance improvements for ReplicatedMap

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapEntrySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapEntrySetMessageTask.java
@@ -50,7 +50,7 @@ public class ReplicatedMapEntrySetMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         ReplicatedMapEntries entries = (ReplicatedMapEntries) response;
-        return ReplicatedMapEntrySetCodec.encodeResponse(entries.getEntries());
+        return ReplicatedMapEntrySetCodec.encodeResponse(entries.entries());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableHook.java
@@ -32,8 +32,7 @@ import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.REPLICAT
  * This class registers all Portable serializers that are needed for communication between nodes and clients
  */
 //CHECKSTYLE:OFF
-public class ReplicatedMapPortableHook
-        implements PortableHook {
+public class ReplicatedMapPortableHook implements PortableHook {
 
     public static final int F_ID = FactoryIdHelper.getFactoryId(REPLICATED_PORTABLE_FACTORY, REPLICATED_PORTABLE_FACTORY_ID);
 
@@ -55,12 +54,6 @@ public class ReplicatedMapPortableHook
             final ConstructorFunction<Integer, Portable> constructors[] = new ConstructorFunction[LENGTH];
 
             {
-                constructors[VALUES_COLLECTION] = new ConstructorFunction<Integer, Portable>() {
-                    @Override
-                    public Portable createNew(Integer arg) {
-                        return new ReplicatedMapValueCollection();
-                    }
-                };
                 constructors[MAP_ENTRIES] = new ConstructorFunction<Integer, Portable>() {
                     @Override
                     public Portable createNew(Integer arg) {
@@ -73,13 +66,18 @@ public class ReplicatedMapPortableHook
                         return new ReplicatedMapKeys();
                     }
                 };
+                constructors[VALUES_COLLECTION] = new ConstructorFunction<Integer, Portable>() {
+                    @Override
+                    public Portable createNew(Integer arg) {
+                        return new ReplicatedMapValueCollection();
+                    }
+                };
                 constructors[MAP_ENTRY_EVENT] = new ConstructorFunction<Integer, Portable>() {
                     @Override
                     public Portable createNew(Integer arg) {
                         return new ReplicatedMapPortableEntryEvent();
                     }
                 };
-
             }
 
             public Portable create(int classId) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
@@ -32,17 +32,16 @@ import com.hazelcast.spi.partition.IPartitionService;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Map;
 
 /**
  * Puts a set of records to the replicated map.
  */
 public class PutAllOperation extends AbstractOperation implements IdentifiedDataSerializable {
+
     private String name;
     private ReplicatedMapEntries entries;
-    private transient ReplicatedMapService service;
-    private transient ReplicatedRecordStore store;
 
+    @SuppressWarnings("unused")
     public PutAllOperation() {
     }
 
@@ -53,29 +52,24 @@ public class PutAllOperation extends AbstractOperation implements IdentifiedData
 
     @Override
     public void run() throws Exception {
+        ReplicatedMapService service = getService();
+        ReplicatedRecordStore store = service.getReplicatedRecordStore(name, true, getPartitionId());
         int partitionId = getPartitionId();
-        service = getService();
-        store = service.getReplicatedRecordStore(name, true, getPartitionId());
         IPartitionService partitionService = getNodeEngine().getPartitionService();
-        for (Map.Entry<Data, Data> entry : entries.getEntries()) {
-            Data key = entry.getKey();
-            Data value = entry.getValue();
+        ReplicatedMapEventPublishingService eventPublishingService = service.getEventPublishingService();
+        for (int i = 0; i < entries.size(); i++) {
+            Data key = entries.getKey(i);
+            Data value = entries.getValue(i);
             if (partitionId != partitionService.getPartitionId(key)) {
                 continue;
             }
             Object putResult = store.put(key, value);
             Data oldValue = getNodeEngine().toData(putResult);
-            publishEvent(key, value, oldValue);
+            eventPublishingService.fireEntryListenerEvent(key, oldValue, value, name, getCallerAddress());
             VersionResponsePair response = new VersionResponsePair(putResult, store.getVersion());
             publishReplicationMessage(key, value, response);
         }
     }
-
-    private void publishEvent(Data key, Data value, Data oldValue) {
-        ReplicatedMapEventPublishingService eventPublishingService = service.getEventPublishingService();
-        eventPublishingService.fireEntryListenerEvent(key, oldValue, value, name, getCallerAddress());
-    }
-
 
     private void publishReplicationMessage(Data key, Data value, VersionResponsePair response) {
         OperationService operationService = getNodeEngine().getOperationService();
@@ -85,14 +79,13 @@ public class PutAllOperation extends AbstractOperation implements IdentifiedData
             if (address.equals(getNodeEngine().getThisAddress())) {
                 continue;
             }
-            ReplicateUpdateOperation updateOperation = new ReplicateUpdateOperation(name, key, value, 0, response,
-                    false, getCallerAddress());
+            ReplicateUpdateOperation updateOperation = new ReplicateUpdateOperation(name, key, value, 0, response, false,
+                    getCallerAddress());
             updateOperation.setPartitionId(getPartitionId());
             updateOperation.setValidateTarget(false);
             operationService.invokeOnTarget(getServiceName(), updateOperation, address);
         }
     }
-
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperationFactory.java
@@ -31,8 +31,9 @@ import java.io.IOException;
 public class PutAllOperationFactory implements OperationFactory {
 
     private String name;
-    private ReplicatedMapEntries entries = new ReplicatedMapEntries();
+    private ReplicatedMapEntries entries;
 
+    @SuppressWarnings("unused")
     public PutAllOperationFactory() {
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
@@ -41,7 +41,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -60,7 +59,6 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(value = {QuickTest.class, ParallelTest.class})
 public class ReplicatedMapTest extends ReplicatedMapBaseTest {
-
 
     @Test
     public void testEmptyMapIsEmpty() throws Exception {
@@ -577,7 +575,6 @@ public class ReplicatedMapTest extends ReplicatedMapBaseTest {
         testSize(buildConfig(InMemoryFormat.BINARY));
     }
 
-
     private void testSize(Config config) throws Exception {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
 
@@ -657,7 +654,6 @@ public class ReplicatedMapTest extends ReplicatedMapBaseTest {
         ReplicatedMap<Integer, Integer> map = node.getReplicatedMap("default");
         assertFalse(map.containsValue(1));
     }
-
 
     @Test
     public void testContainsValueObject() throws Exception {
@@ -1032,7 +1028,6 @@ public class ReplicatedMapTest extends ReplicatedMapBaseTest {
         assertTrue(map.size() == 0);
     }
 
-
     @Test
     public void testDestroy() throws Exception {
         HazelcastInstance instance = createHazelcastInstance();
@@ -1043,7 +1038,6 @@ public class ReplicatedMapTest extends ReplicatedMapBaseTest {
         assertEquals(0, objects.size());
     }
 
-
     /**
      * This method works around a bug in IBM's Java 6 J9 JVM where ArrayList's copy constructor
      * is somehow broken and either includes nulls as values or copies not all elements.
@@ -1053,9 +1047,8 @@ public class ReplicatedMapTest extends ReplicatedMapBaseTest {
      */
     private <V> List<V> copyToList(Collection<V> collection) {
         List<V> values = new ArrayList<V>();
-        Iterator<V> iterator = collection.iterator();
-        while (iterator.hasNext()) {
-            values.add(iterator.next());
+        for (V value : collection) {
+            values.add(value);
         }
         return values;
     }
@@ -1064,8 +1057,7 @@ public class ReplicatedMapTest extends ReplicatedMapBaseTest {
 
         @Override
         public int compare(Integer o1, Integer o2) {
-            return o1 == o2 ? 0 : o1 > o2 ? -1 : 1;
+            return o1.equals(o2) ? 0 : o1 > o2 ? -1 : 1;
         }
     }
-
 }


### PR DESCRIPTION
* Reduced litter in `ReplicatedMapEntries`

This is a partly adoption of https://github.com/hazelcast/hazelcast/pull/8023 for the `ReplicatedMap`.

I made a very short benchmark with 100 entries per user map for this PR:
```
50000 operations done in   44142 ms (+844 ms) (1184.83 ops/s) (844 µs per op)
(1132.71 ops/s avg) (882 µs per op avg)...

vs.

50000 operations done in   39366 ms (+807 ms) (1239.16 ops/s) (807 µs per op)
(1270.13 ops/s avg) (787 µs per op avg)...
```