### PR TITLE
Remove unnecessary serialization/deserialization of 'name' field from QueryOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -67,7 +67,6 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(name);
         out.writeObject(predicate);
         out.writeByte(iterationType.getId());
     }
@@ -75,7 +74,6 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        name = in.readUTF();
         predicate = in.readObject();
         iterationType = IterationType.getById(in.readByte());
     }


### PR DESCRIPTION
'name' field's serialization/deserialization is already handled by [AbstractNamedOperation](https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractNamedOperation.java#L43)