### PR TITLE
Change access modifier of variable in MapServiceContextImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -105,7 +105,7 @@ class MapServiceContextImpl implements MapServiceContext {
     protected EventService eventService;
     protected MapOperationProviders operationProviders;
 
-    private final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
+    protected final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
 
     MapServiceContextImpl(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;


### PR DESCRIPTION
Required for subclasses to be able to properly access map containers, as updated in #8105 