### PR TITLE
[BACKPORT] Interpret duration time `0` as eternal for cache entry expiration

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -857,4 +857,18 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         }
         return false;
     }
+
+    @Test
+    public void entryShouldNotBeExpiredWhenDurationIsZero() {
+        Duration duration = new Duration(TimeUnit.MILLISECONDS, 0);
+        CacheConfig<Integer, String> cacheConfig = new CacheConfig<Integer, String>();
+        cacheConfig.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(duration));
+
+        Cache<Integer, String> cache = createCache(cacheConfig);
+        cache.put(1, "value");
+
+        sleepAtLeastMillis(1);
+
+        assertNotNull(cache.get(1));
+    }
 }


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/8206