### PR TITLE
[BACKPORT] MorphingPortableReader should check for existence of ClassDefinition for UTF_ARRAY types

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/MorphingPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/MorphingPortableReader.java
@@ -42,6 +42,7 @@ import static com.hazelcast.nio.serialization.FieldType.PORTABLE;
 import static com.hazelcast.nio.serialization.FieldType.PORTABLE_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.SHORT_ARRAY;
 import static com.hazelcast.nio.serialization.FieldType.UTF;
+import static com.hazelcast.nio.serialization.FieldType.UTF_ARRAY;
 
 /**
  * Enables reading from a portable byte stream if the portableVersion from the classDefinition is different than
@@ -279,6 +280,16 @@ public class MorphingPortableReader extends DefaultPortableReader {
         }
         validateTypeCompatibility(fd, SHORT_ARRAY);
         return super.readShortArray(fieldName);
+    }
+
+    @Override
+    public String[] readUTFArray(String fieldName) throws IOException {
+        FieldDefinition fd = cd.getField(fieldName);
+        if (fd == null) {
+            return null;
+        }
+        validateTypeCompatibility(fd, UTF_ARRAY);
+        return super.readUTFArray(fieldName);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/MorphingPortableReaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/MorphingPortableReaderTest.java
@@ -257,6 +257,11 @@ public class MorphingPortableReaderTest {
     }
 
     @Test
+    public void testReadUTFArray() throws Exception {
+        assertNull(reader.readUTFArray("NO SUCH FIELD"));
+    }
+
+    @Test
     public void testReadPortable() throws Exception {
         assertNull(reader.readPortable("NO SUCH FIELD"));
     }


### PR DESCRIPTION
MorphingPortableReader should check for existence of ClassDefinition for UTF_ARRAY types