### PR TITLE
Fixes and improvements for Hazelcast instance related classes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -25,7 +25,6 @@ import com.hazelcast.core.OutOfMemoryHandler;
 
 import java.util.Collection;
 
-
 /**
  * The HazelcastClient is comparable to the {@link com.hazelcast.core.Hazelcast} class and provides the ability
  * the create and manage Hazelcast clients. Hazelcast clients are {@link HazelcastInstance} implementations, so
@@ -48,6 +47,7 @@ import java.util.Collection;
  * When the connected cluster member dies, client will automatically switch to another live member.
  */
 public final class HazelcastClient {
+
     private static final HazelcastClientFactory HAZELCAST_CLIENT_FACTORY = new HazelcastClientFactory() {
         @Override
         public HazelcastClientInstanceImpl createHazelcastInstanceClient(ClientConfig config,

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientFactory.java
@@ -21,9 +21,10 @@ import com.hazelcast.client.impl.ClientConnectionManagerFactory;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 
-/***
- * This is interface which provides capability for Hazelcast client factories customization;
- * It's implementation can be changed and passed to the HazelcastClientManager's constructors;
+/**
+ * Provides the capability for the customization of Hazelcast client factories.
+ *
+ * Its implementation can be changed and passed to the constructors of {@link HazelcastClientManager}.
  *
  * @param <T> type of {@link HazelcastClientInstanceImpl}
  * @param <V> type of {@link HazelcastClientProxy}
@@ -32,8 +33,8 @@ import com.hazelcast.client.impl.HazelcastClientProxy;
 public interface HazelcastClientFactory<T extends HazelcastClientInstanceImpl,
         V extends HazelcastClientProxy,
         C extends ClientConfig> {
-    T createHazelcastInstanceClient(C config,
-                                    ClientConnectionManagerFactory hazelcastClientFactory);
+
+    T createHazelcastInstanceClient(C config, ClientConnectionManagerFactory hazelcastClientFactory);
 
     V createProxy(T client);
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientManager.java
@@ -34,14 +34,15 @@ import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-/***
- * This is central manager for all Hazelcast clients in JVM;
- * All creation functionality will be stored here and particular;
- * instance of Client will delegate here;
+/**
+ * Central manager for all Hazelcast clients of the JVM.
+ *
+ * All creation functionality will be stored here and a particular instance of a client will delegate here.
  */
 public final class HazelcastClientManager {
-    /***
-     * Instance for clientManagers
+
+    /**
+     * Global instance of {@link HazelcastClientManager}
      */
     public static final HazelcastClientManager INSTANCE = new HazelcastClientManager();
 
@@ -65,7 +66,7 @@ public final class HazelcastClientManager {
             config = new XmlClientConfigBuilder().build();
         }
 
-        final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         HazelcastClientProxy proxy;
         try {
             Thread.currentThread().setContextClassLoader(HazelcastClient.class.getClassLoader());
@@ -83,7 +84,7 @@ public final class HazelcastClientManager {
                         + "' already exists!");
             }
         } finally {
-            Thread.currentThread().setContextClassLoader(tccl);
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
         }
         return proxy;
     }
@@ -113,7 +114,6 @@ public final class HazelcastClientManager {
         OutOfMemoryErrorDispatcher.clearClients();
         INSTANCE.clients.clear();
     }
-
 
     public static void shutdown(HazelcastInstance instance) {
         if (instance instanceof HazelcastClientProxy) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/HazelcastFactoryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/HazelcastFactoryTest.java
@@ -23,6 +23,8 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -33,16 +35,26 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelTest.class})
 public class HazelcastFactoryTest extends HazelcastTestSupport {
 
+    private TestHazelcastFactory instanceFactory;
+
+    @Before
+    public void setUp() {
+        instanceFactory = new TestHazelcastFactory();
+    }
+
+    @After
+    public void tearDown() {
+        instanceFactory.terminateAll();
+    }
+
     @Test
     public void testTestHazelcastInstanceFactory_smartClients() {
-        TestHazelcastFactory instanceFactory = new TestHazelcastFactory();
         final HazelcastInstance instance1 = instanceFactory.newHazelcastInstance();
         final HazelcastInstance instance2 = instanceFactory.newHazelcastInstance();
         final HazelcastInstance instance3 = instanceFactory.newHazelcastInstance();
 
         final HazelcastInstance client1 = instanceFactory.newHazelcastClient();
         final HazelcastInstance client2 = instanceFactory.newHazelcastClient();
-
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -59,18 +71,10 @@ public class HazelcastFactoryTest extends HazelcastTestSupport {
                 assertEquals(2, instance3.getClientService().getConnectedClients().size());
             }
         });
-
-        instanceFactory.terminateAll();
-
-    }
-
-    private void touchRandomNode(HazelcastInstance hazelcastInstance) {
-        hazelcastInstance.getMap(randomString()).get(randomString());
     }
 
     @Test
     public void testTestHazelcastInstanceFactory_dummyClients() {
-        TestHazelcastFactory instanceFactory = new TestHazelcastFactory();
         final HazelcastInstance instance1 = instanceFactory.newHazelcastInstance();
         final HazelcastInstance instance2 = instanceFactory.newHazelcastInstance();
         final HazelcastInstance instance3 = instanceFactory.newHazelcastInstance();
@@ -79,7 +83,6 @@ public class HazelcastFactoryTest extends HazelcastTestSupport {
         clientConfig.getNetworkConfig().setSmartRouting(false);
         final HazelcastInstance client1 = instanceFactory.newHazelcastClient(clientConfig);
         final HazelcastInstance client2 = instanceFactory.newHazelcastClient(clientConfig);
-
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -110,8 +113,9 @@ public class HazelcastFactoryTest extends HazelcastTestSupport {
                 assertEquals(3, client1.getCluster().getMembers().size());
             }
         });
+    }
 
-        instanceFactory.terminateAll();
-
+    private static void touchRandomNode(HazelcastInstance hazelcastInstance) {
+        hazelcastInstance.getMap(randomString()).get(randomString());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -47,18 +47,21 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-@SuppressWarnings("SynchronizationOnStaticField")
+/**
+ * Central manager for all Hazelcast members of the JVM.
+ *
+ * All creation functionality will be stored here and a particular instance of a member will delegate here.
+ */
 @PrivateApi
+@SuppressWarnings("SynchronizationOnStaticField")
 public final class HazelcastInstanceFactory {
-    /***
-     * Instance for clientManagers
-     */
-    private static final AtomicInteger FACTORY_ID_GEN = new AtomicInteger();
+
     private static final int ADDITIONAL_SLEEP_SECONDS_FOR_NON_FIRST_MEMBERS = 4;
+
+    private static final AtomicInteger FACTORY_ID_GEN = new AtomicInteger();
     private static final ConcurrentMap<String, InstanceFuture> INSTANCE_MAP = new ConcurrentHashMap<String, InstanceFuture>(5);
 
     private HazelcastInstanceFactory() {
-
     }
 
     public static Set<HazelcastInstance> getAllHazelcastInstances() {
@@ -221,7 +224,7 @@ public final class HazelcastInstanceFactory {
             boolean firstMember = isFirstMember(node);
             long initialWaitSeconds = node.getProperties().getSeconds(GroupProperty.INITIAL_WAIT_SECONDS);
             if (initialWaitSeconds > 0) {
-                hazelcastInstance.logger.info(format("Waiting %d ms before completing HazelcastInstance startup...",
+                hazelcastInstance.logger.info(format("Waiting %d seconds before completing HazelcastInstance startup...",
                         initialWaitSeconds));
                 try {
                     SECONDS.sleep(initialWaitSeconds);
@@ -339,6 +342,7 @@ public final class HazelcastInstanceFactory {
     }
 
     private static class InstanceFuture {
+
         private volatile HazelcastInstanceProxy hz;
         private volatile Throwable throwable;
 


### PR DESCRIPTION
* Ensured proper shutdown of instances in `HazelcastInstanceManagerTest` and `HazelcastFactoryTest`.
* Fixed time unit from ms to seconds in log message in `HazelcastInstanceManager`.
* Improved JavaDoc of `HazelcastClientFactory`, `HazelcastClientManager` and `HazelcastInstanceManager`.

In my local runs the `HazelcastInstanceManagerTest` seemed to keep alive zombie instances, even after the test properly finished (was green after it's normal test time). Those instances spammed my logs even an hour later with messages like:
```
20:27:21,083 TRACE |test_NewInstance_failedAfterStartAndBeforeShutdown| - [OperationService] hz.520873f0-cb63-4254-a2d2-85a12f96357c.InvocationMonitorThread - [127.0.0.1]:5000 [dev] [3.7-SNAPSHOT] Scanning all invocations
20:27:22,083 TRACE |test_NewInstance_failedAfterStartAndBeforeShutdown| - [OperationService] hz.520873f0-cb63-4254-a2d2-85a12f96357c.InvocationMonitorThread - [127.0.0.1]:5000 [dev] [3.7-SNAPSHOT] Scanning all invocations
20:27:23,083 TRACE |test_NewInstance_failedAfterStartAndBeforeShutdown| - [OperationService] hz.520873f0-cb63-4254-a2d2-85a12f96357c.InvocationMonitorThread - [127.0.0.1]:5000 [dev] [3.7-SNAPSHOT] Scanning all invocations
20:27:23,084 TRACE |test_NewInstance_failedAfterStartAndBeforeShutdown| - [OperationService] hz.520873f0-cb63-4254-a2d2-85a12f96357c.InvocationMonitorThread - [127.0.0.1]:5000 [dev] [3.7-SNAPSHOT] Broadcasting operation heartbeats to: 1 members
```
It may or may not be related that the whole test suite was deadly slow (even my mouse stuttered sometimes) and random tests were stuck forever (e.g. `TopicTest` in one run and one of the `Long2...` tests in another run). I'm also not sure that all created instances are using the mocked network connection, so maybe they directly interfered with the stuck tests.

To prevent this I ensured that all instances are properly shutdown after the test completes. I also removed the `ParallelTest` category to let this test run in isolation. After those changes the testsuite completed without interruptions in a feasible time.

The other changes are small JavaDoc improvements and a log message fix.