### PR TITLE
Check migration tasks counter only

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/InternalPartitionServiceImpl.java
@@ -1462,10 +1462,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             return true;
         }
 
-        int queueSize = migrationQueue.size();
-        if (queueSize != 0) {
+        final boolean hasMigrationTasks = migrationQueue.hasMigrationTasks();
+        if (hasMigrationTasks) {
             if (logger.isLoggable(level)) {
-                logger.log(level, "Waiting for cluster migration tasks: " + queueSize);
+                logger.log(level, "Waiting for cluster migration tasks");
             }
             return true;
         }


### PR DESCRIPTION
The migration queue has both repartioning and migration tasks. During gracefully shutdown, it should only concern migration tasks, and ignore repartioning task. Otherwise, any failure in migration task will create new repartiong task which become a infinite loop until timeout.

for issue: https://github.com/hazelcast/hazelcast/issues/8217