### PR TITLE
[FORWARD PORT] Avoid deadlocks on new member joining cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoaderLifecycleSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoaderLifecycleSupport.java
@@ -32,7 +32,19 @@ public interface MapLoaderLifecycleSupport {
      * HazelcastInstance. Implementation can
      * initialize required resources for the implementing
      * mapLoader, such as reading a config file and/or creating a
-     * database connection.
+     * database connection. References to maps, other than the one on which
+     * this {@code MapLoader} is configured, can be obtained from the
+     * {@code hazelcastInstance} in this method's implementation.
+     * <p>
+     * On members joining a cluster, this method is executed during finalization
+     * of the join operation, therefore care should be taken to adhere to the
+     * rules for {@link com.hazelcast.spi.PostJoinAwareService#getPostJoinOperation()}.
+     * If the implementation executes operations which may wait on locks or otherwise
+     * block (e.g. waiting for network operations), this may result in a time-out and
+     * obstruct the new member from joining the cluster. If blocking operations are
+     * required for initialization of the {@code MapLoader}, consider deferring them
+     * with a lazy initialization scheme.
+     * </p>
      *
      * @param hazelcastInstance HazelcastInstance of this mapLoader.
      * @param properties        Properties set for this mapStore. see MapStoreConfig

--- a/hazelcast/src/main/java/com/hazelcast/core/MapStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapStoreFactory.java
@@ -25,6 +25,9 @@ public interface MapStoreFactory<K, V> {
 
     /**
      * Produces a MapLoader or a MapStore for the given map name and properties.
+     * This method will be executed as part of a Hazelcast member's post-join operations,
+     * therefore it needs to adhere to the rules for post join operations, as described in
+     * {@link com.hazelcast.spi.PostJoinAwareService#getPostJoinOperation()}.
      *
      * @param mapName    name of the distributed map that the produced MapLoader or MapStore will serve
      * @param properties the properties of the MapStoreConfig for the produced MapLoader or MapStore

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.core.PartitioningStrategy;
@@ -32,7 +31,6 @@ import com.hazelcast.map.impl.record.DataRecordFactory;
 import com.hazelcast.map.impl.record.ObjectRecordFactory;
 import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.map.merge.MapMergePolicy;
-import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -41,7 +39,6 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ConstructorFunction;
-import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.RuntimeMemoryInfoAccessor;
 import com.hazelcast.wan.WanReplicationPublisher;
 import com.hazelcast.wan.WanReplicationService;
@@ -156,20 +153,8 @@ public class MapContainer {
     }
 
     private PartitioningStrategy createPartitioningStrategy() {
-        PartitioningStrategy strategy = null;
-        PartitioningStrategyConfig partitioningStrategyConfig = mapConfig.getPartitioningStrategyConfig();
-        if (partitioningStrategyConfig != null) {
-            strategy = partitioningStrategyConfig.getPartitioningStrategy();
-            if (strategy == null && partitioningStrategyConfig.getPartitioningStrategyClass() != null) {
-                try {
-                    strategy = ClassLoaderUtil.newInstance(mapServiceContext.getNodeEngine().getConfigClassLoader(),
-                            partitioningStrategyConfig.getPartitioningStrategyClass());
-                } catch (Exception e) {
-                    throw ExceptionUtil.rethrow(e);
-                }
-            }
-        }
-        return strategy;
+        return PartitioningStrategyFactory.getPartitioningStrategy(mapServiceContext.getNodeEngine(),
+                mapConfig.getName(), mapConfig.getPartitioningStrategyConfig());
     }
 
     public Indexes getIndexes() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -49,9 +49,9 @@ class MapRemoteService implements RemoteService {
         if (mapConfig.isNearCacheEnabled()) {
             checkInMemoryFormat(mapConfig.getNearCacheConfig().getInMemoryFormat());
 
-            return new NearCachedMapProxyImpl(name, mapServiceContext.getService(), nodeEngine);
+            return new NearCachedMapProxyImpl(name, mapServiceContext.getService(), nodeEngine, mapConfig);
         } else {
-            return new MapProxyImpl(name, mapServiceContext.getService(), nodeEngine);
+            return new MapProxyImpl(name, mapServiceContext.getService(), nodeEngine, mapConfig);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
@@ -134,6 +135,8 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     LocalMapStatsProvider getLocalMapStatsProvider();
 
     MapOperationProvider getMapOperationProvider(String name);
+
+    MapOperationProvider getMapOperationProvider(MapConfig mapConfig);
 
     Extractors getExtractors(String mapName);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -53,6 +53,7 @@ import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.ContextMutexFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -103,6 +104,7 @@ class MapServiceContextImpl implements MapServiceContext {
     protected final MergePolicyProvider mergePolicyProvider;
     protected final MapQueryEngine mapQueryEngine;
     protected final QueryOptimizer queryOptimizer;
+    protected final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
     protected MapEventPublisher mapEventPublisher;
     protected MapService mapService;
     protected EventService eventService;
@@ -155,7 +157,7 @@ class MapServiceContextImpl implements MapServiceContext {
 
     @Override
     public MapContainer getMapContainer(String mapName) {
-        return ConcurrencyUtil.getOrPutSynchronized(mapContainers, mapName, mapContainers, mapConstructor);
+        return ConcurrencyUtil.getOrPutSynchronized(mapContainers, mapName, contextMutexFactory, mapConstructor);
     }
 
 
@@ -563,6 +565,11 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public MapOperationProvider getMapOperationProvider(String name) {
         return operationProviders.getOperationProvider(name);
+    }
+
+    @Override
+    public MapOperationProvider getMapOperationProvider(MapConfig mapConfig) {
+        return operationProviders.getOperationProvider(mapConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitioningStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitioningStrategyFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.config.PartitioningStrategyConfig;
+import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.nio.ClassLoaderUtil;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Factory for {@link PartitioningStrategy} instances.
+ */
+public final class PartitioningStrategyFactory {
+
+    private static final ConcurrentHashMap<String, PartitioningStrategy> CACHE =
+            new ConcurrentHashMap<String, PartitioningStrategy>();
+
+    private PartitioningStrategyFactory() {
+    }
+
+    /**
+     * Obtain a {@link PartitioningStrategy} for the given {@code NodeEngine} and {@code PartitioningStrategyConfig}. This method
+     * first attempts locating a {@link PartitioningStrategy} in {code config.getPartitioningStrategy()}. If this is {@code null},
+     * then looks up its internal cache of partitioning strategies; if one has already been created for the given
+     * {@code mapName}, it is returned, otherwise it is instantiated, cached and returned.
+     * @param nodeEngine    Hazelcast NodeEngine
+     * @param mapName       Map for which this partitioning strategy is being created
+     * @param config        the partitioning strategy configuration
+     * @return
+     */
+    public static PartitioningStrategy getPartitioningStrategy(NodeEngine nodeEngine, String mapName,
+                                                               PartitioningStrategyConfig config) {
+            PartitioningStrategy strategy = null;
+            if (config != null) {
+                strategy = config.getPartitioningStrategy();
+                if (strategy == null) {
+                    if (CACHE.containsKey(mapName)) {
+                        strategy = CACHE.get(mapName);
+                    } else if (config.getPartitioningStrategyClass() != null) {
+                        try {
+                            strategy = ClassLoaderUtil.newInstance(nodeEngine.getConfigClassLoader(),
+                                    config.getPartitioningStrategyClass());
+                            CACHE.put(mapName, strategy);
+                        } catch (Exception e) {
+                            throw ExceptionUtil.rethrow(e);
+                        }
+                    }
+                }
+            }
+            return strategy;
+    }
+
+    /**
+     * Remove the cached {@code PartitioningStrategy} from the internal cache, if it exists.
+     * @param mapName name of the map whose partitioning strategy will be removed from internal cache
+     */
+    public static void removePartitioningStrategyFromCache(String mapName) {
+        CACHE.remove(mapName);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviders.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviders.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapServiceContext;
 
@@ -45,5 +46,21 @@ public class MapOperationProviders {
     public MapOperationProvider getOperationProvider(String name) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(name);
         return mapContainer.isWanReplicationEnabled() ? wanAwareProvider : defaultProvider;
+    }
+
+    /**
+     * Returns a {@link MapOperationProvider} instance, depending on whether the provided {@code MapConfig} has a
+     * WAN replication policy configured or not.
+     *
+     * @param mapConfig the map configuration to query whether WAN replication is configured
+     * @return {@link DefaultMapOperationProvider} or {@link WANAwareOperationProvider} depending on the WAN replication
+     * config of the map configuration provided as parameter.
+     */
+    public MapOperationProvider getOperationProvider(MapConfig mapConfig) {
+        if (mapConfig.getWanReplicationRef() == null) {
+            return defaultProvider;
+        } else {
+            return wanAwareProvider;
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.proxy;
 
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
@@ -67,6 +68,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkPositive;
+import static com.hazelcast.util.Preconditions.checkTrue;
 import static com.hazelcast.util.Preconditions.isNotNull;
 import static java.util.Collections.emptyMap;
 
@@ -76,10 +78,11 @@ import static java.util.Collections.emptyMap;
  * @param <K> the key type of map.
  * @param <V> the value type of map.
  */
+@SuppressWarnings("checkstyle:classfanoutcomplexity")
 public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, InitializingObject {
 
-    public MapProxyImpl(String name, MapService mapService, NodeEngine nodeEngine) {
-        super(name, mapService, nodeEngine);
+    public MapProxyImpl(String name, MapService mapService, NodeEngine nodeEngine, MapConfig mapConfig) {
+        super(name, mapService, nodeEngine, mapConfig);
     }
 
     @Override
@@ -553,14 +556,14 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public void loadAll(boolean replaceExistingValues) {
-        checkNotNull(getMapStore(), "First you should configure a map store");
+        checkTrue(isMapStoreEnabled(), "First you should configure a map store");
 
         loadAllInternal(replaceExistingValues);
     }
 
     @Override
     public void loadAll(Set<K> keys, boolean replaceExistingValues) {
-        checkNotNull(getMapStore(), "First you should configure a map store");
+        checkTrue(isMapStoreEnabled(), "First you should configure a map store");
         checkNotNull(keys, "Parameter keys should not be null.");
 
         Iterable<Data> dataKeys = convertToData(keys);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.proxy;
 
 import com.hazelcast.cache.impl.nearcache.NearCache;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.map.EntryProcessor;
@@ -51,8 +52,8 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     protected NearCache<Data, Data> nearCache;
     protected boolean cacheLocalEntries;
 
-    public NearCachedMapProxyImpl(String name, MapService mapService, NodeEngine nodeEngine) {
-        super(name, mapService, nodeEngine);
+    public NearCachedMapProxyImpl(String name, MapService mapService, NodeEngine nodeEngine, MapConfig mapConfig) {
+        super(name, mapService, nodeEngine, mapConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/util/ContextMutexFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ContextMutexFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+
+import java.io.Closeable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class that provides reference-counted mutexes suitable for synchronization in the context of a supplied object.
+ * Context objects and their associated mutexes are stored in a {@code Map}. Client code is responsible to invoke
+ * {@link Mutex#close()} on the obtained {@code Mutex} after having synchronized on the mutex; failure to do so, will leave an
+ * entry residing in the internal {@code Map} which may have adverse effects on the ability to garbage collect the context object
+ * and the mutex. The returned {@link Mutex}es implement Closeable, so can be conveniently used in a try-with-resources statement.
+ * Typical usage would allow, for example, synchronizing access to a non-thread-safe {@code Map} on a per-key basis,
+ * to avoid blocking other threads who would perform updates on other entries of the {@code Map}.
+ * <pre>
+ *     class Test {
+ *
+ *         private static final ContextMutexFactory mutexFactory = new ContextMutexFactory();
+ *         private Map&lt;String, String&gt; mapToSync = new HashMap&lt;String, String&gt;();
+ *
+ *         public void test(String key, String value) {
+ *             // critical section
+ *             ContextMutexFactory.Mutex mutex = mutexFactory.mutexFor(key);
+ *             try {
+ *                 synchronized (mutex) {
+ *                      if (mapToSync.get(key) == null) {
+ *                          mapToSync.put(key, value);
+ *                      }
+ *                 }
+ *             }
+ *             finally {
+ *                 mutex.close();
+ *             }
+ *         }
+ *     }
+ * </pre>
+ *
+ */
+public final class ContextMutexFactory {
+    Map<Object, Mutex> mutexMap = new HashMap<Object, Mutex>();
+    // synchronizes access to mutexMap and Mutex.referenceCount
+    private Object mainMutex = new Object();
+
+    public Mutex mutexFor(Object mutexKey) {
+        Mutex mutex;
+        synchronized (mainMutex) {
+            mutex = mutexMap.get(mutexKey);
+            if (mutex == null) {
+                mutex = new Mutex(mutexKey);
+                mutexMap.put(mutexKey, mutex);
+            }
+            mutex.referenceCount++;
+        }
+        return mutex;
+    }
+
+    /**
+     * Reference counted mutex, which will remove itself from the mutexMap when it is no longer referenced.
+     */
+    public final class Mutex implements Closeable {
+        private final Object key;
+        private int referenceCount;
+
+        private Mutex(Object key) {
+            this.key = key;
+        }
+
+        @Override
+        public void close() {
+            synchronized (mainMutex) {
+                referenceCount--;
+                if (referenceCount == 0) {
+                    mutexMap.remove(key);
+                }
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.config;
 
 import com.hazelcast.config.helpers.DummyMapStore;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -688,7 +689,9 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
 
         Config config = buildConfig(xml);
         HazelcastInstance hz = createHazelcastInstance(config);
-        hz.getMap(mapName);
+        IMap map = hz.getMap(mapName);
+        // MapStore is not instantiated until the MapContainer is created lazily
+        map.put("sample", "data");
 
         MapConfig mapConfig = hz.getConfig().getMapConfig(mapName);
         MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapStatisticsAwareServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapStatisticsAwareServiceTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Test for MapStatisticsAwareService
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapStatisticsAwareServiceTest extends HazelcastTestSupport {
+
+    @Test
+    public void getStats() {
+        HazelcastInstance hz = createHazelcastInstance();
+        warmUpPartitions(hz);
+        // when one map exists
+        hz.getMap("map");
+        MapService mapService = getNodeEngineImpl(hz).getService(MapService.SERVICE_NAME);
+        Map<String, LocalMapStats> mapStats = mapService.getStats();
+
+        // then we obtain 1 local map stats instance
+        assertEquals(1, mapStats.size());
+        assertNotNull(mapStats.get("map"));
+
+        hz.shutdown();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/PartitioningStrategyFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/PartitioningStrategyFactoryTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.config.PartitioningStrategyConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+/**
+ *
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PartitioningStrategyFactoryTest extends HazelcastTestSupport {
+
+    @Test
+    public void getPartitioningStrategy_whenConfigNull()
+            throws Exception {
+        HazelcastInstance hz = createHazelcastInstance();
+        NodeEngine nodeEngine = getNodeEngineImpl(hz);
+        PartitioningStrategy partitioningStrategy = PartitioningStrategyFactory.getPartitioningStrategy(nodeEngine, "map", null);
+        assertNull(partitioningStrategy);
+    }
+
+    @Test
+    public void getPartitioningStrategy_whenPartitioningStrategyDefined()
+            throws Exception {
+        HazelcastInstance hz = createHazelcastInstance();
+        NodeEngine nodeEngine = getNodeEngineImpl(hz);
+        PartitioningStrategy configuredPartitioningStrategy = new StringPartitioningStrategy();
+        PartitioningStrategyConfig cfg = new PartitioningStrategyConfig(configuredPartitioningStrategy);
+        PartitioningStrategy partitioningStrategy = PartitioningStrategyFactory.getPartitioningStrategy(nodeEngine, "map", cfg);
+        assertSame(configuredPartitioningStrategy, partitioningStrategy);
+    }
+
+    @Test
+    public void getPartitioningStrategy_whenPartitioningStrategyClassDefined()
+            throws Exception {
+        HazelcastInstance hz = createHazelcastInstance();
+        NodeEngine nodeEngine = getNodeEngineImpl(hz);
+        PartitioningStrategyConfig cfg = new PartitioningStrategyConfig();
+        cfg.setPartitioningStrategyClass("com.hazelcast.partition.strategy.StringPartitioningStrategy");
+        PartitioningStrategy partitioningStrategy = PartitioningStrategyFactory.getPartitioningStrategy(nodeEngine, "map", cfg);
+        assertEquals(StringPartitioningStrategy.class, partitioningStrategy.getClass());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderLifecycleTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.mapstore;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapLoader;
 import com.hazelcast.core.MapLoaderLifecycleSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -53,7 +54,9 @@ public class MapLoaderLifecycleTest extends HazelcastTestSupport {
 
         HazelcastInstance hz = createHazelcastInstance(config);
 
-        hz.getMap("map");
+        IMap map = hz.getMap("map");
+        // MapStore creation is deferred, so trigger map store creation by putting some data in the map
+        map.put("a", "b");
 
         verify(loader).init(eq(hz), eq(new Properties()), eq("map"));
     }
@@ -63,7 +66,10 @@ public class MapLoaderLifecycleTest extends HazelcastTestSupport {
 
         HazelcastInstance hz = createHazelcastInstance(config);
 
-        hz.getMap("map");
+        IMap map = hz.getMap("map");
+        // MapStore creation is deferred, so trigger map store creation by putting some data in the map
+        map.put("a", "b");
+
         hz.shutdown();
 
         verify(loader).destroy();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.query.IndexAwarePredicate;
+import com.hazelcast.query.impl.ComparisonType;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.QueryContext;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verify that maps created on a member joining the cluster, do actually include index & interceptors
+ * as expected through execution of PostJoinMapOperation on the joining member.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PostJoinMapOperationTest extends HazelcastTestSupport {
+
+    public final AtomicInteger isIndexedInvoked = new AtomicInteger(0);
+
+    private static class Person implements Serializable {
+        private final int age;
+        private final String name;
+
+        public Person(String name, int age) {
+            this.age = age;
+            this.name = name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Person)) {
+                return false;
+            }
+
+            Person person = (Person) o;
+
+            if (age != person.age) {
+                return false;
+            }
+            return name != null ? name.equals(person.name) : person.name == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = age;
+            result = 31 * result + (name != null ? name.hashCode() : 0);
+            return result;
+        }
+    }
+
+    private static final Person RETURNED_FROM_INTERCEPTOR = new Person("THE_PERSON", 100);
+
+    public static class FixedReturnInterceptor implements MapInterceptor {
+
+        @Override
+        public Object interceptGet(Object value) {
+            return RETURNED_FROM_INTERCEPTOR;
+        }
+
+        @Override
+        public void afterGet(Object value) {
+
+        }
+
+        @Override
+        public Object interceptPut(Object oldValue, Object newValue) {
+            // allow put operations to proceed
+            return null;
+        }
+
+        @Override
+        public void afterPut(Object value) {
+
+        }
+
+        @Override
+        public Object interceptRemove(Object removedValue) {
+            return RETURNED_FROM_INTERCEPTOR;
+        }
+
+        @Override
+        public void afterRemove(Object value) {
+
+        }
+    }
+
+    // if it locates an index on Person.age, increments isIndexedInvoked
+    public class AgePredicate implements IndexAwarePredicate {
+        @Override
+        public Set<QueryableEntry> filter(QueryContext queryContext) {
+            Index ix = queryContext.getIndex("age");
+            if (ix != null) {
+                return ix.getSubRecords(ComparisonType.GREATER, 50);
+            }
+            else {
+                return null;
+            }
+        }
+
+        @Override
+        public boolean isIndexed(QueryContext queryContext) {
+            Index ix = queryContext.getIndex("age");
+            if (ix != null) {
+                isIndexedInvoked.incrementAndGet();
+                return true;
+            }
+            else {
+                return false;
+            }
+        }
+
+        @Override
+        public boolean apply(Map.Entry mapEntry) {
+            if (mapEntry.getValue() instanceof Person) {
+                return ((Person)mapEntry.getValue()).getAge() > 50;
+            }
+            else {
+                return false;
+            }
+        }
+    }
+
+    @Test
+    public void testPostJoinMapOperation_mapWithInterceptor() {
+        TestHazelcastInstanceFactory hzFactory = createHazelcastInstanceFactory(2);
+
+        HazelcastInstance hz1 = hzFactory.newHazelcastInstance();
+        IMap<String, Person> map = hz1.getMap("map");
+        map.put("foo", new Person("foo", 32));
+        map.put("bar", new Person("bar", 35));
+        map.addInterceptor(new FixedReturnInterceptor());
+
+        assertEquals(RETURNED_FROM_INTERCEPTOR, map.get("foo"));
+
+        // new member joins cluster
+        HazelcastInstance hz2 = hzFactory.newHazelcastInstance();
+        waitAllForSafeState(hz1, hz2);
+
+        IMap<String, Person> mapOnNode2 = hz2.getMap("map");
+        assertEquals(RETURNED_FROM_INTERCEPTOR, mapOnNode2.get("whatever"));
+
+        // put a value on node 2, then get it and verify it is the one returned by the interceptor
+        String keyOwnedByNode2 = generateKeyOwnedBy(hz2);
+        map.put(keyOwnedByNode2, new Person("not to be returned", 39));
+        assertEquals(RETURNED_FROM_INTERCEPTOR, map.get(keyOwnedByNode2));
+
+        hzFactory.terminateAll();
+    }
+
+    @Test
+    public void testPostJoinMapOperation_mapWithIndex() {
+        TestHazelcastInstanceFactory hzFactory = createHazelcastInstanceFactory(2);
+
+        HazelcastInstance hz1 = hzFactory.newHazelcastInstance();
+        IMap<String, Person> map = hz1.getMap("map");
+        map.put("foo", new Person("foo", 32));
+        map.put("bar", new Person("bar", 70));
+        map.addIndex("age", true);
+
+        HazelcastInstance hz2 = hzFactory.newHazelcastInstance();
+        waitAllForSafeState(hz1, hz2);
+
+        hzFactory.terminate(hz1);
+        waitAllForSafeState(hz1, hz2);
+
+        IMap<String, Person> mapOnNode2 = hz2.getMap("map");
+        Collection<Person> personsWithAgePredicate = mapOnNode2.values(new AgePredicate());
+        assertEqualsEventually(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return isIndexedInvoked.get();
+            }
+        }, 1);
+        assertEquals(1, personsWithAgePredicate.size());
+
+        hzFactory.terminate(hz2);
+    }
+
+    @Test
+    public void testPostJoinMapOperation_whenMapHasNoData() {
+        TestHazelcastInstanceFactory hzFactory = createHazelcastInstanceFactory(2);
+
+        HazelcastInstance hz1 = hzFactory.newHazelcastInstance();
+        IMap<String, Person> map = hz1.getMap("map");
+        map.addIndex("age", true);
+        map.addInterceptor(new FixedReturnInterceptor());
+
+        assertEquals(RETURNED_FROM_INTERCEPTOR, map.get("foo"));
+
+        HazelcastInstance hz2 = hzFactory.newHazelcastInstance();
+        waitAllForSafeState(hz1, hz2);
+        MapService mapService = getNodeEngineImpl(hz2).getService(MapService.SERVICE_NAME);
+        // verify index & interceptor exist on internal MapContainer
+        MapContainer mapContainerOnNode2 = mapService.getMapServiceContext().getMapContainer("map");
+        assertEquals(1,  mapContainerOnNode2.getIndexes().getIndexes().length);
+        assertEquals(1,  mapContainerOnNode2.getInterceptorRegistry().getInterceptors().size());
+        assertEquals(Person.class,
+                mapContainerOnNode2.getInterceptorRegistry().getInterceptors().get(0).interceptGet("anything").getClass());
+        assertEquals(RETURNED_FROM_INTERCEPTOR.getAge(),
+                ((Person)mapContainerOnNode2.getInterceptorRegistry().getInterceptors().get(0).interceptGet("anything")).getAge());
+
+        // also verify via user API
+        IMap<String, Person> mapOnNode2 = hz2.getMap("map");
+        assertEquals(RETURNED_FROM_INTERCEPTOR, mapOnNode2.get("whatever"));
+
+        hzFactory.terminateAll();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/ContextMutexFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ContextMutexFactoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test basic lock operation of {@link ContextMutexFactory}
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class ContextMutexFactoryTest {
+
+    private ContextMutexFactory contextMutexFactory;
+    private final AtomicBoolean testFailed = new AtomicBoolean(false);
+
+    @Before
+    public void setup() {
+        contextMutexFactory = new ContextMutexFactory();
+    }
+
+    @Test
+    public void testConcurrentMutexOperation() {
+        final String[] keys = new String[] {"a", "b", "c"};
+        final Map<String, Integer> timesAcquired = new HashMap<String, Integer>();
+
+        int concurrency = Runtime.getRuntime().availableProcessors()*3;
+        final CyclicBarrier cyc = new CyclicBarrier(concurrency+1);
+
+        for (int i=0; i<concurrency; i++) {
+            new Thread(new Runnable() {
+
+                @Override
+                public void run() {
+                    await(cyc);
+
+                    for (String key : keys) {
+                        ContextMutexFactory.Mutex mutex = contextMutexFactory.mutexFor(key);
+                        try {
+                            synchronized (mutex) {
+                                Integer value = timesAcquired.get(key);
+                                if (value == null) {
+                                    timesAcquired.put(key, 1);
+                                } else {
+                                    timesAcquired.put(key, value + 1);
+                                }
+                            }
+                        }
+                        finally {
+                            mutex.close();
+                        }
+                    }
+
+                    await(cyc);
+                }
+            }).start();
+        }
+        // start threads, wait for them to finish
+        await(cyc);
+        await(cyc);
+
+        // assert each key's lock was acquired by each thread
+        for (String key : keys) {
+            assertEquals(concurrency, timesAcquired.get(key).longValue());
+        }
+        // assert there are no mutexes leftover
+        assertEquals(0, contextMutexFactory.mutexMap.size());
+
+        if (testFailed.get()) {
+            fail("Failure due to exception while waiting on cyclic barrier.");
+        }
+    }
+
+    private void await(CyclicBarrier cyc) {
+        try {
+            cyc.await();
+        } catch (InterruptedException e) {
+            testFailed.set(true);
+        } catch (BrokenBarrierException e) {
+            testFailed.set(true);
+        }
+    }
+}


### PR DESCRIPTION
* Decoupled MapProxyImpl from MapContainer (forward port of #8105)
* Using fine-grained locking on MapServiceContextImpl#mapContainers and PartitionContainer#maps. 
* MapPartitionAwareService now publishes events on all map proxies registered (instead of map containers).
* When evaluating condition for publishing map partition lost event, take into account sync + async backup count.
* MapStatisticsAwareService now obtains map names from proxy registry (forward port of #8209)
* Adds a test to verify map indexes & interceptors are created on members joining the cluster via PostJoinMapOperation

An EE counterpart is required.