### PR TITLE
Prevent confusing behavior where the DiscoveryService is started and …

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -281,6 +281,12 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     private DiscoveryService initDiscoveryService(ClientConfig config) {
+        // Prevent confusing behavior where the DiscoveryService is started
+        // and strategies are resolved but the AddressProvider is never registered
+        if (!properties.getBoolean(ClientProperty.DISCOVERY_SPI_ENABLED)) {
+            return null;
+        }
+
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
         DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig().getAsReadOnly();
         if (discoveryConfig == null || !discoveryConfig.isEnabled()) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -151,6 +151,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
         try {
             ClientConfig clientConfig = new ClientConfig();
+            clientConfig.setProperty("hazelcast.discovery.enabled", "true");
             discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
             discoveryConfig.getDiscoveryStrategyConfigs().clear();
 
@@ -424,7 +425,9 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         @Override
         public void start() {
             super.start();
-            discoveryNodes.add(discoveryNode);
+            if (discoveryNode != null) {
+                discoveryNodes.add(discoveryNode);
+            }
             getLogger();
             getProperties();
         }


### PR DESCRIPTION
…strategies are resolved but the AddressProvider is never registered

Is this still allowed to be merged into 3.7? Just figured it out because of a user :)
