### PR TITLE
Guard casting to InitialMembershipListener

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -226,7 +226,9 @@ public class ClientClusterServiceImpl extends ClusterListenerSupport {
 
     private void fireInitialMembershipEvent(InitialMembershipEvent event) {
         for (MembershipListener listener : listeners.values()) {
-            ((InitialMembershipListener) listener).init(event);
+            if (listener instanceof InitialMembershipListener) {
+                ((InitialMembershipListener) listener).init(event);
+            }
         }
     }
 


### PR DESCRIPTION
Not every listener is an initial listener.
Without this guard event thread was throwing ClassCastException