### PR TITLE
Do not perform migration flow tasks after shut down

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -726,6 +726,11 @@ public class MigrationManager {
 
             partitionServiceLock.lock();
             try {
+                if (!partitionStateManager.isInitialized()) {
+                    logger.info("Skipping partition table assertions since partition table state is reset");
+                    return;
+                }
+
                 final InternalPartition[] partitions = partitionStateManager.getPartitions();
                 final int maxBackupCount = partitionService.getMaxAllowedBackupCount();
                 final Set<Address> replicas = new HashSet<Address>();
@@ -1152,6 +1157,11 @@ public class MigrationManager {
             partitionServiceLock.lock();
             try {
                 migrationQueue.clear();
+
+                if (!partitionStateManager.isInitialized()) {
+                    logger.info("Skipping control task since partition table state is reset");
+                    return;
+                }
 
                 if (partitionService.scheduleFetchMostRecentPartitionTableTaskIfRequired()) {
                     if (logger.isFinestEnabled()) {


### PR DESCRIPTION
If a shutting-down node becomes master after it has been notified to complete its shutdown by the old master, it should not perform any migration flow tasks if it has reset its state.

pair-investigated with @mdogan 