### PR TITLE
Make RequireAssertEnabled print to stdout

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/AssertEnabledFilterRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AssertEnabledFilterRule.java
@@ -38,7 +38,7 @@ public class AssertEnabledFilterRule implements TestRule {
                 if (assertEnabled) {
                     base.evaluate();
                 } else {
-                    System.err.println("WARNING! Test cannot run when Java assertions are not enabled (java -ea ...): "
+                    System.out.println("WARNING! Test cannot run when Java assertions are not enabled (java -ea ...): "
                             + description.getDisplayName());
                 }
             }


### PR DESCRIPTION
Apparently our Surefire configuration drops stderr from saved test output.