### PR TITLE
Attempt flattening consequent OR and AND predicates in SqlPredicate

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -408,5 +408,21 @@
             <version>${javax.inject.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+            <version>0.9.10</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -307,14 +307,14 @@ public class SqlPredicate
      * Return a {@link CompoundPredicate}, possibly flattened if one or both arguments is an instance of
      * {@code CompoundPredicate}.
      *
-     * The following could have been achieved with {@link com.hazelcast.query.impl.predicates.FlatteningVisitor},
-     * however since we only care for 2-argument flattening, we can avoid constructing a visitor and its internals
-     * for each token pass at the cost of the following ugly piece of code.
      */
-     static <T extends CompoundPredicate> T flattenCompound(Predicate predicateLeft, Predicate predicateRight, Class<T> klass) {
+    static <T extends CompoundPredicate> T flattenCompound(Predicate predicateLeft, Predicate predicateRight, Class<T> klass) {
+        // The following could have been achieved with {@link com.hazelcast.query.impl.predicates.FlatteningVisitor},
+        // however since we only care for 2-argument flattening, we can avoid constructing a visitor and its internals
+        // for each token pass at the cost of the following explicit code.
         Predicate[] subpredicatesLeft;
         Predicate[] subpredicatesRight;
-         Predicate[] predicates;
+        Predicate[] predicates;
         if (klass.isInstance(predicateLeft)) {
             subpredicatesLeft = ((CompoundPredicate) predicateLeft).getPredicates();
             if (predicateRight instanceof CompoundPredicate) {
@@ -331,15 +331,15 @@ public class SqlPredicate
         } else {
             predicates = new Predicate[] {predicateLeft, predicateRight};
         }
-         try {
-             CompoundPredicate compoundPredicate = klass.newInstance();
-             compoundPredicate.setPredicates(predicates);
-             return (T) compoundPredicate;
-         } catch (InstantiationException e) {
-             throw new RuntimeException(String.format("%s should have a public default constructor", klass.getName()));
-         } catch (IllegalAccessException e) {
-             throw new RuntimeException(String.format("%s should have a public default constructor", klass.getName()));
-         }
+        try {
+            CompoundPredicate compoundPredicate = klass.newInstance();
+            compoundPredicate.setPredicates(predicates);
+            return (T) compoundPredicate;
+        } catch (InstantiationException e) {
+            throw new RuntimeException(String.format("%s should have a public default constructor", klass.getName()));
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(String.format("%s should have a public default constructor", klass.getName()));
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -22,6 +22,8 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.predicates.AndPredicate;
+import com.hazelcast.query.impl.predicates.CompoundPredicate;
 import com.hazelcast.query.impl.predicates.OrPredicate;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 import com.hazelcast.query.impl.predicates.Visitor;
@@ -35,7 +37,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
-import static com.hazelcast.query.Predicates.and;
 import static com.hazelcast.query.Predicates.between;
 import static com.hazelcast.query.Predicates.equal;
 import static com.hazelcast.query.Predicates.greaterEqual;
@@ -234,13 +235,13 @@ public class SqlPredicate
                         validateOperandPosition(position);
                         Object first = toValue(tokens.remove(position), mapPhrases);
                         Object second = toValue(tokens.remove(position), mapPhrases);
-                        setOrAdd(tokens, position, and(eval(first), eval(second)));
+                        setOrAdd(tokens, position, flattenCompound(eval(first), eval(second), AndPredicate.class));
                     } else if ("OR".equalsIgnoreCase(token)) {
                         int position = i - 2;
                         validateOperandPosition(position);
                         Object first = toValue(tokens.remove(position), mapPhrases);
                         Object second = toValue(tokens.remove(position), mapPhrases);
-                        setOrAdd(tokens, position, or(eval(first), eval(second)));
+                        setOrAdd(tokens, position, flattenCompound(eval(first), eval(second), OrPredicate.class));
                     } else {
                         throw new RuntimeException("Unknown token " + token);
                     }
@@ -303,33 +304,42 @@ public class SqlPredicate
     }
 
     /**
-     * Return an {@link OrPredicate}, possibly flattened if one or both arguments is an instance of {@code OrPredicate}.
+     * Return a {@link CompoundPredicate}, possibly flattened if one or both arguments is an instance of
+     * {@code CompoundPredicate}.
      *
      * The following could have been achieved with {@link com.hazelcast.query.impl.predicates.FlatteningVisitor},
      * however since we only care for 2-argument flattening, we can avoid constructing a visitor and its internals
-     * for each token pass at the cost of explicit code.
+     * for each token pass at the cost of the following ugly piece of code.
      */
-     static Predicate or(Predicate predicateLeft, Predicate predicateRight) {
-        Predicate[] leftPredicates;
-        Predicate[] rightPredicates;
-        if (predicateLeft instanceof OrPredicate) {
-            leftPredicates = ((OrPredicate) predicateLeft).getPredicates();
-            if (predicateRight instanceof OrPredicate) {
-                rightPredicates = ((OrPredicate) predicateRight).getPredicates();
+     static <T extends CompoundPredicate> T flattenCompound(Predicate predicateLeft, Predicate predicateRight, Class<T> klass) {
+        Predicate[] subpredicatesLeft;
+        Predicate[] subpredicatesRight;
+         Predicate[] predicates;
+        if (klass.isInstance(predicateLeft)) {
+            subpredicatesLeft = ((CompoundPredicate) predicateLeft).getPredicates();
+            if (predicateRight instanceof CompoundPredicate) {
+                subpredicatesRight = ((CompoundPredicate) predicateRight).getPredicates();
             } else {
-                rightPredicates = new Predicate[] {predicateRight};
+                subpredicatesRight = new Predicate[] {predicateRight};
             }
-            Predicate[] predicates = new Predicate[leftPredicates.length + rightPredicates.length];
-            ArrayUtils.concat(leftPredicates, rightPredicates, predicates);
-            return new OrPredicate(predicates);
-        } else if (predicateRight instanceof OrPredicate) {
-            rightPredicates = ((OrPredicate) predicateRight).getPredicates();
-            Predicate[] predicates = new Predicate[rightPredicates.length + 1];
-            ArrayUtils.concat(new Predicate[] {predicateLeft}, rightPredicates, predicates);
-            return new OrPredicate(predicates);
+            predicates = new Predicate[subpredicatesLeft.length + subpredicatesRight.length];
+            ArrayUtils.concat(subpredicatesLeft, subpredicatesRight, predicates);
+        } else if (klass.isInstance(predicateRight)) {
+            subpredicatesRight = ((CompoundPredicate) predicateRight).getPredicates();
+            predicates = new Predicate[subpredicatesRight.length + 1];
+            ArrayUtils.concat(new Predicate[] {predicateLeft}, subpredicatesRight, predicates);
         } else {
-            return Predicates.or(predicateLeft, predicateRight);
+            predicates = new Predicate[] {predicateLeft, predicateRight};
         }
+         try {
+             CompoundPredicate compoundPredicate = klass.newInstance();
+             compoundPredicate.setPredicates(predicates);
+             return (T) compoundPredicate;
+         } catch (InstantiationException e) {
+             throw new RuntimeException(String.format("%s should have a public default constructor", klass.getName()));
+         } catch (IllegalAccessException e) {
+             throw new RuntimeException(String.format("%s should have a public default constructor", klass.getName()));
+         }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -39,7 +39,7 @@ import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICAT
  * And Predicate
  */
 public final class AndPredicate
-        implements IndexAwarePredicate, IdentifiedDataSerializable, VisitablePredicate, NegatablePredicate {
+        implements IndexAwarePredicate, IdentifiedDataSerializable, VisitablePredicate, NegatablePredicate, CompoundPredicate {
 
     protected Predicate[] predicates;
 
@@ -177,5 +177,15 @@ public final class AndPredicate
     @Override
     public int getId() {
         return PredicateDataSerializerHook.AND_PREDICATE;
+    }
+
+    @Override
+    public <K, V> Predicate<K, V>[] getPredicates() {
+        return predicates;
+    }
+
+    @Override
+    public <K, V> void setPredicates(Predicate<K, V>[] predicates) {
+        this.predicates = predicates;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -186,6 +186,10 @@ public final class AndPredicate
 
     @Override
     public <K, V> void setPredicates(Predicate<K, V>[] predicates) {
-        this.predicates = predicates;
+        if (this.predicates == null) {
+            this.predicates = predicates;
+        } else {
+            throw new IllegalStateException("Cannot reset predicates in an AndPredicate after they have been already set.");
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompoundPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompoundPredicate.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+
+/**
+ * Interface for predicates which operate on an array of sub-predicates.
+ * Implementations of this interface must include a default no-args constructor.
+ */
+public interface CompoundPredicate {
+
+    /**
+     * An array of predicates which compose this predicate.
+     * @return array of predicates which will be applied by this predicate
+     */
+    <K, V> Predicate<K, V>[] getPredicates();
+
+    // only required to set predicates after construction with the default constructor
+    <K, V> void setPredicates(Predicate<K, V>[] predicates);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompoundPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompoundPredicate.java
@@ -21,6 +21,10 @@ import com.hazelcast.query.Predicate;
 /**
  * Interface for predicates which operate on an array of sub-predicates.
  * Implementations of this interface must include a default no-args constructor.
+ * If a {@code CompoundPredicate} is also a {@link com.hazelcast.query.VisitablePredicate}, taking into account
+ * the immutability requirements for {@code VisitablePredicate}s, {@link #setPredicates(Predicate[])} should
+ * throw an {@code IllegalStateException} when invoked on a {@code CompoundStatement} whose sub-predicates
+ * have already been set.
  */
 public interface CompoundPredicate {
 
@@ -30,7 +34,14 @@ public interface CompoundPredicate {
      */
     <K, V> Predicate<K, V>[] getPredicates();
 
-    // only required to set predicates after construction with the default constructor
+    /**
+     * Set the sub-predicates of this {@code CompoundPredicate}. If a predicate should be treated as effectively
+     * immutable, such as a {@link com.hazelcast.query.VisitablePredicate}, it is advised that this method throws
+     * {@link IllegalStateException} when sub-predicates have already been defined.
+     * @param predicates
+     * @param <K>
+     * @param <V>
+     */
     <K, V> void setPredicates(Predicate<K, V>[] predicates);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -163,4 +163,8 @@ public final class OrPredicate
     public int getId() {
         return PredicateDataSerializerHook.OR_PREDICATE;
     }
+
+    public Predicate[] getPredicates() {
+        return predicates;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -39,7 +39,7 @@ import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICAT
  * Or Predicate
  */
 public final class OrPredicate
-        implements IndexAwarePredicate, VisitablePredicate, NegatablePredicate, IdentifiedDataSerializable {
+        implements IndexAwarePredicate, VisitablePredicate, NegatablePredicate, IdentifiedDataSerializable, CompoundPredicate {
 
     protected Predicate[] predicates;
 
@@ -164,7 +164,13 @@ public final class OrPredicate
         return PredicateDataSerializerHook.OR_PREDICATE;
     }
 
-    public Predicate[] getPredicates() {
+    @Override
+    public <K, V> Predicate<K, V>[] getPredicates() {
         return predicates;
+    }
+
+    @Override
+    public <K, V> void setPredicates(Predicate<K, V>[] predicates) {
+        this.predicates = predicates;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -171,6 +171,10 @@ public final class OrPredicate
 
     @Override
     public <K, V> void setPredicates(Predicate<K, V>[] predicates) {
-        this.predicates = predicates;
+        if (this.predicates == null) {
+            this.predicates = predicates;
+        } else {
+            throw new IllegalStateException("Cannot reset predicates in an OrPredicate after they have been already set.");
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.util.collection;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 
 /**
@@ -81,5 +82,18 @@ public final class ArrayUtils {
             return array[position];
         }
         return null;
+    }
+
+    /**
+     * Copies in order {@code sourceFirst} and {@code sourceSecond} into {@code dest},
+     * i
+     * @param sourceFirst
+     * @param sourceSecond
+     * @param dest
+     * @param <T>
+     */
+    public static <T> void concat(T[] sourceFirst, T[] sourceSecond, T[] dest) {
+        System.arraycopy(sourceFirst, 0, dest, 0, sourceFirst.length);
+        System.arraycopy(sourceSecond, 0, dest, sourceFirst.length, sourceSecond.length);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.util.collection;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/ArrayUtils.java
@@ -84,8 +84,7 @@ public final class ArrayUtils {
     }
 
     /**
-     * Copies in order {@code sourceFirst} and {@code sourceSecond} into {@code dest},
-     * i
+     * Copies in order {@code sourceFirst} and {@code sourceSecond} into {@code dest}.
      * @param sourceFirst
      * @param sourceSecond
      * @param dest

--- a/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
@@ -41,6 +41,7 @@ import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.query.impl.predicates.AndPredicate;
 import com.hazelcast.query.impl.predicates.OrPredicate;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -379,7 +380,8 @@ public class SqlPredicateTest {
     // https://github.com/hazelcast/hazelcast/issues/7583
     @Test
     public void testLongPredicate() {
-        HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
+        TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory(1);
+        HazelcastInstance hazelcastInstance = factory.newHazelcastInstance();
         IMap<Integer, Integer> map = hazelcastInstance.getMap(randomString());
 
         for (int i=0; i < 8000; i++) {
@@ -399,7 +401,7 @@ public class SqlPredicateTest {
         Set<Map.Entry<Integer, Integer>> entries = map.entrySet(predicate);
         assertEquals(map.size(), entries.size());
 
-        hazelcastInstance.shutdown();
+        factory.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/CompoundPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/CompoundPredicateTest.java
@@ -1,0 +1,76 @@
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.FalsePredicate;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test all classes which implement CompoundStatement in package com.hazelcast.query.impl.predicates
+ * for compliance with CompoundStatement contract.
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CompoundPredicateTest {
+
+    @Parameterized.Parameters
+    public static Collection<Class<? extends CompoundPredicate>> getCompoundPredicateImplementations() {
+        // locate all classes which implement CompoundPredicate and exercise them
+        Reflections reflections = new Reflections(new ConfigurationBuilder()
+                .forPackages("com.hazelcast.query.impl.predicates")
+                .addScanners(new SubTypesScanner())
+                .build());
+
+        return reflections.getSubTypesOf(CompoundPredicate.class);
+    }
+
+    @Parameterized.Parameter
+    public Class<? extends CompoundPredicate> klass;
+
+    @Test
+    public void test_newInstance()
+            throws IllegalAccessException, InstantiationException {
+        // all CompoundStatement classes must provide a default constructor
+        Object o = klass.newInstance();
+        assertTrue(o instanceof CompoundPredicate);
+    }
+
+    @Test
+    public void test_whenSetPredicatesOnNewInstance()
+            throws IllegalAccessException, InstantiationException {
+
+        CompoundPredicate o = klass.newInstance();
+        Predicate truePredicate = new TruePredicate();
+        o.setPredicates(new Predicate[] {truePredicate});
+        assertEquals(truePredicate, o.getPredicates()[0]);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void test_whenSetPredicatesOnExistingPredicates_thenThrowException()
+            throws IllegalAccessException, InstantiationException {
+
+        CompoundPredicate o = klass.newInstance();
+        Predicate truePredicate = new TruePredicate();
+        o.setPredicates(new Predicate[] {truePredicate});
+
+        Predicate falsePredicate = new FalsePredicate();
+        o.setPredicates(new Predicate[] {falsePredicate});
+
+        fail();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/ArrayUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/ArrayUtilsTest.java
@@ -28,11 +28,13 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -149,5 +151,45 @@ public class ArrayUtilsTest extends HazelcastTestSupport {
         Object result = ArrayUtils.getItemAtPositionOrNull(src, 1);
 
         assertNull(result);
+    }
+
+    @Test
+    public void concat() {
+        Integer[] first = new Integer[] {1,2,3};
+        Integer[] second = new Integer[] {4};
+        Integer[] concatenated = new Integer[4];
+        ArrayUtils.concat(first, second, concatenated);
+        assertEquals(4, concatenated.length);
+        assertEquals(Integer.valueOf(1), concatenated[0]);
+        assertEquals(Integer.valueOf(2), concatenated[1]);
+        assertEquals(Integer.valueOf(3), concatenated[2]);
+        assertEquals(Integer.valueOf(4), concatenated[3]);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void concat_whenFirstNull() {
+        Integer[] first = null;
+        Integer[] second = new Integer[] {4};
+        Integer[] concatenated = new Integer[4];
+        ArrayUtils.concat(first, second, concatenated);
+        fail();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void concat_whenSecondNull() {
+        Integer[] first = new Integer[] {1,2,3};
+        Integer[] second = null;
+        Integer[] concatenated = new Integer[4];
+        ArrayUtils.concat(first, second, concatenated);
+        fail();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void concat_whenDestNull() {
+        Integer[] first = new Integer[] {1,2,3};
+        Integer[] second = new Integer[] {4};
+        Integer[] concatenated = null;
+        ArrayUtils.concat(first, second, concatenated);
+        fail();
     }
 }

--- a/hazelcast/src/test/resources/logback.xml
+++ b/hazelcast/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
While processing tokens in `SqlPredicate`, attempt to flatten consequent compound predicates (OR and AND). This is normally achieved with the `FlatteningVisitor` used by the rule-based query optimizer, however in long SQL predicates, current implementation nesting may result in `StackOverflowException` before we make it to the optimizer.
Fixes #7583 