### PR TITLE
Fail-fast @RequireAssertEnabled

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/AssertEnabledFilterRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AssertEnabledFilterRule.java
@@ -35,12 +35,11 @@ public class AssertEnabledFilterRule implements TestRule {
             public void evaluate() throws Throwable {
                 boolean assertEnabled = false;
                 assert assertEnabled = true;
-                if (assertEnabled) {
-                    base.evaluate();
-                } else {
-                    System.out.println("WARNING! Test cannot run when Java assertions are not enabled (java -ea ...): "
+                if (!assertEnabled) {
+                    throw new AssertionError("Java assertions are not enabled (java -ea ...), but this test requires them: "
                             + description.getDisplayName());
                 }
+                base.evaluate();
             }
         };
     }

--- a/pom.xml
+++ b/pom.xml
@@ -244,8 +244,7 @@
                     <threadCount>1</threadCount>
                     <perCoreThreadCount>true</perCoreThreadCount>
                     <parallel>methods</parallel -->
-
-                    <!-- the argLine variable is needed for JaCoco -->
+                    <!-- JaCoCo will use the argLine set here. Test profiles override it. -->
                     <argLine>
                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
                         -Dhazelcast.phone.home.enabled=false
@@ -296,7 +295,6 @@
                                     <!-- 1C means 1 process per cpu core -->
                                     <forkCount>1C</forkCount>
                                     <reuseForks>true</reuseForks>
-                                    <!-- the argLine variable is needed for JaCoco -->
                                     <argLine>
                                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
                                         -Dhazelcast.phone.home.enabled=false
@@ -304,7 +302,6 @@
                                         -Dhazelcast.logging.type=none
                                         -Dhazelcast.test.use.network=false
                                         -Dhazelcast.test.multiple.jvm=true
-                                        -ea
                                     </argLine>
                                     <includes>
                                         <include>**/**.java</include>
@@ -332,7 +329,6 @@
                                 <configuration combine.self="override">
                                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
-                                    <!-- the argLine variable is needed for JaCoco -->
                                     <argLine>
                                         -Xms128m -Xmx1G -XX:MaxPermSize=128M
                                         -Dhazelcast.phone.home.enabled=false
@@ -831,7 +827,8 @@
                         <configuration combine.self="override">
                             <parallel>none</parallel>
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                            <argLine>-Xms128m -Xmx1G -XX:MaxPermSize=128M
+                            <argLine>
+                                -Xms128m -Xmx1G -XX:MaxPermSize=128M
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
@@ -862,7 +859,8 @@
                         <configuration combine.self="override">
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <parallel>none</parallel>
-                            <argLine>-Xms512m -Xmx2G -XX:MaxPermSize=128M
+                            <argLine>
+                                -Xms512m -Xmx2G -XX:MaxPermSize=128M
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none


### PR DESCRIPTION
A `@RequireAssertEnabled` test now fails if assert not enabled. Before it just quietly cried in a corner.