### PR TITLE
Make a better test for #1719

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -165,7 +165,9 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         map.put("b", new TempData("abc", "123"));
         TestPredicate predicate = new TestPredicate("foo");
         Map<String, Object> entries = map.executeOnEntries(new LoggingEntryProcessor(), predicate);
-        assertEquals("The predicate should be applied to only one entry if indexing works!", entries.size(), 1);
+        assertEquals("The predicate should only relate to one entry!", 1, entries.size());
+        assertEquals("The predicate's apply method should only be invoked once!", 1, predicate.getApplied());
+        assertTrue("The predicate should only be used via index service!", predicate.isFilteredAndAppliedOnlyOnce());
     }
 
     /**
@@ -1211,7 +1213,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         @Override
         public boolean isIndexed(QueryContext queryContext) {
             indexCalled.set(true);
-            return false;
+            return true;
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestPredicate.java
@@ -26,19 +26,21 @@ import java.util.Set;
 public class TestPredicate implements IndexAwarePredicate<String, TempData> {
 
     private String value;
-    private boolean didApply;
+    private boolean filtered;
+    private int applied;
 
     public TestPredicate(String value) {
         this.value = value;
     }
 
     public boolean apply(Map.Entry<String, TempData> mapEntry) {
-        didApply = true;
+        applied++;
         TempData data = (TempData) mapEntry.getValue();
         return data.getAttr1().equals(value);
     }
 
     public Set<QueryableEntry<String, TempData>> filter(QueryContext queryContext) {
+        filtered = true;
         return (Set) queryContext.getIndex("attr1").getRecords(value);
     }
 
@@ -46,8 +48,12 @@ public class TestPredicate implements IndexAwarePredicate<String, TempData> {
         return queryContext.getIndex("attr1") != null;
     }
 
-    public boolean didApply() {
-        return didApply;
+    public boolean isFilteredAndAppliedOnlyOnce() {
+        return filtered && applied == 1;
+    }
+
+    public int getApplied() {
+        return applied;
     }
 
 }


### PR DESCRIPTION
Don't just track when TestPredicate.apply was invoked, but TestPredicate.filter too.
Replace didApply with isFilteredAndAppliedOnlyOnce.

This has largely been superseded by tests implemented in #8053 but is left here since
it tests if the predicate is actually working by only being applied only to one entry