### PR TITLE
Fix & improve member restart handling in partition system

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.partition;
 
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
 import com.hazelcast.spi.partition.IPartitionService;
 
 import java.util.concurrent.TimeUnit;
@@ -62,6 +63,8 @@ public interface InternalPartitionService extends IPartitionService {
     void pauseMigration();
 
     void resumeMigration();
+
+    boolean isMemberAllowedToJoin(Address address);
 
     void memberAdded(MemberImpl newMember);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
@@ -16,120 +16,101 @@
 
 package com.hazelcast.internal.partition;
 
-import com.hazelcast.core.Member;
-import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
+
+import static com.hazelcast.internal.partition.InternalPartition.MAX_REPLICA_COUNT;
 
 public final class PartitionRuntimeState implements IdentifiedDataSerializable {
 
-    private MemberInfo[] members;
+    // used for writing state
+    private Map<Address, Integer> addressToIndexes;
+
+    // used for reading state
+    private Address[] addresses;
+
     private int[][] minimizedPartitionTable;
     private int version;
     private Collection<MigrationInfo> completedMigrations;
     // used to know ongoing migrations when master changed
     private MigrationInfo activeMigration;
 
-    // transient fields
-    private ILogger logger;
     private Address endpoint;
 
     public PartitionRuntimeState() {
     }
 
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP",
-            justification = "Members array is used internally by partitioning system.")
-    public PartitionRuntimeState(ILogger logger,
-                                 MemberInfo[] members,
-                                 InternalPartition[] partitions,
-                                 Collection<MigrationInfo> migrationInfos,
-                                 int version) {
-        this.logger = logger;
+    public PartitionRuntimeState(InternalPartition[] partitions, Collection<MigrationInfo> migrationInfos, int version) {
         this.version = version;
-        this.members = members;
         completedMigrations = migrationInfos != null ? migrationInfos : Collections.<MigrationInfo>emptyList();
+        addressToIndexes = createAddressToIndexMap(partitions);
         minimizedPartitionTable = createMinimizedPartitionTable(partitions);
     }
 
     private int[][] createMinimizedPartitionTable(InternalPartition[] partitions) {
-        int[][] partitionTable = new int[partitions.length][InternalPartition.MAX_REPLICA_COUNT];
-        Map<Address, Integer> addressIndexes = addressToIndexMap();
+        int[][] partitionTable = new int[partitions.length][MAX_REPLICA_COUNT];
 
-        List<String> unmatchedAddresses = new LinkedList<String>();
         for (InternalPartition partition : partitions) {
             int[] indexes = partitionTable[partition.getPartitionId()];
 
-            for (int replicaIndex = 0; replicaIndex < InternalPartition.MAX_REPLICA_COUNT; replicaIndex++) {
+            for (int replicaIndex = 0; replicaIndex < MAX_REPLICA_COUNT; replicaIndex++) {
                 Address address = partition.getReplicaAddress(replicaIndex);
                 if (address == null) {
                     indexes[replicaIndex] = -1;
                 } else {
-                    Integer knownIndex = addressIndexes.get(address);
-
-                    if (knownIndex == null && replicaIndex == 0) {
-                        unmatchedAddresses.add(address + " -> " + partition);
-                    }
-                    if (knownIndex == null) {
-                        indexes[replicaIndex] = -1;
-                    } else {
-                        indexes[replicaIndex] = knownIndex;
-                    }
+                    int index = addressToIndexes.get(address);
+                    indexes[replicaIndex] = index;
                 }
             }
-        }
-
-        if (logger.isFineEnabled() && !unmatchedAddresses.isEmpty()) {
-            // it can happen that the primary address at any given moment is not known,
-            // most probably because master node has updated/published the partition table yet
-            // or partition table update is not received yet.
-            logger.fine("Unknown owner addresses in partition state! "
-                    + "(Probably they have recently joined to or left the cluster.) " + unmatchedAddresses);
         }
         return partitionTable;
     }
 
-    private Map<Address, Integer> addressToIndexMap() {
-        Map<Address, Integer> addressIndexes = new HashMap<Address, Integer>(members.length);
-        for (int ix = 0; ix < members.length; ix++) {
-            addressIndexes.put(members[ix].getAddress(), ix);
+    private Map<Address, Integer> createAddressToIndexMap(InternalPartition[] partitions) {
+        Map<Address, Integer> map = new HashMap<Address, Integer>();
+        int addressIndex = 0;
+        for (InternalPartition partition : partitions) {
+            for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
+                Address address = partition.getReplicaAddress(i);
+                if (address == null) {
+                    continue;
+                }
+                if (map.containsKey(address)) {
+                    continue;
+                }
+                map.put(address, addressIndex++);
+            }
         }
-        return addressIndexes;
+        return map;
     }
 
     public Address[][] getPartitionTable() {
         int length = minimizedPartitionTable.length;
-        Address[][] result = new Address[length][InternalPartition.MAX_REPLICA_COUNT];
+        Address[][] result = new Address[length][MAX_REPLICA_COUNT];
         for (int partitionId = 0; partitionId < length; partitionId++) {
             Address[] replicas = result[partitionId];
             int[] addressIndexes = minimizedPartitionTable[partitionId];
             for (int replicaIndex = 0; replicaIndex < addressIndexes.length; replicaIndex++) {
                 int index = addressIndexes[replicaIndex];
                 if (index != -1) {
-                    replicas[replicaIndex] = members[index].getAddress();
+                    Address address = addresses[index];
+                    assert address != null;
+                    replicas[replicaIndex] = address;
                 }
             }
         }
         return result;
-    }
-
-    @SuppressFBWarnings(value = "EI_EXPOSE_REP",
-            justification = "Members array is used internally by partitioning system.")
-    public MemberInfo[] getMembers() {
-        return members;
     }
 
     public Address getEndpoint() {
@@ -156,32 +137,25 @@ public final class PartitionRuntimeState implements IdentifiedDataSerializable {
         this.completedMigrations = completedMigrations;
     }
 
-    public boolean isKnownOrNewMember(Member member) {
-        for (MemberInfo m : members) {
-            if (member.getAddress().equals(m.getAddress())) {
-                return member.getUuid().equals(m.getUuid());
-            }
-        }
-
-        return true;
-    }
-
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         version = in.readInt();
-        int size = in.readInt();
-        members = new MemberInfo[size];
-        for (int memberIndex = 0; memberIndex < size; memberIndex++) {
-            MemberInfo memberInfo = new MemberInfo();
-            memberInfo.readData(in);
-            members[memberIndex] = memberInfo;
+        int memberCount = in.readInt();
+        addresses = new Address[memberCount];
+        for (int i = 0; i < memberCount; i++) {
+            Address address = new Address();
+            address.readData(in);
+            int index = in.readInt();
+            assert addresses[index] == null : "Duplicate address! Address: " + address + ", index: " + index
+                    + ", addresses: " + Arrays.toString(addresses);
+            addresses[index] = address;
         }
 
         int partitionCount = in.readInt();
-        minimizedPartitionTable = new int[partitionCount][InternalPartition.MAX_REPLICA_COUNT];
+        minimizedPartitionTable = new int[partitionCount][MAX_REPLICA_COUNT];
         for (int i = 0; i < partitionCount; i++) {
             int[] indexes = minimizedPartitionTable[i];
-            for (int ix = 0; ix < InternalPartition.MAX_REPLICA_COUNT; ix++) {
+            for (int ix = 0; ix < MAX_REPLICA_COUNT; ix++) {
                 indexes[ix] = in.readInt();
             }
         }
@@ -205,15 +179,18 @@ public final class PartitionRuntimeState implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(version);
-        int memberSize = members.length;
-        out.writeInt(memberSize);
-        for (MemberInfo memberInfo : members) {
-            memberInfo.writeData(out);
+        int memberCount = addressToIndexes.size();
+        out.writeInt(memberCount);
+        for (Map.Entry<Address, Integer> entry : addressToIndexes.entrySet()) {
+            Address address = entry.getKey();
+            address.writeData(out);
+            int index = entry.getValue();
+            out.writeInt(index);
         }
 
         out.writeInt(minimizedPartitionTable.length);
         for (int[] indexes : minimizedPartitionTable) {
-            for (int ix = 0; ix < InternalPartition.MAX_REPLICA_COUNT; ix++) {
+            for (int ix = 0; ix < MAX_REPLICA_COUNT; ix++) {
                 out.writeInt(indexes[ix]);
             }
         }
@@ -239,7 +216,7 @@ public final class PartitionRuntimeState implements IdentifiedDataSerializable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("PartitionRuntimeState [" + version + "]{\n");
-        for (MemberInfo address : members) {
+        for (Address address : addressToIndexes.keySet()) {
             sb.append(address).append('\n');
         }
         sb.append(", completedMigrations=").append(completedMigrations);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateVersionMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateVersionMismatchException.java
@@ -24,9 +24,6 @@ import com.hazelcast.core.HazelcastException;
  */
 public class PartitionStateVersionMismatchException extends HazelcastException {
 
-    public PartitionStateVersionMismatchException() {
-    }
-
     public PartitionStateVersionMismatchException(String message) {
         super(message);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ShutdownRequestOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.partition.operation;
 
-import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
@@ -24,9 +23,7 @@ import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.AbstractOperation;
-import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.exception.TargetNotMemberException;
 
 public class ShutdownRequestOperation extends AbstractOperation implements MigrationCycleOperation {
 
@@ -65,13 +62,4 @@ public class ShutdownRequestOperation extends AbstractOperation implements Migra
     public String getServiceName() {
         return InternalPartitionService.SERVICE_NAME;
     }
-
-    @Override
-    public ExceptionAction onInvocationException(Throwable throwable) {
-        if (throwable instanceof MemberLeftException || throwable instanceof TargetNotMemberException) {
-            return ExceptionAction.THROW_EXCEPTION;
-        }
-        return super.onInvocationException(throwable);
-    }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/SlowMigrationCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/SlowMigrationCorrectnessTest.java
@@ -63,6 +63,8 @@ public class SlowMigrationCorrectnessTest extends AbstractMigrationCorrectnessTe
         config.setProperty(GroupProperty.PARTITION_MIGRATION_INTERVAL.getName(), "1");
 
         HazelcastInstance[] instances = factory.newInstances(config, nodeCount);
+        warmUpPartitions(instances);
+
         fillData(instances[instances.length - 1]);
         assertSizeAndDataEventually();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionImplTest.java
@@ -192,37 +192,6 @@ public class InternalPartitionImplTest {
     }
 
     @Test
-    public void testRemoveAddress_whenAddressExists() throws Exception {
-        for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
-            replicaAddresses[i] = newAddress(5000 + i);
-        }
-        partition.setInitialReplicaAddresses(replicaAddresses);
-
-        int replicaIndex = partition.getReplicaIndex(thisAddress);
-        assertEquals(replicaIndex, partition.removeAddress(thisAddress));
-
-        assertNull(partition.getReplicaAddress(replicaIndex));
-        for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
-            if (i != replicaIndex) {
-                assertEquals(replicaAddresses[i], partition.getReplicaAddress(i));
-            }
-        }
-    }
-
-    @Test
-    public void testRemoveAddress_whenAddressNOTExists() throws Exception {
-        for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
-            replicaAddresses[i] = newAddress(5000 + i);
-        }
-        partition.setInitialReplicaAddresses(replicaAddresses);
-
-        assertEquals(-1, partition.removeAddress(newAddress(6000)));
-        for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
-            assertEquals(replicaAddresses[i], partition.getReplicaAddress(i));
-        }
-    }
-
-    @Test
     public void testReset() throws Exception {
         for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
             replicaAddresses[i] = newAddress(5000 + i);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -18,7 +18,6 @@
 package com.hazelcast.test.mocknetwork;
 
 import com.hazelcast.core.Member;
-import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
@@ -123,10 +122,8 @@ public class MockConnectionManager implements ConnectionManager {
                         ILogger otherLogger = otherNode.getLogger(MockConnectionManager.class);
                         otherLogger.fine(localMember + " will be removed from the cluster if present, "
                                 + "because it has requested to leave.");
-                        MemberImpl member = clusterService.getMember(thisAddress);
-                        if (member != null && member.getUuid().equals(localMember.getUuid())) {
-                            clusterService.removeAddress(thisAddress, "Connection manager is stopped on " + localMember);
-                        }
+                        clusterService.removeAddress(localMember.getAddress(), localMember.getUuid(),
+                                "Connection manager is stopped on " + localMember);
                     }
                 });
             }


### PR DESCRIPTION
When a member is restarted, partition system should detect that,
invalidate & fail pending and ongoing migrations/replications to that
member.
Before there was a member-uuid mapping bound to the partition
table which is used to detect restarting member. But there is a racy
window that caused missing member uuid in the mapping table which fails
the migrations. Another downside is, keeping uuid mapping table up to date
was a complex mechanism.
Instead, now join request of restarting member is denied until it's completely
removed from partition table. Join request will be retried by restarting member
periodically and when partition table repair is completed after member remove,
join will be allowed.

Also members should send their uuid during shutdown and MemberRemoveOperation
will check if that specific member is present. Otherwise, operation will fail.
This is required to avoid removal of a restarting member by mistake.

_Pair-implemented with @metanet_

Fixes #8005
Fixes #8226