### PR TITLE
Fix infinite waiting on ICondition when waiting deadline is in the past

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
@@ -91,8 +91,11 @@ public class ClientConditionProxy extends PartitionSpecificClientProxy implement
     @Override
     public boolean awaitUntil(Date deadline) throws InterruptedException {
         long until = deadline.getTime();
-        final long timeToDeadline = until - Clock.currentTimeMillis();
-        return await(timeToDeadline, TimeUnit.MILLISECONDS);
+        final long durationMs = until - Clock.currentTimeMillis();
+        if (durationMs <= 0) {
+            return false;
+        }
+        return await(durationMs, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -32,6 +32,7 @@ import com.hazelcast.util.ThreadUtil;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkPositive;
 
 /**
@@ -90,6 +91,7 @@ public class ClientLockProxy extends PartitionSpecificClientProxy implements ILo
     }
 
     public ICondition newCondition(String name) {
+        checkNotNull(name, "Condition name can't be null");
         ClientConditionProxy clientConditionProxy = new ClientConditionProxy(this, name, getContext());
         clientConditionProxy.onInitialize();
         return clientConditionProxy;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConditionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConditionTest.java
@@ -1,189 +1,31 @@
 package com.hazelcast.client.lock;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.concurrent.lock.ConditionAbstractTest;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ICondition;
-import com.hazelcast.core.ILock;
-import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientConditionTest extends HazelcastTestSupport {
+public class ClientConditionTest extends ConditionAbstractTest {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-    private HazelcastInstance client;
-    private ILock lock;
 
-    @Before
-    public void setup() {
-        hazelcastFactory.newHazelcastInstance();
-        client = hazelcastFactory.newHazelcastClient();
-        lock = client.getLock(randomString());
+    @Override
+    protected HazelcastInstance[] newInstances() {
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        return new HazelcastInstance[]{client, member};
     }
 
     @After
     public void tearDown() {
-        lock.forceUnlock();
         hazelcastFactory.terminateAll();
-    }
-
-    @Test
-    public void testLockConditionSimpleUsage() throws InterruptedException {
-        final String name = randomString();
-        final ILock lock = client.getLock(name);
-        final ICondition condition = lock.newCondition(randomString());
-        final AtomicInteger count = new AtomicInteger(0);
-        final CountDownLatch threadGetTheLock = new CountDownLatch(1);
-
-        Thread t = new Thread(new Runnable() {
-            public void run() {
-                lock.lock();
-                threadGetTheLock.countDown();
-                try {
-                    if (lock.isLockedByCurrentThread()) {
-                        count.incrementAndGet();
-                    }
-                    condition.await();
-                    if (lock.isLockedByCurrentThread()) {
-                        count.incrementAndGet();
-                    }
-                } catch (InterruptedException ignored) {
-                } finally {
-                    lock.unlock();
-                }
-            }
-        });
-        t.start();
-        assertOpenEventually(threadGetTheLock);
-
-        lock.lock();
-        assertEquals(true, lock.isLocked());
-        condition.signal();
-        lock.unlock();
-        t.join();
-        assertEquals(2, count.get());
-    }
-
-    @Test
-    public void testLockConditionSignalAll() throws InterruptedException {
-        final String name = "testLockConditionSimpleUsage";
-        final ILock lock = client.getLock(name);
-        final ICondition condition = lock.newCondition(name + "c");
-        final AtomicInteger count = new AtomicInteger(0);
-        final int k = 50;
-
-        final CountDownLatch awaitLatch = new CountDownLatch(k);
-        final CountDownLatch finalLatch = new CountDownLatch(k);
-        for (int i = 0; i < k; i++) {
-            new Thread(new Runnable() {
-                public void run() {
-                    lock.lock();
-                    try {
-                        if (lock.isLockedByCurrentThread()) {
-                            count.incrementAndGet();
-                        }
-                        awaitLatch.countDown();
-                        condition.await();
-                        if (lock.isLockedByCurrentThread()) {
-                            count.incrementAndGet();
-                        }
-                    } catch (InterruptedException ignored) {
-                    } finally {
-                        lock.unlock();
-                        finalLatch.countDown();
-                    }
-
-                }
-            }).start();
-        }
-
-        awaitLatch.await(1, TimeUnit.MINUTES);
-        lock.lock();
-        condition.signalAll();
-        lock.unlock();
-        finalLatch.await(1, TimeUnit.MINUTES);
-        assertEquals(k * 2, count.get());
-    }
-
-
-    @Test(expected = DistributedObjectDestroyedException.class)
-    public void testDestroyLockWhenOtherWaitingOnConditionAwait() {
-        final ILock lock = client.getLock("testDestroyLockWhenOtherWaitingOnConditionAwait");
-        final ICondition condition = lock.newCondition("condition");
-        final CountDownLatch latch = new CountDownLatch(1);
-
-        new Thread(new Runnable() {
-            public void run() {
-                try {
-                    latch.await(30, TimeUnit.SECONDS);
-                    Thread.sleep(5000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                lock.destroy();
-            }
-        }).start();
-
-        lock.lock();
-        try {
-            latch.countDown();
-            condition.await();
-        } catch (InterruptedException e) {
-        }
-        lock.unlock();
-    }
-
-    @Test(expected = IllegalMonitorStateException.class)
-    public void testIllegalConditionUsageWithoutAcquiringLock() {
-        final ICondition condition = lock.newCondition("condition");
-        try {
-            condition.await();
-        } catch (InterruptedException e) {
-        }
-    }
-
-    @Test(expected = IllegalMonitorStateException.class)
-    public void testIllegalConditionUsageSignalToNonAwaiter() {
-        final ICondition condition = lock.newCondition("condition");
-        condition.signal();
-    }
-
-    @Test
-    public void testConditionUsage() throws InterruptedException {
-        lock.lock();
-        final ICondition condition = lock.newCondition("condition");
-        condition.await(1, TimeUnit.SECONDS);
-        lock.unlock();
-    }
-
-    @Test
-    public void testAwaitNanos_remainingTime() throws InterruptedException {
-        ICondition condition = lock.newCondition("condition");
-
-        lock.lock();
-        try {
-            long timeout = 1000L;
-            long remainingTimeout = condition.awaitNanos(timeout);
-            assertTrue("Remaining timeout should be <= 0, but it's = " + remainingTimeout,
-                    remainingTimeout <= 0);
-        } finally {
-            lock.unlock();
-        }
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/LegacyClientConditionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/LegacyClientConditionTest.java
@@ -1,0 +1,189 @@
+package com.hazelcast.client.lock;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICondition;
+import com.hazelcast.core.ILock;
+import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LegacyClientConditionTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance client;
+    private ILock lock;
+
+    @Before
+    public void setup() {
+        hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+        lock = client.getLock(randomString());
+    }
+
+    @After
+    public void tearDown() {
+        lock.forceUnlock();
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testLockConditionSimpleUsage() throws InterruptedException {
+        final String name = randomString();
+        final ILock lock = client.getLock(name);
+        final ICondition condition = lock.newCondition(randomString());
+        final AtomicInteger count = new AtomicInteger(0);
+        final CountDownLatch threadGetTheLock = new CountDownLatch(1);
+
+        Thread t = new Thread(new Runnable() {
+            public void run() {
+                lock.lock();
+                threadGetTheLock.countDown();
+                try {
+                    if (lock.isLockedByCurrentThread()) {
+                        count.incrementAndGet();
+                    }
+                    condition.await();
+                    if (lock.isLockedByCurrentThread()) {
+                        count.incrementAndGet();
+                    }
+                } catch (InterruptedException ignored) {
+                } finally {
+                    lock.unlock();
+                }
+            }
+        });
+        t.start();
+        assertOpenEventually(threadGetTheLock);
+
+        lock.lock();
+        assertEquals(true, lock.isLocked());
+        condition.signal();
+        lock.unlock();
+        t.join();
+        assertEquals(2, count.get());
+    }
+
+    @Test
+    public void testLockConditionSignalAll() throws InterruptedException {
+        final String name = "testLockConditionSimpleUsage";
+        final ILock lock = client.getLock(name);
+        final ICondition condition = lock.newCondition(name + "c");
+        final AtomicInteger count = new AtomicInteger(0);
+        final int k = 50;
+
+        final CountDownLatch awaitLatch = new CountDownLatch(k);
+        final CountDownLatch finalLatch = new CountDownLatch(k);
+        for (int i = 0; i < k; i++) {
+            new Thread(new Runnable() {
+                public void run() {
+                    lock.lock();
+                    try {
+                        if (lock.isLockedByCurrentThread()) {
+                            count.incrementAndGet();
+                        }
+                        awaitLatch.countDown();
+                        condition.await();
+                        if (lock.isLockedByCurrentThread()) {
+                            count.incrementAndGet();
+                        }
+                    } catch (InterruptedException ignored) {
+                    } finally {
+                        lock.unlock();
+                        finalLatch.countDown();
+                    }
+
+                }
+            }).start();
+        }
+
+        awaitLatch.await(1, TimeUnit.MINUTES);
+        lock.lock();
+        condition.signalAll();
+        lock.unlock();
+        finalLatch.await(1, TimeUnit.MINUTES);
+        assertEquals(k * 2, count.get());
+    }
+
+
+    @Test(expected = DistributedObjectDestroyedException.class)
+    public void testDestroyLockWhenOtherWaitingOnConditionAwait() {
+        final ILock lock = client.getLock("testDestroyLockWhenOtherWaitingOnConditionAwait");
+        final ICondition condition = lock.newCondition("condition");
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        new Thread(new Runnable() {
+            public void run() {
+                try {
+                    latch.await(30, TimeUnit.SECONDS);
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                lock.destroy();
+            }
+        }).start();
+
+        lock.lock();
+        try {
+            latch.countDown();
+            condition.await();
+        } catch (InterruptedException e) {
+        }
+        lock.unlock();
+    }
+
+    @Test(expected = IllegalMonitorStateException.class)
+    public void testIllegalConditionUsageWithoutAcquiringLock() {
+        final ICondition condition = lock.newCondition("condition");
+        try {
+            condition.await();
+        } catch (InterruptedException e) {
+        }
+    }
+
+    @Test(expected = IllegalMonitorStateException.class)
+    public void testIllegalConditionUsageSignalToNonAwaiter() {
+        final ICondition condition = lock.newCondition("condition");
+        condition.signal();
+    }
+
+    @Test
+    public void testConditionUsage() throws InterruptedException {
+        lock.lock();
+        final ICondition condition = lock.newCondition("condition");
+        condition.await(1, TimeUnit.SECONDS);
+        lock.unlock();
+    }
+
+    @Test
+    public void testAwaitNanos_remainingTime() throws InterruptedException {
+        ICondition condition = lock.newCondition("condition");
+
+        lock.lock();
+        try {
+            long timeout = 1000L;
+            long remainingTimeout = condition.awaitNanos(timeout);
+            assertTrue("Remaining timeout should be <= 0, but it's = " + remainingTimeout,
+                    remainingTimeout <= 0);
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
@@ -107,7 +107,11 @@ final class ConditionImpl implements ICondition {
     @Override
     public boolean awaitUntil(Date deadline) throws InterruptedException {
         long until = deadline.getTime();
-        return await(until - Clock.currentTimeMillis(), TimeUnit.MILLISECONDS);
+        long durationMs = until - Clock.currentTimeMillis();
+        if (durationMs <= 0) {
+            return false;
+        }
+        return await(durationMs, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAbstractTest.java
@@ -440,6 +440,17 @@ public abstract class ConditionAbstractTest extends HazelcastTestSupport {
         assertFalse(condition.awaitUntil(currentTimeAfterGivenMillis(1000)));
     }
 
+
+    @Test(timeout = 60000)
+    public void testAwaitUntil_whenDeadLineInThePast() throws InterruptedException {
+        ILock lock = callerInstance.getLock(newName());
+        ICondition condition = lock.newCondition(newName());
+
+        lock.lock();
+
+        assertFalse(condition.awaitUntil(currentTimeAfterGivenMillis(-1000)));
+    }
+
     // https://github.com/hazelcast/hazelcast/issues/3262
     @Test(timeout = 60000)
     @Ignore


### PR DESCRIPTION
See [commit message](https://github.com/hazelcast/hazelcast/commit/768b06e52b35f4e20f04434b8154389877bc9713) for details.

There are also 2 additional changes:
- Client lock proxy fails fast on `newCondition()` when name is `null`. This makes it consistent with member proxy impl. This behaviour is specified in `ILock` contract since at least Hazelcast 3.2, but it wasn't enforced on a client-side. See https://github.com/jerrinot/hazelcast/commit/57941a237ea4f3701089ee96c8a8ba9405511152#diff-05672139fa6d01518bb60ac3ffc60a4fR97

- Re-use `ConditionAbstractTest` on a client side. 

Fixes #4372