### PR TITLE
Fixes in ICondition

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionKey.java
@@ -24,16 +24,24 @@ public final class ConditionKey implements WaitNotifyKey {
     private final String name;
     private final Data key;
     private final String conditionId;
+    private final long threadId;
+    private final String uuid;
 
-    public ConditionKey(String name, Data key, String conditionId) {
+    public ConditionKey(String name, Data key, String conditionId, String uuid, long threadId) {
         this.name = name;
         this.key = key;
         this.conditionId = conditionId;
+        this.uuid = uuid;
+        this.threadId = threadId;
     }
 
     @Override
     public String getServiceName() {
         return LockServiceImpl.SERVICE_NAME;
+    }
+
+    public String getUuid() {
+        return uuid;
     }
 
     @Override
@@ -49,31 +57,53 @@ public final class ConditionKey implements WaitNotifyKey {
         return conditionId;
     }
 
+    public long getThreadId() {
+        return threadId;
+    }
+
     @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof ConditionKey)) {
             return false;
         }
-
         ConditionKey that = (ConditionKey) o;
-
-        if (key != null ? !key.equals(that.key) : that.key != null) {
+        if (threadId != that.threadId) {
             return false;
         }
-        if (conditionId != null ? !conditionId.equals(that.conditionId) : that.conditionId != null) {
+        if (!name.equals(that.name)) {
             return false;
         }
+        if (!key.equals(that.key)) {
+            return false;
+        }
+        if (!uuid.equals(that.uuid)) {
+            return false;
+        }
+        return conditionId.equals(that.conditionId);
 
-        return true;
     }
 
     @Override
     public int hashCode() {
-        int result = key != null ? key.hashCode() : 0;
-        result = 31 * result + (conditionId != null ? conditionId.hashCode() : 0);
+        int result = name.hashCode();
+        result = 31 * result + key.hashCode();
+        result = 31 * result + conditionId.hashCode();
+        result = 31 * result + (int) (threadId ^ (threadId >>> 32));
+        result = 31 * result + uuid.hashCode();
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ConditionKey{"
+                + "name='" + name + '\''
+                + ", key=" + key
+                + ", conditionId='" + conditionId + '\''
+                + ", threadId=" + threadId
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AbstractLockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AbstractLockOperation.java
@@ -104,12 +104,12 @@ public abstract class AbstractLockOperation extends AbstractOperation
         }
     }
 
-    protected final void setReferenceCallId(long refCallId) {
-        this.referenceCallId = refCallId;
-    }
-
     protected final long getReferenceCallId() {
         return referenceCallId != 0 ? referenceCallId : getCallId();
+    }
+
+    protected final void setReferenceCallId(long refCallId) {
+        this.referenceCallId = refCallId;
     }
 
     @Override
@@ -149,7 +149,7 @@ public abstract class AbstractLockOperation extends AbstractOperation
     @Override
     protected void toString(StringBuilder sb) {
         super.toString(sb);
-
         sb.append(", namespace=").append(namespace);
+        sb.append(", threadId=").append(threadId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -47,7 +47,7 @@ public class AwaitBackupOperation extends AbstractLockOperation
     public void run() throws Exception {
         LockStoreImpl lockStore = getLockStore();
         lockStore.lock(key, originalCaller, threadId, getReferenceCallId(), leaseTime);
-        ConditionKey conditionKey = new ConditionKey(namespace.getObjectName(), key, conditionId);
+        ConditionKey conditionKey = new ConditionKey(namespace.getObjectName(), key, conditionId, originalCaller, threadId);
         lockStore.removeSignalKey(conditionKey);
         lockStore.removeAwait(key, conditionId, originalCaller, threadId);
         response = true;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.concurrent.lock.operations;
 
-import com.hazelcast.concurrent.lock.ConditionKey;
 import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -42,23 +41,11 @@ abstract class BaseSignalOperation extends AbstractLockOperation {
 
     @Override
     public void run() throws Exception {
-        LockStoreImpl lockStore = getLockStore();
-        awaitCount = lockStore.getAwaitCount(key, conditionId);
-        int signalCount;
-        if (awaitCount > 0) {
-            if (all) {
-                signalCount = awaitCount;
-            } else {
-                signalCount = 1;
-            }
-        } else {
-            signalCount = 0;
-        }
-        ConditionKey notifiedKey = new ConditionKey(namespace.getObjectName(), key, conditionId);
-        for (int i = 0; i < signalCount; i++) {
-            lockStore.registerSignalKey(notifiedKey);
-        }
         response = true;
+
+        LockStoreImpl lockStore = getLockStore();
+        int signalCount = all ? Integer.MAX_VALUE : 1;
+        lockStore.signal(key, conditionId, signalCount);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.concurrent.lock.operations;
 
 import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.concurrent.lock.LockStoreImpl;
-import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -80,7 +79,8 @@ public class BeforeAwaitOperation extends AbstractLockOperation implements Notif
 
     @Override
     public WaitNotifyKey getNotifiedKey() {
-        return new LockWaitNotifyKey(namespace, key);
+        LockStoreImpl lockStore = getLockStore();
+        return lockStore.getNotifiedKey(key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.concurrent.lock.operations;
 
-import com.hazelcast.concurrent.lock.ConditionKey;
 import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.concurrent.lock.LockStoreImpl;
-import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -114,12 +112,7 @@ public class UnlockOperation extends AbstractLockOperation implements Notifier, 
     @Override
     public final WaitNotifyKey getNotifiedKey() {
         LockStoreImpl lockStore = getLockStore();
-        ConditionKey conditionKey = lockStore.getSignalKey(key);
-        if (conditionKey == null) {
-            return new LockWaitNotifyKey(namespace, key);
-        } else {
-            return conditionKey;
-        }
+        return lockStore.getNotifiedKey(key);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAdvancedTest.java
@@ -161,7 +161,6 @@ public class ConditionAdvancedTest extends HazelcastTestSupport {
 
 
     @Test
-    @Ignore // https://github.com/hazelcast/hazelcast/issues/2272
     public void testLockConditionSignalAllShutDownKeyOwner() throws InterruptedException {
         final TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
         final String name = randomString();

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ProducerConsumerConditionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ProducerConsumerConditionStressTest.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.assertNull;
 
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Ignore // https://github.com/hazelcast/hazelcast/issues/2272
 public class ProducerConsumerConditionStressTest extends HazelcastTestSupport {
 
     private static volatile Object object;
@@ -27,20 +26,19 @@ public class ProducerConsumerConditionStressTest extends HazelcastTestSupport {
     public void test() {
         HazelcastInstance[] instances = createHazelcastInstanceFactory(INSTANCE_COUNT).newInstances();
         HazelcastInstance hz = instances[0];
-        //Hazelcast.newHazelcastInstance();
         ILock lock = hz.getLock(randomString());
         ICondition condition = lock.newCondition(randomString());
 
         ConsumerThread[] consumers = new ConsumerThread[CONSUMER_COUNT];
         for (int k = 0; k < consumers.length; k++) {
-            ConsumerThread thread = new ConsumerThread(1, lock, condition);
+            ConsumerThread thread = new ConsumerThread(k, lock, condition);
             thread.start();
             consumers[k] = thread;
         }
 
         ProducerThread[] producers = new ProducerThread[PRODUCER_COUNT];
         for (int k = 0; k < producers.length; k++) {
-            ProducerThread thread = new ProducerThread(1, lock, condition);
+            ProducerThread thread = new ProducerThread(k, lock, condition);
             thread.start();
             producers[k] = thread;
         }


### PR DESCRIPTION
See #2272 for further discussion.

There are 2 big fixes:
- `ConditionKey` is tight to a particular Waiter.
This is needed as otherwise a thread might eat its own signal.
- BeforeAwaitOperation::getNotifiedKey returns `ConditionKey` when there
is a pending signal.

There are also additional improvements:
- Move getNotifiedKey() up to `LockStoreImpl`
- Map notifiers use this idiom for creating a notifier key:  If there is a pending signal (ConditionKey) then use it as a notifier. Otherwise use a regular LockWaitNotifyKey
- `ConditionInfo` simplification

Fixes #3317, #2272, #3789