### PR TITLE
Fixed failure in IMap.putAll() on bouncing members

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultiPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultiPartitionOperation.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionResponse;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.Future;
+
+/**
+ * Abstract {@link MultiPartitionOperation} which takes care about the partitions and the response of the operation.
+ */
+public abstract class AbstractMultiPartitionOperation extends MapOperation implements MultiPartitionOperation, DataSerializable {
+
+    private int[] partitions;
+
+    private transient Object[] results;
+
+    @SuppressWarnings("unused")
+    public AbstractMultiPartitionOperation() {
+    }
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public AbstractMultiPartitionOperation(String name, int[] partitions) {
+        super(name);
+        this.partitions = partitions;
+    }
+
+    protected int getPartitionCount() {
+        return partitions.length;
+    }
+
+    protected abstract void doRun(int[] partitions, Future[] futures);
+
+    protected abstract Operation createFailureOperation(int failedPartitionId, int partitionIndex);
+
+    @Override
+    public final void run() throws Exception {
+        Future[] futures = new Future[partitions.length];
+        doRun(partitions, futures);
+        // TODO: this should be done non-blocking to free the operation thread as soon as possible
+        results = new Object[partitions.length];
+        for (int i = 0; i < partitions.length; i++) {
+            try {
+                results[i] = futures[i].get();
+            } catch (Throwable t) {
+                results[i] = t;
+            }
+        }
+    }
+
+    @Override
+    public final Object getResponse() {
+        return new PartitionResponse(partitions, results);
+    }
+
+    @Override
+    @SuppressFBWarnings("EI_EXPOSE_REP")
+    public final int[] getPartitions() {
+        return partitions;
+    }
+
+    @Override
+    public final Operation createFailureOperation(int failedPartitionId) {
+        for (int i = 0; i < partitions.length; i++) {
+            if (partitions[i] == failedPartitionId) {
+                return createFailureOperation(failedPartitionId, i);
+            }
+        }
+        throw new IllegalArgumentException("Unknown partitionId " + failedPartitionId + " (" + Arrays.toString(partitions) + ")");
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeIntArray(partitions);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        partitions = in.readIntArray();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -225,7 +225,7 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries) {
+    public MultiPartitionOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries) {
         return new PutAllPerMemberOperation(name, partitions, mapEntries);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -72,7 +72,7 @@ public interface MapOperationProvider {
 
     MapOperation createPutAllOperation(String name, MapEntries mapEntries);
 
-    MapOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries);
+    MultiPartitionOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries);
 
     MapOperation createPutFromLoadAllOperation(String name, List<Data> keyValueSequence);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -138,7 +138,7 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries) {
+    public MultiPartitionOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries) {
         return getDelegate().createPutAllPerMemberOperation(name, partitions, mapEntries);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultiPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultiPartitionOperation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.spi.Operation;
+
+/**
+ * An interface that can be implemented by an operation to indicate that it contains
+ * data for multiple partitions.
+ */
+public interface MultiPartitionOperation {
+
+    /**
+     * Returns the partitions this operations contains.
+     *
+     * @return array with all partitions of this operation
+     */
+    int[] getPartitions();
+
+    /**
+     * Creates a new operation for a failed partition id.
+     *
+     * @param failedPartitionId the failed partition id
+     * @return a new operation
+     */
+    Operation createFailureOperation(int failedPartitionId);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
@@ -125,7 +125,7 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
     }
 
     @Override
-    public MapOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries) {
+    public MultiPartitionOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries) {
         checkWanReplicationQueues(name);
         return getDelegate().createPutAllPerMemberOperation(name, partitions, mapEntries);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -38,7 +38,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.impl.nearcache.NearCache.NULL_OBJECT;
@@ -303,16 +302,14 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Future createPutAllOperationFuture(String name, long size, int[] partitions, MapEntries[] entries,
-                                                 Address address) {
-        Future future = super.createPutAllOperationFuture(name, size, partitions, entries, address);
-
+    protected void createPutAllPerMemberOperation(Address address, long size, int[] partitions, MapEntries[] entries)
+            throws Exception {
+        super.createPutAllPerMemberOperation(address, size, partitions, entries);
         for (MapEntries mapEntries : entries) {
             for (int i = 0; i < mapEntries.size(); i++) {
                 invalidateCache(mapEntries.getKey(i));
             }
         }
-        return future;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.eventservice.impl.EventEnvelope;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
-import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation.PartitionResponse;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -18,11 +18,14 @@ package com.hazelcast.spi.impl.operationservice;
 
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
+import com.hazelcast.map.impl.operation.MultiPartitionOperation;
+import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * This is the interface that needs to be implemented by actual InternalOperationService. Currently there is a single
@@ -106,6 +109,20 @@ public interface InternalOperationService extends OperationService {
      * @return list of {@link SlowOperationDTO} instances.
      */
     List<SlowOperationDTO> getSlowOperationDTOs();
+
+    /**
+     * Invokes a {@link MultiPartitionOperation} on a selected target node.
+     * * <p/>
+     * This method blocks until the operation completes for all partitions.
+     *
+     * @param serviceName the name of the service
+     * @param op          the operation
+     * @param address     the target node the operation should be executed on
+     * @return a Map with partitionId as key and the outcome of the operation as value.
+     * @throws Exception
+     */
+    Map<Integer, Object> invokeMultiplePartitionOperation(String serviceName, MultiPartitionOperation op, Address address,
+                                                          ExecutionCallback<Object> executionCallback) throws Exception;
 
     <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnMultiplePartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnMultiplePartitions.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.map.impl.operation.MultiPartitionOperation;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionResponse;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ * Executes a {@link MultiPartitionOperation} with multiple partitions on a target.
+ */
+final class InvokeOnMultiplePartitions {
+
+    private final OperationServiceImpl operationService;
+    private final String serviceName;
+    private final MultiPartitionOperation operation;
+    private final Address address;
+    private final ExecutionCallback<Object> executionCallback;
+    private final Map<Integer, Object> partitionResults;
+
+    InvokeOnMultiplePartitions(OperationServiceImpl operationService, String serviceName, MultiPartitionOperation operation,
+                               Address address, ExecutionCallback<Object> executionCallback) {
+        int partitionCount = operationService.nodeEngine.getPartitionService().getPartitionCount();
+
+        this.operationService = operationService;
+        this.serviceName = serviceName;
+        this.operation = operation;
+        this.address = address;
+        this.executionCallback = executionCallback;
+        this.partitionResults = new HashMap<Integer, Object>(partitionCount);
+    }
+
+    /**
+     * Executes all the operations on the partitions.
+     */
+    Map<Integer, Object> invoke() throws Exception {
+        ensureNotCallingFromOperationThread();
+
+        InternalCompletableFuture<Object> future = operationService
+                .createInvocationBuilder(serviceName, (Operation) operation, address)
+                .setTryCount(1)
+                .invoke();
+        if (executionCallback != null) {
+            future.andThen(executionCallback);
+        }
+
+        NodeEngineImpl nodeEngine = operationService.nodeEngine;
+        try {
+            Object response = future.get();
+            PartitionResponse result = (PartitionResponse) nodeEngine.toObject(response);
+            result.addResults(partitionResults);
+        } catch (Throwable t) {
+            if (operationService.logger.isFinestEnabled()) {
+                operationService.logger.finest(t);
+            } else {
+                operationService.logger.warning(t.getMessage());
+            }
+            for (Integer partition : operation.getPartitions()) {
+                partitionResults.put(partition, t);
+            }
+        }
+
+        retryFailedPartitions();
+
+        return partitionResults;
+    }
+
+    private void ensureNotCallingFromOperationThread() {
+        if (operationService.operationExecutor.isOperationThread()) {
+            throw new IllegalThreadStateException(Thread.currentThread() + " cannot make invocation on multiple partitions!");
+        }
+    }
+
+    private void retryFailedPartitions() throws InterruptedException, ExecutionException {
+        List<Integer> failedPartitions = new LinkedList<Integer>();
+        for (Map.Entry<Integer, Object> partitionResult : partitionResults.entrySet()) {
+            int partitionId = partitionResult.getKey();
+            Object result = partitionResult.getValue();
+            if (result instanceof Throwable) {
+                failedPartitions.add(partitionId);
+            }
+        }
+
+        if (failedPartitions.isEmpty()) {
+            return;
+        }
+
+        for (Integer failedPartition : failedPartitions) {
+            Operation op = operation.createFailureOperation(failedPartition);
+            Future future = operationService.createInvocationBuilder(serviceName, op, failedPartition).invoke();
+            partitionResults.put(failedPartition, future);
+        }
+
+        for (Integer failedPartition : failedPartitions) {
+            Future future = (Future) partitionResults.get(failedPartition);
+            Object result = future.get();
+            partitionResults.put(failedPartition, result);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionResponse;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -93,8 +94,7 @@ final class InvokeOnPartitions {
         for (Map.Entry<Address, Future> response : futures.entrySet()) {
             try {
                 Future future = response.getValue();
-                PartitionIteratingOperation.PartitionResponse result = (PartitionIteratingOperation.PartitionResponse)
-                        nodeEngine.toObject(future.get());
+                PartitionResponse result = (PartitionResponse) nodeEngine.toObject(future.get());
                 result.addResults(partitionResults);
             } catch (Throwable t) {
                 if (operationService.logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.impl.operation.MultiPartitionOperation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionManager;
@@ -375,6 +376,13 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         }
         InvokeOnPartitions invokeOnPartitions = new InvokeOnPartitions(this, serviceName, operationFactory, memberPartitions);
         return invokeOnPartitions.invoke();
+    }
+
+    @Override
+    public Map<Integer, Object> invokeMultiplePartitionOperation(String serviceName, MultiPartitionOperation op, Address address,
+                                                                 ExecutionCallback<Object> executionCallback) throws Exception {
+        InvokeOnMultiplePartitions invocation = new InvokeOnMultiplePartitions(this, serviceName, op, address, executionCallback);
+        return invocation.invoke();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -33,7 +33,6 @@ import com.hazelcast.util.ResponseQueueFactory;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 
 import static com.hazelcast.util.CollectionUtil.toIntArray;
@@ -213,64 +212,4 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
         operationFactory = in.readObject();
         partitions = in.readIntArray();
     }
-
-    // implements IdentifiedDataSerializable to speed up serialization of arrays
-    public static final class PartitionResponse implements IdentifiedDataSerializable {
-
-        private int[] partitions;
-        private Object[] results;
-
-        public PartitionResponse() {
-        }
-
-        PartitionResponse(int[] partitions, Object[] results) {
-            this.partitions = partitions;
-            this.results = results;
-        }
-
-        public void addResults(Map<Integer, Object> partitionResults) {
-            if (results == null) {
-                return;
-            }
-            for (int i = 0; i < results.length; i++) {
-                partitionResults.put(partitions[i], results[i]);
-            }
-        }
-
-        @Override
-        public int getFactoryId() {
-            return SpiDataSerializerHook.F_ID;
-        }
-
-        @Override
-        public int getId() {
-            return SpiDataSerializerHook.PARTITION_RESPONSE;
-        }
-
-        @Override
-        public void writeData(ObjectDataOutput out) throws IOException {
-            out.writeIntArray(partitions);
-            int resultLength = (results != null ? results.length : 0);
-            out.writeInt(resultLength);
-            if (resultLength > 0) {
-                for (Object result : results) {
-                    out.writeObject(result);
-                }
-            }
-        }
-
-        @Override
-        public void readData(ObjectDataInput in) throws IOException {
-            partitions = in.readIntArray();
-            int resultLength = in.readInt();
-            if (resultLength > 0) {
-                results = new Object[resultLength];
-                for (int i = 0; i < resultLength; i++) {
-                    results[i] = in.readObject();
-                }
-            }
-        }
-    }
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionResponse.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl.operations;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.impl.SpiDataSerializerHook;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.util.Map;
+
+public final class PartitionResponse implements IdentifiedDataSerializable {
+
+    private int[] partitions;
+    private Object[] results;
+
+    public PartitionResponse() {
+    }
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public PartitionResponse(int[] partitions, Object[] results) {
+        this.partitions = partitions;
+        this.results = results;
+    }
+
+    public void addResults(Map<Integer, Object> partitionResults) {
+        if (results == null) {
+            return;
+        }
+        for (int i = 0; i < results.length; i++) {
+            partitionResults.put(partitions[i], results[i]);
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SpiDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return SpiDataSerializerHook.PARTITION_RESPONSE;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeIntArray(partitions);
+        int resultLength = (results != null ? results.length : 0);
+        out.writeInt(resultLength);
+        if (resultLength > 0) {
+            for (Object result : results) {
+                out.writeObject(result);
+            }
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        partitions = in.readIntArray();
+        int resultLength = in.readInt();
+        if (resultLength > 0) {
+            results = new Object[resultLength];
+            for (int i = 0; i < resultLength; i++) {
+                results[i] = in.readObject();
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class MapPutAllWithBouncingMemberTest extends HazelcastTestSupport {
+
+    private static final int MAP_SIZE = 1000;
+    private static final int DURATION_SECONDS = 30;
+
+    private TestHazelcastInstanceFactory factory;
+    private Config config;
+
+    @Before
+    public void setUp() {
+        factory = createHazelcastInstanceFactory();
+        config = new Config();
+    }
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testPutAll_whenAddingAndTerminatingMembers_thenPutAllShouldNotFail() {
+        testPutAll();
+    }
+
+    @Test
+    public void testPutAll_whenAddingAndTerminatingMembers_thenPutAllShouldNotFail_withBatching() {
+        config.setProperty("hazelcast.map.put.all.batch.size", "2");
+
+        testPutAll();
+    }
+
+    private void testPutAll() {
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        final IMap<Integer, Integer> map = instance.getMap(randomMapName());
+
+        final AtomicBoolean done = new AtomicBoolean(false);
+        Thread bouncingThread = new Thread() {
+            public void run() {
+                while (!done.get()) {
+                    HazelcastInstance newInstance = factory.newHazelcastInstance(config);
+                    sleepSeconds(5);
+                    factory.terminate(newInstance);
+                }
+            }
+        };
+        bouncingThread.start();
+
+        HashMap<Integer, Integer> batch = new HashMap<Integer, Integer>();
+        for (int i = 0; i < MAP_SIZE; i++) {
+            batch.put(i, i);
+        }
+
+        long started = System.nanoTime();
+        long elapsed;
+        int i = 0;
+        do {
+            map.clear();
+            map.putAll(batch);
+            sleepMillis(3);
+
+            elapsed = NANOSECONDS.toSeconds(System.nanoTime() - started);
+            if (++i % 500 == 0) {
+                System.out.println(elapsed + " sec (" + i + " iterations)");
+            }
+        } while (elapsed < DURATION_SECONDS);
+        System.out.println(elapsed + " sec (" + i + " iterations)");
+
+        done.set(true);
+        assertJoinable(bouncingThread);
+
+        assertEquals("The map size should be " + MAP_SIZE, MAP_SIZE, map.size());
+        assertTrue("There should have been multiple iterations, but was " + i, i > 1);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyMultiPartitionOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyMultiPartitionOperation.java
@@ -1,0 +1,78 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.map.impl.operation.AbstractMultiPartitionOperation;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationAccessor;
+import com.hazelcast.test.HazelcastTestSupport;
+
+import java.io.IOException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class DummyMultiPartitionOperation extends AbstractMultiPartitionOperation implements DataSerializable {
+
+    private final AtomicBoolean failureOperationCreated = new AtomicBoolean();
+
+    private Object[] data;
+
+    @SuppressWarnings("unused")
+    public DummyMultiPartitionOperation() {
+    }
+
+    DummyMultiPartitionOperation(int partition, Object data) {
+        this(new int[]{partition}, new Object[]{data});
+    }
+
+    private DummyMultiPartitionOperation(int[] partitions, Object[] data) {
+        super(HazelcastTestSupport.randomMapName(), partitions);
+        this.data = data;
+    }
+
+    boolean getFailureOperationCreated() {
+        return failureOperationCreated.get();
+    }
+
+    @Override
+    protected void doRun(int[] partitions, Future[] futures) {
+        NodeEngine nodeEngine = getNodeEngine();
+        for (int i = 0; i < partitions.length; i++) {
+            Operation op = new DummyOperation(data[i]);
+            op.setNodeEngine(nodeEngine)
+                    .setPartitionId(partitions[i])
+                    .setReplicaIndex(getReplicaIndex())
+                    .setService(getService())
+                    .setCallerUuid(getCallerUuid());
+            OperationAccessor.setCallerAddress(op, getCallerAddress());
+            futures[i] = nodeEngine.getOperationService().invokeOnPartition(op);
+        }
+    }
+
+    @Override
+    public Operation createFailureOperation(int failedPartitionId, int partitionIndex) {
+        failureOperationCreated.set(true);
+        return new DummyOperation(data[partitionIndex]);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(data.length);
+        for (Object aData : data) {
+            out.writeObject(aData);
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int size = in.readInt();
+        data = new Object[size];
+        for (int i = 0; i < size; i++) {
+            data[i] = in.readObject();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnMultiplePartitionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnMultiplePartitionsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.ExceptionThrowingCallable;
+import com.hazelcast.test.ExpectedRuntimeException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OperationServiceImpl_invokeOnMultiplePartitionsTest extends HazelcastTestSupport {
+
+    private HazelcastInstance local;
+    private HazelcastInstance remote;
+
+    private Address localAddress;
+    private Address remoteAddress;
+
+    private InternalOperationService operationService;
+
+    @Before
+    public void setup() {
+        HazelcastInstance[] nodes = createHazelcastInstanceFactory(2).newInstances();
+        warmUpPartitions(nodes);
+
+        local = nodes[0];
+        remote = nodes[1];
+
+        localAddress = local.getCluster().getLocalMember().getAddress();
+        remoteAddress = remote.getCluster().getLocalMember().getAddress();
+
+        operationService = getOperationService(local);
+    }
+
+    @Test
+    public void whenLocalPartition() throws Exception {
+        int partitionId = getPartitionId(local);
+        String expected = "foobar";
+        DummyMultiPartitionOperation operation = new DummyMultiPartitionOperation(partitionId, expected);
+
+        Map<Integer, Object> resultMap = operationService.invokeMultiplePartitionOperation(null, operation, localAddress, null);
+
+        assertEquals(1, resultMap.size());
+        assertEquals(expected, resultMap.get(partitionId));
+
+        assertFalse("A failure operation was created, although this was not expected", operation.getFailureOperationCreated());
+    }
+
+    @Test
+    public void whenRemotePartition() throws Exception {
+        int partitionId = getPartitionId(remote);
+        String expected = "foobar";
+        DummyMultiPartitionOperation operation = new DummyMultiPartitionOperation(partitionId, expected);
+
+        Map<Integer, Object> resultMap = operationService.invokeMultiplePartitionOperation(null, operation, remoteAddress, null);
+
+        assertEquals(1, resultMap.size());
+        assertEquals(expected, resultMap.get(partitionId));
+
+        assertFalse("A failure operation was created, although this was not expected", operation.getFailureOperationCreated());
+    }
+
+    @Test
+    public void whenExceptionThrownInOperationRun() throws Exception {
+        int partitionId = getPartitionId(remote);
+        DummyMultiPartitionOperation operation = new DummyMultiPartitionOperation(partitionId, new ExceptionThrowingCallable());
+
+        try {
+            operationService.invokeMultiplePartitionOperation(null, operation, remoteAddress, null);
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof ExpectedRuntimeException);
+        }
+
+        assertTrue("No failure operation was created, although this was expected", operation.getFailureOperationCreated());
+    }
+}


### PR DESCRIPTION
See this comment: https://github.com/hazelcast/hazelcast/pull/8023/files#r64714809

Thanks to @ahmetmircik for the original test. Since the `MapPutAllWithBouncingMemberTest` is running for about a minute, but contributes to the code coverage, I made it a slow test.