### PR TITLE
[BACKPORT] Ensure skipping previously removed `CacheEntryListenerConfiguration` …

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -35,6 +35,7 @@ import javax.cache.spi.CachingProvider;
 import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -412,9 +413,14 @@ public abstract class AbstractHazelcastCacheManager
     protected <K, V> void registerListeners(CacheConfig<K, V> cacheConfig, ICache<K, V> source) {
         Iterator<CacheEntryListenerConfiguration<K, V>> iterator =
                 cacheConfig.getCacheEntryListenerConfigurations().iterator();
+        Set<CacheEntryListenerConfiguration> removedListenerConfigs = new HashSet<CacheEntryListenerConfiguration>();
         while (iterator.hasNext()) {
             CacheEntryListenerConfiguration<K, V> listenerConfig = iterator.next();
+            if (removedListenerConfigs.contains(listenerConfig)) {
+                continue;
+            }
             iterator.remove();
+            removedListenerConfigs.add(listenerConfig);
             source.registerCacheEntryListener(listenerConfig);
         }
     }


### PR DESCRIPTION
…entries while iterating over added `CacheEntryListenerConfiguration`s in the `CacheConfig` for registering listeners

Backport of https://github.com/hazelcast/hazelcast/pull/8280