### PR TITLE
Fix handling of MemberLeftException in cluster state change tx commit

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -268,7 +268,7 @@ public class ClusterStateManager {
         try {
             tx.commit();
         } catch (Throwable  e) {
-            if (e instanceof TargetNotMemberException || e instanceof MemberLeftException) {
+            if (e instanceof TargetNotMemberException || e.getCause() instanceof MemberLeftException) {
                 // Member left while tx is being committed after prepare successful.
                 // We cannot rollback tx after this point. Cluster state change is done
                 // on other members.


### PR DESCRIPTION
If a member leaves during cluster change transaction commit, commit operation succeeds with swallowing the exception. As MemberLeftException is not an unchecked exception, it will be wrapped within tx.commit() call. So it should be handled with checking the cause of the outer exception.

Fixes #8227 