### PR TITLE
Deregister invocation only when you manage to complete a future

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -472,8 +472,9 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
     }
 
     private void complete(Object value) {
-        context.invocationRegistry.deregister(this);
-        future.complete(value);
+        if (future.complete(value)) {
+            context.invocationRegistry.deregister(this);
+        }
     }
 
     private void handleRetry(Object cause) {


### PR DESCRIPTION
There is a race between `notifyNormalResponse()` and `notifyBackupComplete()`
both are trying to complete a future. Only the thread which wins should deregister
an invocation from a registry.