### PR TITLE
[BACKPORT] Wait for proxies to be created before firing a partition lost event

### DIFF
--- a/hazelcast-client-legacy/src/test/java/com/hazelcast/client/map/ClientMapPartitionLostListenerTest.java
+++ b/hazelcast-client-legacy/src/test/java/com/hazelcast/client/map/ClientMapPartitionLostListenerTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.MapPartitionLostEvent;
 import com.hazelcast.map.MapPartitionLostListenerStressTest.EventCollectingMapPartitionLostListener;
@@ -14,16 +15,20 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.partition.InternalPartitionLostEvent;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
+import com.hazelcast.spi.impl.proxyservice.InternalProxyService;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Collection;
 import java.util.List;
+
 
 import static com.hazelcast.client.impl.ClientTestUtil.getHazelcastClientInstanceImpl;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
@@ -124,9 +129,6 @@ public class ClientMapPartitionLostListenerTest {
         clientConfig.getNetworkConfig().setSmartRouting(false);
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
-        assertMapContainerCreated(instance1, mapName);
-        assertMapContainerCreated(instance2, mapName);
-
         final HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
         final Address clientOwnerAddress = clientInstanceImpl.getClientClusterService().getOwnerConnectionAddress();
 
@@ -138,6 +140,9 @@ public class ClientMapPartitionLostListenerTest {
         assertRegistrationEventually(instance1, mapName, true);
         assertRegistrationEventually(instance2, mapName, true);
 
+        assertProxyExistsEventually(instance1, mapName);
+        assertProxyExistsEventually(instance2, mapName);
+
         final MapService mapService = getNode(other).getNodeEngine().getService(SERVICE_NAME);
         final int partitionId = 5;
         mapService.onPartitionLost(new InternalPartitionLostEvent(partitionId, 0, null));
@@ -145,13 +150,18 @@ public class ClientMapPartitionLostListenerTest {
         assertMapPartitionLostEventEventually(listener, partitionId);
     }
 
-    private void assertMapContainerCreated(final HazelcastInstance instance, final String mapName) {
+    private void assertProxyExistsEventually(HazelcastInstance instance, final String proxyName) {
+        final InternalProxyService proxyService = getNodeEngineImpl(instance).getProxyService();
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
-                final MapService mapService = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
-                assertNotNull(mapService.getMapServiceContext().getMapContainer(mapName));
+            public void run() throws Exception {
+                Collection<DistributedObject> allDistributedObjects = proxyService.getAllDistributedObjects();
+                for (DistributedObject distributedObject : allDistributedObjects) {
+                    if (distributedObject.getName().equals(proxyName)) {
+                        return;
+                    }
+                }
+                fail("There is no proxy with name " + proxyName + " created (yet)");
             }
         });
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapPartitionLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapPartitionLostListenerTest.java
@@ -4,6 +4,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.MapPartitionLostEvent;
 import com.hazelcast.map.MapPartitionLostListenerStressTest.EventCollectingMapPartitionLostListener;
@@ -14,16 +15,20 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.partition.InternalPartitionLostEvent;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
+import com.hazelcast.spi.impl.proxyservice.InternalProxyService;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Collection;
 import java.util.List;
+
 
 import static com.hazelcast.client.impl.ClientTestUtil.getHazelcastClientInstanceImpl;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
@@ -124,9 +129,6 @@ public class ClientMapPartitionLostListenerTest {
         clientConfig.getNetworkConfig().setSmartRouting(false);
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
-        assertMapContainerCreated(instance1, mapName);
-        assertMapContainerCreated(instance2, mapName);
-
         final HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
         final Address clientOwnerAddress = clientInstanceImpl.getClientClusterService().getOwnerConnectionAddress();
 
@@ -138,6 +140,9 @@ public class ClientMapPartitionLostListenerTest {
         assertRegistrationEventually(instance1, mapName, true);
         assertRegistrationEventually(instance2, mapName, true);
 
+        assertProxyExistsEventually(instance1, mapName);
+        assertProxyExistsEventually(instance2, mapName);
+
         final MapService mapService = getNode(other).getNodeEngine().getService(SERVICE_NAME);
         final int partitionId = 5;
         mapService.onPartitionLost(new InternalPartitionLostEvent(partitionId, 0, null));
@@ -145,13 +150,18 @@ public class ClientMapPartitionLostListenerTest {
         assertMapPartitionLostEventEventually(listener, partitionId);
     }
 
-    private void assertMapContainerCreated(final HazelcastInstance instance, final String mapName) {
+    private void assertProxyExistsEventually(HazelcastInstance instance, final String proxyName) {
+        final InternalProxyService proxyService = getNodeEngineImpl(instance).getProxyService();
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run()
-                    throws Exception {
-                final MapService mapService = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
-                assertNotNull(mapService.getMapServiceContext().getMapContainer(mapName));
+            public void run() throws Exception {
+                Collection<DistributedObject> allDistributedObjects = proxyService.getAllDistributedObjects();
+                for (DistributedObject distributedObject : allDistributedObjects) {
+                    if (distributedObject.getName().equals(proxyName)) {
+                        return;
+                    }
+                }
+                fail("There is no proxy with name " + proxyName + " created (yet)");
             }
         });
     }


### PR DESCRIPTION
Partition proxies are created eventually on all members. However
this is an async process driven by eventing system.

If a member does not have a proxy in its registry then it will
not fire MapPartitionLostListener.

I also removed the assertMapContainerCreated as it served no purpose -
- MapServiceContext.getMapContainer() has getOrCreateSemantic
-> the assert was always true.

fixes #7049, backport of #8291