### PR TITLE
Test Fix: Increase timeout to avoid spurious failures

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
@@ -310,7 +310,7 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
             public void run() throws Exception {
                 assertFalse(lock.isLocked());
             }
-        }, 5);
+        }, 20);
     }
 
     @Test(expected = NullPointerException.class, timeout = 60000)


### PR DESCRIPTION
5s is way too short timeout - a 4s long GC pause could
cause a test failure.

Fixes #8155