### PR TITLE
Revert partition table initialization check in migration flow tasks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -1171,11 +1171,6 @@ public class MigrationManager {
             try {
                 migrationQueue.clear();
 
-                if (!partitionStateManager.isInitialized()) {
-                    logger.info("Skipping control task since partition table state is reset");
-                    return;
-                }
-
                 if (partitionService.scheduleFetchMostRecentPartitionTableTaskIfRequired()) {
                     if (logger.isFinestEnabled()) {
                         logger.finest("FetchMostRecentPartitionTableTask scheduled");


### PR DESCRIPTION
They have been introduced to prevent false-positive failures of an assertion but they introduced bugs into the system. So we prefer to revert those changes and remove the assertion since it is very likely to produce false positive failures. It turned out that the assertion is not a very useful one. 