### PR TITLE
Fixed IMap.putAll() on bouncing members with PutAllPartitionAwareOperationFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -24,7 +24,6 @@ import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
 import com.hazelcast.map.impl.operation.ContainsKeyOperation;
 import com.hazelcast.map.impl.operation.EvictBackupOperation;
 import com.hazelcast.map.impl.operation.GetOperation;
-import com.hazelcast.map.impl.operation.PutAllPerMemberOperation;
 import com.hazelcast.map.impl.operation.PutBackupOperation;
 import com.hazelcast.map.impl.operation.PutOperation;
 import com.hazelcast.map.impl.operation.RemoveBackupOperation;
@@ -55,9 +54,8 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int QUERY_RESULT = 10;
     public static final int EVICT_BACKUP = 11;
     public static final int CONTAINS_KEY = 12;
-    public static final int PUT_ALL_PER_MEMBER = 13;
-    public static final int KEYS_WITH_CURSOR = 14;
-    public static final int ENTRIES_WITH_CURSOR = 15;
+    public static final int KEYS_WITH_CURSOR = 13;
+    public static final int ENTRIES_WITH_CURSOR = 14;
 
     private static final int LEN = ENTRIES_WITH_CURSOR + 1;
 
@@ -133,11 +131,6 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[CONTAINS_KEY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new ContainsKeyOperation();
-            }
-        };
-        constructors[PUT_ALL_PER_MEMBER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PutAllPerMemberOperation();
             }
         };
         constructors[KEYS_WITH_CURSOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -225,8 +225,8 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries) {
-        return new PutAllPerMemberOperation(name, partitions, mapEntries);
+    public OperationFactory createPutAllOperationFactory(String name, int[] partitions, MapEntries[] mapEntries) {
+        return new PutAllPartitionAwareOperationFactory(name, partitions, mapEntries);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -72,8 +72,6 @@ public interface MapOperationProvider {
 
     MapOperation createPutAllOperation(String name, MapEntries mapEntries);
 
-    MapOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries);
-
     MapOperation createPutFromLoadAllOperation(String name, List<Data> keyValueSequence);
 
     MapOperation createTxnDeleteOperation(String name, Data dataKey, long version);
@@ -115,5 +113,7 @@ public interface MapOperationProvider {
     OperationFactory createGetAllOperationFactory(String name, List<Data> keys);
 
     OperationFactory createMapSizeOperationFactory(String name);
+
+    OperationFactory createPutAllOperationFactory(String name, int[] partitions, MapEntries[] mapEntries);
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -138,8 +138,8 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries) {
-        return getDelegate().createPutAllPerMemberOperation(name, partitions, mapEntries);
+    public OperationFactory createPutAllOperationFactory(String name, int[] partitions, MapEntries[] mapEntries) {
+        return getDelegate().createPutAllOperationFactory(name, partitions, mapEntries);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
@@ -125,9 +125,9 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
     }
 
     @Override
-    public MapOperation createPutAllPerMemberOperation(String name, int[] partitions, MapEntries[] mapEntries) {
+    public OperationFactory createPutAllOperationFactory(String name, int[] partitions, MapEntries[] mapEntries) {
         checkWanReplicationQueues(name);
-        return getDelegate().createPutAllPerMemberOperation(name, partitions, mapEntries);
+        return getDelegate().createPutAllOperationFactory(name, partitions, mapEntries);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -38,7 +38,6 @@ import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.EntryEventFilter;
-import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -115,7 +114,6 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.lang.Math.ceil;
 import static java.lang.Math.log10;
 import static java.lang.Math.min;
-import static java.lang.Math.round;
 import static java.util.Collections.singleton;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.WARNING;
@@ -740,8 +738,8 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     }
 
     /**
-     * This method will group all puts per partition and send a {@link com.hazelcast.map.impl.operation.PutAllPerMemberOperation}
-     * per member.
+     * This method will group all puts per partition and send a
+     * {@link com.hazelcast.map.impl.operation.PutAllPartitionAwareOperationFactory} per member.
      * <p/>
      * If there are e.g. five keys for a single member, there will only be a single remote invocation
      * instead of having five remote invocations.
@@ -763,7 +761,6 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
             int initialSize = getPutAllInitialSize(useBatching, mapSize, partitionCount);
 
             Map<Address, List<Integer>> memberPartitionsMap = partitionService.getMemberPartitionsMap();
-            List<Future> futures = new ArrayList<Future>(getPutAllFutureSize(mapSize, useBatching, partitionCount));
 
             // init counters for batching
             MutableLong[] counterPerMember = null;
@@ -801,31 +798,22 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
                     long currentSize = ++counterPerMember[partitionId].value;
                     if (currentSize % putAllBatchSize == 0) {
                         List<Integer> partitions = memberPartitionsMap.get(addresses[partitionId]);
-                        invokePutAllOperation(addresses[partitionId], partitions, futures, entriesPerPartition);
+                        invokePutAllOperation(addresses[partitionId], partitions, entriesPerPartition);
                     }
                 }
             }
 
             // invoke operations for entriesPerPartition
             for (Entry<Address, List<Integer>> entry : memberPartitionsMap.entrySet()) {
-                invokePutAllOperation(entry.getKey(), entry.getValue(), futures, entriesPerPartition);
-            }
-
-            // sync on completion of the operations
-            for (Future future : futures) {
-                future.get();
+                invokePutAllOperation(entry.getKey(), entry.getValue(), entriesPerPartition);
             }
         } catch (Exception e) {
             throw rethrow(e);
         }
     }
 
-    private int getPutAllFutureSize(int mapSize, boolean useBatching, int partitionCount) {
-        return (useBatching ? round((float) partitionCount * mapSize / putAllBatchSize) : partitionCount);
-    }
-
-    private void invokePutAllOperation(Address address, List<Integer> memberPartitions, List<Future> futures,
-                                       MapEntries[] entriesPerPartition) {
+    private void invokePutAllOperation(Address address, List<Integer> memberPartitions, MapEntries[] entriesPerPartition)
+            throws Exception {
         int size = memberPartitions.size();
         int[] partitions = new int[size];
         int index = 0;
@@ -857,29 +845,15 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
             return;
         }
 
-        Future future = createPutAllOperationFuture(name, totalSize, partitions, entries, address);
-        futures.add(future);
+        invokePutAllOperationFactory(address, totalSize, partitions, entries);
     }
 
-    protected Future createPutAllOperationFuture(final String name, final long size, int[] partitions, MapEntries[] entries,
-                                                 Address address) {
-        MapOperation op = operationProvider.createPutAllPerMemberOperation(name, partitions, entries);
+    protected void invokePutAllOperationFactory(Address address, final long size, int[] partitions, MapEntries[] entries)
+            throws Exception {
+        OperationFactory factory = operationProvider.createPutAllOperationFactory(name, partitions, entries);
         final long time = System.currentTimeMillis();
-        InternalCompletableFuture<Object> future = operationService.invokeOnTarget(SERVICE_NAME, op, address);
-        future.andThen(new ExecutionCallback<Object>() {
-            @Override
-            public void onResponse(Object response) {
-                LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
-                LocalMapStatsImpl localMapStats = localMapStatsProvider.getLocalMapStatsImpl(name);
-                long currentTime = System.currentTimeMillis();
-                localMapStats.incrementPuts(size, currentTime - time);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-            }
-        });
-        return future;
+        operationService.invokeOnPartitions(SERVICE_NAME, factory, partitions);
+        localMapStats.incrementPuts(size, System.currentTimeMillis() - time);
     }
 
     // TODO: add a feature to mancenter to sync cache to db completely

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -38,7 +38,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.impl.nearcache.NearCache.NULL_OBJECT;
@@ -303,16 +302,14 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Future createPutAllOperationFuture(String name, long size, int[] partitions, MapEntries[] entries,
-                                                 Address address) {
-        Future future = super.createPutAllOperationFuture(name, size, partitions, entries, address);
-
+    protected void invokePutAllOperationFactory(Address address, long size, int[] partitions, MapEntries[] entries)
+            throws Exception {
+        super.invokePutAllOperationFactory(address, size, partitions, entries);
         for (MapEntries mapEntries : entries) {
             for (int i = 0; i < mapEntries.size(); i++) {
                 invalidateCache(mapEntries.getKey(i));
             }
         }
-        return future;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -106,6 +106,20 @@ public interface OperationService {
                                             Collection<Integer> partitions) throws Exception;
 
     /**
+     * Invokes an set of operation on selected set of partitions
+     * * <p/>
+     * This method blocks until all operations complete.
+     *
+     * @param serviceName      the name of the service
+     * @param operationFactory the factory responsible for creating operations
+     * @param partitions       the partitions the operation should be executed on.
+     * @return a Map with partitionId as key and the outcome of the operation as value.
+     * @throws Exception
+     */
+    Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory,
+                                            int[] partitions) throws Exception;
+
+    /**
      * Executes an operation remotely.
      * <p/>
      * It isn't allowed

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -378,6 +378,24 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     }
 
     @Override
+    public Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory, int[] partitions)
+            throws Exception {
+        Map<Address, List<Integer>> memberPartitions = new HashMap<Address, List<Integer>>(3);
+        InternalPartitionService partitionService = nodeEngine.getPartitionService();
+        for (int partition : partitions) {
+            Address owner = partitionService.getPartitionOwnerOrWait(partition);
+
+            if (!memberPartitions.containsKey(owner)) {
+                memberPartitions.put(owner, new ArrayList<Integer>());
+            }
+
+            memberPartitions.get(owner).add(partition);
+        }
+        InvokeOnPartitions invokeOnPartitions = new InvokeOnPartitions(this, serviceName, operationFactory, memberPartitions);
+        return invokeOnPartitions.invoke();
+    }
+
+    @Override
     public boolean send(Operation op, Address target) {
         checkNotNull(target, "Target is required!");
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBatchingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBatchingTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.spi.properties.GroupProperty;
@@ -51,15 +50,13 @@ public class MapPutAllWithBatchingTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        MapConfig mapConfig = new MapConfig("*");
-        mapConfig.setBackupCount(1);
-        mapConfig.setAsyncBackupCount(0);
-
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), valueOf(INSTANCE_COUNT * 2));
         config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "3000");
         config.setProperty("hazelcast.map.put.all.batch.size", valueOf(BATCH_SIZE));
-        config.addMapConfig(mapConfig);
+        config.getMapConfig("default")
+                .setBackupCount(1)
+                .setAsyncBackupCount(0);
 
         factory = createHazelcastInstanceFactory(INSTANCE_COUNT);
         instances = factory.newInstances(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithBouncingMemberTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class MapPutAllWithBouncingMemberTest extends HazelcastTestSupport {
+
+    private static final int MAP_SIZE = 1000;
+    private static final int DURATION_SECONDS = 30;
+
+    private TestHazelcastInstanceFactory factory;
+    private Config config;
+
+    @Before
+    public void setUp() {
+        factory = createHazelcastInstanceFactory();
+        config = getConfig();
+    }
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void testPutAll_whenAddingAndTerminatingMembers_thenPutAllShouldNotFail() {
+        testPutAll();
+    }
+
+    @Test
+    public void testPutAll_whenAddingAndTerminatingMembers_thenPutAllShouldNotFail_withBatching() {
+        config.setProperty("hazelcast.map.put.all.batch.size", "2");
+
+        testPutAll();
+    }
+
+    private void testPutAll() {
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+        final IMap<Integer, Integer> map = instance.getMap(randomMapName());
+
+        final AtomicBoolean done = new AtomicBoolean(false);
+        Thread bouncingThread = new Thread() {
+            public void run() {
+                while (!done.get()) {
+                    HazelcastInstance newInstance = factory.newHazelcastInstance(config);
+                    sleepSeconds(5);
+                    factory.terminate(newInstance);
+                }
+            }
+        };
+        bouncingThread.start();
+
+        HashMap<Integer, Integer> batch = new HashMap<Integer, Integer>();
+        for (int i = 0; i < MAP_SIZE; i++) {
+            batch.put(i, i);
+        }
+
+        long started = System.nanoTime();
+        long elapsed;
+        int i = 0;
+        do {
+            map.clear();
+            map.putAll(batch);
+            sleepMillis(3);
+
+            elapsed = NANOSECONDS.toSeconds(System.nanoTime() - started);
+            if (++i % 500 == 0) {
+                System.out.println(elapsed + " sec (" + i + " iterations)");
+            }
+        } while (elapsed < DURATION_SECONDS);
+        System.out.println(elapsed + " sec (" + i + " iterations)");
+
+        done.set(true);
+        assertJoinable(bouncingThread);
+
+        assertEquals("The map size should be " + MAP_SIZE, MAP_SIZE, map.size());
+        assertTrue("There should have been multiple iterations, but was " + i, i > 1);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithCustomInitialSizeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWithCustomInitialSizeTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.spi.properties.GroupProperty;
@@ -47,15 +46,13 @@ public class MapPutAllWithCustomInitialSizeTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        MapConfig mapConfig = new MapConfig("*");
-        mapConfig.setBackupCount(1);
-        mapConfig.setAsyncBackupCount(0);
-
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "2");
         config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "3000");
         config.setProperty("hazelcast.map.put.all.initial.size.factor", "10");
-        config.addMapConfig(mapConfig);
+        config.getMapConfig("default")
+                .setBackupCount(1)
+                .setAsyncBackupCount(0);
 
         factory = createHazelcastInstanceFactory(1);
         instances = factory.newInstances(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactoryTest.java
@@ -1,0 +1,40 @@
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PutAllPartitionAwareOperationFactoryTest extends HazelcastTestSupport {
+
+    private PutAllPartitionAwareOperationFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        String name = randomMapName();
+        int[] partitions = new int[0];
+        MapEntries[] mapEntries = new MapEntries[0];
+        factory = getFactory(name, partitions, mapEntries);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testCreateOperation() {
+        factory.createOperation();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreatePartitionOperation() {
+        factory.createPartitionOperation(0);
+    }
+
+    protected PutAllPartitionAwareOperationFactory getFactory(String name, int[] partitions, MapEntries[] mapEntries) {
+        return new PutAllPartitionAwareOperationFactory(name, partitions, mapEntries);
+    }
+}


### PR DESCRIPTION
Replaced `PutAllPerMemberOperation` with `PutAllPartitionAwareOperationFactory` to fix failure in `IMap.putAll()` on bouncing members.