### PR TITLE
Introduced FileMetricSet + cleanup

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -102,6 +102,12 @@ import com.hazelcast.internal.diagnostics.MetricsPlugin;
 import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.diagnostics.SystemPropertiesPlugin;
 import com.hazelcast.internal.diagnostics.SystemLogPlugin;
+import com.hazelcast.internal.metrics.metricsets.ClassLoadingMetricSet;
+import com.hazelcast.internal.metrics.metricsets.FileMetricSet;
+import com.hazelcast.internal.metrics.metricsets.GarbageCollectionMetricSet;
+import com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet;
+import com.hazelcast.internal.metrics.metricsets.RuntimeMetricSet;
+import com.hazelcast.internal.metrics.metricsets.ThreadMetricSet;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
@@ -231,7 +237,15 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     private MetricsRegistryImpl initMetricsRegistry() {
         ProbeLevel probeLevel = properties.getEnum(Diagnostics.METRICS_LEVEL, ProbeLevel.class);
-        return new MetricsRegistryImpl(loggingService.getLogger(MetricsRegistryImpl.class), probeLevel);
+        ILogger logger = loggingService.getLogger(MetricsRegistryImpl.class);
+        MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(logger, probeLevel);
+        RuntimeMetricSet.register(metricsRegistry);
+        GarbageCollectionMetricSet.register(metricsRegistry);
+        OperatingSystemMetricSet.register(metricsRegistry);
+        ThreadMetricSet.register(metricsRegistry);
+        ClassLoadingMetricSet.register(metricsRegistry);
+        FileMetricSet.register(metricsRegistry);
+        return metricsRegistry;
     }
 
     private Collection<AddressProvider> createAddressProviders(AddressProvider externalAddressProvider) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -23,11 +23,6 @@ import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.ProbeFunction;
 import com.hazelcast.internal.metrics.ProbeLevel;
-import com.hazelcast.internal.metrics.metricsets.ClassLoadingMetricSet;
-import com.hazelcast.internal.metrics.metricsets.GarbageCollectionMetricSet;
-import com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet;
-import com.hazelcast.internal.metrics.metricsets.RuntimeMetricSet;
-import com.hazelcast.internal.metrics.metricsets.ThreadMetricSet;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
 import com.hazelcast.logging.ILogger;
 
@@ -68,8 +63,6 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     /**
      * Creates a MetricsRegistryImpl instance.
      *
-     * Automatically registers the com.hazelcast.internal.metrics.metricsets
-     *
      * @param logger       the ILogger used
      * @param minimumLevel the minimum ProbeLevel. If a probe is registered with a ProbeLevel lower than the minimum ProbeLevel,
      *                     then the registration is skipped.
@@ -82,12 +75,6 @@ public class MetricsRegistryImpl implements MetricsRegistry {
         if (logger.isFinestEnabled()) {
             logger.finest("MetricsRegistry minimumLevel:" + minimumLevel);
         }
-
-        RuntimeMetricSet.register(this);
-        GarbageCollectionMetricSet.register(this);
-        OperatingSystemMetricSet.register(this);
-        ThreadMetricSet.register(this);
-        ClassLoadingMetricSet.register(this);
     }
 
     int modCount() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/FileMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/FileMetricSet.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.metricsets;
+
+import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+
+import java.io.File;
+
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * A MetricSet for files. Currently only displays space statistics for the partition of the user.home
+ */
+public final class FileMetricSet {
+
+    private FileMetricSet() {
+    }
+
+    /**
+     * Registers all the metrics in this metric pack.
+     *
+     * @param metricsRegistry the MetricsRegistry upon which the metrics are registered.
+     */
+    public static void register(MetricsRegistry metricsRegistry) {
+        checkNotNull(metricsRegistry, "metricsRegistry");
+
+        File file = new File(System.getProperty("user.home"));
+
+        metricsRegistry.register(file, "file.partition[user.home].freeSpace", MANDATORY,
+                new LongProbeFunction<File>() {
+                    @Override
+                    public long get(File file) {
+                        return file.getFreeSpace();
+                    }
+                }
+        );
+
+        metricsRegistry.register(file, "file.partition[user.home].totalSpace", MANDATORY,
+                new LongProbeFunction<File>() {
+                    @Override
+                    public long get(File file) {
+                        return file.getTotalSpace();
+                    }
+                }
+        );
+
+        metricsRegistry.register(file, "file.partition[user.home].usableSpace", MANDATORY,
+                new LongProbeFunction<File>() {
+                    @Override
+                    public long get(File file) {
+                        return file.getUsableSpace();
+                    }
+                }
+        );
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -38,6 +38,12 @@ import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.diagnostics.SlowOperationPlugin;
 import com.hazelcast.internal.diagnostics.SystemPropertiesPlugin;
 import com.hazelcast.internal.diagnostics.SystemLogPlugin;
+import com.hazelcast.internal.metrics.metricsets.ClassLoadingMetricSet;
+import com.hazelcast.internal.metrics.metricsets.FileMetricSet;
+import com.hazelcast.internal.metrics.metricsets.GarbageCollectionMetricSet;
+import com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet;
+import com.hazelcast.internal.metrics.metricsets.RuntimeMetricSet;
+import com.hazelcast.internal.metrics.metricsets.ThreadMetricSet;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.logging.ILogger;
@@ -172,6 +178,13 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     public void start() {
+        RuntimeMetricSet.register(metricsRegistry);
+        GarbageCollectionMetricSet.register(metricsRegistry);
+        OperatingSystemMetricSet.register(metricsRegistry);
+        ThreadMetricSet.register(metricsRegistry);
+        ClassLoadingMetricSet.register(metricsRegistry);
+        FileMetricSet.register(metricsRegistry);
+
         metricsRegistry.collectMetrics(operationService);
         metricsRegistry.collectMetrics(proxyService);
         metricsRegistry.collectMetrics(eventService);

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSetTest.java
@@ -29,6 +29,7 @@ public class ClassLoadingMetricSetTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
+        ClassLoadingMetricSet.register(metricsRegistry);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/FileMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/FileMetricSetTest.java
@@ -1,0 +1,66 @@
+package com.hazelcast.internal.metrics.metricsets;
+
+import com.hazelcast.internal.metrics.LongGauge;
+import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class FileMetricSetTest extends HazelcastTestSupport {
+    private MetricsRegistryImpl metricsRegistry;
+
+    @Before
+    public void setup() {
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
+        FileMetricSet.register(metricsRegistry);
+    }
+
+    @Test
+    public void utilityConstructor() {
+        assertUtilityConstructor(FileMetricSet.class);
+    }
+
+    @Test
+    public void freeSpace() {
+        File file = new File(System.getProperty("user.home"));
+
+        LongGauge freeSpaceGauge = metricsRegistry.newLongGauge("file.partition[user.home].freeSpace");
+
+        assertAlmostEquals(file.getFreeSpace(), freeSpaceGauge.read());
+    }
+
+    @Test
+    public void totalSpace() {
+        File file = new File(System.getProperty("user.home"));
+
+        LongGauge totalSpaceGauge = metricsRegistry.newLongGauge("file.partition[user.home].totalSpace");
+
+        assertAlmostEquals(file.getTotalSpace(), totalSpaceGauge.read());
+    }
+
+    @Test
+    public void usableSpace() {
+        File file = new File(System.getProperty("user.home"));
+
+        LongGauge usableSpaceGauge = metricsRegistry.newLongGauge("file.partition[user.home].usableSpace");
+
+        assertAlmostEquals(file.getUsableSpace(), usableSpaceGauge.read());
+    }
+
+    public static void assertAlmostEquals(long expected, long found) {
+        assertTrue(found >= 0.9 * expected);
+        assertTrue(found <= 1.1 * expected);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSetTest.java
@@ -26,6 +26,7 @@ public class GarbageCollectionMetricSetTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
+        GarbageCollectionMetricSet.register(metricsRegistry);
         gcStats = new GarbageCollectionMetricSet.GcStats();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
@@ -33,6 +33,7 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
+        OperatingSystemMetricSet.register(metricsRegistry);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
@@ -30,6 +30,7 @@ public class RuntimeMetricSetTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), ProbeLevel.INFO);
+        RuntimeMetricSet.register(metricsRegistry);
         runtime = Runtime.getRuntime();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/ThreadMetricSetTest.java
@@ -29,6 +29,7 @@ public class ThreadMetricSetTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
+        ThreadMetricSet.register(metricsRegistry);
     }
 
     @Test


### PR DESCRIPTION
The FIleMetricSet is introduced that shows some statistics for diskspace
on the partition of the user.home directory.

Also a cleanup was done to not automatically register all metric sets in the
metrics registry; it isn't the responsibility of the registry.