### PR TITLE
Probe names for the operation thread is between brackets

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -145,7 +145,7 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
 
     @Override
     public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "operation." + getName());
+        metricsRegistry.scanAndRegister(this, "operation.thread[" + getName() + "]");
     }
 
     public final void shutdown() {


### PR DESCRIPTION
We use it with other probes so you get operation.thread[name].someproperty. To put it in line with other properties like tcp.connect[a->b].bla