### PR TITLE
Fix NPE when a lock is removed by LocalLockCleanupOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -195,7 +195,9 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
 
     void cleanWaitersAndSignalsFor(Data key, String uuid) {
         LockResourceImpl lockResource = locks.get(key);
-        lockResource.cleanWaitersAndSignalsFor(uuid);
+        if (lockResource != null) {
+            lockResource.cleanWaitersAndSignalsFor(uuid);
+        }
     }
 
     public int getVersion(Data key) {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -501,6 +501,15 @@ public abstract class HazelcastTestSupport {
         }
     }
 
+    protected String[] generateKeysBelongingToSamePartitionsOwnedBy(HazelcastInstance instance, int keyCount) {
+        int partitionId = getPartitionId(instance);
+        String[] keys = new String[keyCount];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = generateKeyForPartition(instance, partitionId);
+        }
+        return keys;
+    }
+
     private static void checkPartitionCountGreaterOrEqualMemberCount(HazelcastInstance instance) {
         Cluster cluster = instance.getCluster();
         int memberCount = cluster.getMembers().size();


### PR DESCRIPTION
The `LocalLockCleanupOperation` is executed on the same thread
just before the cleanWaitersAndSignalsFor is called.

The a lock is removed then the `cleanWaitersAndSignalsFor` might
throw NPE.

It's a regression introduced by #8269