### PR TITLE
Test Fix: Increase timeout to prevent spurious failures

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
@@ -175,7 +175,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
 
     @Test
     public void testOperationTimeoutForLongRunningRemoteOperation() throws Exception {
-        int callTimeoutMillis = 1000;
+        int callTimeoutMillis = 3000;
         Config config = new Config().setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + callTimeoutMillis);
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);


### PR DESCRIPTION
 The test used 1000ms as a (global) call timeout.
 However this timeout also drives a frequency within
 a MonitorInvocationTask is expecting to receive heartbeats.

 So with 1s call timeout the MonitorInvocationtTasks
 expects to receive a heartbeat (at least) every 1s
 ->  a bad thread scheduling or GC can cause the timeout.

 Increasing call timeout will make it less sensitive to scheduling
 however it also makes the test longer.

 Fixed #7940