### PR TITLE
Test Fix: Increased timeout in try-lock

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapLockTest.java
@@ -347,7 +347,7 @@ public class ClientMultiMapLockTest extends HazelcastTestSupport {
         new Thread() {
             public void run() {
                 try {
-                    if (mm.tryLock(key, 4, TimeUnit.SECONDS)) {
+                    if (mm.tryLock(key, 10, TimeUnit.SECONDS)) {
                         tryLockSuccess.countDown();
                     }
                 } catch (InterruptedException e) {


### PR DESCRIPTION
4 seconds is too aggressive given the original lease is for 2 seconds.

Fixed #7765