### PR TITLE
Fix Named-based Data Affinity

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -34,6 +34,7 @@ import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.ringbuffer.Ringbuffer;
@@ -83,7 +84,8 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
 
     @Override
     protected void onInitialize() {
-        partitionId = getContext().getPartitionService().getPartitionId(name);
+        String partitionKey = StringPartitioningStrategy.getPartitionKey(name);
+        partitionId = getContext().getPartitionService().getPartitionId(partitionKey);
         final SerializationService serializationService = getContext().getSerializationService();
 
         readManyAsyncResponseDecoder = new ClientMessageDecoder() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.util.ClientDelegatingFuture;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -38,7 +39,8 @@ abstract class PartitionSpecificClientProxy extends ClientProxy {
 
     @Override
     protected void onInitialize() {
-        partitionId = getContext().getPartitionService().getPartitionId(name);
+        String partitionKey = StringPartitioningStrategy.getPartitionKey(name);
+        partitionId = getContext().getPartitionService().getPartitionId(partitionKey);
     }
 
     protected ClientMessage invokeOnPartition(ClientMessage req) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/collections/impl/set/SetBasicClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/collections/impl/set/SetBasicClientTest.java
@@ -1,0 +1,25 @@
+package com.hazelcast.client.collections.impl.set;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.collection.impl.set.SetAbstractTest;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.After;
+
+public class SetBasicClientTest extends SetAbstractTest {
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @After
+    public void teardown() {
+        factory.terminateAll();
+    }
+
+
+    @Override
+    protected HazelcastInstance[] newInstances(Config config) {
+        HazelcastInstance member = factory.newHazelcastInstance(config);
+        HazelcastInstance client = factory.newHazelcastClient();
+
+        return new HazelcastInstance[]{client, member};
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetAbstractTest.java
@@ -40,14 +40,17 @@ public abstract class SetAbstractTest extends HazelcastTestSupport {
     protected IAtomicLong atomicLong;
     private ISet<String> set;
 
+    private HazelcastInstance local;
+    private HazelcastInstance target;
+
     @Before
     public void setup() {
         Config config = new Config();
         config.addSetConfig(new SetConfig("testAdd_withMaxCapacity*").setMaxSize(1));
 
         instances = newInstances(config);
-        HazelcastInstance local = instances[0];
-        HazelcastInstance target = instances[instances.length - 1];
+        local = instances[0];
+        target = instances[instances.length - 1];
         String methodName = getTestMethodName();
         String name = randomNameOwnedBy(target, methodName);
         set = local.getSet(name);
@@ -80,6 +83,8 @@ public abstract class SetAbstractTest extends HazelcastTestSupport {
 
     @Test
     public void testAdd_withMaxCapacity() {
+        String name = randomNameOwnedBy(target, "testAdd_withMaxCapacity");
+        set = local.getSet(name);
         set.add("item");
         for (int i = 1; i <= 10; i++) {
             assertFalse(set.add("item" + i));

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBasicDistributedTest.java
@@ -3,8 +3,10 @@ package com.hazelcast.collection.impl.set;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -12,8 +14,22 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelTest.class})
 public class SetBasicDistributedTest extends SetAbstractTest {
 
+    private static final int INSTANCE_COUNT = 2;
+
+    private TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory();
+
+
     @Override
     protected HazelcastInstance[] newInstances(Config config) {
-        return createHazelcastInstanceFactory(2).newInstances(config);
+        HazelcastInstance[] instances = new HazelcastInstance[INSTANCE_COUNT];
+        for (int i = 0; i < INSTANCE_COUNT; i++) {
+            instances[i] = factory.newHazelcastInstance(config);
+        }
+        return instances;
+    }
+
+    @After
+    public void teardown() {
+        factory.terminateAll();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBasicLocalTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetBasicLocalTest.java
@@ -15,4 +15,9 @@ public class SetBasicLocalTest extends SetAbstractTest {
     protected HazelcastInstance[] newInstances(Config config) {
         return createHazelcastInstanceFactory(1).newInstances(config);
     }
+
+    @Override
+    public void testNameBasedAffinity() {
+        //no-op. This test has no meaning with a single node
+    }
 }


### PR DESCRIPTION
Fix named-based affinity when using structures mapped to a partition by name. 

It also re-uses `SetAbstractTest` on a client side.
Fixes #7947

Partition Strategy on a client side looks quite complicated, It should be reviewed by @asimarslan or @ihsandemir to make sure I didn't forget anything. 