### PR TITLE
[DONT_MERGE] Add Storage#getIfSameKey

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
@@ -32,15 +32,10 @@ public class NativeMemoryConfig {
      */
     public static final int DEFAULT_MIN_BLOCK_SIZE = 16;
     /**
-     * Default power for page size
-     */
-    // this field does not have a special usage
-    // extracted because of checkstyle rules
-    public static final int DEFAULT_POWER = 22;
-    /**
      * Default page size
      */
-    public static final int DEFAULT_PAGE_SIZE = 1 << DEFAULT_POWER;
+    @SuppressWarnings("checkstyle:magicnumber")
+    public static final int DEFAULT_PAGE_SIZE = 1 << 22;
     /**
      * Default metadata space percentage
      */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
@@ -35,6 +35,14 @@ public interface Storage<K, R> {
 
     R get(K key);
 
+    /**
+     * Gives the same result as {@link #get(Object)}, but with the additional constraint
+     * that the supplied key must not just be equal to, but be exactly the same key blob (at the
+     * same memory address) as the one stored. The implementation of this method is only needed
+     * for the HD memory-based implementations.
+     */
+    R getIfSameKey(K key);
+
     void removeRecord(R record);
 
     boolean containsKey(K key);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -89,6 +89,11 @@ public class StorageImpl<R extends Record> implements Storage<Data, R> {
     }
 
     @Override
+    public R getIfSameKey(Data key) {
+        throw new UnsupportedOperationException("StorageImpl#getIfSameKey");
+    }
+
+    @Override
     public int size() {
         return records.size();
     }


### PR DESCRIPTION
Supports pointer validation in HD HotRestart code.

Merging this will make EE build broken until the new API implementation is merged.

The un-breaking EE PR is [#918](https://github.com/hazelcast/hazelcast-enterprise/pull/918).