### PR TITLE
Fix partition promotion lifecycle

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionRuntimeState.java
@@ -97,6 +97,13 @@ public final class PartitionRuntimeState implements IdentifiedDataSerializable {
     }
 
     public Address[][] getPartitionTable() {
+        if (addresses == null) {
+            addresses = new Address[addressToIndexes.size()];
+            for (Map.Entry<Address, Integer> entry : addressToIndexes.entrySet()) {
+                addresses[entry.getValue()] = entry.getKey();
+            }
+        }
+
         int length = minimizedPartitionTable.length;
         Address[][] result = new Address[length][MAX_REPLICA_COUNT];
         for (int partitionId = 0; partitionId < length; partitionId++) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPromotionOperation.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.operation;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MigrationEvent;
+import com.hazelcast.core.MigrationEvent.MigrationStatus;
+import com.hazelcast.internal.partition.MigrationCycleOperation;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.MigrationAwareService;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.PartitionMigrationEvent;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static com.hazelcast.internal.partition.InternalPartitionService.MIGRATION_EVENT_TOPIC;
+import static com.hazelcast.internal.partition.InternalPartitionService.SERVICE_NAME;
+import static com.hazelcast.spi.partition.MigrationEndpoint.DESTINATION;
+
+// Runs locally when the node becomes owner of a partition
+abstract class AbstractPromotionOperation extends AbstractOperation
+        implements PartitionAwareOperation, MigrationCycleOperation {
+
+    // this is the replica index of the partition owner before the promotion.
+    final int currentReplicaIndex;
+
+    AbstractPromotionOperation(int currentReplicaIndex) {
+        this.currentReplicaIndex = currentReplicaIndex;
+    }
+
+    void sendMigrationEvent(final MigrationStatus status) {
+        final int partitionId = getPartitionId();
+        final NodeEngine nodeEngine = getNodeEngine();
+        final Member localMember = nodeEngine.getLocalMember();
+        final MigrationEvent event = new MigrationEvent(partitionId, null, localMember, status);
+
+        final EventService eventService = nodeEngine.getEventService();
+        final Collection<EventRegistration> registrations = eventService.getRegistrations(SERVICE_NAME, MIGRATION_EVENT_TOPIC);
+        eventService.publishEvent(SERVICE_NAME, registrations, event, partitionId);
+    }
+
+    Collection<MigrationAwareService> getMigrationAwareServices() {
+        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
+        return nodeEngine.getServices(MigrationAwareService.class);
+    }
+
+    PartitionMigrationEvent getPartitionMigrationEvent() {
+        return new PartitionMigrationEvent(DESTINATION, getPartitionId(), currentReplicaIndex, 0);
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return false;
+    }
+
+    @Override
+    public boolean validatesTarget() {
+        return false;
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in)
+            throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out)
+            throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.operation;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.MigrationAwareService;
+import com.hazelcast.spi.PartitionMigrationEvent;
+
+import static com.hazelcast.core.MigrationEvent.MigrationStatus.STARTED;
+
+// Runs locally when the node becomes owner of a partition,
+// before applying promotion result to the partition table.
+final class BeforePromotionOperation extends AbstractPromotionOperation {
+
+    BeforePromotionOperation(int currentReplicaIndex) {
+        super(currentReplicaIndex);
+    }
+
+    @Override
+    public void beforeRun() throws Exception {
+        sendMigrationEvent(STARTED);
+    }
+
+    @Override
+    public void run() throws Exception {
+        ILogger logger = getLogger();
+        if (logger.isFinestEnabled()) {
+            logger.finest("Running before promotion for " + getPartitionMigrationEvent());
+        }
+
+        PartitionMigrationEvent event = getPartitionMigrationEvent();
+        for (MigrationAwareService service : getMigrationAwareServices()) {
+            try {
+                service.beforeMigration(event);
+            } catch (Throwable e) {
+                logger.warning("While promoting partitionId=" + getPartitionId(), e);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.operation;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.partition.MigrationCycleOperation;
+import com.hazelcast.internal.partition.MigrationInfo;
+import com.hazelcast.internal.partition.PartitionRuntimeState;
+import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ExceptionAction;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.exception.TargetNotMemberException;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.util.Preconditions;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Used for committing a promotion on destination.
+ * Updates the partition table on destination and commits the promotion.
+ */
+public class PromotionCommitOperation extends AbstractOperation implements MigrationCycleOperation {
+
+    private PartitionRuntimeState partitionState;
+
+    private Collection<MigrationInfo> promotions;
+
+    private String expectedMemberUuid;
+
+    private transient boolean success;
+
+    // Used while PromotionCommitOperation is running to separate before and after phases
+    private transient boolean beforeStateCompleted;
+
+    public PromotionCommitOperation() {
+    }
+
+    public PromotionCommitOperation(PartitionRuntimeState partitionState, Collection<MigrationInfo> promotions,
+            String expectedMemberUuid) {
+        Preconditions.checkNotNull(promotions);
+        this.partitionState = partitionState;
+        this.promotions = promotions;
+        this.expectedMemberUuid = expectedMemberUuid;
+    }
+
+    @Override
+    public void beforeRun() throws Exception {
+        super.beforeRun();
+
+        NodeEngine nodeEngine = getNodeEngine();
+        final Member localMember = nodeEngine.getLocalMember();
+        if (!localMember.getUuid().equals(expectedMemberUuid)) {
+            throw new IllegalStateException("This " + localMember
+                    + " is promotion commit destination but most probably it's restarted "
+                    + "and not the expected target.");
+        }
+    }
+
+    @Override
+    public void run() {
+        if (beforeStateCompleted) {
+            finalizePromotion();
+        }
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+        super.afterRun();
+
+        if (!beforeStateCompleted) {
+            // Triggering before-promotion tasks in afterRun() after response phase is done,
+            // to avoid inadvertently reading `beforeStateCompleted` as true when asked to send a response.
+            // `beforeStateCompleted` will be set when all before-promotion tasks are completed.
+            beforePromotion();
+        }
+    }
+
+    private void beforePromotion() {
+        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
+        InternalOperationService operationService = nodeEngine.getOperationService();
+        AtomicInteger tasks = new AtomicInteger(promotions.size());
+
+        ILogger logger = getLogger();
+        if (logger.isFinestEnabled()) {
+            logger.finest("Submitting before promotion tasks for " + promotions);
+        } else if (logger.isFineEnabled()) {
+            logger.fine("Submitting before promotion tasks for " + promotions.size() + " promotions.");
+        }
+        for (MigrationInfo promotion : promotions) {
+            operationService.execute(new BeforePromotionTask(this, promotion, nodeEngine, tasks));
+        }
+    }
+
+    private void finalizePromotion() {
+        ILogger logger = getLogger();
+        if (logger.isFineEnabled()) {
+            logger.fine("Running promotion finalization for " + promotions.size() + " promotions.");
+        }
+        NodeEngine nodeEngine = getNodeEngine();
+        InternalPartitionServiceImpl partitionService = getService();
+        OperationService operationService = nodeEngine.getOperationService();
+
+        partitionState.setEndpoint(getCallerAddress());
+        success = partitionService.processPartitionRuntimeState(partitionState);
+
+        if (logger.isFinestEnabled()) {
+            logger.finest("Submitting finalize promotion operations for " + promotions);
+        } else if (logger.isFineEnabled()) {
+            logger.fine("Submitting finalize promotion operations for " + promotions.size() + " promotions.");
+        }
+        for (MigrationInfo promotion : promotions) {
+            int currentReplicaIndex = promotion.getDestinationCurrentReplicaIndex();
+            FinalizePromotionOperation op = new FinalizePromotionOperation(currentReplicaIndex, success);
+            op.setPartitionId(promotion.getPartitionId()).setNodeEngine(nodeEngine).setService(partitionService);
+            operationService.executeOperation(op);
+        }
+    }
+
+    private static class BeforePromotionTask implements PartitionSpecificRunnable {
+        private final PromotionCommitOperation promotionCommitOperation;
+        private final MigrationInfo promotion;
+        private final NodeEngineImpl nodeEngine;
+        private final AtomicInteger tasks;
+
+        BeforePromotionTask(PromotionCommitOperation promotionCommitOperation, MigrationInfo promotion,
+                NodeEngineImpl nodeEngine, AtomicInteger tasks) {
+            this.promotionCommitOperation = promotionCommitOperation;
+            this.promotion = promotion;
+            this.nodeEngine = nodeEngine;
+            this.tasks = tasks;
+        }
+
+        @Override
+        public void run() {
+            try {
+                int currentReplicaIndex = promotion.getDestinationCurrentReplicaIndex();
+                BeforePromotionOperation op = new BeforePromotionOperation(currentReplicaIndex);
+                op.setPartitionId(promotion.getPartitionId()).setNodeEngine(nodeEngine)
+                        .setService(nodeEngine.getPartitionService());
+
+                InternalOperationService operationService = nodeEngine.getOperationService();
+                operationService.runOperationOnCallingThread(op);
+            } finally {
+                completeTask();
+            }
+        }
+
+        private void completeTask() {
+            final int remainingTasks = tasks.decrementAndGet();
+
+            ILogger logger = nodeEngine.getLogger(getClass());
+            if (logger.isFinestEnabled()) {
+                logger.finest("Remaining before promotion tasks: " + remainingTasks);
+            }
+
+            if (remainingTasks == 0) {
+                logger.fine("All before promotion tasks are completed, re-submitting PromotionCommitOperation.");
+                promotionCommitOperation.beforeStateCompleted = true;
+                nodeEngine.getOperationService().executeOperation(promotionCommitOperation);
+            }
+        }
+
+        @Override
+        public int getPartitionId() {
+            return promotion.getPartitionId();
+        }
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return beforeStateCompleted;
+    }
+
+    @Override
+    public Object getResponse() {
+        return success;
+    }
+
+    @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
+    }
+
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        if (throwable instanceof MemberLeftException
+                || throwable instanceof TargetNotMemberException) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+        return super.onInvocationException(throwable);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        expectedMemberUuid = in.readUTF();
+        partitionState = new PartitionRuntimeState();
+        partitionState.readData(in);
+
+        int len = in.readInt();
+        if (len > 0) {
+            promotions = new ArrayList<MigrationInfo>(len);
+            for (int i = 0; i < len; i++) {
+                MigrationInfo migrationInfo = new MigrationInfo();
+                migrationInfo.readData(in);
+                promotions.add(migrationInfo);
+            }
+        }
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeUTF(expectedMemberUuid);
+        partitionState.writeData(out);
+
+        int len = promotions.size();
+        out.writeInt(len);
+        for (MigrationInfo migrationInfo : promotions) {
+            migrationInfo.writeData(out);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
@@ -394,7 +394,7 @@ public class MigrationCommitTest
             public void run()
                     throws Exception {
                 assertTrue(masterListener.commit);
-                assertTrue(migrationManager.getCompletedMigrations().isEmpty());
+                assertTrue(migrationManager.getCompletedMigrationsCopy().isEmpty());
             }
         });
     }
@@ -534,7 +534,7 @@ public class MigrationCommitTest
                 final InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) getPartitionService(
                         instance);
                 final MigrationManager migrationManager = partitionService.getMigrationManager();
-                nonEmptyCompletedMigrationsVerified = !migrationManager.getCompletedMigrations().isEmpty();
+                nonEmptyCompletedMigrationsVerified = !migrationManager.getCompletedMigrationsCopy().isEmpty();
                 resetInternalMigrationListener(instance);
             } else {
                 start = true;


### PR DESCRIPTION
By contract, `MigrationAwareService.beforeMigration()` is called
before applying migration result to the partition table. And `commitMigration()`
is called after partition table is updated. This makes services able to hook
custom logic into migration lifecycle, before and after migration happens.

But for promotion migrations, which are created to promote a backup replica to
primary when a member is terminated before transferring its partition assignments
to a live member, this migration lifecycle was broken. `beforeMigration()` was being
called after promotion result was applied to the partition table.

This change introduces a new path for promotion commits, which executes `beforeMigration()`
methods first, updates partition table and executes `commitMigration()` in order.
Promotion finalizations are not handled alongside with normal migration commits anymore.