### PR TITLE
fixed non-executed wm tests issue

### DIFF
--- a/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
+++ b/hazelcast-wm/src/test/java/com/hazelcast/wm/test/AbstractWebFilterTest.java
@@ -116,6 +116,17 @@ public abstract class AbstractWebFilterTest extends HazelcastTestSupport {
     @Before
     public void setup() throws Exception {
         ContainerContext cc = CONTAINER_CONTEXT_MAP.get(getClass());
+
+        // if configuration is changed, we need to stop containers and cc should equals to null
+        if (cc != null) {
+            if (!cc.serverXml1.equals(serverXml1) || !cc.serverXml2.equals(serverXml2)) {
+                cc.server1.stop();
+                cc.server2.stop();
+                cc = null;
+            }
+        }
+
+
         // If container is not exist yet or
         // Hazelcast instance is not active (because of such as server shutdown)
         if (cc == null) {

--- a/hazelcast-wm/src/test/webapp/WEB-INF/node1-node-deferred.xml
+++ b/hazelcast-wm/src/test/webapp/WEB-INF/node1-node-deferred.xml
@@ -28,7 +28,7 @@
         </init-param>
         <init-param>
             <param-name>sticky-session</param-name>
-            <param-value>false</param-value>
+            <param-value>true</param-value>
         </init-param>
         <init-param>
             <param-name>debug</param-name>

--- a/hazelcast-wm/src/test/webapp/WEB-INF/node2-node-deferred.xml
+++ b/hazelcast-wm/src/test/webapp/WEB-INF/node2-node-deferred.xml
@@ -28,7 +28,7 @@
         </init-param>
         <init-param>
             <param-name>sticky-session</param-name>
-            <param-value>false</param-value>
+            <param-value>true</param-value>
         </init-param>
         <init-param>
             <param-name>debug</param-name>


### PR DESCRIPTION
after some observations, we realized that web filter slow tests don't run in different configurations.
this issue fix this. also related to https://github.com/hazelcast/hazelcast/issues/7942