### PR TITLE
MemberAttributeEvent doesn't return null members

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 
 import static com.hazelcast.cluster.MemberAttributeOperationType.PUT;
+import static java.util.Collections.EMPTY_SET;
 
 @SuppressFBWarnings("SE_BAD_FIELD")
 public class MemberAttributeEvent extends MembershipEvent implements DataSerializable {
@@ -37,12 +38,12 @@ public class MemberAttributeEvent extends MembershipEvent implements DataSeriali
     private Member member;
 
     public MemberAttributeEvent() {
-        super(null, null, MEMBER_ATTRIBUTE_CHANGED, null);
+        super(null, null, MEMBER_ATTRIBUTE_CHANGED, EMPTY_SET);
     }
 
     public MemberAttributeEvent(Cluster cluster, Member member, MemberAttributeOperationType operationType,
                                 String key, Object value) {
-        super(cluster, member, MEMBER_ATTRIBUTE_CHANGED, null);
+        super(cluster, member, MEMBER_ATTRIBUTE_CHANGED, EMPTY_SET);
         this.member = member;
         this.operationType = operationType;
         this.key = key;

--- a/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
@@ -28,8 +28,6 @@ import static java.lang.String.format;
  * or when there is a member attribute change via {@link Member#setBooleanAttribute(String, boolean)}
  * and similar methods.
  *
- * Warning: If the event is triggered by a member attribute change then {@link #members} is <code>null</code>!
- *
  * @see MembershipListener
  */
 @SuppressFBWarnings("SE_BAD_FIELD")
@@ -79,6 +77,8 @@ public class MembershipEvent extends EventObject {
      * you cannot get a deterministic view of the members. This method solves that problem.
      * <p/>
      * The set is immutable and ordered. For more information see {@link com.hazelcast.core.Cluster#getMembers()}.
+     *
+     * Warning: If the event is triggered by a member attribute change then {@link #members} is empty.
      *
      * @return the members at the moment after this event.
      */


### PR DESCRIPTION
Instead and EMPTY_SET is returned. This doesn't cause any incompatibilities and prevents
running into an NPE.

fix #7429