### PR TITLE
[BACKPORT] Use return value from TestHazelcastInstanceFactory.initOrCreateConfig

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -107,7 +107,7 @@ public class TestHazelcastInstanceFactory {
     public HazelcastInstance newHazelcastInstance(Config config) {
         String instanceName = config != null ? config.getInstanceName() : null;
         if (mockNetwork) {
-            init(config);
+            config = initOrCreateConfig(config);
             NodeContext nodeContext = registry.createNodeContext(pickAddress());
             return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
         }
@@ -132,7 +132,7 @@ public class TestHazelcastInstanceFactory {
     public HazelcastInstance newHazelcastInstance(Address address, Config config) {
         final String instanceName = config != null ? config.getInstanceName() : null;
         if (mockNetwork) {
-            init(config);
+            config = initOrCreateConfig(config);
             NodeContext nodeContext = registry.createNodeContext(address);
             return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
         }
@@ -249,7 +249,7 @@ public class TestHazelcastInstanceFactory {
         }
     }
 
-    private static Config init(Config config) {
+    private static Config initOrCreateConfig(Config config) {
         if (config == null) {
             config = new XmlConfigBuilder().build();
         }


### PR DESCRIPTION
When `null` config is passed to `TestHazelcastInstanceFactory.initOrCreateConfig()`,
it creates a new one returns it, otherwise initializes the config. But if returned
config is not used, a new default config is created while starting a new Hazelcast
instance and that causes failures on build system because multicast is enabled
in default config and that breaks isolation between tests.

Backport of #8085