### PR TITLE
Fixes infinite loop in io system

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
@@ -80,12 +80,6 @@ public class ClientReadHandler
         eventCount.inc();
 
         lastHandle = Clock.currentTimeMillis();
-        if (!connection.isAlive()) {
-            if (logger.isFinestEnabled()) {
-                logger.finest("We are being asked to read, but connection is not live so we won't");
-            }
-            return;
-        }
 
         int readBytes = socketChannel.read(buffer);
         if (readBytes <= 0) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -137,11 +137,6 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
         // the connection is going to be closed anyway.
         lastReadTime = currentTimeMillis();
 
-        if (!connection.isAlive()) {
-            logger.finest("We are being asked to read, but connection is not live so we won't");
-            return;
-        }
-
         if (readHandler == null) {
             initReadHandler();
             if (readHandler == null) {


### PR DESCRIPTION
Fixes #7522

The fix is done by removing the connection check and let the io thread run into
a socketchannel read/write and throw an ioexception.

Also exception logging has been cleaned up. Instead of having logging at 2 places, the connection.close and abstracthandler.onFailure; all logging is moved into the connection.close where one can properly check if the exception is causing the connection to get closed, or if the connection close is causing the exception (cause vs effect).