### PR TITLE
Do no rely on object name when creating a signal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
@@ -22,6 +22,30 @@ import com.hazelcast.spi.ObjectNamespace;
 
 import java.io.IOException;
 
+/**
+ * A specialization of {@link ObjectNamespace} intended to be used by ILock proxies.
+ *
+ * It intentionally <b>does not</b> use {@link #name} field in <code>equals()</code>
+ * and <code>hashcode()</code> methods. This is a hack to share a single instance of
+ * {@link LockStore} for all ILocks proxies (per partition).
+ *
+ * Discussion:
+ *
+ * If we included the name in equals()/hashcode() methods then each ILock would create
+ * its own {@link LockStoreImpl}. Each <code>LockStoreImpl</code> contains additional
+ * mapping key -&gt; LockResource. However ILock proxies always use a single key only
+ * thus creating a <code>LockStoreImpl</code> for each ILock would introduce an unnecessary
+ * indirection and memory waster. Also each LockStoreImpl is maintaining its own
+ * scheduler for lock eviction purposes, etc.
+ *
+ * I originally wanted to remove the <code>name</code> field and use a constant,
+ * but it has side-effects - for example when a ILock proxy is destroyed then you
+ * want to destroy all pending {@link com.hazelcast.spi.BlockingOperation}
+ *
+ * @see LockStoreContainer#getOrCreateLockStore(ObjectNamespace)
+ * @see com.hazelcast.spi.impl.waitnotifyservice.impl.WaitNotifyServiceImpl#cancelWaitingOps(String, Object, Throwable)
+ *
+ */
 public final class InternalLockNamespace implements ObjectNamespace {
 
     private String name;
@@ -61,13 +85,13 @@ public final class InternalLockNamespace implements ObjectNamespace {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        //todo: we don't include the name in the equals?
+        //warning: this intentionally does not use name field see class-level JavaDoc above
         return true;
     }
 
     @Override
     public int hashCode() {
-        //todo: we don't include the name in the hash?
+        //warning: this intentionally does not use name field see class-level JavaDoc above
         return getServiceName().hashCode();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -191,7 +191,18 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         }
     }
 
-    public void signal(String conditionId, int maxSignalCount) {
+    /**
+     * Signal a waiter.
+     *
+     * We need to pass objectName because the name in {#objectName} is unrealible.
+     *
+     * @param conditionId
+     * @param maxSignalCount
+     * @param objectName
+     *
+     * @see InternalLockNamespace
+     */
+    public void signal(String conditionId, int maxSignalCount, String objectName) {
         if (waiters == null) {
             return;
         }
@@ -206,7 +217,6 @@ final class LockResourceImpl implements DataSerializable, LockResource {
         if (waiters == null) {
             return;
         }
-        String objectName = lockStore.getNamespace().getObjectName();
         Iterator<WaitersInfo.ConditionWaiter> iterator = waiters.iterator();
         for (int i = 0; iterator.hasNext() && i < maxSignalCount; i++) {
             WaitersInfo.ConditionWaiter waiter = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -46,6 +46,10 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
             };
 
     private final ConcurrentMap<Data, LockResourceImpl> locks = new ConcurrentHashMap<Data, LockResourceImpl>();
+
+    // warning: the namespace field is unreliable if this LockStoreImpl was created for ILock proxy
+    // ObjectNameSpace.getObjectName() can give you a wrong name because LockStoreImpl instances
+    // are shared for ILock proxies. see InternalLockNamespace for details.
     private ObjectNamespace namespace;
     private int backupCount;
     private int asyncBackupCount;
@@ -276,9 +280,9 @@ public final class LockStoreImpl implements DataSerializable, LockStore {
         lock.removeAwait(conditionId, caller, threadId);
     }
 
-    public void signal(Data key, String conditionId, int maxSignalCount) {
+    public void signal(Data key, String conditionId, int maxSignalCount, String objectName) {
         LockResourceImpl lock = getLock(key);
-        lock.signal(conditionId, maxSignalCount);
+        lock.signal(conditionId, maxSignalCount, objectName);
     }
 
     public WaitNotifyKey getNotifiedKey(Data key) {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
@@ -45,7 +45,8 @@ abstract class BaseSignalOperation extends AbstractLockOperation {
 
         LockStoreImpl lockStore = getLockStore();
         int signalCount = all ? Integer.MAX_VALUE : 1;
-        lockStore.signal(key, conditionId, signalCount);
+
+        lockStore.signal(key, conditionId, signalCount, namespace.getObjectName());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAbstractTest.java
@@ -6,6 +6,7 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestThread;
+import com.hazelcast.test.annotation.Repeat;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;


### PR DESCRIPTION
Fixes #8350
This is an alternative implementation of https://github.com/hazelcast/hazelcast/pull/8353
It does not force creation for LockStoreImpl per key.