### PR TITLE
Deprecated hazelcast.application.validation.token

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -50,6 +50,7 @@ public final class GroupProperty {
      * <p/>
      * This validation-token will be checked before member join the cluster.
      */
+    @Deprecated
     public static final HazelcastProperty APPLICATION_VALIDATION_TOKEN
             = new HazelcastProperty("hazelcast.application.validation.token");
 


### PR DESCRIPTION
This token was added for a potential customer some years ago, but I doubt it is being used.
So lets deprecate is so we can get rid of it in 3.8.

If people complain, we can always remove the deprecation.
