### PR TITLE
TCKMBeanServerBuilder moved to test classes

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/TCKMBeanServerBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/TCKMBeanServerBuilder.java
@@ -28,7 +28,6 @@ import javax.management.NotificationListener;
 /**
  * An MBeanServer builder required by TCK tests. Has no function in the implementation itself.
  */
-//TODO should we move this into tests?
 public class TCKMBeanServerBuilder
         extends MBeanServerBuilder {
 


### PR DESCRIPTION
Fixed #3873 

It's a class used by JSR107 TCK tests only. 
I assume it was in the `main` by accident. Let's see what will break when we move it. 