### PR TITLE
AsyncAtomicReference deprecated

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicReference.java
@@ -23,6 +23,7 @@ import com.hazelcast.spi.annotation.Beta;
  * so it can be used in the reactive programming model approach.
  *
  * @since 3.2
+ * @deprecated since 3.7. The methods will be directly integrated into the {@link IAtomicReference}.
  */
 @Beta
 public interface AsyncAtomicReference<E> extends IAtomicReference<E> {


### PR DESCRIPTION
The class is deprecated. Methods can be directly integrated into the IAtomicReference.

There is no official published way to get access to the AsyncAtomicReference.