### PR TITLE
Unwanted responsenotsendexception stacktrace

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/ResponseNotSentException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/ResponseNotSentException.java
@@ -24,6 +24,8 @@ import com.hazelcast.core.HazelcastException;
  * <p/>
  * This can happen when connection to target member is dropped for any reason,
  * either a short network disconnection or target member leaves the cluster.
+ *
+ * @deprecated since 3.7. This exception isn't used anymore
  */
 public class ResponseNotSentException extends HazelcastException {
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -43,7 +43,6 @@ import com.hazelcast.spi.ReadonlyOperation;
 import com.hazelcast.spi.exception.CallerNotMemberException;
 import com.hazelcast.spi.exception.PartitionMigratingException;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
-import com.hazelcast.spi.exception.ResponseNotSentException;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.WrongTargetException;
@@ -345,7 +344,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
 
         operation.logError(e);
 
-        if (e instanceof ResponseNotSentException || !operation.returnsResponse()) {
+        if (!operation.returnsResponse()) {
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RemoteInvocationResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RemoteInvocationResponseHandler.java
@@ -19,7 +19,6 @@ package com.hazelcast.spi.impl.operationservice.impl;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
-import com.hazelcast.spi.exception.ResponseNotSentException;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
@@ -50,8 +49,8 @@ final class RemoteInvocationResponseHandler implements OperationResponseHandler 
         }
 
         if (!operationService.send(response, operation.getCallerAddress())) {
-            throw new ResponseNotSentException("Cannot send response: " + obj + " to " + conn.getEndPoint()
-                    + ". Op: " + operation);
+            operationService.logger.warning("Cannot send response: " + obj + " to " + conn.getEndPoint()
+                    + ". " + operation);
         }
     }
 


### PR DESCRIPTION
When a response can't be send because the member that send the invocation has left the cluster, you get a stacktrace due to the responsenotsendexception. 

Throwing of this exception has been replaced by a simple logging in the RemoteInvocationResponseHandler. Otherwise you need to deal with this exception at a different place. This causes the response sending logic (sending + failure handling) to be smeared over multiple locations.

ResponseNotSentException has been deprecated as well since it doesn't serve a purpose any longer.