### PR TITLE
Update HazelcastInstance.getCache return type to allow proxying

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -143,6 +143,7 @@ import com.hazelcast.transaction.impl.xa.XAService;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.ServiceLoader;
 
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -474,9 +475,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     @Override
-    public <K, V> ICache<K, V> getCache(String name) {
+    public <T extends Closeable & ICache> T getCache(String name) {
         checkNotNull(name, "Retrieving a cache instance with a null name is not allowed!");
-        return getCacheByFullName(HazelcastCacheManager.CACHE_MANAGER_PREFIX + name);
+        return (T) getCacheByFullName(HazelcastCacheManager.CACHE_MANAGER_PREFIX + name);
     }
 
     public <K, V> ICache<K, V> getCacheByFullName(String fullName) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -55,6 +55,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
 
@@ -135,8 +136,8 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     }
 
     @Override
-    public <K, V> ICache<K, V> getCache(String name) {
-        return getClient().getCache(name);
+    public <T extends Closeable & ICache> T getCache(String name) {
+        return getClient().<T>getCache(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheUtil.java
@@ -20,6 +20,8 @@ import java.net.URI;
 
 /**
  * Utility class for various cache related operations to be used by our internal structure and end user.
+ *
+ * @since 3.7
  */
 public final class CacheUtil {
 
@@ -75,5 +77,43 @@ public final class CacheUtil {
         } else {
             return name;
         }
+    }
+
+    /**
+     * Convenience method to obtain the name of Hazelcast distributed object corresponding to the cache identified
+     * by the given arguments. The distributed object name returned by this method can be used to obtain the cache as
+     * a Hazelcast {@link ICache} as shown in this example:
+     * <pre>
+     *      HazelcastInstance hz = Hazelcast.newHazelcastInstance();
+     *
+     *      // Obtain Cache via JSR-107 API
+     *      CachingProvider hazelcastCachingProvider = Caching.getCachingProvider(
+     *                  "com.hazelcast.cache.HazelcastCachingProvider",
+     *                  HazelcastCachingProvider.class.getClassLoader());
+     *      CacheManager cacheManager = hazelcastCachingProvider.getCacheManager();
+     *      Cache testCache = cacheManager.createCache("test", new MutableConfiguration&lt;String, String&gt;());
+     *
+     *      // URI and ClassLoader are null, since we created this cache with the default CacheManager,
+     *      // otherwise we should pass the owning CacheManager's URI & ClassLoader as arguments.
+     *      String distributedObjectName = CacheUtil.asDistributedObjectName("test", null, null);
+     *
+     *      // Obtain a reference to the backing ICache via HazelcastInstance.getDistributedObject.
+     *      // You may invoke this on any member of the cluster.
+     *      ICache&lt;String, String&gt; distributedObjectCache = (ICache) hz.getDistributedObject(
+     *                  ICacheService.SERVICE_NAME,
+     *                  distributedObjectName);
+     * </pre>
+     *
+     * @param cacheName   the simple name of the cache without any prefix
+     * @param uri         an implementation specific URI for the
+     *                    Hazelcast's {@link javax.cache.CacheManager} (null means use
+     *                    Hazelcast's {@link javax.cache.spi.CachingProvider#getDefaultURI()})
+     * @param classLoader the {@link ClassLoader}  to use for the
+     *                    Hazelcast's {@link javax.cache.CacheManager} (null means use
+     *                    Hazelcast's {@link javax.cache.spi.CachingProvider#getDefaultClassLoader()})
+     * @return the name of the {@link ICache} distributed object corresponding to given arguments.
+     */
+    public static String getDistributedObjectName(String cacheName, URI uri, ClassLoader classLoader) {
+        return HazelcastCacheManager.CACHE_MANAGER_PREFIX + getPrefixedCacheName(cacheName, uri, classLoader);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -29,6 +29,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
 
@@ -287,10 +288,14 @@ public interface HazelcastInstance {
 
     /**
      * <p>
-     * Returns the cache instance with the specified prefixed cache name.
+     * Returns the cache instance with the specified prefixed cache name. For example:
      * </p>
+     * <pre>
+     *     com.hazelcast.cache.ICache cache = hazelcastInstance.getCache("sessionCache");
+     * </pre>
      *
      * <p>
+     * This method returns an instance of {@link com.hazelcast.cache.ICache}.
      * Prefixed cache name is the name with URI and classloader prefixes if available.
      * There is no Hazelcast prefix (`/hz/`). For example, `myURI/foo`.
      *
@@ -312,10 +317,10 @@ public interface HazelcastInstance {
      *
      * @throws com.hazelcast.cache.CacheNotExistsException  if there is no configured or created cache
      *                                                      with the specified prefixed name
-     * @throws java.lang.IllegalStateException              if a valid (rather than `1.0.0-PFD` or `0.x` versions)
-     *                                                      JCache library is not exist at classpath
+     * @throws java.lang.IllegalStateException              if a valid (other than `1.0.0-PFD` or `0.x` versions)
+     *                                                      JCache library does not exist in the classpath
      */
-    <K, V> ICache<K, V> getCache(String name);
+    <T extends Closeable & ICache> T getCache(String name);
 
     /**
      * Returns all {@link DistributedObject}'s such as; queue, map, set, list, topic, lock, multimap.

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -84,6 +84,7 @@ import com.hazelcast.transaction.impl.xa.XAService;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -299,7 +300,11 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
     }
 
     @Override
-    public <K, V> ICache<K, V> getCache(String name) {
+    public <T extends Closeable & ICache> T getCache(String name) {
+        return (T) getCache1(name);
+    }
+
+    public <K, V> ICache<K, V> getCache1(String name) {
         checkNotNull(name, "Retrieving a cache instance with a null name is not allowed!");
         return getCacheByFullName(HazelcastCacheManager.CACHE_MANAGER_PREFIX + name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -54,6 +54,7 @@ import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
 
@@ -192,8 +193,8 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
     }
 
     @Override
-    public <K, V> ICache<K, V> getCache(String name) {
-        return getOriginal().getCache(name);
+    public <T extends Closeable & ICache> T getCache(String name) {
+        return getOriginal().<T>getCache(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -54,6 +54,7 @@ import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 import com.hazelcast.util.StringUtil;
 
+import java.io.Closeable;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
 
@@ -134,8 +135,8 @@ class HazelcastOSGiInstanceImpl
     }
 
     @Override
-    public <K, V> ICache<K, V> getCache(String name) {
-        return delegatedInstance.getCache(name);
+    public <T extends Closeable & ICache> T getCache(String name) {
+        return delegatedInstance.<T>getCache(name);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
@@ -48,7 +48,7 @@ public class CacheThroughHazelcastInstanceTest extends HazelcastTestSupport {
 
     private ICache retrieveCache(HazelcastInstance instance, String cacheName, boolean getCache) {
         return getCache
-                ? instance.getCache(cacheName)
+                ? (ICache) instance.getCache(cacheName)
                 : (ICache) instance.getDistributedObject(ICacheService.SERVICE_NAME,
                                                          HazelcastCacheManager.CACHE_MANAGER_PREFIX + cacheName);
     }


### PR DESCRIPTION
Avoid `ClassNotFoundException` when JCache is not in the classpath and `HazelcastInstance` is proxied (eg. when mocking with Mockito, instantiating as Spring bean).
In a separate commit, added a convenience method in `CacheUtil` that returns the distributed object name for the given cache, which can be used to obtain an `ICache` reference from `HazelcastInstance.getDistributedObject`.
Fixes #8352 