### PR TITLE
NullPointerException If new member suddenly goes down

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -165,7 +165,7 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
                     try {
                         invoke(registrationKey, member.getAddress());
                     } catch (Exception e) {
-                        logger.warning("Listener " + registrationKey + " can not added to new member " + member);
+                        logger.warning("Listener " + registrationKey + " can not added to new member " + member + ". Reason:" + e);
                     }
                 }
             }
@@ -181,7 +181,9 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
                 members.remove(member);
                 for (Map<Address, ClientEventRegistration> registrationMap : registrations.values()) {
                     ClientEventRegistration registration = registrationMap.remove(member.getAddress());
-                    removeEventHandler(registration.getCallId());
+                    if (null != registration) {
+                        removeEventHandler(registration.getCallId());
+                    }
                 }
             }
         });

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -165,7 +165,7 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
                     try {
                         invoke(registrationKey, member.getAddress());
                     } catch (Exception e) {
-                        logger.warning("Listener " + registrationKey + " can not be added to new member " + member + ". "+ e);
+                        logger.warning("Listener " + registrationKey + " can not be added to new member " + member, e);
                     }
                 }
             }
@@ -205,7 +205,7 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
                         try {
                             invoke(registrationKey, member.getAddress());
                         } catch (Exception e) {
-                            logger.warning("Listener " + registrationKey + " can not be added to new member " + member + ". "+ e);
+                            logger.warning("Listener " + registrationKey + " can not be added to new member " + member, e);
                         }
                     }
                 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -165,7 +165,7 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
                     try {
                         invoke(registrationKey, member.getAddress());
                     } catch (Exception e) {
-                        logger.warning("Listener " + registrationKey + " can not added to new member " + member + ". Reason:" + e);
+                        logger.warning("Listener " + registrationKey + " can not be added to new member " + member + ". "+ e);
                     }
                 }
             }
@@ -205,7 +205,7 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
                         try {
                             invoke(registrationKey, member.getAddress());
                         } catch (Exception e) {
-                            logger.warning("Listener " + registrationKey + " can not added to new member " + member);
+                            logger.warning("Listener " + registrationKey + " can not be added to new member " + member + ". "+ e);
                         }
                     }
                 }


### PR DESCRIPTION
Fix for handling the NullPointerException probability when the listener registration for the failed member (e.g. Member is shutdown just when starting and listener could not be registered, then we can not remove the registration for the member, since the registration for that member could not be added at the first place). 

Note: This PR only aims at eliminating the possibility of NullPointerException and it does not aim at fixing any other possible event system problem.

I could not generate the problem in UIT tests, hence I do not have an additional test for the fix but a user reported such a case.
