### PR TITLE
AbstractOperation deprecated

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractOperation.java
@@ -16,40 +16,12 @@
 
 package com.hazelcast.spi;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-
-import java.io.IOException;
-
 /**
  * Abstract {@link com.hazelcast.spi.Operation} implementation with some basic methods
  * implemented.
+ *
+ * @deprecated since 3.7. Use {@link Operation} directly.
  */
 public abstract class AbstractOperation extends Operation {
 
-    @Override
-    public void afterRun() throws Exception {
-    }
-
-    @Override
-    public void beforeRun() throws Exception {
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
-    public Object getResponse() {
-        return null;
-    }
-
-    @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-    }
-
-    @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -89,17 +89,23 @@ public abstract class Operation implements DataSerializable {
     }
 
     // runs before wait-support
-    public abstract void beforeRun() throws Exception;
+    public void beforeRun() throws Exception {
+    }
 
     // runs after wait-support, supposed to do actual operation
     public abstract void run() throws Exception;
 
     // runs after backups, before wait-notify
-    public abstract void afterRun() throws Exception;
+    public void afterRun() throws Exception {
+    }
 
-    public abstract boolean returnsResponse();
+    public boolean returnsResponse() {
+        return true;
+    }
 
-    public abstract Object getResponse();
+    public Object getResponse() {
+        return null;
+    }
 
     // Gets the actual service name without looking at overriding methods. This method only exists for testing purposes.
     String getRawServiceName() {
@@ -282,7 +288,7 @@ public abstract class Operation implements DataSerializable {
         operationResponseHandler.sendResponse(this, value);
     }
 
-     /**
+    /**
      * Gets the time in milliseconds since this invocation started.
      *
      * For more information, see {@link ClusterClock#getClusterTime()}.
@@ -520,9 +526,11 @@ public abstract class Operation implements DataSerializable {
         readInternal(in);
     }
 
-    protected abstract void writeInternal(ObjectDataOutput out) throws IOException;
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+    }
 
-    protected abstract void readInternal(ObjectDataInput in) throws IOException;
+    protected void readInternal(ObjectDataInput in) throws IOException {
+    }
 
     /**
      * A template method allows for additional information to be passed into the {@link #toString()} method. So an Operation


### PR DESCRIPTION
Instead of the Operation providing abstract methods, it provide a default implementation (which was
the task of the AbstractOperation). Now there is no more need for an AbstractOperation.

AbstractOperation will be fully removed in 3.8.