### PR TITLE
Renamed OperationService methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -35,15 +35,31 @@ public interface OperationService {
      * Runs an operation in the calling thread.
      *
      * @param op the operation to execute in the calling thread
+     * @deprecated since 3.7. Use {@link #run(Operation)}
      */
     void runOperationOnCallingThread(Operation op);
+
+    /**
+     * Runs an operation in the calling thread.
+     *
+     * @param op the operation to execute in the calling thread
+     */
+    void run(Operation op);
+
+    /**
+     * Executes an operation in the operation executor pool.
+     *
+     * @param op the operation to execute in the operation executor pool.
+     * @deprecated since 3.7. Use {@link #execute(Operation)}.
+     */
+    void executeOperation(Operation op);
 
     /**
      * Executes an operation in the operation executor pool.
      *
      * @param op the operation to execute in the operation executor pool.
      */
-    void executeOperation(Operation op);
+    void execute(Operation op);
 
     <E> InternalCompletableFuture<E> invokeOnPartition(String serviceName, Operation op, int partitionId);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -255,11 +255,21 @@ public final class OperationServiceImpl implements InternalOperationService, Met
 
     @Override
     public void runOperationOnCallingThread(Operation op) {
+        run(op);
+    }
+
+    @Override
+    public void run(Operation op) {
         operationExecutor.run(op);
     }
 
     @Override
     public void executeOperation(Operation op) {
+        execute(op);
+    }
+
+    @Override
+    public void execute(Operation op) {
         operationExecutor.execute(op);
     }
 


### PR DESCRIPTION
executeOperation:execute runOperationOnCallingThread to run

These names are in line with the OperationExecutor. Otherwise we have naming inconsistencies
which make the code more difficult to understand than needs to be.