### PR TITLE
Avoid sporadic failures in RingbufferAddReadOneStressTest.whenLongTTLAndSmallBuffer

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddReadOneStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddReadOneStressTest.java
@@ -42,7 +42,7 @@ public class RingbufferAddReadOneStressTest extends HazelcastTestSupport {
     @Test
     public void whenLongTTLAndSmallBuffer() throws Exception {
         RingbufferConfig ringbufferConfig = new RingbufferConfig("foo")
-                .setCapacity(1000)
+                .setCapacity(3 * 1000)
                 .setTimeToLiveSeconds(30);
         test(ringbufferConfig);
     }


### PR DESCRIPTION
Increased buffer capacity in specific test. The failures are caused by a consumer falling behind most probably due to other load in the test environment. Should fix #8228 and #7339