### PR TITLE
Fixes 8303: sync_whenManyGettersAndLotsOfWaiting

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
@@ -269,7 +269,7 @@ public class Invocation_BlockingTest extends HazelcastTestSupport {
      */
     @Test
     public void sync_whenManyGettersAndLotsOfWaiting() throws Exception {
-        int callTimeout = 5000;
+        int callTimeout = 10000;
         Config config = new Config().setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + callTimeout);
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);


### PR DESCRIPTION
Doubled the call timeout. Will make the test slower, but also less prone due to
delays e.g. a major gc.

Fix #8303