### PR TITLE
Fixes async_whenMultipleAndThenOnSameFuture

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_BlockingTest.java
@@ -334,7 +334,7 @@ public class Invocation_BlockingTest extends HazelcastTestSupport {
      */
     @Test
     public void async_whenMultipleAndThenOnSameFuture() throws Exception {
-        int callTimeout = 1000;
+        int callTimeout = 5000;
         Config config = new Config().setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + callTimeout);
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);


### PR DESCRIPTION
Increased the calltimeout to make test less sensitive to delays.

Fixes #8015 