### PR TITLE
Moved multicast discovery to spi

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientToMemberDiscoveryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientToMemberDiscoveryTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
-import com.hazelcast.internal.plugin.multicast.MulticastDiscoveryStrategy;
+import com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategyFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.plugin.multicast;
+package com.hazelcast.spi.discovery.multicast;
 
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.logging.ILogger;
@@ -25,6 +25,9 @@ import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
 import java.util.Collection;
 import java.util.Map;
 
+/**
+ * TODO:
+ */
 public class MulticastDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
     @Override
     public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastProperties.java
@@ -14,32 +14,30 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.plugin.multicast;
+package com.hazelcast.spi.discovery.multicast;
 
 import com.hazelcast.config.properties.PropertyDefinition;
 import com.hazelcast.config.properties.PropertyTypeConverter;
 import com.hazelcast.config.properties.SimplePropertyDefinition;
-import com.hazelcast.config.properties.ValidationException;
 import com.hazelcast.config.properties.ValueValidator;
 
 import static com.hazelcast.config.properties.PropertyTypeConverter.INTEGER;
 import static com.hazelcast.config.properties.PropertyTypeConverter.STRING;
 
 /**
- * Defines the name and default value for Multicast Plugin properties
+ * Defines the name and default value for Multicast Discovery Strategy.
  */
 public final class MulticastProperties {
 
-
+    /**
+     * Property used to define multicast port.
+     */
     public static final PropertyDefinition PORT = property("port", INTEGER);
+
     /**
      * Property used to define zones for node filtering
      */
     public static final PropertyDefinition GROUP = property("group", STRING);
-
-
-    private static final int MIN_PORT = 0;
-    private static final int MAX_PORT = 65535;
 
     private MulticastProperties() {
     }
@@ -52,20 +50,4 @@ public final class MulticastProperties {
                                                ValueValidator valueValidator) {
         return new SimplePropertyDefinition(key, true, typeConverter, valueValidator);
     }
-
-    /**
-     * Validator for valid network ports
-     */
-    protected static class PortValueValidator implements ValueValidator<Integer> {
-
-        public void validate(Integer value) throws ValidationException {
-            if (value < MIN_PORT) {
-                throw new ValidationException("hz-port number must be greater 0");
-            }
-            if (value > MAX_PORT) {
-                throw new ValidationException("hz-port number must be less or equal to 65535");
-            }
-        }
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoveryReceiver.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoveryReceiver.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.plugin.multicast;
+package com.hazelcast.spi.discovery.multicast.impl;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.IOUtil;
@@ -27,10 +27,10 @@ import java.net.MulticastSocket;
 public class MulticastDiscoveryReceiver {
 
     private static final int DATAGRAM_BUFFER_SIZE = 64 * 1024;
-    MulticastSocket multicastSocket;
-    DatagramPacket datagramPacketReceive = new DatagramPacket(new byte[DATAGRAM_BUFFER_SIZE], DATAGRAM_BUFFER_SIZE);
-    ILogger logger;
 
+    private final MulticastSocket multicastSocket;
+    private final DatagramPacket datagramPacketReceive = new DatagramPacket(new byte[DATAGRAM_BUFFER_SIZE], DATAGRAM_BUFFER_SIZE);
+    private final ILogger logger;
 
     public MulticastDiscoveryReceiver(MulticastSocket multicastSocket, ILogger logger) {
         this.multicastSocket = multicastSocket;
@@ -51,7 +51,9 @@ public class MulticastDiscoveryReceiver {
             multicastMemberInfo = (MulticastMemberInfo) o;
             return multicastMemberInfo;
         } catch (Exception e) {
-            logger.finest("Couldn't get member info from multicast channel " + e.getMessage());
+            if (logger.isFinestEnabled()) {
+                logger.finest("Couldn't get member info from multicast channel " + e.getMessage());
+            }
         } finally {
             IOUtil.closeResource(bis);
             IOUtil.closeResource(in);

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.plugin.multicast;
+package com.hazelcast.spi.discovery.multicast.impl;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -31,12 +31,12 @@ import java.net.MulticastSocket;
 public class MulticastDiscoverySender implements Runnable {
 
     private static final int SLEEP_DURATION = 2000;
-    MulticastSocket multicastSocket;
-    MulticastMemberInfo multicastMemberInfo;
-    DatagramPacket datagramPacket;
-    ILogger logger;
-    String group;
-    int port;
+    private MulticastSocket multicastSocket;
+    private MulticastMemberInfo multicastMemberInfo;
+    private DatagramPacket datagramPacket;
+    private ILogger logger;
+    private String group;
+    private int port;
     private volatile boolean stop;
 
     public MulticastDiscoverySender(DiscoveryNode discoveryNode, MulticastSocket multicastSocket,
@@ -83,7 +83,7 @@ public class MulticastDiscoverySender implements Runnable {
         multicastSocket.send(datagramPacket);
     }
 
-    void stop() {
+    public void stop() {
         stop = true;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
@@ -14,7 +14,25 @@
  * limitations under the License.
  */
 
-/**
- * Contains the hazelcast multicast plugin classes
- */
-package com.hazelcast.internal.plugin.multicast;
+package com.hazelcast.spi.discovery.multicast.impl;
+
+import java.io.Serializable;
+
+public class MulticastMemberInfo implements Serializable {
+
+    private String host;
+    private int port;
+
+    public MulticastMemberInfo(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/package-info.java
@@ -14,26 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.plugin.multicast;
-
-import java.io.Serializable;
-
-
-public class MulticastMemberInfo implements Serializable {
-
-    private String host;
-    private int port;
-
-    public MulticastMemberInfo(String host, int port) {
-        this.host = host;
-        this.port = port;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-    public String getHost() {
-        return host;
-    }
-}
+/**
+ * Contains the hazelcast multicast plugin classes
+ */
+package com.hazelcast.spi.discovery.multicast;

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.spi.discovery.DiscoveryStrategyFactory
@@ -1,1 +1,1 @@
-com.hazelcast.internal.plugin.multicast.MulticastDiscoveryStrategyFactory
+com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategyFactory

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.plugin.multicast;
+package com.hazelcast.spi.discovery.multicast;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;

--- a/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
@@ -25,7 +25,7 @@
 
     <network>
         <discovery-strategies>
-            <discovery-strategy enabled="true" class="com.hazelcast.internal.plugin.multicast.MulticastDiscoveryStrategy">
+            <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy">
             </discovery-strategy>
         </discovery-strategies>
     </network>

--- a/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-multicast-plugin.xml
@@ -30,7 +30,7 @@
             <tcp-ip enabled="false" />
             <aws enabled="false"/>
             <discovery-strategies>
-                <discovery-strategy enabled="true" class="com.hazelcast.internal.plugin.multicast.MulticastDiscoveryStrategy">
+                <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy">
                 </discovery-strategy>
             </discovery-strategies>
         </join>


### PR DESCRIPTION
The multicast functionality should not be put in com.hazelcast.internal since this is private and should  not be known to an end user. However to configure multicast, a user will be pointing to the internal package, which is a clear violation.

the multicast package has been moved to com.hazelcast.spi.discovery.multicast and the implementation has been seprated from the public part by adding a com.hazelcast.spi.discovery.multicast.impl.
