### PR TITLE
Fixes race in MulticastDiscoverySender

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/plugin/multicast/MulticastDiscoverySender.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/plugin/multicast/MulticastDiscoverySender.java
@@ -37,7 +37,7 @@ public class MulticastDiscoverySender implements Runnable {
     ILogger logger;
     String group;
     int port;
-    private boolean stop;
+    private volatile boolean stop;
 
     public MulticastDiscoverySender(DiscoveryNode discoveryNode, MulticastSocket multicastSocket,
                                     ILogger logger, String group, int port)


### PR DESCRIPTION
stop needs to be volatile. Otherwise there is no happens before relation between
wring stop and reading stop.

A potential bug could be that the JIT decide to move the run check completely
out of the loop and the loop would never end; no matter how many times stop
is being called.