### PR TITLE
Test fix: serialization compatibility file was all big endian. now it cons…

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityFileGenerator.java
@@ -79,17 +79,17 @@ public class BinaryCompatibilityFileGenerator {
             serializerConfig.setImplementation(new CustomStreamSerializer()).setTypeClass(CustomStreamSerializable.class);
             config.addSerializerConfig(serializerConfig);
         }
+        config.setByteOrder(byteOrder);
         ClassDefinition classDefinition =
                 new ClassDefinitionBuilder(ReferenceObjects.PORTABLE_FACTORY_ID, ReferenceObjects.INNER_PORTABLE_CLASS_ID)
                         .addIntField("i").addFloatField("f").build();
 
         return new DefaultSerializationServiceBuilder()
+                .setConfig(config)
                 .setVersion(VERSION)
-                .setByteOrder(byteOrder)
                 .addPortableFactory(ReferenceObjects.PORTABLE_FACTORY_ID, new APortableFactory())
                 .addDataSerializableFactory(ReferenceObjects.IDENTIFIED_DATA_SERIALIZABLE_FACTORY_ID,
                         new ADataSerializableFactory())
-                .setConfig(config)
                 .addClassDefinition(classDefinition)
                 .build();
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/compatibility/BinaryCompatibilityTest.java
@@ -122,18 +122,18 @@ public class BinaryCompatibilityTest {
             serializerConfig.setImplementation(new CustomStreamSerializer()).setTypeClass(CustomStreamSerializable.class);
             config.addSerializerConfig(serializerConfig);
         }
+        config.setAllowUnsafe(allowUnsafe);
+        config.setByteOrder(byteOrder);
         ClassDefinition classDefinition =
                 new ClassDefinitionBuilder(ReferenceObjects.PORTABLE_FACTORY_ID, ReferenceObjects.INNER_PORTABLE_CLASS_ID)
                         .addIntField("i").addFloatField("f").build();
 
         return new DefaultSerializationServiceBuilder()
+                .setConfig(config)
                 .setVersion(version)
-                .setByteOrder(byteOrder)
-                .setAllowUnsafe(allowUnsafe)
                 .addPortableFactory(ReferenceObjects.PORTABLE_FACTORY_ID, new APortableFactory())
                 .addDataSerializableFactory(ReferenceObjects.IDENTIFIED_DATA_SERIALIZABLE_FACTORY_ID,
                         new ADataSerializableFactory())
-                .setConfig(config)
                 .addClassDefinition(classDefinition)
                 .build();
     }


### PR DESCRIPTION
…ists of big endian and little endian objects

Previously `DefaultSerializationServiceBuilder.setConfig` was overriding `.setByteOrder` and `.setAllowUnsafe`. Therefore serialized byte array representations of all objects were in big endian format.
I verified newly generated binary file both with test in here and Node.js client version of the same test (which failed before this change).