### PR TITLE
Query engine should not attempt to use indexes until all migrations are committed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceFactory.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
+import com.hazelcast.spi.impl.DelegatingMigrationAwareService;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -53,7 +54,7 @@ abstract class AbstractMapServiceFactory implements MapServiceFactory {
      * @return Creates a new {@link MigrationAwareService} implementation.
      * @see com.hazelcast.spi.MigrationAwareService
      */
-    abstract MigrationAwareService createMigrationAwareService();
+    abstract DelegatingMigrationAwareService createMigrationAwareService();
 
     /**
      * Creates a new {@link TransactionalService} for {@link MapService}.
@@ -147,7 +148,7 @@ abstract class AbstractMapServiceFactory implements MapServiceFactory {
     public MapService createMapService() {
         MapServiceContext mapServiceContext = getMapServiceContext();
         ManagedService managedService = createManagedService();
-        MigrationAwareService migrationAwareService = createMigrationAwareService();
+        DelegatingMigrationAwareService migrationAwareService = createMigrationAwareService();
         TransactionalService transactionalService = createTransactionalService();
         RemoteService remoteService = createRemoteService();
         EventPublishingService eventPublishingService = createEventPublishingService();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
@@ -20,7 +20,6 @@ import com.hazelcast.map.impl.event.MapEventPublishingService;
 import com.hazelcast.spi.ClientAwareService;
 import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.ManagedService;
-import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.QuorumAwareService;
 import com.hazelcast.spi.RemoteService;
@@ -28,6 +27,7 @@ import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
+import com.hazelcast.spi.impl.DelegatingMigrationAwareService;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -55,8 +55,8 @@ class DefaultMapServiceFactory extends AbstractMapServiceFactory {
     }
 
     @Override
-    MigrationAwareService createMigrationAwareService() {
-        return new MapMigrationAwareService(mapServiceContext);
+    DelegatingMigrationAwareService createMigrationAwareService() {
+        return new DelegatingMigrationAwareService(new MapMigrationAwareService(mapServiceContext));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -38,6 +38,7 @@ import com.hazelcast.spi.ReplicationSupportingService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.TransactionalService;
+import com.hazelcast.spi.impl.DelegatingMigrationAwareService;
 import com.hazelcast.spi.partition.IPartitionLostEvent;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
@@ -73,7 +74,7 @@ public class MapService implements ManagedService, MigrationAwareService,
     public static final String SERVICE_NAME = "hz:impl:mapService";
 
     protected ManagedService managedService;
-    protected MigrationAwareService migrationAwareService;
+    protected DelegatingMigrationAwareService migrationAwareService;
     protected TransactionalService transactionalService;
     protected RemoteService remoteService;
     protected EventPublishingService eventPublishingService;
@@ -208,5 +209,9 @@ public class MapService implements ManagedService, MigrationAwareService,
 
         MapContainer mapContainer = mapServiceContext.getMapContainer(topic);
         mapContainer.decreaseInvalidationListenerCount();
+    }
+
+    public int getOwnerMigrationsInFlight() {
+        return migrationAwareService.getOwnerMigrationsInFlight();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingMigrationAwareService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.spi.MigrationAwareService;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PartitionMigrationEvent;
+import com.hazelcast.spi.PartitionReplicationEvent;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A {@link MigrationAwareService} that delegates to another {@link MigrationAwareService} and keeps track of the number of
+ * migrations concerning the partition owner (either as current or new replica index) currently in-flight.
+ */
+public class DelegatingMigrationAwareService implements MigrationAwareService {
+
+    private static final int PARTITION_OWNER_INDEX = 0;
+
+    private final MigrationAwareService migrationAwareService;
+    // number of currently executing migrations on the partition owner
+    private final AtomicInteger ownerMigrationsInFlight;
+
+    public DelegatingMigrationAwareService(MigrationAwareService migrationAwareService) {
+        this.migrationAwareService = migrationAwareService;
+        this.ownerMigrationsInFlight = new AtomicInteger();
+    }
+
+    @Override
+    public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
+        return migrationAwareService.prepareReplicationOperation(event);
+    }
+
+    @Override
+    public void beforeMigration(PartitionMigrationEvent event) {
+        if (event.getCurrentReplicaIndex() == PARTITION_OWNER_INDEX || event.getNewReplicaIndex() == PARTITION_OWNER_INDEX) {
+            ownerMigrationsInFlight.incrementAndGet();
+        }
+        migrationAwareService.beforeMigration(event);
+    }
+
+    @Override
+    public void commitMigration(PartitionMigrationEvent event) {
+        try {
+            migrationAwareService.commitMigration(event);
+        } finally {
+            if (event.getCurrentReplicaIndex() == PARTITION_OWNER_INDEX || event.getNewReplicaIndex() == PARTITION_OWNER_INDEX) {
+                int count = ownerMigrationsInFlight.decrementAndGet();
+                assert count >= 0;
+            }
+        }
+    }
+
+    @Override
+    public void rollbackMigration(PartitionMigrationEvent event) {
+        try {
+            migrationAwareService.rollbackMigration(event);
+        } finally {
+            if (event.getCurrentReplicaIndex() == PARTITION_OWNER_INDEX || event.getNewReplicaIndex() == PARTITION_OWNER_INDEX) {
+                int count = ownerMigrationsInFlight.decrementAndGet();
+                assert count >= 0;
+            }
+        }
+    }
+
+    /**
+     * Get the number of currently executing migrations. This is actually
+     * (count of beforeMigration) - (count of rollbackMigration + count of commitMigration)
+     * @return the number of migrations which are currently processed.
+     */
+    public int getOwnerMigrationsInFlight() {
+        return ownerMigrationsInFlight.get();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingMigrationAwareServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/DelegatingMigrationAwareServiceTest.java
@@ -1,0 +1,176 @@
+package com.hazelcast.spi.impl;
+
+import com.hazelcast.spi.MigrationAwareService;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PartitionMigrationEvent;
+import com.hazelcast.spi.PartitionReplicationEvent;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test count-tracking functionality of DelegatingMigrationAwareService
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DelegatingMigrationAwareServiceTest {
+
+    public static final int PRIMARY_REPLICA_INDEX = 0;
+
+    @Parameterized.Parameter
+    public MigrationAwareService wrappedMigrationAwareService;
+
+    @Parameterized.Parameter(1)
+    public PartitionMigrationEvent event;
+
+    private DelegatingMigrationAwareService delegatingMigrationAwareService;
+
+    @Parameterized.Parameters(name = "{0}, replica: {1}")
+    public static Collection<Object> parameters() {
+        PartitionMigrationEvent promotionEvent = mock(PartitionMigrationEvent.class);
+        when(promotionEvent.getNewReplicaIndex()).thenReturn(PRIMARY_REPLICA_INDEX);
+        when(promotionEvent.getCurrentReplicaIndex()).thenReturn(1);
+        when(promotionEvent.toString()).thenReturn("1 > 0");
+        PartitionMigrationEvent demotionEvent = mock(PartitionMigrationEvent.class);
+        when(demotionEvent.getNewReplicaIndex()).thenReturn(1);
+        when(demotionEvent.getCurrentReplicaIndex()).thenReturn(PRIMARY_REPLICA_INDEX);
+        when(demotionEvent.toString()).thenReturn("0 > 1");
+        PartitionMigrationEvent backupsEvent = mock(PartitionMigrationEvent.class);
+        when(backupsEvent.getNewReplicaIndex()).thenReturn(1);
+        when(backupsEvent.getCurrentReplicaIndex()).thenReturn(2);
+        when(backupsEvent.toString()).thenReturn("2 > 1");
+
+        return Arrays.asList(new Object[] {
+                new Object[] {new NoOpMigrationAwareService(), promotionEvent},
+                new Object[] {new NoOpMigrationAwareService(), demotionEvent},
+                new Object[] {new NoOpMigrationAwareService(), backupsEvent},
+                new Object[] {new ExceptionThrowingMigrationAwareService(), promotionEvent},
+                new Object[] {new ExceptionThrowingMigrationAwareService(), demotionEvent},
+                new Object[] {new ExceptionThrowingMigrationAwareService(), backupsEvent},
+        });
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        // setup the counting migration aware service and execute 1 prepareReplicationOperation (which does not
+        // affect the counter)
+        delegatingMigrationAwareService = new DelegatingMigrationAwareService(wrappedMigrationAwareService);
+        delegatingMigrationAwareService.prepareReplicationOperation(null);
+        // also execute the first part of migration: beforeMigration
+        try {
+            delegatingMigrationAwareService.beforeMigration(event);
+        }
+        catch (RuntimeException e) {
+            // we do not care whether the wrapped service throws an exception
+        }
+    }
+
+    @Test
+    public void beforeMigration() throws Exception {
+        // when: countingMigrationAwareService.beforeMigration was invoked (in setUp method)
+        // then: if event involves primary replica, count is incremented to 1, otherwise it is 0
+        if (involvesPrimaryReplica(event)) {
+            assertEquals(1, delegatingMigrationAwareService.getOwnerMigrationsInFlight());
+        } else {
+            assertEquals(0, delegatingMigrationAwareService.getOwnerMigrationsInFlight());
+        }
+    }
+
+    @Test
+    public void commitMigration() throws Exception {
+        // when: before - commit migration methods have been executed
+        try {
+            delegatingMigrationAwareService.commitMigration(event);
+        }
+        catch (RuntimeException e) {
+            // we do not care whether the wrapped service throws an exception
+        }
+        // then: count should be 0, regardles of replica indices involved in event
+        assertEquals(0, delegatingMigrationAwareService.getOwnerMigrationsInFlight());
+    }
+
+    @Test
+    public void rollbackMigration() throws Exception {
+        // when: before - rollback migration methods have been executed
+        try {
+            delegatingMigrationAwareService.rollbackMigration(event);
+        }
+        catch (RuntimeException e) {
+            // we do not care whether the wrapped service throws an exception
+        }
+        // then: count should be 0, regardles of replica indices involved in event
+        assertEquals(0, delegatingMigrationAwareService.getOwnerMigrationsInFlight());
+    }
+
+    private boolean involvesPrimaryReplica(PartitionMigrationEvent event) {
+        return (event.getCurrentReplicaIndex() == PRIMARY_REPLICA_INDEX || event.getNewReplicaIndex() == PRIMARY_REPLICA_INDEX);
+    }
+
+    static class ExceptionThrowingMigrationAwareService implements MigrationAwareService {
+        @Override
+        public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
+            return null;
+        }
+
+        @Override
+        public void beforeMigration(PartitionMigrationEvent event) {
+            throw new RuntimeException("");
+        }
+
+        @Override
+        public void commitMigration(PartitionMigrationEvent event) {
+            throw new RuntimeException("");
+        }
+
+        @Override
+        public void rollbackMigration(PartitionMigrationEvent event) {
+            throw new RuntimeException("");
+        }
+
+        @Override
+        public String toString() {
+            return "ExceptionThrowingMigrationAwareService";
+        }
+    }
+
+
+    static class NoOpMigrationAwareService implements MigrationAwareService {
+        @Override
+        public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
+            return null;
+        }
+
+        @Override
+        public void beforeMigration(PartitionMigrationEvent event) {
+
+        }
+
+        @Override
+        public void commitMigration(PartitionMigrationEvent event) {
+
+        }
+
+        @Override
+        public void rollbackMigration(PartitionMigrationEvent event) {
+
+        }
+
+        @Override
+        public String toString() {
+            return "NoOpMigrationAwareService";
+        }
+    }
+}


### PR DESCRIPTION
There is a time window between partition table update and `commitMigration` execution is completed, during which the `QueryEngineImpl` will attempt to use an index, however the index may have not been created yet. In order to avoid this, in `MapMigrationAwareService` we keep track of the count of `beforeMigration` invocations vs `commitMigration`/`rollbackMigration` and only allow the `QueryEngineImpl` to use an index when this counter is 0.
This is a temporary workaround for 3.7, the root cause will be fixed in 3.8 (see #8385).
Fixes #8257 , #8046, #4517.
An EE counterpart is required.