### PR TITLE
Ensure the ordering between transaction prepare and rollback operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -57,6 +57,7 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.util.FutureUtil.RETHROW_TRANSACTION_EXCEPTION;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
+import static com.hazelcast.util.FutureUtil.waitUntilAllRespondedWithDeadline;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
 import static java.lang.Boolean.TRUE;
@@ -228,7 +229,7 @@ public class TransactionImpl implements Transaction {
             createBackupLogs();
             state = PREPARING;
             List<Future> futures = transactionLog.prepare(nodeEngine);
-            waitWithDeadline(futures, timeoutMillis, MILLISECONDS, RETHROW_TRANSACTION_EXCEPTION);
+            waitUntilAllRespondedWithDeadline(futures, timeoutMillis, MILLISECONDS, RETHROW_TRANSACTION_EXCEPTION);
             state = PREPARED;
             replicateTxnLog();
         } catch (Throwable e) {


### PR DESCRIPTION
Transaction prepare step sends prepare operations simultaneously and triggers rollback on first failure. Since other nodes may not receive the prepare operation yet, it is possible that a rollback operation hits a node before prepare. We must ensure that a rollback operation happens after the prepare operation.

Fixes #6383

Pair-investigated with @mdogan 