### PR TITLE
Transaction ownerUuid is set to the transactional queue blocking operattions as callerUuid

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnDisconnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnDisconnectionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.txn;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.TransactionalQueue;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.waitnotifyservice.impl.WaitNotifyServiceImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionContext;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.randomString;
+import static com.hazelcast.test.HazelcastTestSupport.spawn;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientTxnDisconnectionTest {
+
+    private static final String BOUNDED_QUEUE_PREFIX = "bounded-queue-*";
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    private WaitNotifyServiceImpl waitNotifyService;
+    private HazelcastInstance client;
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Before
+    public void setup() {
+        Config config = new Config();
+        config.getQueueConfig(BOUNDED_QUEUE_PREFIX).setMaxSize(1);
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance(config);
+        NodeEngineImpl nodeEngine = HazelcastTestSupport.getNode(instance).nodeEngine;
+        waitNotifyService = (WaitNotifyServiceImpl) nodeEngine.getWaitNotifyService();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @Test
+    public void testQueueTake() {
+        testQueue(new Callable() {
+            @Override
+            public Object call() throws InterruptedException {
+                TransactionContext context = client.newTransactionContext();
+                context.beginTransaction();
+                TransactionalQueue<Object> queue = context.getQueue(randomString());
+                return queue.take();
+            }
+        });
+    }
+
+    @Test
+    public void testQueuePoll() {
+        testQueue(new Callable() {
+            @Override
+            public Object call() throws InterruptedException {
+                TransactionContext context = client.newTransactionContext();
+                context.beginTransaction();
+                TransactionalQueue<Object> queue = context.getQueue(randomString());
+                return queue.poll(20, SECONDS);
+            }
+        });
+    }
+
+    @Test
+    public void testQueueOffer() {
+        testQueue(new Callable() {
+            @Override
+            public Object call() throws InterruptedException {
+                String name = BOUNDED_QUEUE_PREFIX + randomString();
+                client.getQueue(name).offer(randomString());
+
+                TransactionContext context = client.newTransactionContext();
+                context.beginTransaction();
+                TransactionalQueue<Object> queue = context.getQueue(name);
+                return queue.offer(randomString(), 20, SECONDS);
+            }
+        });
+    }
+
+    private void testQueue(Callable task) {
+        spawn(task);
+        assertValidWaitingOperationCount(1);
+        client.shutdown();
+        assertValidWaitingOperationCount(0);
+    }
+
+    private void assertValidWaitingOperationCount(final int count) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Assert.assertEquals(count, waitNotifyService.getTotalValidWaitingOperationCount());
+            }
+        }, 10);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
@@ -72,6 +72,7 @@ public abstract class TransactionalQueueProxySupport extends TransactionalDistri
     public boolean offerInternal(Data data, long timeout) {
         TxnReserveOfferOperation operation
                 = new TxnReserveOfferOperation(name, timeout, offeredQueue.size(), tx.getTxnId());
+        operation.setCallerUuid(tx.getOwnerUuid());
         try {
             Future<Long> f = invoke(operation);
             Long itemId = f.get();
@@ -111,6 +112,7 @@ public abstract class TransactionalQueueProxySupport extends TransactionalDistri
         QueueItem reservedOffer = offeredQueue.peek();
         long itemId = reservedOffer == null ? -1 : reservedOffer.getItemId();
         TxnReservePollOperation operation = new TxnReservePollOperation(name, timeout, itemId, tx.getTxnId());
+        operation.setCallerUuid(tx.getOwnerUuid());
         try {
             Future<QueueItem> f = invoke(operation);
             QueueItem item = f.get();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/waitnotifyservice/impl/WaitNotifyServiceImpl.java
@@ -169,6 +169,19 @@ public class WaitNotifyServiceImpl implements WaitNotifyService, LiveOperationsT
         return count;
     }
 
+    // for testing purposes only
+    public int getTotalValidWaitingOperationCount() {
+        int count = 0;
+        for (Queue<WaitingOperation> queue : mapWaitingOps.values()) {
+            for (WaitingOperation waitingOperation : queue) {
+                if (waitingOperation.valid) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
     // invalidated waiting ops will removed from queue eventually by notifiers.
     public void onMemberLeft(MemberImpl leftMember) {
         invalidateWaitingOps(leftMember.getUuid());


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/7535