### PR TITLE
[DO NOT MERGE] Delay invocation when node is not joined

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -311,6 +311,18 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
      * @return {@code true} if the initialization was a success, {@code false} otherwise
      */
     boolean initInvocationTarget() {
+        // When a cluster is being merged into another one then local node is marked as not-joined and invocations are
+        // notified with MemberLeftException.
+        // We do not want to retry them before the node is joined again because partition table is stale at this point.
+        if (!context.node.joined() && !isJoinOperation(op)) {
+            if (context.logger.isFinestEnabled()) {
+                context.logger.finest("Node is not joined. Re-scheduling " + this
+                        + " to be executed in " + tryPauseMillis + " ms.");
+            }
+            context.executionService.schedule(ASYNC_EXECUTOR, this, tryPauseMillis, MILLISECONDS);
+            return false;
+        }
+
         invTarget = getTarget();
 
         if (invTarget == null) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -314,7 +314,7 @@ public abstract class Invocation implements OperationResponseHandler, Runnable {
         // When a cluster is being merged into another one then local node is marked as not-joined and invocations are
         // notified with MemberLeftException.
         // We do not want to retry them before the node is joined again because partition table is stale at this point.
-        if (!context.node.joined() && !isJoinOperation(op)) {
+        if (!context.node.joined() && !isJoinOperation(op) && !(op instanceof AllowedDuringPassiveState)) {
             if (context.logger.isFinestEnabled()) {
                 context.logger.finest("Node is not joined. Re-scheduling " + this
                         + " to be executed in " + tryPauseMillis + " ms.");


### PR DESCRIPTION
Reasoning:
When a cluster is being merged into another one
then a local node is marked as not-joined and invocations are
notified with MemberLeftException.

We do not want to retry them before the node is joined
again because partition table is still stale at this point.

Fix #3754