### PR TITLE
[BACKPORT]Raw protocol test fix: corrected invalid message size

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/RawProtocolAuthenticationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/RawProtocolAuthenticationTest.java
@@ -8,7 +8,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -21,7 +20,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -29,6 +27,7 @@ import java.nio.channels.SocketChannel;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -92,22 +91,7 @@ public class RawProtocolAuthenticationTest {
         final ClientProtocolBuffer byteBuffer = authMessage.buffer();
         channel.write(ByteBuffer.wrap(byteBuffer.byteArray(), 0, authMessage.getFrameLength()));
 
-        final ByteBuffer socketBuffer = ByteBuffer.allocate(4096);
-        ClientMessage clientMessage = ClientMessage.create();
-
-        do {
-            int read = channel.read(socketBuffer);
-            if(read < 0) {
-                throw new EOFException();
-            }
-            socketBuffer.flip();
-            clientMessage.readFrom(socketBuffer);
-            if (socketBuffer.hasRemaining()) {
-                socketBuffer.compact();
-            } else {
-                socketBuffer.clear();
-            }
-        } while (!clientMessage.isComplete());
+        ClientMessage clientMessage = readMessageFromChannel();
 
         assertTrue(clientMessage.isComplete());
 
@@ -139,22 +123,7 @@ public class RawProtocolAuthenticationTest {
         final ClientProtocolBuffer byteBuffer = authMessage.buffer();
         channel.write(ByteBuffer.wrap(byteBuffer.byteArray(), 0, authMessage.getFrameLength()));
 
-        final ByteBuffer socketBuffer = ByteBuffer.allocate(4096);
-        ClientMessage clientMessage = ClientMessage.create();
-
-        do {
-            int read = channel.read(socketBuffer);
-            if(read < 0) {
-                throw new EOFException();
-            }
-            socketBuffer.flip();
-            clientMessage.readFrom(socketBuffer);
-            if (socketBuffer.hasRemaining()) {
-                socketBuffer.compact();
-            } else {
-                socketBuffer.clear();
-            }
-        } while (!clientMessage.isComplete());
+        ClientMessage clientMessage = readMessageFromChannel();
 
         assertTrue(clientMessage.isComplete());
 
@@ -186,22 +155,7 @@ public class RawProtocolAuthenticationTest {
         final ClientProtocolBuffer byteBuffer = authMessage.buffer();
         channel.write(ByteBuffer.wrap(byteBuffer.byteArray(), 0, authMessage.getFrameLength()));
 
-        final ByteBuffer socketBuffer = ByteBuffer.allocate(4096);
-        ClientMessage clientMessage = ClientMessage.create();
-
-        do {
-            int read = channel.read(socketBuffer);
-            if(read < 0) {
-                throw new EOFException();
-            }
-            socketBuffer.flip();
-            clientMessage.readFrom(socketBuffer);
-            if (socketBuffer.hasRemaining()) {
-                socketBuffer.compact();
-            } else {
-                socketBuffer.clear();
-            }
-        } while (!clientMessage.isComplete());
+        ClientMessage clientMessage = readMessageFromChannel();
 
         assertTrue(clientMessage.isComplete());
 
@@ -216,7 +170,7 @@ public class RawProtocolAuthenticationTest {
         assertNull(resultParameters.address);
     }
 
-    @Test(expected = EOFException.class)
+    @Test
     public void testAuthenticateWithUsernameAndPassword_with_Invalid_MessageSize()
             throws IOException, InterruptedException {
 
@@ -230,16 +184,28 @@ public class RawProtocolAuthenticationTest {
                 .encodeRequest(username, pass, null, null, true, ClientTypes.JAVA, (byte) 0);
         authMessage.setCorrelationId(1).addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
 
-        final ClientProtocolBuffer byteBuffer = authMessage.buffer();
-        channel.write(ByteBuffer.wrap(byteBuffer.byteArray()));
+        //set invalid message size
+        authMessage.setFrameLength(ClientMessage.HEADER_SIZE - 1);
 
+        final ClientProtocolBuffer byteBuffer = authMessage.buffer();
+        channel.write(ByteBuffer.wrap(byteBuffer.byteArray(), 0, authMessage.getFrameLength()));
+
+        ClientMessage clientMessage = readMessageFromChannel();
+
+        assertFalse(clientMessage.isComplete());
+    }
+
+    private ClientMessage readMessageFromChannel()
+            throws IOException {
         final ByteBuffer socketBuffer = ByteBuffer.allocate(4096);
         ClientMessage clientMessage = ClientMessage.create();
-
         do {
             int read = channel.read(socketBuffer);
-            if(read < 0) {
-                throw new EOFException();
+            if (read <= 0) {
+                if (read == -1) {
+                    break;
+                }
+                continue;
             }
             socketBuffer.flip();
             clientMessage.readFrom(socketBuffer);
@@ -249,6 +215,6 @@ public class RawProtocolAuthenticationTest {
                 socketBuffer.clear();
             }
         } while (!clientMessage.isComplete());
+        return clientMessage;
     }
-
 }


### PR DESCRIPTION
Invalid message size case should be tested with a value less than header size.

fixes #8131 