### PR TITLE
Access ICache's via separate ICacheManager available from HazelcastInstance

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -112,7 +112,8 @@ public final class HazelcastClientCacheManager
         clientCacheProxyFactory.addCacheConfig(cacheConfig.getNameWithPrefix(), cacheConfig);
         try {
             ClientCacheProxy<K, V> clientCacheProxy =
-                    (ClientCacheProxy<K, V>) client.getCacheByFullName(cacheConfig.getNameWithPrefix());
+                    (ClientCacheProxy<K, V>) client.getCacheManager()
+                                                   .getCacheByFullName(cacheConfig.getNameWithPrefix());
             clientCacheProxy.setCacheManager(this);
             return clientCacheProxy;
         } catch (Throwable t) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientICacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientICacheManager.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl;
+
+import com.hazelcast.cache.HazelcastCacheManager;
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.client.spi.impl.ClientServiceNotFoundException;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICacheManager;
+import com.hazelcast.spi.exception.ServiceNotFoundException;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Hazelcast instance cache manager provides a means to obtain JCache caches via HazelcastInstance API.
+ * Note that this is not a JCache {@code CacheManager}.
+ *
+ * @see ICacheManager
+ */
+public class ClientICacheManager implements ICacheManager {
+
+    private final HazelcastInstance instance;
+
+    ClientICacheManager(HazelcastInstance instance) {
+        this.instance = instance;
+    }
+
+    @Override
+    public <K, V> ICache<K, V> getCache(String name) {
+        checkNotNull(name, "Retrieving a cache instance with a null name is not allowed!");
+        return getCacheByFullName(HazelcastCacheManager.CACHE_MANAGER_PREFIX + name);
+    }
+
+    public <K, V> ICache<K, V> getCacheByFullName(String fullName) {
+        checkNotNull(fullName, "Retrieving a cache instance with a null name is not allowed!");
+        try {
+            return instance.getDistributedObject(ICacheService.SERVICE_NAME, fullName);
+        } catch (ClientServiceNotFoundException e) {
+            // Cache support is not available at client side
+            throw new IllegalStateException("At client, " + ICacheService.CACHE_SUPPORT_NOT_AVAILABLE_ERROR_MESSAGE);
+        } catch (HazelcastException e) {
+            if (e.getCause() instanceof ServiceNotFoundException) {
+                // Cache support is not available at server side
+                throw new IllegalStateException("At server, " + ICacheService.CACHE_SUPPORT_NOT_AVAILABLE_ERROR_MESSAGE);
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientProxy.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.impl;
 
-import com.hazelcast.cache.ICache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Client;
@@ -26,6 +25,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.ICacheManager;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.ICountDownLatch;
@@ -135,8 +135,8 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     }
 
     @Override
-    public <K, V> ICache<K, V> getCache(String name) {
-        return getClient().getCache(name);
+    public ICacheManager getCacheManager() {
+        return getClient().getCacheManager();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheUtil.java
@@ -20,6 +20,8 @@ import java.net.URI;
 
 /**
  * Utility class for various cache related operations to be used by our internal structure and end user.
+ *
+ * @since 3.7
  */
 public final class CacheUtil {
 
@@ -75,5 +77,58 @@ public final class CacheUtil {
         } else {
             return name;
         }
+    }
+
+    /**
+     * Convenience method to obtain the name of Hazelcast distributed object corresponding to the cache identified
+     * by the given {@code cacheName}, assuming {@code null URI} and {@code ClassLoader} prefixes. This is equivalent to
+     * invoking {@link #getDistributedObjectName(String, URI, ClassLoader)} with {@code null} passed as {@code URI} and
+     * {@code ClassLoader} arguments.
+     *
+     * @param cacheName   the simple name of the cache without any prefix
+     * @return            the name of the {@link ICache} distributed object corresponding to given cacheName, assuming
+     *                    null URI & class loader prefixes.
+     * @see #getDistributedObjectName(String, URI, ClassLoader)
+     */
+    public static String getDistributedObjectName(String cacheName) {
+        return getDistributedObjectName(cacheName, null, null);
+    }
+
+    /**
+     * Convenience method to obtain the name of Hazelcast distributed object corresponding to the cache identified
+     * by the given arguments. The distributed object name returned by this method can be used to obtain the cache as
+     * a Hazelcast {@link ICache} as shown in this example:
+     * <pre>
+     *      HazelcastInstance hz = Hazelcast.newHazelcastInstance();
+     *
+     *      // Obtain Cache via JSR-107 API
+     *      CachingProvider hazelcastCachingProvider = Caching.getCachingProvider(
+     *                  "com.hazelcast.cache.HazelcastCachingProvider",
+     *                  HazelcastCachingProvider.class.getClassLoader());
+     *      CacheManager cacheManager = hazelcastCachingProvider.getCacheManager();
+     *      Cache testCache = cacheManager.createCache("test", new MutableConfiguration&lt;String, String&gt;());
+     *
+     *      // URI and ClassLoader are null, since we created this cache with the default CacheManager,
+     *      // otherwise we should pass the owning CacheManager's URI & ClassLoader as arguments.
+     *      String distributedObjectName = CacheUtil.asDistributedObjectName("test", null, null);
+     *
+     *      // Obtain a reference to the backing ICache via HazelcastInstance.getDistributedObject.
+     *      // You may invoke this on any member of the cluster.
+     *      ICache&lt;String, String&gt; distributedObjectCache = (ICache) hz.getDistributedObject(
+     *                  ICacheService.SERVICE_NAME,
+     *                  distributedObjectName);
+     * </pre>
+     *
+     * @param cacheName   the simple name of the cache without any prefix
+     * @param uri         an implementation specific URI for the
+     *                    Hazelcast's {@link javax.cache.CacheManager} (null means use
+     *                    Hazelcast's {@link javax.cache.spi.CachingProvider#getDefaultURI()})
+     * @param classLoader the {@link ClassLoader}  to use for the
+     *                    Hazelcast's {@link javax.cache.CacheManager} (null means use
+     *                    Hazelcast's {@link javax.cache.spi.CachingProvider#getDefaultClassLoader()})
+     * @return            the name of the {@link ICache} distributed object corresponding to given arguments.
+     */
+    public static String getDistributedObjectName(String cacheName, URI uri, ClassLoader classLoader) {
+        return HazelcastCacheManager.CACHE_MANAGER_PREFIX + getPrefixedCacheName(cacheName, uri, classLoader);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -180,7 +180,8 @@ public class HazelcastServerCacheManager
 
     @Override
     protected <K, V> ICacheInternal<K, V> createCacheProxy(CacheConfig<K, V> cacheConfig) {
-        CacheProxy<K, V> cacheProxy = (CacheProxy<K, V>) instance.getCacheByFullName(cacheConfig.getNameWithPrefix());
+        CacheProxy<K, V> cacheProxy = (CacheProxy<K, V>) instance.getCacheManager()
+                                                                 .getCacheByFullName(cacheConfig.getNameWithPrefix());
         cacheProxy.setCacheManager(this);
         return cacheProxy;
     }

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.cache.ICache;
 import com.hazelcast.config.Config;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.mapreduce.JobTracker;
@@ -286,38 +285,6 @@ public interface HazelcastInstance {
     ISemaphore getSemaphore(String name);
 
     /**
-     * <p>
-     * Returns the cache instance with the specified prefixed cache name.
-     * </p>
-     *
-     * <p>
-     * Prefixed cache name is the name with URI and classloader prefixes if available.
-     * There is no Hazelcast prefix (`/hz/`). For example, `myURI/foo`.
-     *
-     * <code>
-     *     <prefixed_cache_name> = [<uri_prefix>/] + [<cl_prefix>/] + <pure_cache_name>
-     * </code>
-     * where `<pure_cache_name>` is the cache name without any prefix. For example `foo`.
-     *
-     * As seen from the definition, URI and classloader prefixes are optional.
-     *
-     * URI prefix is generated as content of this URI as a US-ASCII string. (<code>uri.toASCIIString()</code>)
-     * Classloader prefix is generated as string representation of the specified classloader. (<code>cl.toString()</code>)
-     *
-     * @see com.hazelcast.cache.CacheUtil#getPrefixedCacheName(String, java.net.URI, ClassLoader)
-     * </p>
-     *
-     * @param name the prefixed name of the cache
-     * @return the cache instance with the specified prefixed name
-     *
-     * @throws com.hazelcast.cache.CacheNotExistsException  if there is no configured or created cache
-     *                                                      with the specified prefixed name
-     * @throws java.lang.IllegalStateException              if a valid (rather than `1.0.0-PFD` or `0.x` versions)
-     *                                                      JCache library is not exist at classpath
-     */
-    <K, V> ICache<K, V> getCache(String name);
-
-    /**
      * Returns all {@link DistributedObject}'s such as; queue, map, set, list, topic, lock, multimap.
      *
      * @return the collection of instances created by Hazelcast.
@@ -423,6 +390,16 @@ public interface HazelcastInstance {
      * @return the xaResource.
      */
     HazelcastXAResource getXAResource();
+
+    /**
+     * Obtain the {@link ICacheManager} that provides access to JSR-107 (JCache) caches configured on a Hazelcast cluster.
+     * <p>Note that this method does not return a JCache {@code CacheManager}; to obtain a JCache
+     * {@link javax.cache.CacheManager} use JCache standard API.</p>
+     *
+     * @see ICacheManager
+     * @return the Hazelcast {@link ICacheManager}
+     */
+    ICacheManager getCacheManager();
 
     /**
      * Shuts down this HazelcastInstance. For more information see {@link com.hazelcast.core.LifecycleService#shutdown()}.

--- a/hazelcast/src/main/java/com/hazelcast/core/ICacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ICacheManager.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.core;
+
+import com.hazelcast.cache.ICache;
+
+/**
+ * {@code ICacheManager} is the entry point to access JSR-107 (JCache) caches via {@link HazelcastInstance} interface.
+ * Hazelcast's {@code ICacheManager} provides access to JCache caches configured cluster-wide, even when created by different
+ * JCache {@link javax.cache.CacheManager}s.
+ *
+ * <p>Note that this interface is not related to JCache {@link javax.cache.CacheManager}. Its purpose is to host
+ * {@code ICache} related methods, separately from {@link HazelcastInstance}, in order to allow frameworks that make
+ * use of reflection and/or dynamic proxies (e.g. Mockito, Spring etc) to operate on {@link HazelcastInstance} when JCache
+ * is not on the classpath.
+ * See also related issue https://github.com/hazelcast/hazelcast/issues/8352.
+ * </p>
+ *
+ * @since 3.7
+ */
+public interface ICacheManager {
+
+    /**
+     * <p>
+     * Returns the cache instance with the specified prefixed cache name.
+     * </p>
+     *
+     * <p>
+     * Prefixed cache name is the name with URI and classloader prefixes if available.
+     * There is no Hazelcast prefix ({@code /hz/}). For example, {@code myURI/foo}.
+     *
+     * <pre>
+     * <code>
+     *     &lt;prefixed_cache_name&gt; = [&lt;uri_prefix&gt;/] + [&lt;cl_prefix&gt;/] + &lt;pure_cache_name&gt;
+     * </code>
+     * </pre>
+     * where {@code <pure_cache_name>} is the cache name without any prefix. For example {@code foo}.
+     *
+     * As seen from the definition, URI and classloader prefixes are optional.
+     *
+     * URI prefix is generated as content of this URI as a US-ASCII string. ({@code uri.toASCIIString()})
+     * Classloader prefix is generated as string representation of the specified classloader. ({@code cl.toString()})
+     *
+     * @see com.hazelcast.cache.CacheUtil#getPrefixedCacheName(String, java.net.URI, ClassLoader)
+     * </p>
+     *
+     * @param name the prefixed name of the cache
+     * @return the cache instance with the specified prefixed name
+     *
+     * @throws com.hazelcast.cache.CacheNotExistsException  if there is no configured or created cache
+     *                                                      with the specified prefixed name
+     * @throws java.lang.IllegalStateException              if a valid JCache library does not exist in the classpath
+     *                                                      ({@code 1.0.0-PFD} or {@code 0.x} versions are not valid)
+     */
+    <K, V> ICache<K, V> getCache(String name);
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceCacheManager.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.cache.HazelcastCacheManager;
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.ICacheManager;
+import com.hazelcast.spi.exception.ServiceNotFoundException;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Hazelcast {@code ICacheManager} implementation accessible via {@code HazelcastInstance} that provides access to JSR-107
+ * (JCache) caches configured on the cluster via Hazelcast API.
+ *
+ * @see com.hazelcast.core.ICacheManager
+ */
+public class HazelcastInstanceCacheManager implements ICacheManager {
+
+    private final HazelcastInstanceImpl original;
+
+    public HazelcastInstanceCacheManager(HazelcastInstanceImpl original) {
+        this.original = original;
+    }
+
+    @Override
+    public <K, V> ICache<K, V> getCache(String name) {
+        checkNotNull(name, "Retrieving a cache instance with a null name is not allowed!");
+        return getCacheByFullName(HazelcastCacheManager.CACHE_MANAGER_PREFIX + name);
+    }
+
+    public <K, V> ICache<K, V> getCacheByFullName(String fullName) {
+        checkNotNull(fullName, "Retrieving a cache instance with a null name is not allowed!");
+        try {
+            return original.getDistributedObject(ICacheService.SERVICE_NAME, fullName);
+        } catch (HazelcastException e) {
+            if (e.getCause() instanceof ServiceNotFoundException) {
+                throw new IllegalStateException(ICacheService.CACHE_SUPPORT_NOT_AVAILABLE_ERROR_MESSAGE);
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.instance;
 
-import com.hazelcast.cache.ICache;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ClientService;
 import com.hazelcast.core.Cluster;
@@ -24,6 +23,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.ICacheManager;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.ICountDownLatch;
@@ -192,8 +192,8 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
     }
 
     @Override
-    public <K, V> ICache<K, V> getCache(String name) {
-        return getOriginal().getCache(name);
+    public ICacheManager getCacheManager() {
+        return getOriginal().getCacheManager();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.osgi.impl;
 
-import com.hazelcast.cache.ICache;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.ClientService;
@@ -25,6 +24,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.Endpoint;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICacheManager;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.ICountDownLatch;
@@ -134,8 +134,8 @@ class HazelcastOSGiInstanceImpl
     }
 
     @Override
-    public <K, V> ICache<K, V> getCache(String name) {
-        return delegatedInstance.getCache(name);
+    public ICacheManager getCacheManager() {
+        return delegatedInstance.getCacheManager();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/instance/CacheThroughHazelcastInstanceTest.java
@@ -48,7 +48,7 @@ public class CacheThroughHazelcastInstanceTest extends HazelcastTestSupport {
 
     private ICache retrieveCache(HazelcastInstance instance, String cacheName, boolean getCache) {
         return getCache
-                ? instance.getCache(cacheName)
+                ? instance.getCacheManager().getCache(cacheName)
                 : (ICache) instance.getDistributedObject(ICacheService.SERVICE_NAME,
                                                          HazelcastCacheManager.CACHE_MANAGER_PREFIX + cacheName);
     }


### PR DESCRIPTION
Access to `ICache` instances is now available via separate `ICacheManager` interface which is accessible from `HazelcastInstance.getCacheManager`.
Fixes #8352 .
An EE counterpart is required.
Also provides a new utility method `CacheUtil.getDistributedObjectName` (in a separate commit).