### PR TITLE
Makes use of callersUUID in OperationFactoryWrapper

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -81,12 +81,22 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
                     .setReplicaIndex(getReplicaIndex())
                     .setOperationResponseHandler(responseQueue)
                     .setServiceName(getServiceName())
-                    .setService(getService())
-                    .setCallerUuid(getCallerUuid());
+                    .setService(getService());
+
+            setCallerUuid(operation);
             OperationAccessor.setCallerAddress(operation, getCallerAddress());
             nodeEngine.getOperationService().executeOperation(operation);
         }
         return responses;
+    }
+
+    private void setCallerUuid(Operation operation) {
+        // Clients callerUUID can be set already. See OperationFactoryWrapper usage.
+        if (operation.getCallerUuid() != null) {
+            return;
+        }
+
+        operation.setCallerUuid(getCallerUuid());
     }
 
 
@@ -110,8 +120,9 @@ public final class PartitionIteratingOperation extends AbstractOperation impleme
                     .setReplicaIndex(getReplicaIndex())
                     .setOperationResponseHandler(responseQueue)
                     .setServiceName(getServiceName())
-                    .setService(getService())
-                    .setCallerUuid(getCallerUuid());
+                    .setService(getService());
+
+            setCallerUuid(operation);
             OperationAccessor.setCallerAddress(operation, getCallerAddress());
             nodeEngine.getOperationService().executeOperation(operation);
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/operations/OperationFactoryWrapperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/operations/OperationFactoryWrapperTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.operations;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OperationFactoryWrapperTest extends HazelcastTestSupport {
+
+    /**
+     * OperationFactoryWrapper gets a UUID and sets it to its created operations.
+     * This test ensures UUID doesn't change through the operation system.
+     */
+    @Test
+    public void testOperationSeesActualCallersUUID() throws Exception {
+        HazelcastInstance hz = createHazelcastInstance();
+        OperationServiceImpl operationService = getOperationServiceImpl(hz);
+
+        String expectedCallersUUID = UUID.randomUUID().toString();
+
+        GetCallersUUIDOperationFactory operationFactory = new GetCallersUUIDOperationFactory();
+        OperationFactoryWrapper wrapper = new OperationFactoryWrapper(operationFactory, expectedCallersUUID);
+
+        int partitionID = 0;
+        Map<Integer, Object> responses = operationService.invokeOnPartitions(SERVICE_NAME, wrapper, asList(partitionID));
+
+        String actualCallersUUID = (String) responses.get(partitionID);
+        assertEquals("Callers UUID should not be changed", expectedCallersUUID, actualCallersUUID);
+    }
+
+
+    private class GetCallersUUIDOperationFactory implements OperationFactory {
+
+        public GetCallersUUIDOperationFactory() {
+        }
+
+        @Override
+        public Operation createOperation() {
+            return new GetCallersUUIDOperation();
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            throw new UnsupportedOperationException("Intended to work locally");
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            throw new UnsupportedOperationException("Intended to work locally");
+        }
+    }
+
+
+    private class GetCallersUUIDOperation extends Operation {
+
+        public GetCallersUUIDOperation() {
+        }
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        public Object getResponse() {
+            return getCallerUuid();
+        }
+
+    }
+
+}


### PR DESCRIPTION
 instead of overriding it on node-side