### PR TITLE
Fix REST shutdownNode test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -28,7 +28,7 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String URI_CHANGE_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/changeState";
     public static final String URI_SHUTDOWN_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/clusterShutdown";
     public static final String URI_FORCESTART_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/forceStart";
-    public static final String URI_KILLNODE_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/memberShutdown";
+    public static final String URI_SHUTDOWN_NODE_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/memberShutdown";
     public static final String URI_CLUSTER_NODES_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/nodes";
     public static final String URI_MANCENTER_CHANGE_URL = "/hazelcast/rest/mancenter/changeurl";
     public static final String URI_WAN_SYNC_MAP = "/hazelcast/rest/wan/sync/map";

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -60,8 +60,8 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 handleForceStart(command);
             } else if (uri.startsWith(URI_CLUSTER_NODES_URL)) {
                 handleListNodes(command);
-            } else if (uri.startsWith(URI_KILLNODE_CLUSTER_URL)) {
-                handleKillNode(command);
+            } else if (uri.startsWith(URI_SHUTDOWN_NODE_CLUSTER_URL)) {
+                handleShutdownNode(command);
             } else if (uri.startsWith(URI_WAN_SYNC_MAP)) {
                 handleWanSyncMap(command);
             } else {
@@ -215,7 +215,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         textCommandService.sendResponse(command);
     }
 
-    private void handleKillNode(HttpPostCommand command) throws UnsupportedEncodingException {
+    private void handleShutdownNode(HttpPostCommand command) throws UnsupportedEncodingException {
         byte[] data = command.getData();
         String[] strList = bytesToString(data).split("&");
         String groupName = URLDecoder.decode(strList[0], "UTF-8");
@@ -230,7 +230,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 res = res.replace("${STATUS}", "success");
                 command.setResponse(HttpCommand.CONTENT_TYPE_JSON, stringToBytes(res));
                 textCommandService.sendResponse(command);
-                node.shutdown(false);
+                node.hazelcastInstance.shutdown();
                 return;
             }
         } catch (Throwable throwable) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -159,7 +159,7 @@ public class HTTPCommunicator {
         return urlConnection.getResponseCode();
     }
 
-    public String killMember(String groupName, String groupPassword) throws IOException {
+    public String shutdownMember(String groupName, String groupPassword) throws IOException {
 
         String url = address + "management/cluster/memberShutdown";
         return doPost(url, groupName, groupPassword);


### PR DESCRIPTION
When node is requested to be shutdown via REST command, response may not be
sent to the caller, if connection is closed before writing response
to the socket channel. In that case, caller will get a connection exception
instead of actual response.

Also, changed shutdown command to use `HazelcastInstance.shutdown()` instead
of `Node.shutdown()`.

Fixes #8106