### PR TITLE
Mark get-operations as read-only

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
@@ -56,7 +56,7 @@ public class MapStableReadStressTest extends StressTestSupport {
         }
     }
 
-    //@Test
+    @Test
     public void testChangingCluster() {
         test(true);
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/GetOperation.java
@@ -18,8 +18,9 @@ package com.hazelcast.concurrent.atomiclong.operations;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
 import com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook;
+import com.hazelcast.spi.ReadonlyOperation;
 
-public class GetOperation extends AbstractAtomicLongOperation {
+public class GetOperation extends AbstractAtomicLongOperation implements ReadonlyOperation {
 
     private long returnValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/GetOperation.java
@@ -18,8 +18,9 @@ package com.hazelcast.concurrent.atomicreference.operations;
 
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ReadonlyOperation;
 
-public class GetOperation extends AbstractAtomicReferenceOperation {
+public class GetOperation extends AbstractAtomicReferenceOperation implements ReadonlyOperation {
 
     private Data returnValue;
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
@@ -24,10 +24,11 @@ import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecordStore;
 import com.hazelcast.spi.AbstractOperation;
+import com.hazelcast.spi.ReadonlyOperation;
 
 import java.io.IOException;
 
-public class GetOperation extends AbstractOperation implements IdentifiedDataSerializable {
+public class GetOperation extends AbstractOperation implements IdentifiedDataSerializable, ReadonlyOperation {
 
     private String name;
     private Data key;

--- a/hazelcast/src/main/java/com/hazelcast/spi/ReadonlyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ReadonlyOperation.java
@@ -19,9 +19,7 @@ package com.hazelcast.spi;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 /**
- * Read-only operations are not retried during migration.
- *
- * @author mdogan 7/17/13
+ * Read-only operations are allowed to run during migration and passive state.
  */
 public interface ReadonlyOperation extends AllowedDuringPassiveState {
 


### PR DESCRIPTION
Marked atomic-long, atomic-reference and replicated-map's `GetOperation`s as
`ReadonlyOperation`.

Fixes #4179