### PR TITLE
SlowOperationDetector improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -131,19 +131,20 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         boolean publishCurrentTask = publishCurrentTask();
 
         if (publishCurrentTask) {
-            currentTask = task;
+            setCurrentTask(task);
         }
 
         try {
             task.run();
         } finally {
             if (publishCurrentTask) {
-                currentTask = null;
+                resetCurrentTask();
             }
         }
     }
 
     private boolean publishCurrentTask() {
+        Object currentTask = currentTask();
         boolean isClientRunnable = currentTask instanceof MessageTask;
         return (getPartitionId() != AD_HOC_PARTITION_ID && (currentTask == null || isClientRunnable));
     }
@@ -159,7 +160,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         boolean publishCurrentTask = publishCurrentTask();
 
         if (publishCurrentTask) {
-            currentTask = op;
+            setCurrentTask(op);
         }
 
         try {
@@ -186,7 +187,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
             handleOperationError(op, e);
         } finally {
             if (publishCurrentTask) {
-                currentTask = null;
+                resetCurrentTask();
             }
         }
     }
@@ -372,7 +373,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         boolean publishCurrentTask = publishCurrentTask();
 
         if (publishCurrentTask) {
-            currentTask = packet;
+            setCurrentTask(packet);
         }
 
         Connection connection = packet.getConn();
@@ -391,7 +392,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
             }
 
             if (publishCurrentTask) {
-                currentTask = null;
+                resetCurrentTask();
             }
             run(op);
         } catch (Throwable throwable) {
@@ -402,7 +403,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
             throw ExceptionUtil.rethrow(throwable);
         } finally {
             if (publishCurrentTask) {
-                currentTask = null;
+                resetCurrentTask();
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -228,13 +228,13 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
         public void run(Operation task) {
             operations.add(task);
 
-            currentTask = task;
+            setCurrentTask(task);
             try {
                 task.run();
             } catch (Exception e) {
                 e.printStackTrace();
             } finally {
-                currentTask = null;
+                resetCurrentTask();
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.Repeat;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_EntryProcessorTest.java
@@ -58,7 +58,7 @@ public class SlowOperationDetector_EntryProcessorTest extends SlowOperationDetec
         Collection<SlowOperationLog.Invocation> invocations = getInvocations(firstLog);
         assertEqualsStringFormat("Expected %d invocations, but was %d", 4, invocations.size());
         for (SlowOperationLog.Invocation invocation : invocations) {
-            assertInvocationDurationBetween(invocation, 1000, 6500);
+            assertInvocationDurationBetween(invocation, 2500, 6500);
         }
     }
 
@@ -93,10 +93,10 @@ public class SlowOperationDetector_EntryProcessorTest extends SlowOperationDetec
                 (firstSize == 1 ^ secondSize == 1) && (firstSize == 4 ^ secondSize == 4));
 
         for (SlowOperationLog.Invocation invocation : firstInvocations) {
-            assertInvocationDurationBetween(invocation, 1000, 5500);
+            assertInvocationDurationBetween(invocation, 2500, 5500);
         }
         for (SlowOperationLog.Invocation invocation : secondInvocations) {
-            assertInvocationDurationBetween(invocation, 1000, 5500);
+            assertInvocationDurationBetween(invocation, 2500, 5500);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
@@ -81,7 +81,7 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
         int invocationCount = invocations.size();
         assertTrue("Expected 1 or 2 invocations, but was " + invocationCount, invocationCount >= 1 && invocationCount <= 2);
         for (SlowOperationLog.Invocation invocation : invocations) {
-            assertInvocationDurationBetween(invocation, 1000, 3500);
+            assertInvocationDurationBetween(invocation, 2500, 4500);
         }
     }
 


### PR DESCRIPTION
Improved `SlowOperationDetector` by moving the start time detection to the `OperationRunner`, which exactly knows when a task was started. This eases especially the unit tests, which were a nightmare to debug before. This also improves the accuracy of the detection, since we don't need to visit a task twice, to measure its runtime.