### PR TITLE
Add new PartitionServiceState.REPLICA_NOT_OWNED

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
@@ -37,6 +37,7 @@ import java.util.logging.Level;
 
 import static com.hazelcast.internal.partition.impl.PartitionServiceState.MIGRATION_LOCAL;
 import static com.hazelcast.internal.partition.impl.PartitionServiceState.MIGRATION_ON_MASTER;
+import static com.hazelcast.internal.partition.impl.PartitionServiceState.REPLICA_NOT_OWNED;
 import static com.hazelcast.internal.partition.impl.PartitionServiceState.REPLICA_NOT_SYNC;
 import static com.hazelcast.internal.partition.impl.PartitionServiceState.SAFE;
 import static com.hazelcast.spi.partition.IPartitionService.SERVICE_NAME;
@@ -72,7 +73,7 @@ public class PartitionReplicaStateChecker {
 
     public PartitionServiceState getPartitionServiceState() {
         if (hasMissingReplicaOwners()) {
-            return REPLICA_NOT_SYNC;
+            return REPLICA_NOT_OWNED;
         }
 
         if (migrationManager.hasOnGoingMigration()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionServiceState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionServiceState.java
@@ -40,6 +40,11 @@ public enum PartitionServiceState {
     /**
      * Indicates that there are out-of-sync replicas for owned partitions by this node.
      */
-    REPLICA_NOT_SYNC
+    REPLICA_NOT_SYNC,
+
+    /**
+     * Indicates that there are some replicas are not owned.
+     */
+    REPLICA_NOT_OWNED
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
@@ -72,7 +72,7 @@ public class AntiEntropyCorrectnessTest extends PartitionCorrectnessTestSupport 
         assertSizeAndDataEventually();
     }
 
-    static void setBackupPacketDropFilter(HazelcastInstance instance, float blockRatio) {
+    public static void setBackupPacketDropFilter(HazelcastInstance instance, float blockRatio) {
         Node node = getNode(instance);
         FirewallingMockConnectionManager cm = (FirewallingMockConnectionManager) node.getConnectionManager();
         cm.setPacketFilter(new BackupPacketDropFilter(node.getSerializationService(), blockRatio));


### PR DESCRIPTION
Currently REPLICA_NOT_SYNC is used to denote both missing replica owners
and not-sync backup replicas.

It makes difficult to detect cause of failures like
https://github.com/hazelcast/hazelcast/issues/8471