### PR TITLE
Allow Value Extractors to be loaded in an OSGi environment

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -87,8 +87,7 @@ class MapServiceContextImpl implements MapServiceContext {
         public MapContainer createNew(String mapName) {
             final MapServiceContext mapServiceContext = getService().getMapServiceContext();
             final Config config = nodeEngine.getConfig();
-            final MapConfig mapConfig = config.findMapConfig(mapName);
-            return new MapContainer(mapName, mapConfig, mapServiceContext);
+            return new MapContainer(mapName, config, mapServiceContext);
         }
     };
     /**

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.mapreduce.aggregation.impl;
 
+import java.util.Collections;
+
 import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
-
-import java.util.Collections;
 
 /**
  * Internal implementation of an map entry with changeable value to prevent
@@ -38,7 +38,7 @@ final class SimpleEntry<K, V>
     private V value;
 
     public SimpleEntry() {
-        this.extractors = new Extractors(Collections.<MapAttributeConfig>emptyList());
+		this.extractors = new Extractors(null, Collections.<MapAttributeConfig> emptyList());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
@@ -46,7 +46,7 @@ public class IndexImplTest {
     @Before
     public void setUp() {
         InternalSerializationService mockSerializationService = mock(InternalSerializationService.class);
-        Extractors mockExtractors = new Extractors(Collections.<MapAttributeConfig>emptyList());
+        Extractors mockExtractors = new Extractors(null, Collections.<MapAttributeConfig>emptyList());
         index = new IndexImpl(ATTRIBUTE_NAME, false, mockSerializationService, mockExtractors);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorHelperTest.java
@@ -1,19 +1,5 @@
 package com.hazelcast.query.impl.getters;
 
-import com.hazelcast.config.MapAttributeConfig;
-import com.hazelcast.query.extractor.ValueCollector;
-import com.hazelcast.query.extractor.ValueExtractor;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-
-import java.util.Map;
-
 import static com.hazelcast.query.impl.getters.ExtractorHelper.extractArgumentsFromAttributeName;
 import static com.hazelcast.query.impl.getters.ExtractorHelper.extractAttributeNameNameWithoutArguments;
 import static groovy.util.GroovyTestCase.assertEquals;
@@ -21,6 +7,22 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isA;
+
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapAttributeConfig;
+import com.hazelcast.query.extractor.ValueCollector;
+import com.hazelcast.query.extractor.ValueExtractor;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -61,12 +63,34 @@ public class ExtractorHelperTest {
         MapAttributeConfig nameExtractor = new MapAttributeConfig("name", "com.hazelcast.query.impl.getters.ExtractorHelperTest$NameExtractor");
 
         // WHEN
-        Map<String, ValueExtractor> extractors = ExtractorHelper.instantiateExtractors(asList(iqExtractor, nameExtractor));
+		Map<String, ValueExtractor> extractors =
+				ExtractorHelper.instantiateExtractors(null, asList(iqExtractor, nameExtractor));
 
         // THEN
         assertThat(extractors.get("iq"), instanceOf(IqExtractor.class));
         assertThat(extractors.get("name"), instanceOf(NameExtractor.class));
     }
+	
+	@Test
+	public void instantiate_extractors_withCustomClassLoader() {
+		// GIVEN
+		MapAttributeConfig iqExtractor =
+				new MapAttributeConfig("iq", "com.hazelcast.query.impl.getters.ExtractorHelperTest$IqExtractor");
+		MapAttributeConfig nameExtractor =
+				new MapAttributeConfig("name", "com.hazelcast.query.impl.getters.ExtractorHelperTest$NameExtractor");
+		Config config = new Config();
+		// For other custom class loaders (from OSGi bundles, for example)
+		ClassLoader customClassLoader = getClass().getClassLoader();
+		config.setClassLoader(customClassLoader);
+		
+		// WHEN
+		Map<String, ValueExtractor> extractors =
+				ExtractorHelper.instantiateExtractors(config, asList(iqExtractor, nameExtractor));
+		
+		// THEN
+		assertThat(extractors.get("iq"), instanceOf(IqExtractor.class));
+		assertThat(extractors.get("name"), instanceOf(NameExtractor.class));
+	}
 
     @Test
     public void instantiate_extractors_oneClassNotExisting() {
@@ -79,7 +103,7 @@ public class ExtractorHelperTest {
         expected.expectCause(isA(ClassNotFoundException.class));
 
         // WHEN
-        ExtractorHelper.instantiateExtractors(asList(iqExtractor, nameExtractor));
+		ExtractorHelper.instantiateExtractors(null, asList(iqExtractor, nameExtractor));
     }
 
     @Test
@@ -92,7 +116,7 @@ public class ExtractorHelperTest {
         expected.expect(IllegalArgumentException.class);
 
         // WHEN
-        ExtractorHelper.instantiateExtractors(asList(iqExtractor, iqExtractorDuplicate));
+		ExtractorHelper.instantiateExtractors(null, asList(iqExtractor, iqExtractorDuplicate));
     }
 
     @Test
@@ -104,7 +128,7 @@ public class ExtractorHelperTest {
         expected.expect(IllegalArgumentException.class);
 
         // WHEN
-        ExtractorHelper.instantiateExtractors(asList(string));
+		ExtractorHelper.instantiateExtractors(null, asList(string));
     }
 
     @Test
@@ -116,7 +140,7 @@ public class ExtractorHelperTest {
         expected.expect(IllegalArgumentException.class);
 
         // WHEN
-        ExtractorHelper.instantiateExtractors(asList(string));
+		ExtractorHelper.instantiateExtractors(null, asList(string));
     }
 
     @Test
@@ -128,7 +152,7 @@ public class ExtractorHelperTest {
         expected.expect(IllegalArgumentException.class);
 
         // WHEN
-        ExtractorHelper.instantiateExtractors(asList(string));
+		ExtractorHelper.instantiateExtractors(null, asList(string));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/ExtractorsTest.java
@@ -55,7 +55,7 @@ public class ExtractorsTest {
     public void getGetter_extractor_cachingWorks() {
         // GIVEN
         MapAttributeConfig config = new MapAttributeConfig("gimmePower", "com.hazelcast.query.impl.getters.ExtractorsTest$PowerExtractor");
-        Extractors extractors = new Extractors(asList(config));
+        Extractors extractors = new Extractors(null, asList(config));
 
         // WHEN
         Getter getterFirstInvocation = extractors.getGetter(UNUSED, bond, "gimmePower");
@@ -70,7 +70,7 @@ public class ExtractorsTest {
     public void extract_extractor_correctValue() {
         // GIVEN
         MapAttributeConfig config = new MapAttributeConfig("gimmePower", "com.hazelcast.query.impl.getters.ExtractorsTest$PowerExtractor");
-        Extractors extractors = new Extractors(asList(config));
+        Extractors extractors = new Extractors(null, asList(config));
 
         // WHEN
         Object power = extractors.extract(UNUSED, bond, "gimmePower");
@@ -118,7 +118,7 @@ public class ExtractorsTest {
     }
 
     private static Extractors extractors() {
-        return new Extractors(Collections.<MapAttributeConfig>emptyList());
+        return new Extractors(null, Collections.<MapAttributeConfig>emptyList());
     }
 
 }


### PR DESCRIPTION
IT resolves https://github.com/hazelcast/hazelcast/issues/8482

Basically, ExtractorsHelper can receive the Config instance now. This way, the extractor class of the MapAttributeConfig can be loaded from Config class loader before try it by doing a Class.forName. 

This is very important to OSGi enviromonment, because we can set an special ClassLoader to the Config instance in order to provide Extractors from diferent bundles.