### PR TITLE
Improve performance of convertions to java.sql classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DateHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DateHelper.java
@@ -44,6 +44,7 @@ final class DateHelper {
 
     static Timestamp parseTimeStamp(final String value) {
         try {
+            // JDK format in Timestamp.valueOf is compatible with TIMESTAMP_FORMAT
             return Timestamp.valueOf(value);
         } catch (IllegalArgumentException e) {
             return throwRuntimeParseException(value, new ParseException(e.getMessage(), 0), TIMESTAMP_FORMAT);
@@ -52,6 +53,7 @@ final class DateHelper {
 
     static java.sql.Date parseSqlDate(final String value) {
         try {
+            // JDK format in Date.valueOf is compatible with DATE_FORMAT
             return java.sql.Date.valueOf(value);
         } catch (IllegalArgumentException e) {
             return throwRuntimeParseException(value, new ParseException(value, 0), SQL_DATE_FORMAT);
@@ -60,6 +62,7 @@ final class DateHelper {
 
     static java.sql.Time parseSqlTime(final String value) {
         try {
+            // JDK format in Time.valueOf is compatible with DATE_FORMAT
             return Time.valueOf(value);
         } catch (IllegalArgumentException e) {
             return throwRuntimeParseException(value, new ParseException(value, 0), SQL_TIME_FORMAT);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DateHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DateHelper.java
@@ -44,25 +44,25 @@ final class DateHelper {
 
     static Timestamp parseTimeStamp(final String value) {
         try {
-            return new Timestamp(getTimestampFormat().parse(value).getTime());
-        } catch (ParseException e) {
-            return throwRuntimeParseException(value, e, TIMESTAMP_FORMAT);
+            return Timestamp.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return throwRuntimeParseException(value, new ParseException(e.getMessage(), 0), TIMESTAMP_FORMAT);
         }
     }
 
     static java.sql.Date parseSqlDate(final String value) {
         try {
-            return new java.sql.Date(getSqlDateFormat().parse(value).getTime());
-        } catch (ParseException e) {
-            return throwRuntimeParseException(value, e, SQL_DATE_FORMAT);
+            return java.sql.Date.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return throwRuntimeParseException(value, new ParseException(value, 0), SQL_DATE_FORMAT);
         }
     }
 
     static java.sql.Time parseSqlTime(final String value) {
         try {
-            return new Time(getSqlTimeFormat().parse(value).getTime());
-        } catch (ParseException e) {
-            return throwRuntimeParseException(value, e, SQL_TIME_FORMAT);
+            return Time.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return throwRuntimeParseException(value, new ParseException(value, 0), SQL_TIME_FORMAT);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/DateHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/DateHelperTest.java
@@ -18,12 +18,17 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
@@ -38,6 +43,10 @@ public class DateHelperTest {
     public static final String DATE_FORMAT = DateHelper.DATE_FORMAT;
     public static final String TIMESTAMP_FORMAT = DateHelper.TIMESTAMP_FORMAT;
     public static final String SQL_DATE_FORMAT = DateHelper.SQL_DATE_FORMAT;
+    public static final String SQL_TIME_FORMAT = DateHelper.SQL_TIME_FORMAT;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testSqlDate() {
@@ -46,10 +55,58 @@ public class DateHelperTest {
         java.sql.Date date1 = new java.sql.Date(now);
         java.sql.Date date2 = DateHelper.parseSqlDate(date1.toString());
 
+        assertSqlDatesEqual(date1, date2);
+    }
+
+    @Test
+    public void testSqlDateWithLeadingZerosInMonthAndDay() throws Exception {
+        // Given
+        long expectedDateInMillis = new SimpleDateFormat(SQL_DATE_FORMAT)
+                .parse("2003-01-04")
+                .getTime();
+        java.sql.Date expectedDate = new java.sql.Date(expectedDateInMillis);
+
+        // When
+        java.sql.Date actualDate = DateHelper.parseSqlDate(expectedDate.toString());
+
+        // Then
+        assertSqlDatesEqual(expectedDate, actualDate);
+    }
+
+    @Test
+    public void testSqlDateWithTrailingZerosInMonthAndDay() throws Exception {
+        // Given
+        long expectedDateInMillis = new SimpleDateFormat(SQL_DATE_FORMAT)
+                .parse("2000-10-20")
+                .getTime();
+        java.sql.Date expectedDate = new java.sql.Date(expectedDateInMillis);
+
+        // When
+        java.sql.Date actualDate = DateHelper.parseSqlDate(expectedDate.toString());
+
+        // Then
+        assertSqlDatesEqual(expectedDate, actualDate);
+    }
+
+    @Test
+    public void testSqlDateFailsForInvalidDate() throws Exception {
+        // Given
+        String invalidDate = "Trust me, I am a date";
+
+        // When
+        thrown.expect(RuntimeException.class);
+        thrown.expectCause(instanceOf(ParseException.class));
+        DateHelper.parseSqlDate(invalidDate);
+
+        // Then
+        // No-op
+    }
+
+    private void assertSqlDatesEqual(java.sql.Date firstDate, java.sql.Date secondDate) {
         Calendar cal1 = Calendar.getInstance(Locale.US);
-        cal1.setTimeInMillis(date1.getTime());
+        cal1.setTimeInMillis(firstDate.getTime());
         Calendar cal2 = Calendar.getInstance(Locale.US);
-        cal2.setTimeInMillis(date2.getTime());
+        cal2.setTimeInMillis(secondDate.getTime());
 
         assertEquals(cal1.get(Calendar.YEAR), cal2.get(Calendar.YEAR));
         assertEquals(cal1.get(Calendar.MONTH), cal2.get(Calendar.MONTH));
@@ -83,10 +140,59 @@ public class DateHelperTest {
         Timestamp date1 = new Timestamp(now);
         Timestamp date2 = DateHelper.parseTimeStamp(date1.toString());
 
+        assertTimestampsEqual(date1, date2);
+    }
+
+    @Test
+    public void testTimestampWithLeadingZeros() throws Exception {
+        // Given
+        Timestamp expectedTimestamp = new Timestamp(new SimpleDateFormat(TIMESTAMP_FORMAT)
+                .parse("2000-01-02 03:04:05.006")
+                .getTime());
+
+        // When
+        Timestamp actualTimestamp = DateHelper.parseTimeStamp(expectedTimestamp.toString());
+
+        // Then
+        assertTimestampsEqual(expectedTimestamp, actualTimestamp);
+    }
+
+    @Test
+    public void testTimestampWithTrailingZeros() throws Exception {
+        // Given
+        Timestamp expectedTimestamp = new Timestamp(new SimpleDateFormat(TIMESTAMP_FORMAT)
+                .parse("2010-10-20 10:20:30.040")
+                .getTime());
+
+        // When
+        Timestamp actualTimestamp = DateHelper.parseTimeStamp(expectedTimestamp.toString());
+
+        // Then
+        assertTimestampsEqual(expectedTimestamp, actualTimestamp);
+    }
+
+    @Test
+    public void testTimestampFailsForInvalidValue() throws Exception {
+        // Given
+        String invalidTimestamp = "Quid temporem est";
+
+        // When
+        thrown.expectCause(instanceOf(ParseException.class));
+        DateHelper.parseTimeStamp(invalidTimestamp);
+
+        // Then
+        // No-op
+    }
+
+    private Matcher<Throwable> instanceOf(Class<?> exceptionClass) {
+        return Matchers.instanceOf(exceptionClass);
+    }
+
+    private void assertTimestampsEqual(Timestamp firstTimestamp, Timestamp secondTimestamp) {
         Calendar cal1 = Calendar.getInstance(Locale.US);
-        cal1.setTimeInMillis(date1.getTime());
+        cal1.setTimeInMillis(firstTimestamp.getTime());
         Calendar cal2 = Calendar.getInstance(Locale.US);
-        cal2.setTimeInMillis(date2.getTime());
+        cal2.setTimeInMillis(secondTimestamp.getTime());
 
         assertEquals(cal1.get(Calendar.YEAR), cal2.get(Calendar.YEAR));
         assertEquals(cal1.get(Calendar.MONTH), cal2.get(Calendar.MONTH));
@@ -103,10 +209,59 @@ public class DateHelperTest {
         Time time1 = new Time(now);
         Time time2 = DateHelper.parseSqlTime(time1.toString());
 
+        assertSqlTimesEqual(time1, time2);
+    }
+
+    @Test
+    public void testTimeWithLeadingZeros() throws Exception {
+        // Given
+        Time expectedTime = new Time(
+                new SimpleDateFormat(SQL_TIME_FORMAT)
+                        .parse("01:02:03")
+                        .getTime()
+        );
+
+        // When
+        Time actualTime = DateHelper.parseSqlTime(expectedTime.toString());
+
+        // Then
+        assertSqlTimesEqual(expectedTime, actualTime);
+    }
+
+    @Test
+    public void testTimeWithTrailingZeros() throws Exception {
+        // Given
+        Time expectedTime = new Time(
+                new SimpleDateFormat(SQL_TIME_FORMAT)
+                        .parse("10:20:30")
+                        .getTime()
+        );
+
+        // When
+        Time actualTime = DateHelper.parseSqlTime(expectedTime.toString());
+
+        // Then
+        assertSqlTimesEqual(expectedTime, actualTime);
+    }
+
+    @Test
+    public void testTimeFailsForInvalidValue() throws Exception {
+        // Given
+        String invalidTime = "Time is now";
+
+        // When
+        thrown.expectCause(instanceOf(ParseException.class));
+        DateHelper.parseSqlTime(invalidTime);
+
+        // Then
+        // No-op
+    }
+
+    private void assertSqlTimesEqual(Time firstTime, Time secondTime) {
         Calendar cal1 = Calendar.getInstance(Locale.US);
-        cal1.setTimeInMillis(time1.getTime());
+        cal1.setTimeInMillis(firstTime.getTime());
         Calendar cal2 = Calendar.getInstance(Locale.US);
-        cal2.setTimeInMillis(time2.getTime());
+        cal2.setTimeInMillis(secondTime.getTime());
 
         assertEquals(cal1.get(Calendar.HOUR_OF_DAY), cal2.get(Calendar.HOUR_OF_DAY));
         assertEquals(cal1.get(Calendar.MINUTE), cal2.get(Calendar.MINUTE));


### PR DESCRIPTION
Converters for `java.sql.{Timestamp, Date, Time}` classes rely on `DateHelper` which uses `SimpleDateFormat` to construct first `java.util.Date` and then instance of target type.
In all three cases, `valueOf` methods exist, which do the same job in shorter time.

Issue: #7591