### PR TITLE
Make HashSlotArrayBase more extensible

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/HashSlotArray.java
@@ -62,16 +62,6 @@ import com.hazelcast.nio.Disposable;
 public interface HashSlotArray extends Disposable {
 
     /**
-     * @return the size, in bytes, of the key part of each slot.
-     */
-    int keySize();
-
-    /**
-     * @return the size, in bytes, of the value part of each slot.
-     */
-    int valueSize();
-
-    /**
      * @return current base address of this flyweight
      */
     long address();

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImpl.java
@@ -62,11 +62,6 @@ public final class HashSlotArray12byteKeyImpl extends HashSlotArrayBase implemen
                 : "Value length must be 4 plus a positive multiple of 8, but was " + valueLength;
     }
 
-    @Override
-    public int keySize() {
-        return KEY_SIZE;
-    }
-
     /**
      * {@inheritDoc}
      *
@@ -90,22 +85,22 @@ public final class HashSlotArray12byteKeyImpl extends HashSlotArrayBase implemen
     }
 
     @Override protected long key2OfSlot(long baseAddress, long slot) {
-        return mem.getInt(slotBase(baseAddress, slot) + KEY_2_OFFSET);
+        return mem().getInt(slotBase(baseAddress, slot) + KEY_2_OFFSET);
     }
 
     @Override protected void putKey(long baseAddress, long slot, long key1, long key2) {
-        mem.putLong(slotBase(baseAddress, slot) + KEY_1_OFFSET, key1);
-        mem.putInt(slotBase(baseAddress, slot) + KEY_2_OFFSET, (int) key2);
+        mem().putLong(slotBase(baseAddress, slot) + KEY_1_OFFSET, key1);
+        mem().putInt(slotBase(baseAddress, slot) + KEY_2_OFFSET, (int) key2);
     }
 
     @Override
     protected void markUnassigned(long baseAddress, long slot) {
-        mem.putInt(slotBase(baseAddress, slot) + offsetOfUnassignedSentinel, (int) unassignedSentinel);
+        mem().putInt(slotBase(baseAddress, slot) + offsetOfUnassignedSentinel, (int) unassignedSentinel);
     }
 
     @Override
     protected boolean isAssigned(long baseAddress, long slot) {
-        return mem.getInt(slotBase(baseAddress, slot) + offsetOfUnassignedSentinel) != unassignedSentinel;
+        return mem().getInt(slotBase(baseAddress, slot) + offsetOfUnassignedSentinel) != unassignedSentinel;
     }
 
     @Override protected long keyHash(long key1, long key2) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyImpl.java
@@ -65,11 +65,6 @@ public class HashSlotArray16byteKeyImpl extends HashSlotArrayBase implements Has
     }
 
 
-    @Override
-    public int keySize() {
-        return KEY_SIZE;
-    }
-
     /**
      * {@inheritDoc}
      *

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImpl.java
@@ -60,11 +60,6 @@ public class HashSlotArray8byteKeyImpl extends HashSlotArrayBase implements Hash
                 : "Value size must be a positive multiple of 8, but was " + valueLength;
     }
 
-    @Override
-    public int keySize() {
-        return KEY_SIZE;
-    }
-
     /**
      * {@inheritDoc}
      *
@@ -92,7 +87,7 @@ public class HashSlotArray8byteKeyImpl extends HashSlotArrayBase implements Hash
     }
 
     @Override protected void putKey(long baseAddress, long slot, long key, long ignored) {
-        mem.putLong(slotBase(baseAddress, slot) + KEY_1_OFFSET, key);
+        mem().putLong(slotBase(baseAddress, slot) + KEY_1_OFFSET, key);
     }
 
     @Override protected long keyHash(long key, long ignored) {


### PR DESCRIPTION
Several non-functional changes to `HashSlotArrayBase` that make it more extensible. Specifically targetted for the needs of Jet.

This PR makes no functional changes, it just rearranges code.