### PR TITLE
Enable ignored QueryIndexMigrationTest.testIndexCleanupOnMigration

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexMigrationTest.java
@@ -35,7 +35,6 @@ import com.hazelcast.util.Clock;
 import com.hazelcast.util.IterableUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -161,8 +160,6 @@ public class QueryIndexMigrationTest extends HazelcastTestSupport {
     /**
      * test for issue #359
      */
-    //Ignored due to : https://github.com/hazelcast/hazelcast/issues/6471
-    @Ignore
     @Test(timeout = MINUTE)
     public void testIndexCleanupOnMigration() throws Exception {
         int nodeCount = 6;


### PR DESCRIPTION
The ignored test was failing months ago during 3.6 development. In 3.7 there have been numerous enhancements in migration and usage of indexes. I have applied the changes suggested by @jerrinot [here](https://github.com/hazelcast/hazelcast/issues/6471#issuecomment-159933869) and verified that:
* on `maintenance-3.x` branch the test fails after 140-200 repetitions of the test
* on current `master` the test did not fail after 3500+ test repetitions

This PR re-enables the test. Fixes #6471  