### PR TITLE
Fix condition await expiration when lock is already held

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -60,6 +60,13 @@ public class AwaitOperation extends AbstractLockOperation
         }
     }
 
+    void runExpired() {
+        LockStoreImpl lockStore = getLockStore();
+        boolean locked = lockStore.lock(key, getCallerUuid(), threadId, getReferenceCallId(), leaseTime);
+        assert locked : "Expired await operation should have acquired the lock!";
+        sendResponse(false);
+    }
+
     @Override
     public ConditionKey getWaitKey() {
         return new ConditionKey(namespace.getObjectName(), key, conditionId, getCallerUuid(), threadId);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
@@ -25,7 +25,6 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.WaitNotifyKey;
 
 import java.io.IOException;
@@ -83,12 +82,11 @@ public class UnlockOperation extends AbstractLockOperation implements Notifier, 
     @Override
     public void afterRun() throws Exception {
         LockStoreImpl lockStore = getLockStore();
-        AwaitOperation awaitResponse = lockStore.pollExpiredAwaitOp(key);
-        if (awaitResponse != null) {
-            OperationService operationService = getNodeEngine().getOperationService();
-            operationService.runOperationOnCallingThread(awaitResponse);
+        AwaitOperation awaitOperation = lockStore.pollExpiredAwaitOp(key);
+        if (awaitOperation != null) {
+            awaitOperation.runExpired();
         }
-        shouldNotify = awaitResponse == null;
+        shouldNotify = awaitOperation == null;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/ConditionAbstractTest.java
@@ -6,7 +6,6 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestThread;
-import com.hazelcast.test.annotation.Repeat;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -300,6 +299,83 @@ public abstract class ConditionAbstractTest extends HazelcastTestSupport {
         } finally {
             ex.shutdownNow();
         }
+    }
+
+    @Test
+    public void testAwaitExpiration_whenLockIsNotAcquired() throws InterruptedException {
+        String lockName = newName();
+        String conditionName = newName();
+        final ILock lock = callerInstance.getLock(lockName);
+        final ICondition condition = lock.newCondition(conditionName);
+        final AtomicInteger expires = new AtomicInteger(0);
+        final int awaitCount = 10;
+
+        final CountDownLatch awaitLatch = new CountDownLatch(awaitCount);
+        for (int i = 0; i < awaitCount; i++) {
+            new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        lock.lock();
+                        awaitLatch.countDown();
+                        boolean signalled = condition.await(1, TimeUnit.SECONDS);
+                        assertFalse(signalled);
+                        expires.incrementAndGet();
+                    } catch (InterruptedException ignored) {
+                    } finally {
+                        lock.unlock();
+                    }
+
+                }
+            }).start();
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(awaitCount, expires.get());
+            }
+        });
+    }
+
+    @Test
+    public void testAwaitExpiration_whenLockIsAcquiredByAnotherThread() throws InterruptedException {
+        String lockName = newName();
+        String conditionName = newName();
+        final ILock lock = callerInstance.getLock(lockName);
+        final ICondition condition = lock.newCondition(conditionName);
+        final AtomicInteger expires = new AtomicInteger(0);
+        final int awaitCount = 10;
+
+        final CountDownLatch awaitLatch = new CountDownLatch(awaitCount);
+        for (int i = 0; i < awaitCount; i++) {
+            new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        lock.lock();
+                        awaitLatch.countDown();
+                        boolean signalled = condition.await(1, TimeUnit.SECONDS);
+                        assertFalse(signalled);
+                        expires.incrementAndGet();
+                    } catch (InterruptedException ignored) {
+                    } finally {
+                        lock.unlock();
+                    }
+
+                }
+            }).start();
+        }
+        awaitLatch.await(2, TimeUnit.MINUTES);
+
+        lock.lock();
+        sleepSeconds(2);
+        lock.unlock();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(awaitCount, expires.get());
+            }
+        });
     }
 
     //if there are multiple waiters, then only 1 waiter should be notified.


### PR DESCRIPTION
Currently, condition await expiration is failing when lock is held by
another thread at the time wait-notify system triggers expiration logic.

When await expiration is triggered, it's registered in lock service as expired
if lock is not available at that moment. We can't send failure response directly,
because thread awaiting should be owner of the lock when await() call returns.
UnlockOperation polls expired awaits after lock is released and executes AwaitOperation
using operation-service.

Problem is, operation-service thinks AwaitOperation is timed-out and returns call-timeout
response to await() which causes await to retry instead of expire immediately.

Fix is to assign lock to the caller of await() and send failure response right away after unlock.