### PR TITLE
Relaxed TTL in RingBufferAsyncAddWithBackoffStressTest.whenShortTTLAndBigBuffer

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAsyncAddWithBackoffStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAsyncAddWithBackoffStressTest.java
@@ -53,7 +53,7 @@ public class RingbufferAsyncAddWithBackoffStressTest extends HazelcastTestSuppor
     public void whenShortTTLAndBigBuffer() throws Exception {
         RingbufferConfig ringbufferConfig = new RingbufferConfig("foo")
                 .setCapacity(20 * 1000 * 1000)
-                .setTimeToLiveSeconds(2);
+                .setTimeToLiveSeconds(3);
         test(ringbufferConfig);
     }
 


### PR DESCRIPTION
Set TTL from 2 to 3 seconds to cope with unpredictable load in build environment
Fixes #7193 