### PR TITLE
Cluster-state should not allowed to change before startup is completed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -139,6 +139,10 @@ public class ClusterStateManager {
         Preconditions.checkNotNull(newState);
         clusterServiceLock.lock();
         try {
+            if (!node.getNodeExtension().isStartCompleted()) {
+                throw new IllegalStateException("Can not lock cluster state! Startup is not completed yet!");
+            }
+
             checkMigrationsAndPartitionStateVersion(newState, partitionStateVersion);
 
             final ClusterStateLock currentLock = getStateLock();

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -67,9 +67,12 @@ public class ClusterStateManagerTest {
 
     @Before
     public void setup() {
+        NodeExtension nodeExtension = mock(NodeExtension.class);
+        when(nodeExtension.isStartCompleted()).thenReturn(true);
+
         when(node.getPartitionService()).thenReturn(partitionService);
         when(node.getClusterService()).thenReturn(clusterService);
-        when(node.getNodeExtension()).thenReturn(mock(NodeExtension.class));
+        when(node.getNodeExtension()).thenReturn(nodeExtension);
         when(node.getLogger(ClusterStateManager.class)).thenReturn(mock(ILogger.class));
 
         clusterStateManager = new ClusterStateManager(node, lock);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -30,12 +30,12 @@ import com.hazelcast.nio.tcp.FirewallingMockConnectionManager;
 
 import java.nio.channels.ServerSocketChannel;
 
-class MockNodeContext implements NodeContext {
+public class MockNodeContext implements NodeContext {
 
     private final TestNodeRegistry registry;
     private final Address thisAddress;
 
-    MockNodeContext(TestNodeRegistry registry, Address thisAddress) {
+    protected MockNodeContext(TestNodeRegistry registry, Address thisAddress) {
         this.registry = registry;
         this.thisAddress = thisAddress;
     }


### PR DESCRIPTION
Normally NodeExtension.isStartCompleted() returns true when node is joined successfully, but when hot-restart is enabled, it returns false until hot-restart process completes on all cluster.

Fixes #8523