### PR TITLE
Cluster-state should not allowed to change before startup is completed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/ClusterStateManager.java
@@ -136,6 +136,10 @@ public class ClusterStateManager {
         Preconditions.checkNotNull(newState);
         clusterServiceLock.lock();
         try {
+            if (!node.getNodeExtension().isStartCompleted()) {
+                throw new IllegalStateException("Can not lock cluster state! Startup is not completed yet!");
+            }
+
             checkMigrationsAndPartitionStateVersion(newState, partitionStateVersion);
 
             final ClusterStateLock currentLock = getStateLock();

--- a/hazelcast/src/test/java/com/hazelcast/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/impl/ClusterStateManagerTest.java
@@ -67,9 +67,12 @@ public class ClusterStateManagerTest {
 
     @Before
     public void setup() {
+        NodeExtension nodeExtension = mock(NodeExtension.class);
+        when(nodeExtension.isStartCompleted()).thenReturn(true);
+
         when(node.getPartitionService()).thenReturn(partitionService);
         when(node.getClusterService()).thenReturn(clusterService);
-        when(node.getNodeExtension()).thenReturn(mock(NodeExtension.class));
+        when(node.getNodeExtension()).thenReturn(nodeExtension);
         when(node.getLogger(ClusterStateManager.class)).thenReturn(mock(ILogger.class));
 
         clusterStateManager = new ClusterStateManager(node, lock);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -33,7 +33,7 @@ import java.nio.channels.ServerSocketChannel;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-class MockNodeContext implements NodeContext {
+public class MockNodeContext implements NodeContext {
 
     private final CopyOnWriteArrayList<Address> joinAddresses;
     private final ConcurrentMap<Address, NodeEngineImpl> nodes;


### PR DESCRIPTION
Normally NodeExtension.isStartCompleted() returns true when node is joined successfully, but when hot-restart is enabled, it returns false until hot-restart process completes on all cluster.

Fixes #8523 

Backport of #8524