### PR TITLE
Do not overwrite SYNC_WAITING_REPLICA flag on migration commit

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/InternalPartitionService.java
@@ -174,6 +174,8 @@ public interface InternalPartitionService extends CoreService {
 
     void clearPartitionReplicaVersions(int partitionId);
 
+    void clearPartitionReplicaVersionsExceptSyncWaitingReplicas(int partitionId);
+
     com.hazelcast.core.PartitionService getPartitionServiceProxy();
 
     int getPartitionStateVersion();

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/FinalizeMigrationOperation.java
@@ -59,9 +59,9 @@ final class FinalizeMigrationOperation extends AbstractOperation
         }
 
         if (endpoint == MigrationEndpoint.SOURCE && success) {
-            partitionService.clearPartitionReplicaVersions(partitionId);
+            partitionService.clearPartitionReplicaVersionsExceptSyncWaitingReplicas(partitionId);
         } else if (endpoint == MigrationEndpoint.DESTINATION && !success) {
-            partitionService.clearPartitionReplicaVersions(partitionId);
+            partitionService.clearPartitionReplicaVersionsExceptSyncWaitingReplicas(partitionId);
         }
 
         partitionService.removeActiveMigration(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/partition/impl/PartitionReplicaVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/impl/PartitionReplicaVersions.java
@@ -73,6 +73,14 @@ final class PartitionReplicaVersions {
         }
     }
 
+    void clearExceptSyncWaitingReplicaIndices() {
+        for (int i = 0; i < versions.length; i++) {
+            if (versions[i] != InternalPartition.SYNC_WAITING) {
+                versions[i] = 0;
+            }
+        }
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{partitionId=" + partitionId + ", versions=" + Arrays.toString(versions) + '}';

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerConfigTest.java
@@ -13,7 +13,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class CachePartitionLostListenerConfigTest extends HazelcastTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CachePartitionLostListenerTest.java
@@ -17,7 +17,7 @@ import com.hazelcast.partition.AbstractPartitionLostListenerTest;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionLostEvent;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class CachePartitionLostListenerTest extends AbstractPartitionLostListenerTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPartitionLostListenerTest.java
@@ -11,7 +11,7 @@ import com.hazelcast.partition.AbstractPartitionLostListenerTest;
 import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionLostEvent;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class MapPartitionLostListenerTest extends AbstractPartitionLostListenerTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QuerySlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QuerySlowTest.java
@@ -22,7 +22,6 @@ import org.junit.runner.RunWith;
 import java.util.Map;
 import java.util.Set;
 
-import static com.hazelcast.instance.GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS;
 import static com.hazelcast.test.TimeConstants.MINUTE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -57,8 +56,6 @@ public class QuerySlowTest extends HazelcastTestSupport {
     private static Config newConfig() {
         Config conf = new Config();
         conf.getMapConfig("default").setBackupCount(0);
-        // disable replication so that indexes are used for queries
-        conf.setProperty(PARTITION_MAX_PARALLEL_REPLICATIONS, "0");
         return conf;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerTest.java
@@ -9,7 +9,7 @@ import com.hazelcast.partition.PartitionLostListenerStressTest.EventCollectingPa
 import com.hazelcast.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class PartitionLostListenerTest extends AbstractPartitionLostListenerTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerLiteMemberTest.java
@@ -5,7 +5,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MigrationEvent;
 import com.hazelcast.core.MigrationListener;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class PartitionMigrationListenerLiteMemberTest
         extends HazelcastTestSupport {

--- a/hazelcast/src/test/java/com/hazelcast/partition/impl/ResetReplicaVersionOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/impl/ResetReplicaVersionOperationTest.java
@@ -39,7 +39,7 @@ public class ResetReplicaVersionOperationTest {
         final long[] versions = {6, 5, 4, 3, 2, 1};
         final long[] updatedVersions = {-1, 5, 4, 3, 2, 1};
 
-        testResetReplicaVersionOperation(1, 1, versions, updatedVersions, MEMBER_REMOVED, false);
+        testResetReplicaVersionOperation(1, 1, versions, updatedVersions, MEMBER_REMOVED);
     }
 
     @Test
@@ -48,15 +48,7 @@ public class ResetReplicaVersionOperationTest {
         final long[] versions = {6, 5, 4, 3, 2, 1};
         final long[] updatedVersions = {-1, 5, 4, 3, 2, 1};
 
-        testResetReplicaVersionOperation(1, 1, versions, updatedVersions, ASSIGNMENT, false);
-    }
-
-    @Test
-    public void test_notSetSyncWaitingFlag_whenAssignmentsAreDone()
-            throws Exception {
-        final long[] versions = {6, 5, 4, 3, 2, 1};
-
-        testResetReplicaVersionOperation(1, 1, versions, versions, ASSIGNMENT, true);
+        testResetReplicaVersionOperation(1, 1, versions, updatedVersions, ASSIGNMENT);
     }
 
     @Test
@@ -65,7 +57,7 @@ public class ResetReplicaVersionOperationTest {
         final long[] versions = {6, -1, -1, 3, 2, 1};
         final long[] updatedVersions = {-1, -1, -1, 3, 2, 1};
 
-        testResetReplicaVersionOperation(1, 1, versions, updatedVersions, MEMBER_REMOVED, false);
+        testResetReplicaVersionOperation(1, 1, versions, updatedVersions, MEMBER_REMOVED);
     }
 
     @Test
@@ -74,14 +66,13 @@ public class ResetReplicaVersionOperationTest {
         final long[] versions = {6, -1, -1, 3, 2, 1};
         final long[] updatedVersions = {-1, 0, 0, 3, 2, 1};
 
-        testResetReplicaVersionOperation(1, 1, versions, updatedVersions, ASSIGNMENT, false);
+        testResetReplicaVersionOperation(1, 1, versions, updatedVersions, ASSIGNMENT);
     }
 
     private void testResetReplicaVersionOperation(final int partitionId, final int replicaIndex, final long[] versions,
-                                                  final long[] updatedVersions, final PartitionReplicaChangeReason reason,
-                                                  final boolean initialAssignment)
+                                                  final long[] updatedVersions, final PartitionReplicaChangeReason reason)
             throws Exception {
-        final ResetReplicaVersionOperation operation = createOperation(partitionId, replicaIndex, reason, initialAssignment);
+        final ResetReplicaVersionOperation operation = createOperation(partitionId, replicaIndex, reason);
 
         when(partitionService.getPartitionReplicaVersions(partitionId)).thenReturn(versions);
 
@@ -92,9 +83,8 @@ public class ResetReplicaVersionOperationTest {
     }
 
     private ResetReplicaVersionOperation createOperation(final int partitionId, final int replicaIndex,
-                                                         final PartitionReplicaChangeReason reason,
-                                                         final boolean initialAssignment) {
-        final ResetReplicaVersionOperation operation = new ResetReplicaVersionOperation(reason, initialAssignment);
+                                                         final PartitionReplicaChangeReason reason) {
+        final ResetReplicaVersionOperation operation = new ResetReplicaVersionOperation(reason);
         operation.setReplicaIndex(replicaIndex);
         operation.setPartitionId(partitionId);
         operation.setNodeEngine(nodeEngine);


### PR DESCRIPTION
If a source node commits a migration, it clears its replica indices. However, it should keep SYNC_WAITING_REPLICA flags if it moves to a backup index in the committed partition.

This behavior doesn't exist in the master branch.

Fixes #8505