### PR TITLE
[BACKPORT][TEST-FIX]Added another constraint to the test to make at least 1000 put operat…

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancerStressTest.java
@@ -76,7 +76,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
         IMap<Integer, Integer> map = instance1.getMap(randomMapName());
 
         long deadLine = System.currentTimeMillis() + TEST_DURATION_SECONDS * 1000;
-        for (int i = 0; System.currentTimeMillis() < deadLine; i++) {
+        for (int i = 0; System.currentTimeMillis() < deadLine && map.size() < 1000; i++) {
             map.put(i % 1000, i);
         }
 


### PR DESCRIPTION
ions before asserting event count

The test was complaining of low amount of selector events of happening, but at the same time there is a time dependence of the test with the amount of work being done. If somehow long GCs has been kicked in, it could happen that the system couldn't make expected amount of work. 

So I've changed the test to verify that at least some amount of work has been done irregardless of the test duration then make assertions.

I've also seen that in the logs of the build there are lines like this, which could back my argument related to GC.

```
**14:53:20 SUREFIRE-859: Detected TTSP issue, cycle start: 15053.157, wait: 2008.144**
14:53:20 Dumping stack for thread 0x0000440066200000
14:53:20 SUREFIRE-859: 		"hz._hzInstance_10379_dev.partition-operation.thread-3", id=30112, prio=5, os_prio=0, sched=SCHED_OTHER, allowed_cpus=000000000f
14:53:20 		JVM lock released at:15055.194
14:53:20 		last cpu:2						thread cpu time:69
14:53:20 		#0 0x000000002086d3a1 SafepointProfilerBuf::record_sync_stack(JavaThread*)
14:53:20 		#1 0x00000000208b1895 JavaThread::poll_at_safepoint_static(JavaThread*)
14:53:20 		#2 0x000000003001568e StubRoutines::safepoint_handler
14:53:20 		#3 0x0000000031a4cc76 com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(Ljava/lang/Runnable;)V
14:53:20 		#4 0x00000000312f03e5 com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(Ljava/lang/Object;)V
14:53:20 		#5 0x0000000030edeb09 com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.run()V
14:53:20 		#6 0x00000000300035d5 StubRoutines::call_stub
14:53:20 		signal sent:15054.188					signal responded:15054.188
14:53:20 		thread state:S						wchan:hrtimer_nanosleep
14:53:20 		last cpu:2						thread cpu time:40
14:53:20 		#0 0x00007f6e9b465e2d nanosleep
14:53:20 SUREFIRE-859: 		#1 0x00000000206af8ef GPGC_ObjectRelocation::mutator_relocate_object(GPGC_Defines::Gens, long, GPGC_Defines::Gens, oopDesc*)
```

Fixes #8229