### PR TITLE
Fix connection blocking in mock connection managers

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
@@ -18,8 +18,10 @@ package com.hazelcast.nio.tcp;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.ConnectionType;
 import com.hazelcast.nio.OutboundFrame;
+import com.hazelcast.test.mocknetwork.MockConnectionManager;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -31,9 +33,11 @@ class DroppingConnection implements Connection {
 
     final Address endpoint;
     final long timestamp = Clock.currentTimeMillis();
+    private final ConnectionManager connectionManager;
 
-    DroppingConnection(Address endpoint) {
+    DroppingConnection(Address endpoint, ConnectionManager connectionManager) {
         this.endpoint = endpoint;
+        this.connectionManager = connectionManager;
     }
 
     @Override
@@ -68,6 +72,9 @@ class DroppingConnection implements Connection {
 
     @Override
     public void close(String msg, Throwable cause) {
+        if (connectionManager instanceof MockConnectionManager) {
+            ((MockConnectionManager)connectionManager).destroyConnection(this);
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
@@ -39,7 +39,7 @@ public class FirewallingMockConnectionManager extends MockConnectionManager {
     }
 
     @Override
-    public Connection getOrConnect(Address address) {
+    public synchronized Connection getOrConnect(Address address) {
         Connection connection = getConnection(address);
         if (connection != null && connection.isAlive()) {
             return connection;
@@ -54,11 +54,11 @@ public class FirewallingMockConnectionManager extends MockConnectionManager {
     }
 
     @Override
-    public Connection getOrConnect(Address address, boolean silent) {
+    public synchronized Connection getOrConnect(Address address, boolean silent) {
         return getOrConnect(address);
     }
 
-    public void block(Address address) {
+    public synchronized void block(Address address) {
         blockedAddresses.add(address);
         Connection connection = getConnection(address);
         if (connection != null) {
@@ -66,7 +66,7 @@ public class FirewallingMockConnectionManager extends MockConnectionManager {
         }
     }
 
-    public void unblock(Address address) {
+    public synchronized void unblock(Address address) {
         blockedAddresses.remove(address);
         Connection connection = getConnection(address);
         if (connection instanceof DroppingConnection) {

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingTcpIpConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingTcpIpConnectionManager.java
@@ -47,7 +47,7 @@ public class FirewallingTcpIpConnectionManager extends TcpIpConnectionManager {
             return connection;
         }
         if (blockedAddresses.contains(address)) {
-            connection = new DroppingConnection(address);
+            connection = new DroppingConnection(address, this);
             registerConnection(address, connection);
             return connection;
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
@@ -116,11 +116,17 @@ public class MockConnection implements Connection {
         live = false;
 
         if (localConnection != null) {
+            //this is a member-to-member connection
             NodeEngineImpl localNodeEngine = localConnection.nodeEngine;
             Node localNode = localNodeEngine.getNode();
             MockConnectionManager connectionManager = (MockConnectionManager) localNode.connectionManager;
             connectionManager.destroyConnection(this);
+        } else {
+            //this is a client-member connection. we need to notify NodeEngine about a client connection being closed.
+            MockConnectionManager connectionManager = (MockConnectionManager) nodeEngine.getNode().connectionManager;
+            connectionManager.destroyConnection(this);
         }
+
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
@@ -17,10 +17,10 @@
 
 package com.hazelcast.test.mocknetwork;
 
+import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.ConnectionType;
 import com.hazelcast.nio.OutboundFrame;
 import com.hazelcast.nio.Packet;
@@ -39,7 +39,7 @@ public class MockConnection implements Connection {
 
     private final Address remoteEndpoint;
 
-    volatile Connection localConnection;
+    volatile MockConnection localConnection;
 
     private volatile boolean live = true;
 
@@ -115,8 +115,12 @@ public class MockConnection implements Connection {
         }
         live = false;
 
-        MockConnectionManager connectionManager = (MockConnectionManager)nodeEngine.getNode().connectionManager;
-        connectionManager.destroyConnection(this);
+        if (localConnection != null) {
+            NodeEngineImpl localNodeEngine = localConnection.nodeEngine;
+            Node localNode = localNodeEngine.getNode();
+            MockConnectionManager connectionManager = (MockConnectionManager) localNode.connectionManager;
+            connectionManager.destroyConnection(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
This is a prerequisite for using mock network for split-brain tests

Main changes:
1. `MockConnection` was calling destroyConnection on a wrong ("remote") connection manager
2. `FirewallingMockConnectionManager` now overrides also `getOrConnect(Address address)` (with a single argument)
3. `DroppingConnection` now calls manager.destroyConnection() on close()
4. Synchronized methods on FirewallingMockConnectionManager (port of https://github.com/hazelcast/hazelcast/pull/8394)