### PR TITLE
adds Node.js client as a known client

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientTypes.java
@@ -54,6 +54,11 @@ public final class ClientTypes {
      */
     public static final String RUBY = "RBY";
 
+    /**
+     * Node.JS client protocol id
+     */
+    public static final String NODEJS = "NJS";
+
     private ClientTypes() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -143,6 +143,9 @@ public final class ClientEndpointImpl implements ClientEndpoint {
             case RUBY_CLIENT:
                 type = ClientType.RUBY;
                 break;
+            case NODEJS_CLIENT:
+                type = ClientType.NODEJS;
+                break;
             case BINARY_CLIENT:
                 type = ClientType.OTHER;
                 break;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -202,6 +202,8 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractCallableM
             connection.setType(ConnectionType.PYTHON_CLIENT);
         } else if (ClientTypes.RUBY.equals(type)) {
             connection.setType(ConnectionType.RUBY_CLIENT);
+        } else if (ClientTypes.NODEJS.equals(type)) {
+            connection.setType(ConnectionType.NODEJS_CLIENT);
         } else {
             clientEngine.getLogger(getClass()).info("Unknown client type: " + type);
             connection.setType(ConnectionType.BINARY_CLIENT);

--- a/hazelcast/src/main/java/com/hazelcast/core/ClientType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ClientType.java
@@ -25,5 +25,6 @@ public enum ClientType {
     CPP,
     PYTHON,
     RUBY,
+    NODEJS,
     OTHER
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionType.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionType.java
@@ -31,6 +31,7 @@ public enum ConnectionType {
     CPP_CLIENT(false, true),
     PYTHON_CLIENT(false, true),
     RUBY_CLIENT(false, true),
+    NODEJS_CLIENT(false, true),
     BINARY_CLIENT(false, true),
     REST_CLIENT(false, false),
     MEMCACHE_CLIENT(false, false);


### PR DESCRIPTION
Adds Node.js client among known clients. So when a Node.js client (0.4 or greater) connects to server, it will not be shown as UNKNOWN BINARY CLIENT.

Here is an example of how it looks:
```
INFO: [192.168.2.31]:5701 [dev] [3.7-SNAPSHOT] Received auth from Connection[id=1, /127.0.0.1:5701->/127.0.0.1:49587, endpoint=null, alive=true, type=NODEJS_CLIENT], successfully authenticated, principal : ClientPrincipal{uuid='cc4ec7d8-c182-4084-aad7-7161f2e3db55', ownerUuid='7a7188e4-2d5a-4ec5-801c-f3faec60bb37'}, owner connection : true
```