### PR TITLE
Connection.getCloseReason()

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -267,7 +267,11 @@ public class ClientConnection implements Connection {
 
     @Override
     public String getCloseReason() {
-        return closeReason;
+        if (closeReason == null) {
+            return closeCause == null ? null : closeCause.getMessage();
+        } else {
+            return closeReason;
+        }
     }
 
     @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT", justification = "incremented in single thread")

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
@@ -81,6 +81,10 @@ public class ClientReadHandler
 
         lastHandle = Clock.currentTimeMillis();
 
+        if(!connection.heartBeating){
+            logger.info(connection+" handled readevent when not heartbeating");
+        }
+
         int readBytes = socketChannel.read(buffer);
         if (readBytes <= 0) {
             if (readBytes == -1) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientReadHandler.java
@@ -81,10 +81,6 @@ public class ClientReadHandler
 
         lastHandle = Clock.currentTimeMillis();
 
-        if(!connection.heartBeating){
-            logger.info(connection+" handled readevent when not heartbeating");
-        }
-
         int readBytes = socketChannel.read(buffer);
         if (readBytes <= 0) {
             if (readBytes == -1) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The Tcp/Ip implementation of the {@link com.hazelcast.nio.Connection}.
- *
+ * <p>
  * A {@link TcpIpConnection} is not responsible for reading or writing data to a socket, this is done through:
  * <ol>
  * <li>{@link SocketReader}: which care of reading from the socket and feeding it into the system/li>
@@ -190,7 +190,7 @@ public final class TcpIpConnection implements Connection {
 
     /**
      * Starts this connection.
-     *
+     * <p>
      * Starting means that the connection is going to register itself to listen to incoming traffic.
      */
     public void start() {
@@ -287,7 +287,11 @@ public final class TcpIpConnection implements Connection {
 
     @Override
     public String getCloseReason() {
-        return closeReason;
+        if (closeReason == null) {
+            return closeCause == null ? null : closeCause.getMessage();
+        } else {
+            return closeReason;
+        }
     }
 
     @Override


### PR DESCRIPTION
If the close cause is not explicitly set, the getCloseReason will look at the closeCause.getMessage. This makes it easier to include it in exceptions/logging.