### PR TITLE
[DONT MERGE] Allow QueryOperation to filter for specific partition IDs

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -20,6 +20,7 @@ import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.util.IterationType;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
@@ -43,6 +44,22 @@ public interface MapQueryEngine {
      * @throws InterruptedException
      */
     QueryResult queryLocalPartitions(String mapName, Predicate predicate, IterationType iterationType)
+            throws ExecutionException, InterruptedException;
+
+    /**
+     * Same as {@link #queryLocalPartitions(String, Predicate, IterationType)}, however only returns results for given
+     * {@code requestedPartitionIds}, if not null, which are owned by the member.
+     *
+     * @param mapName
+     * @param predicate
+     * @param iterationType
+     * @param requestedPartitionIds
+     * @return
+     * @throws ExecutionException
+     * @throws InterruptedException
+     */
+    QueryResult queryLocalPartitions(String mapName, Predicate predicate, IterationType iterationType,
+                                     List<Integer> requestedPartitionIds)
             throws ExecutionException, InterruptedException;
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.util.IterationType;
 
 import java.io.IOException;
+import java.util.List;
 
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 
@@ -35,6 +36,7 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
     private Predicate predicate;
     private QueryResult result;
     private IterationType iterationType;
+    private List<Integer> partitionIds;
 
     public QueryOperation() {
     }
@@ -45,10 +47,17 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
         this.iterationType = iterationType;
     }
 
+    public QueryOperation(String mapName, Predicate predicate, IterationType iterationType, List<Integer> partitionIds) {
+        super(mapName);
+        this.predicate = predicate;
+        this.iterationType = iterationType;
+        this.partitionIds = partitionIds;
+    }
+
     @Override
     public void run() throws Exception {
         MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
-        result = queryEngine.queryLocalPartitions(name, predicate, iterationType);
+        result = queryEngine.queryLocalPartitions(name, predicate, iterationType, partitionIds);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultRow.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultRow.java
@@ -46,6 +46,10 @@ public class QueryResultRow implements IdentifiedDataSerializable, Map.Entry<Dat
         return key;
     }
 
+    public void setKey(Data key) {
+        this.key = key;
+    }
+
     public Data getValue() {
         return value;
     }


### PR DESCRIPTION
WIP
Update query operation with an optional list of "requested for" partition IDs. When these are not null, QueryOperation will return results for those partition IDs owned by the member listed in requested-for partition IDs.