### PR TITLE
Removes check for MapReduce usage on NATIVE storage

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
@@ -42,7 +42,7 @@ import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.ExceptionUtil;
 
-import static com.hazelcast.map.impl.MapConfigValidator.checkInMemoryFormat;
+import static com.hazelcast.map.impl.MapConfigValidator.checkNotNative;
 
 public class DefaultClientExtension implements ClientExtension {
 
@@ -121,7 +121,7 @@ public class DefaultClientExtension implements ClientExtension {
             public ClientProxy create(String id) {
                 NearCacheConfig nearCacheConfig = client.getClientConfig().getNearCacheConfig(id);
                 if (nearCacheConfig != null) {
-                    checkInMemoryFormat(nearCacheConfig.getInMemoryFormat());
+                    checkNotNative(nearCacheConfig.getInMemoryFormat());
                     return new NearCachedClientMapProxy(MapService.SERVICE_NAME, id);
                 } else {
                     return new ClientMapProxy(MapService.SERVICE_NAME, id);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapConfigValidator.java
@@ -40,7 +40,7 @@ public final class MapConfigValidator {
      *
      * @param inMemoryFormat supplied inMemoryFormat.
      */
-    public static void checkInMemoryFormat(InMemoryFormat inMemoryFormat) {
+    public static void checkNotNative(InMemoryFormat inMemoryFormat) {
         if (NATIVE == inMemoryFormat) {
             throw new IllegalArgumentException("NATIVE storage format is supported in Hazelcast Enterprise only. "
                     + "Make sure you have Hazelcast Enterprise JARs on your classpath!");
@@ -53,7 +53,7 @@ public final class MapConfigValidator {
      * @param mapConfig the mapConfig
      */
     public static void checkMapConfig(MapConfig mapConfig) {
-        checkInMemoryFormat(mapConfig.getInMemoryFormat());
+        checkNotNative(mapConfig.getInMemoryFormat());
 
         logIgnoredConfig(mapConfig);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -23,7 +23,7 @@ import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
 
-import static com.hazelcast.map.impl.MapConfigValidator.checkInMemoryFormat;
+import static com.hazelcast.map.impl.MapConfigValidator.checkNotNative;
 import static com.hazelcast.map.impl.MapConfigValidator.checkMapConfig;
 
 /**
@@ -47,7 +47,7 @@ class MapRemoteService implements RemoteService {
         checkMapConfig(mapConfig);
 
         if (mapConfig.isNearCacheEnabled()) {
-            checkInMemoryFormat(mapConfig.getNearCacheConfig().getInMemoryFormat());
+            checkNotNative(mapConfig.getNearCacheConfig().getInMemoryFormat());
 
             return new NearCachedMapProxyImpl(name, mapServiceContext.getService(), nodeEngine, mapConfig);
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
@@ -35,8 +35,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
-import static com.hazelcast.map.impl.MapConfigValidator.checkInMemoryFormat;
-
 /**
  * This {@link com.hazelcast.mapreduce.KeyValueSource} implementation is used in
  * {@link com.hazelcast.mapreduce.KeyValueSource#fromMap(com.hazelcast.core.IMap)} to generate a default
@@ -81,7 +79,6 @@ public class MapKeyValueSource<K, V>
             return false;
         }
         RecordStore recordStore = mapService.getMapServiceContext().getRecordStore(partitionId, mapName);
-        checkInMemoryFormat(recordStore.getMapContainer().getMapConfig().getInMemoryFormat());
         iterator = recordStore.iterator();
         return true;
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapConfigValidatorTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.map.impl.MapConfigValidator.checkInMemoryFormat;
+import static com.hazelcast.map.impl.MapConfigValidator.checkNotNative;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -34,17 +34,17 @@ public class MapConfigValidatorTest {
      * Not supported in open source version, so test is expected to throw exception.
      */
     @Test(expected = IllegalArgumentException.class)
-    public void test_checkInMemoryFormat_NATIVE() {
-        checkInMemoryFormat(InMemoryFormat.NATIVE);
+    public void test_checkNotNative_NATIVE() {
+        checkNotNative(InMemoryFormat.NATIVE);
     }
 
     @Test
-    public void test_checkInMemoryFormat_OBJECT() {
-        checkInMemoryFormat(InMemoryFormat.OBJECT);
+    public void test_checkNotNative_OBJECT() {
+        checkNotNative(InMemoryFormat.OBJECT);
     }
 
     @Test
-    public void test_checkInMemoryFormat_BINARY() {
-        checkInMemoryFormat(InMemoryFormat.BINARY);
+    public void test_checkNotNative_BINARY() {
+        checkNotNative(InMemoryFormat.BINARY);
     }
 }


### PR DESCRIPTION
Check for NATIVE storage is moved to ee.
fixes https://github.com/hazelcast/hazelcast-enterprise/issues/926

tests are here: https://github.com/hazelcast/hazelcast-enterprise/pull/966