### PR TITLE
increased TTL and removed premature assertion of the TTL expiration s…

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadAbstractTest.java
@@ -26,12 +26,10 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadException;
 import com.hazelcast.util.EmptyStatement;
-import org.junit.Ignore;
+import java.util.concurrent.Future;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -121,8 +119,7 @@ public abstract class TopicOverloadAbstractTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore("please see issue #6819")
-    public void whenBlock_whenNoSpace() {
+    public void whenBlock_whenNoSpace() throws Exception {
         for (int k = 0; k < ringbuffer.capacity(); k++) {
             topic.publish("old");
         }
@@ -138,7 +135,6 @@ public abstract class TopicOverloadAbstractTest extends HazelcastTestSupport {
             }
         });
 
-        // make sure it doesn't complete within 3 seconds. We have a 2 second error margin to prevent spurious test failures
         assertTrueAllTheTime(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -146,12 +142,9 @@ public abstract class TopicOverloadAbstractTest extends HazelcastTestSupport {
                 assertEquals(tail, ringbuffer.tailSequence());
                 assertEquals(head, ringbuffer.headSequence());
             }
-        }, 3);
+        }, 5);
 
+        // assert that message is published eventually
         assertCompletesEventually(f);
-
-        assertEquals(tail + 1, ringbuffer.tailSequence());
-        // since the ringbuffer got cleaned, the head is at the tail
-        assertEquals(tail + 1, ringbuffer.headSequence());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadDistributedTest.java
@@ -38,7 +38,7 @@ public class TopicOverloadDistributedTest extends TopicOverloadAbstractTest {
     public void setupCluster() {
         Config config = new Config();
         config.addRingBufferConfig(new RingbufferConfig("when*")
-                .setCapacity(100).setTimeToLiveSeconds(5));
+                .setCapacity(100).setTimeToLiveSeconds(30));
         config.addReliableTopicConfig(new ReliableTopicConfig("whenError_*")
                 .setTopicOverloadPolicy(TopicOverloadPolicy.ERROR));
         config.addReliableTopicConfig(new ReliableTopicConfig("whenDiscardOldest_*")

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadTest.java
@@ -38,7 +38,7 @@ public class TopicOverloadTest extends TopicOverloadAbstractTest {
     public void setupCluster() {
         Config config = new Config();
         config.addRingBufferConfig(new RingbufferConfig("when*")
-                .setCapacity(100).setTimeToLiveSeconds(5));
+                .setCapacity(100).setTimeToLiveSeconds(30));
         config.addReliableTopicConfig(new ReliableTopicConfig("whenError_*")
                 .setTopicOverloadPolicy(TopicOverloadPolicy.ERROR));
         config.addReliableTopicConfig(new ReliableTopicConfig("whenDiscardOldest_*")


### PR DESCRIPTION
…ince at the time of the assertion all the items might not be evicted. Also the aim of the test is not to test whether if TTL works or not, so it is better to remove the TTL assertion since we already have TTL tests.

Fixes #6819