### PR TITLE
Deprecates AsyncAtomicReference. Introduces async methods in IAtomicReference public API.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -83,6 +83,7 @@
     <suppress checks="JavadocType" files="com/hazelcast/concurrent/"/>
     <suppress checks="JavadocVariable" files="com/hazelcast/concurrent/"/>
     <suppress checks="MethodCount" files="com/hazelcast/concurrent/atomiclong/AtomicLongProxy"/>
+    <suppress checks="MethodCount" files="com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/concurrent/lock/LockServiceImpl"/>
     <suppress checks="MethodCount" files="com/hazelcast/concurrent/lock/LockResourceImpl"/>
     <suppress checks="MethodCount" files="com/hazelcast/concurrent/lock/LockStoreImpl"/>
@@ -95,6 +96,7 @@
 
     <!-- Client -->
     <suppress checks="MethodCount" files="com/hazelcast/client/cache/impl/ClientCacheProxy"/>
+    <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientAtomicReferenceProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientQueueProxy"/>
     <suppress checks="MethodCount" files="com/hazelcast/client/proxy/ClientListProxy"/>
     <suppress checks="ParameterNumber" files="com/hazelcast/client/proxy/ClientMapReduceProxy"/>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.proxy;
 
+import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.AtomicReferenceAlterAndGetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicReferenceAlterCodec;
@@ -31,6 +32,7 @@ import com.hazelcast.client.impl.protocol.codec.AtomicReferenceSetAndGetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicReferenceSetCodec;
 import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.IFunction;
+import com.hazelcast.spi.InternalCompletableFuture;
 
 import static com.hazelcast.util.Preconditions.isNotNull;
 
@@ -41,96 +43,228 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  */
 public class ClientAtomicReferenceProxy<E> extends PartitionSpecificClientProxy implements IAtomicReference<E> {
 
+    private static final ClientMessageDecoder APPLY_DECODER = new ClientMessageDecoder() {
+        @Override
+        public <R> R decodeClientMessage(ClientMessage clientMessage) {
+            return (R) AtomicReferenceApplyCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder ALTER_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Void decodeClientMessage(ClientMessage clientMessage) {
+            return null;
+        }
+    };
+
+    private static final ClientMessageDecoder ALTER_AND_GET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public <E> E decodeClientMessage(ClientMessage clientMessage) {
+            return (E) AtomicReferenceAlterAndGetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder GET_AND_ALTER_DECODER = new ClientMessageDecoder() {
+        @Override
+        public <E> E decodeClientMessage(ClientMessage clientMessage) {
+            return (E) AtomicReferenceGetAndAlterCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder COMPARE_AND_SET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Boolean decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicReferenceCompareAndSetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder CONTAINS_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Boolean decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicReferenceContainsCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder GET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public <E> E decodeClientMessage(ClientMessage clientMessage) {
+            return (E) AtomicReferenceGetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder SET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Void decodeClientMessage(ClientMessage clientMessage) {
+            return null;
+        }
+    };
+
+    private static final ClientMessageDecoder CLEAR_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Void decodeClientMessage(ClientMessage clientMessage) {
+            return null;
+        }
+    };
+
+    private static final ClientMessageDecoder GET_AND_SET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public <E> E decodeClientMessage(ClientMessage clientMessage) {
+            return (E) AtomicReferenceGetAndSetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder SET_AND_GET_DECODER = new ClientMessageDecoder() {
+        @Override
+        public <E> E decodeClientMessage(ClientMessage clientMessage) {
+            return (E) AtomicReferenceSetAndGetCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
+    private static final ClientMessageDecoder IS_NULL_DECODER = new ClientMessageDecoder() {
+        @Override
+        public Boolean decodeClientMessage(ClientMessage clientMessage) {
+            return AtomicReferenceIsNullCodec.decodeResponse(clientMessage).response;
+        }
+    };
+
     public ClientAtomicReferenceProxy(String serviceName, String objectId) {
         super(serviceName, objectId);
     }
 
     @Override
-    public <R> R apply(IFunction<E, R> function) {
+    public <R> InternalCompletableFuture<R> applyAsync(IFunction<E, R> function) {
         isNotNull(function, "function");
         ClientMessage request = AtomicReferenceApplyCodec.encodeRequest(name, toData(function));
-        ClientMessage response = invokeOnPartition(request);
-        AtomicReferenceApplyCodec.ResponseParameters resultParameters =
-                AtomicReferenceApplyCodec.decodeResponse(response);
-        return toObject(resultParameters.response);
+        return invokeOnPartitionAsync(request, APPLY_DECODER);
+    }
+
+    @Override
+    public <R> R apply(IFunction<E, R> function) {
+        return applyAsync(function).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Void> alterAsync(IFunction<E, E> function) {
+        isNotNull(function, "function");
+        ClientMessage request = AtomicReferenceAlterCodec.encodeRequest(name, toData(function));
+        return invokeOnPartitionAsync(request, ALTER_DECODER);
     }
 
     @Override
     public void alter(IFunction<E, E> function) {
+        alterAsync(function).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<E> alterAndGetAsync(IFunction<E, E> function) {
         isNotNull(function, "function");
-        ClientMessage request = AtomicReferenceAlterCodec.encodeRequest(name, toData(function));
-        invokeOnPartition(request);
+        ClientMessage request = AtomicReferenceAlterAndGetCodec.encodeRequest(name, toData(function));
+        return invokeOnPartitionAsync(request, ALTER_AND_GET_DECODER);
     }
 
     @Override
     public E alterAndGet(IFunction<E, E> function) {
+        return alterAndGetAsync(function).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<E> getAndAlterAsync(IFunction<E, E> function) {
         isNotNull(function, "function");
-        ClientMessage request = AtomicReferenceAlterAndGetCodec.encodeRequest(name, toData(function));
-        ClientMessage response = invokeOnPartition(request);
-        return toObject(AtomicReferenceAlterAndGetCodec.decodeResponse(response).response);
+        ClientMessage request = AtomicReferenceGetAndAlterCodec.encodeRequest(name, toData(function));
+        return invokeOnPartitionAsync(request, GET_AND_ALTER_DECODER);
     }
 
     @Override
     public E getAndAlter(IFunction<E, E> function) {
-        isNotNull(function, "function");
-        ClientMessage request = AtomicReferenceGetAndAlterCodec.encodeRequest(name, toData(function));
-        ClientMessage response = invokeOnPartition(request);
-        return toObject(AtomicReferenceGetAndAlterCodec.decodeResponse(response).response);
+        return getAndAlterAsync(function).join();
+    }
 
+    @Override
+    public InternalCompletableFuture<Boolean> compareAndSetAsync(E expect, E update) {
+        ClientMessage request = AtomicReferenceCompareAndSetCodec.encodeRequest(name, toData(expect), toData(update));
+        return invokeOnPartitionAsync(request, COMPARE_AND_SET_DECODER);
     }
 
     @Override
     public boolean compareAndSet(E expect, E update) {
-        ClientMessage request = AtomicReferenceCompareAndSetCodec.encodeRequest(name, toData(expect), toData(update));
-        ClientMessage response = invokeOnPartition(request);
-        return AtomicReferenceCompareAndSetCodec.decodeResponse(response).response;
+        return compareAndSetAsync(expect, update).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Boolean> containsAsync(E expected) {
+        ClientMessage request = AtomicReferenceContainsCodec.encodeRequest(name, toData(expected));
+        return invokeOnPartitionAsync(request, CONTAINS_DECODER);
     }
 
     @Override
     public boolean contains(E expected) {
-        ClientMessage request = AtomicReferenceContainsCodec.encodeRequest(name, toData(expected));
-        ClientMessage response = invokeOnPartition(request);
-        return AtomicReferenceContainsCodec.decodeResponse(response).response;
+        return containsAsync(expected).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<E> getAsync() {
+        ClientMessage request = AtomicReferenceGetCodec.encodeRequest(name);
+        return invokeOnPartitionAsync(request, GET_DECODER);
     }
 
     @Override
     public E get() {
-        ClientMessage request = AtomicReferenceGetCodec.encodeRequest(name);
-        ClientMessage response = invokeOnPartition(request);
-        return toObject(AtomicReferenceGetCodec.decodeResponse(response).response);
+        return getAsync().join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Void> setAsync(E newValue) {
+        ClientMessage request = AtomicReferenceSetCodec.encodeRequest(name, toData(newValue));
+        return invokeOnPartitionAsync(request, SET_DECODER);
     }
 
     @Override
     public void set(E newValue) {
-        ClientMessage request = AtomicReferenceSetCodec.encodeRequest(name, toData(newValue));
-        invokeOnPartition(request);
+        setAsync(newValue).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Void> clearAsync() {
+        ClientMessage request = AtomicReferenceClearCodec.encodeRequest(name);
+        return invokeOnPartitionAsync(request, CLEAR_DECODER);
     }
 
     @Override
     public void clear() {
-        ClientMessage request = AtomicReferenceClearCodec.encodeRequest(name);
-        invokeOnPartition(request);
+        clearAsync().join();
+    }
+
+    @Override
+    public InternalCompletableFuture<E> getAndSetAsync(E newValue) {
+        ClientMessage request = AtomicReferenceGetAndSetCodec.encodeRequest(name, toData(newValue));
+        return invokeOnPartitionAsync(request, GET_AND_SET_DECODER);
     }
 
     @Override
     public E getAndSet(E newValue) {
-        ClientMessage request = AtomicReferenceGetAndSetCodec.encodeRequest(name, toData(newValue));
-        ClientMessage response = invokeOnPartition(request);
-        return toObject(AtomicReferenceGetAndSetCodec.decodeResponse(response).response);
+        return getAndSetAsync(newValue).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<E> setAndGetAsync(E update) {
+        ClientMessage request = AtomicReferenceSetAndGetCodec.encodeRequest(name, toData(update));
+        return invokeOnPartitionAsync(request, SET_AND_GET_DECODER);
     }
 
     @Override
     public E setAndGet(E update) {
-        ClientMessage request = AtomicReferenceSetAndGetCodec.encodeRequest(name, toData(update));
-        ClientMessage response = invokeOnPartition(request);
-        return toObject(AtomicReferenceSetAndGetCodec.decodeResponse(response).response);
+        return setAndGetAsync(update).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Boolean> isNullAsync() {
+        ClientMessage request = AtomicReferenceIsNullCodec.encodeRequest(name);
+        return invokeOnPartitionAsync(request, IS_NULL_DECODER);
     }
 
     @Override
     public boolean isNull() {
-        ClientMessage request = AtomicReferenceIsNullCodec.encodeRequest(name);
-        ClientMessage response = invokeOnPartition(request);
-        return AtomicReferenceIsNullCodec.decodeResponse(response).response;
+        return isNullAsync().join();
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
@@ -113,13 +113,6 @@ public class ClientAtomicReferenceProxy<E> extends PartitionSpecificClientProxy 
         }
     };
 
-    private static final ClientMessageDecoder SET_AND_GET_DECODER = new ClientMessageDecoder() {
-        @Override
-        public <E> E decodeClientMessage(ClientMessage clientMessage) {
-            return (E) AtomicReferenceSetAndGetCodec.decodeResponse(clientMessage).response;
-        }
-    };
-
     private static final ClientMessageDecoder IS_NULL_DECODER = new ClientMessageDecoder() {
         @Override
         public Boolean decodeClientMessage(ClientMessage clientMessage) {
@@ -246,14 +239,10 @@ public class ClientAtomicReferenceProxy<E> extends PartitionSpecificClientProxy 
     }
 
     @Override
-    public InternalCompletableFuture<E> setAndGetAsync(E update) {
-        ClientMessage request = AtomicReferenceSetAndGetCodec.encodeRequest(name, toData(update));
-        return invokeOnPartitionAsync(request, SET_AND_GET_DECODER);
-    }
-
-    @Override
     public E setAndGet(E update) {
-        return setAndGetAsync(update).join();
+        ClientMessage request = AtomicReferenceSetAndGetCodec.encodeRequest(name, toData(update));
+        ClientMessage response = invokeOnPartition(request);
+        return toObject(AtomicReferenceSetAndGetCodec.decodeResponse(response).response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
@@ -50,11 +50,11 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public void alter(IFunction<E, E> function) {
-        asyncAlter(function).join();
+        alterAsync(function).join();
     }
 
     @Override
-    public InternalCompletableFuture<Void> asyncAlter(IFunction<E, E> function) {
+    public InternalCompletableFuture<Void> alterAsync(IFunction<E, E> function) {
         isNotNull(function, "function");
 
         Operation operation = new AlterOperation(name, toData(function))
@@ -63,12 +63,17 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
     }
 
     @Override
-    public E alterAndGet(IFunction<E, E> function) {
-        return asyncAlterAndGet(function).join();
+    public InternalCompletableFuture<Void> asyncAlter(IFunction<E, E> function) {
+        return alterAsync(function);
     }
 
     @Override
-    public InternalCompletableFuture<E> asyncAlterAndGet(IFunction<E, E> function) {
+    public E alterAndGet(IFunction<E, E> function) {
+        return alterAndGetAsync(function).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<E> alterAndGetAsync(IFunction<E, E> function) {
         isNotNull(function, "function");
 
         Operation operation = new AlterAndGetOperation(name, toData(function))
@@ -77,12 +82,17 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
     }
 
     @Override
-    public E getAndAlter(IFunction<E, E> function) {
-        return asyncGetAndAlter(function).join();
+    public InternalCompletableFuture<E> asyncAlterAndGet(IFunction<E, E> function) {
+        return alterAndGetAsync(function);
     }
 
     @Override
-    public InternalCompletableFuture<E> asyncGetAndAlter(IFunction<E, E> function) {
+    public E getAndAlter(IFunction<E, E> function) {
+        return getAndAlterAsync(function).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<E> getAndAlterAsync(IFunction<E, E> function) {
         isNotNull(function, "function");
 
         Operation operation = new GetAndAlterOperation(name, toData(function))
@@ -91,12 +101,17 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
     }
 
     @Override
-    public <R> R apply(IFunction<E, R> function) {
-        return asyncApply(function).join();
+    public InternalCompletableFuture<E> asyncGetAndAlter(IFunction<E, E> function) {
+        return getAndAlterAsync(function);
     }
 
     @Override
-    public <R> InternalCompletableFuture<R> asyncApply(IFunction<E, R> function) {
+    public <R> R apply(IFunction<E, R> function) {
+        return applyAsync(function).join();
+    }
+
+    @Override
+    public <R> InternalCompletableFuture<R> applyAsync(IFunction<E, R> function) {
         isNotNull(function, "function");
 
         Operation operation = new ApplyOperation(name, toData(function))
@@ -105,54 +120,86 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
     }
 
     @Override
+    public <R> InternalCompletableFuture<R> asyncApply(IFunction<E, R> function) {
+        return applyAsync(function);
+    }
+
+    @Override
     public void clear() {
-        asyncClear().join();
+        clearAsync().join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Void> clearAsync() {
+        return setAsync(null);
     }
 
     @Override
     public InternalCompletableFuture<Void> asyncClear() {
-        return asyncSet(null);
+        return clearAsync();
     }
 
     @Override
     public boolean compareAndSet(E expect, E update) {
-        return asyncCompareAndSet(expect, update).join();
+        return compareAndSetAsync(expect, update).join();
     }
 
     @Override
-    public InternalCompletableFuture<Boolean> asyncCompareAndSet(E expect, E update) {
+    public InternalCompletableFuture<Boolean> compareAndSetAsync(E expect, E update) {
         Operation operation = new CompareAndSetOperation(name, toData(expect), toData(update))
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
-    public E get() {
-        return asyncGet().join();
+    public InternalCompletableFuture<Boolean> asyncCompareAndSet(E expect, E update) {
+        return compareAndSetAsync(expect, update);
     }
 
     @Override
-    public InternalCompletableFuture<E> asyncGet() {
+    public E get() {
+        return getAsync().join();
+    }
+
+    @Override
+    public InternalCompletableFuture<E> getAsync() {
         Operation operation = new GetOperation(name)
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
-    public boolean contains(E expected) {
-        return asyncContains(expected).join();
+    public InternalCompletableFuture<E> asyncGet() {
+        return getAsync();
     }
 
     @Override
-    public InternalCompletableFuture<Boolean> asyncContains(E value) {
-        Operation operation = new ContainsOperation(name, toData(value))
+    public boolean contains(E expected) {
+        return containsAsync(expected).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Boolean> containsAsync(E expected) {
+        Operation operation = new ContainsOperation(name, toData(expected))
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
+    public InternalCompletableFuture<Boolean> asyncContains(E value) {
+        return containsAsync(value);
+    }
+
+    @Override
     public void set(E newValue) {
-        asyncSet(newValue).join();
+        setAsync(newValue).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Void> setAsync(E newValue) {
+        Operation operation = new SetOperation(name, toData(newValue))
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
@@ -164,38 +211,53 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public E getAndSet(E newValue) {
-        return asyncGetAndSet(newValue).join();
+        return getAndSetAsync(newValue).join();
     }
 
     @Override
-    public InternalCompletableFuture<E> asyncGetAndSet(E newValue) {
+    public InternalCompletableFuture<E> getAndSetAsync(E newValue) {
         Operation operation = new GetAndSetOperation(name, toData(newValue))
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
-    public E setAndGet(E update) {
-        return asyncSetAndGet(update).join();
+    public InternalCompletableFuture<E> asyncGetAndSet(E newValue) {
+        return getAndSetAsync(newValue);
     }
 
     @Override
-    public InternalCompletableFuture<E> asyncSetAndGet(E update) {
+    public E setAndGet(E update) {
+        return setAndGetAsync(update).join();
+    }
+
+    @Override
+    public InternalCompletableFuture<E> setAndGetAsync(E update) {
         Operation operation = new SetAndGetOperation(name, toData(update))
                 .setPartitionId(partitionId);
         return invokeOnPartition(operation);
     }
 
     @Override
+    public InternalCompletableFuture<E> asyncSetAndGet(E update) {
+        return setAndGetAsync(update);
+    }
+
+    @Override
     public boolean isNull() {
-        return asyncIsNull().join();
+        return isNullAsync().join();
+    }
+
+    @Override
+    public InternalCompletableFuture<Boolean> isNullAsync() {
+        Operation operation = new IsNullOperation(name)
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override
     public InternalCompletableFuture<Boolean> asyncIsNull() {
-        Operation operation = new IsNullOperation(name)
-                .setPartitionId(partitionId);
-        return invokeOnPartition(operation);
+        return isNullAsync();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceProxy.java
@@ -228,19 +228,14 @@ public class AtomicReferenceProxy<E> extends AbstractDistributedObject<AtomicRef
 
     @Override
     public E setAndGet(E update) {
-        return setAndGetAsync(update).join();
-    }
-
-    @Override
-    public InternalCompletableFuture<E> setAndGetAsync(E update) {
-        Operation operation = new SetAndGetOperation(name, toData(update))
-                .setPartitionId(partitionId);
-        return invokeOnPartition(operation);
+        return asyncSetAndGet(update).join();
     }
 
     @Override
     public InternalCompletableFuture<E> asyncSetAndGet(E update) {
-        return setAndGetAsync(update);
+        Operation operation = new SetAndGetOperation(name, toData(update))
+                .setPartitionId(partitionId);
+        return invokeOnPartition(operation);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicReference.java
@@ -22,9 +22,13 @@ import com.hazelcast.spi.annotation.Beta;
  * A {@link IAtomicReference} that exposes its operations using a {@link ICompletableFuture}
  * so it can be used in the reactive programming model approach.
  *
+ * Instead of this interface, use the equivalent async methods in the public {@link IAtomicReference} interface.
+ * This interface has been deprecated and will be removed in a future version.
+ *
  * @since 3.2
  */
 @Beta
+@Deprecated
 public interface AsyncAtomicReference<E> extends IAtomicReference<E> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
@@ -177,15 +177,6 @@ public interface IAtomicReference<E> extends DistributedObject {
     ICompletableFuture<E> getAndSetAsync(E newValue);
 
     /**
-     * Sets and gets the value.
-     *
-     * @param update the new value
-     * @return  the new value
-     * @deprecated will be removed from Hazelcast 3.4 since it doesn't really serve a purpose.
-     */
-    ICompletableFuture<E> setAndGetAsync(E update);
-
-    /**
      * Checks if the stored reference is null.
      *
      * @return true if null, false otherwise.

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
@@ -21,6 +21,26 @@ package com.hazelcast.core;
  * IAtomicReference is a redundant and highly available distributed alternative to the
  * {@link java.util.concurrent.atomic.AtomicReference java.util.concurrent.atomic.AtomicReference}.
  *
+ * Asynchronous variants have been introduced in version 3.7.
+ * Async methods return immediately an {@link ICompletableFuture} from which the operation's result
+ * can be obtained either in a blocking manner or by registering a callback to be executed
+ * upon completion. For example:
+ *
+ * <p>
+ * <pre>
+ *     ICompletableFuture&lt;E&gt; future = atomicRef.getAsync();
+ *     future.andThen(new ExecutionCallback&lt;E&gt;() {
+ *          void onResponse(Long response) {
+ *              // do something with the result
+ *          }
+ *
+ *          void onFailure(Throwable t) {
+ *              // handle failure
+ *          }
+ *     });
+ * </pre>
+ * </p>
+ *
  * @see IAtomicLong
  * @since 3.2
  */
@@ -122,4 +142,101 @@ public interface IAtomicReference<E> extends DistributedObject {
      * @throws IllegalArgumentException if function is null.
      */
     <R> R apply(IFunction<E, R> function);
+
+    /**
+     * Atomically sets the value to the given updated value
+     * only if the current value {@code ==} the expected value.
+     *
+     * @param expect the expected value
+     * @param update the new value
+     * @return true if successful; or false if the actual value
+     *         was not equal to the expected value.
+     */
+    ICompletableFuture<Boolean> compareAndSetAsync(E expect, E update);
+
+    /**
+     * Gets the current value.
+     *
+     * @return the current value
+     */
+    ICompletableFuture<E> getAsync();
+
+    /**
+     * Atomically sets the given value.
+     *
+     * @param newValue the new value
+     */
+    ICompletableFuture<Void> setAsync(E newValue);
+
+    /**
+     * Gets the value and sets the new value.
+     *
+     * @param newValue the new value.
+     * @return the old value.
+     */
+    ICompletableFuture<E> getAndSetAsync(E newValue);
+
+    /**
+     * Sets and gets the value.
+     *
+     * @param update the new value
+     * @return  the new value
+     * @deprecated will be removed from Hazelcast 3.4 since it doesn't really serve a purpose.
+     */
+    ICompletableFuture<E> setAndGetAsync(E update);
+
+    /**
+     * Checks if the stored reference is null.
+     *
+     * @return true if null, false otherwise.
+     */
+    ICompletableFuture<Boolean> isNullAsync();
+
+    /**
+     * Clears the current stored reference.
+     */
+    ICompletableFuture<Void> clearAsync();
+
+    /**
+     * Checks if the reference contains the value.
+     *
+     * @param expected the value to check (is allowed to be null).
+     * @return true if the value is found, false otherwise.
+     */
+    ICompletableFuture<Boolean> containsAsync(E expected);
+
+    /**
+     * Alters the currently stored reference by applying a function on it.
+     *
+     * @param function the function
+     * @throws IllegalArgumentException if function is null.
+     */
+    ICompletableFuture<Void> alterAsync(IFunction<E, E> function);
+
+    /**
+     * Alters the currently stored reference by applying a function on it and gets the result.
+     *
+     * @param function the function
+     * @return the new value.
+     * @throws IllegalArgumentException if function is null.
+     */
+    ICompletableFuture<E> alterAndGetAsync(IFunction<E, E> function);
+
+    /**
+     * Alters the currently stored reference by applying a function on it on and gets the old value.
+     *
+     * @param function the function
+     * @return  the old value
+     * @throws IllegalArgumentException if function is null.
+     */
+    ICompletableFuture<E> getAndAlterAsync(IFunction<E, E> function);
+
+    /**
+     * Applies a function on the value, the actual stored value will not change.
+     *
+     * @param function the function
+     * @return  the result of the function application
+     * @throws IllegalArgumentException if function is null.
+     */
+    <R> ICompletableFuture<R> applyAsync(IFunction<E, R> function);
 }


### PR DESCRIPTION
Async methods in `IAtomicReference` follow the `Async`-suffix naming convention; `async`-prefixed methods will be removed once `AsyncAtomicReference` is also removed.