### PR TITLE
discovery spi client "inside cloud" fix

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientProperty.java
@@ -86,6 +86,13 @@ public enum ClientProperty implements HazelcastProperty {
     DISCOVERY_SPI_ENABLED("hazelcast.discovery.enabled", false),
 
     /**
+     * <p>Enables the Discovery Joiner to use public ips from DiscoveredNode. This property is temporary and will
+     * eventually be removed when the experimental marker is removed.</p>
+     * <p>Discovery SPI is <b>disabled</b> by default</p>
+     */
+    DISCOVERY_SPI_PUBLIC_IP_ENABLED("hazelcast.discovery.public.ip.enabled", false),
+
+    /**
      * Configures pool size of internal client executor. Private configuration, for internal usage only.
      */
     INTERNAL_EXECUTOR_POOL_SIZE("hazelcast.client.internal.executor.pool.size", 3);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
@@ -52,7 +53,8 @@ public class DefaultClientConnectionManagerFactory implements ClientConnectionMa
                 throw e;
             }
         } else if (discoveryService != null) {
-            addressTranslator = new DiscoveryAddressTranslator(discoveryService);
+            addressTranslator = new DiscoveryAddressTranslator(discoveryService,
+                    client.getClientProperties().getBoolean(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED));
         } else {
             addressTranslator = new DefaultAddressTranslator();
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
@@ -28,17 +28,24 @@ public class DiscoveryAddressTranslator
         implements AddressTranslator {
 
     private final DiscoveryService discoveryService;
+    private final boolean usePublic;
 
     private volatile Map<Address, Address> privateToPublic;
 
-    public DiscoveryAddressTranslator(DiscoveryService discoveryService) {
+    public DiscoveryAddressTranslator(DiscoveryService discoveryService, boolean usePublic) {
         this.discoveryService = discoveryService;
+        this.usePublic = usePublic;
     }
 
     @Override
     public Address translate(Address address) {
         if (address == null) {
             return null;
+        }
+
+        // if it is inside cloud, return private address otherwise we need to translate it.
+        if (!usePublic) {
+            return address;
         }
 
         // Refresh only once to prevent load on service discovery

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.spi.impl.discovery;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.config.AwsConfig;
@@ -218,7 +219,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         DiscoveryServiceProvider provider = new DefaultDiscoveryServiceProvider();
         DiscoveryService discoveryService = provider.newDiscoveryService(buildDiscoveryServiceSettings(discoveryConfig));
 
-        AddressTranslator translator = new DiscoveryAddressTranslator(discoveryService);
+        AddressTranslator translator = new DiscoveryAddressTranslator(discoveryService, false);
 
         Address address = new Address("127.0.0.1", 50001);
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -206,6 +206,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         assertEquals(4, nodeFilter.getNodes().size());
     }
 
+
     @Test
     public void test_discovery_address_translator() throws Exception {
         String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
@@ -228,6 +229,28 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
         // Enforce refresh of the internal mapping
         assertEquals(address, translator.translate(address));
+    }
+
+
+    @Test
+    public void test_discovery_address_translator_with_public_ip() throws Exception {
+        String xmlFileName = "hazelcast-client-discovery-spi-test.xml";
+        InputStream xmlResource = ClientDiscoverySpiTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        ClientConfig clientConfig = new XmlClientConfigBuilder(xmlResource).build();
+
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+
+        DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig();
+
+        DiscoveryServiceProvider provider = new DefaultDiscoveryServiceProvider();
+        DiscoveryService discoveryService = provider.newDiscoveryService(buildDiscoveryServiceSettings(discoveryConfig));
+
+        AddressTranslator translator = new DiscoveryAddressTranslator(discoveryService, true);
+
+        Address publicAddress = new Address("127.0.0.1", 50001);
+        Address privateAddress = new Address("127.0.0.1", 1);
+        // Enforce refresh of the internal mapping
+        assertEquals(publicAddress, translator.translate(privateAddress));
     }
 
     @Test
@@ -284,7 +307,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
 
     private DiscoveryServiceSettings buildDiscoveryServiceSettings(DiscoveryConfig config) {
         return new DiscoveryServiceSettings().setConfigClassLoader(ClientDiscoverySpiTest.class.getClassLoader())
-                                             .setDiscoveryConfig(config).setDiscoveryMode(DiscoveryMode.Client).setLogger(LOGGER);
+                .setDiscoveryConfig(config).setDiscoveryMode(DiscoveryMode.Client).setLogger(LOGGER);
     }
 
     private static class TestDiscoveryStrategy implements DiscoveryStrategy {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.test;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientProperty;
 import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnection;
@@ -92,7 +93,7 @@ public class TestClientRegistry {
                     throw e;
                 }
             } else if (discoveryService != null) {
-                addressTranslator = new DiscoveryAddressTranslator(discoveryService);
+                addressTranslator = new DiscoveryAddressTranslator(discoveryService, client.getClientProperties().getBoolean(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED));
             } else {
                 addressTranslator = new DefaultAddressTranslator();
             }


### PR DESCRIPTION
for the client side, we have spi address translator that provides public/private address of the node. So that user can use client outside of the cloud. Currently we look inside cloud flag in old-aws-discovery https://github.com/hazelcast/hazelcast/blob/master/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressTranslator.java#L54

now we need to look this flag in DiscoveryAddressTranslator.

fixes https://github.com/hazelcast/hazelcast/issues/8595