### PR TITLE
stabilize hazelcast client protocol version at most recent version 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.2.0-SNAPSHOT</client.protocol.version>
+        <client.protocol.version>1.2.0</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
Should be green once client protocol 1.2 is released.