### PR TITLE
[TEST-FIX] SlowOperation should block a partition thread just enough to cause Call-Timeout

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TimeoutTest.java
@@ -269,7 +269,6 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
     // ===========================================================================================================================
 
     @Test
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/7932
     public void sync_whenCallTimeout_thenOperationTimeoutException() throws Exception {
         long callTimeoutMs = 60000;
         Config config = new Config().setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + callTimeoutMs);
@@ -281,7 +280,8 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         OperationService opService = getOperationService(local);
 
         int partitionId = getPartitionId(remote);
-        opService.invokeOnPartition(new SlowOperation(callTimeoutMs * 2).setPartitionId(partitionId));
+        long slowOperationDurationMs = (long) (callTimeoutMs * 1.1);
+        opService.invokeOnPartition(new SlowOperation(slowOperationDurationMs).setPartitionId(partitionId));
 
         Future future = opService.invokeOnPartition(new DummyOperation().setPartitionId(partitionId));
 
@@ -296,7 +296,6 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore //https://github.com/hazelcast/hazelcast/issues/7932
     public void async_whenCallTimeout_thenOperationTimeoutException() throws Exception {
         long callTimeoutMs = 60000;
         Config config = new Config().setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + callTimeoutMs);
@@ -308,7 +307,8 @@ public class Invocation_TimeoutTest extends HazelcastTestSupport {
         OperationService opService = getOperationService(local);
 
         int partitionId = getPartitionId(remote);
-        opService.invokeOnPartition(new SlowOperation(callTimeoutMs * 2).setPartitionId(partitionId));
+        long slowOperationDurationMs = (long) (callTimeoutMs * 1.1);
+        opService.invokeOnPartition(new SlowOperation(slowOperationDurationMs).setPartitionId(partitionId));
 
         ICompletableFuture<Object> future = opService.invokeOnPartition(new DummyOperation().setPartitionId(partitionId));
 


### PR DESCRIPTION
Fix #7932

Reasoning: We want the `SlowOperation` to block just slightly over the call-timeout.
This is sufficient to get the `DummyOperation` refused with call-timeout exception.

Having `SlowOperation` too slow means the invocation with `DummyOperation` will
fail due lack of heartbeat.

In other words: We want Invocation System to actively refuse `DummyOperation` to
be executed.