### PR TITLE
Avoid wrong results when querying with full table scan during migrations

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -305,6 +305,7 @@
     <suppress checks="ClassDataAbstractionCoupling" files="com/hazelcast/map/impl/tx/TransactionalMapProxySupport"/>
     <suppress checks="NPathComplexity|CyclomaticComplexity"
               files="com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData"/>
+    <suppress checks="MethodCount" files="com/hazelcast/map/impl/query/MapQueryEngineImpl"/>
     <suppress checks="NPathComplexity|CyclomaticComplexity" files="com/hazelcast/map/impl/SimpleEntryView"/>
 
     <!-- Util (written by Doug Lea, Agrona backport etc.) -->

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -35,6 +35,10 @@ public interface MapQueryEngine {
      * - Accepts PagingPredicate
      * - Query executed in the calling thread
      * - predicate evaluation will be parallelized if QUERY_PREDICATE_PARALLEL_EVALUATION is enabled or a PagingPredicate is used.
+     * - may return empty QueryResult (with a properly initialized result limit size) if query is executed during migrations and
+     * migration conditions do not allow for safe retrieval of results (ie. there are migrations in flight or partition state
+     * version is different at the end of query vs the version observed at the beginning of query). In this case, partitionIds
+     * are not set on the QueryResult, so callers will ignore these results and fallback to {@code QueryPartitionOperation}s.
      *
      * @param mapName   the name of the map
      * @param predicate the predicate


### PR DESCRIPTION
Applies validation of no owner migrations in flight and partition state version at beginning & end of `querySequential` to avoid query correctness issues. Also, added the no owner migrations in flight condition at end of `tryQueryUsingIndexes`.
Fixes #6471 
Fixes #8046 