### PR TITLE
Locale specific string in MutliLineDiagnosticsLogWriter

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/AbstractMapReduceTask.java
@@ -46,11 +46,11 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.mapreduce.impl.MapReduceUtil.executeOperation;
+import static com.hazelcast.util.StringUtil.LOCALE_INTERNAL;
 
 public abstract class AbstractMapReduceTask<Parameters>
         extends AbstractMessageTask<Parameters>
@@ -146,7 +146,7 @@ public abstract class AbstractMapReduceTask<Parameters>
         if (topologyChangedStrategyStr == null) {
             topologyChangedStrategy = config.getTopologyChangedStrategy();
         } else {
-            topologyChangedStrategy = TopologyChangedStrategy.valueOf(topologyChangedStrategyStr.toUpperCase(Locale.ENGLISH));
+            topologyChangedStrategy = TopologyChangedStrategy.valueOf(topologyChangedStrategyStr.toUpperCase(LOCALE_INTERNAL));
         }
         return topologyChangedStrategy;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriter.java
@@ -17,13 +17,14 @@
 package com.hazelcast.internal.diagnostics;
 
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
+import static com.hazelcast.util.StringUtil.LOCALE_INTERNAL;
 
 /**
  * A {@link DiagnosticsLogWriter} that writes over multiple lines. Useful for human reading.
  */
 class MultiLineDiagnosticsLogWriter extends DiagnosticsLogWriter {
 
-    private static final String STR_LONG_MIN_VALUE = String.format("%,d", Long.MIN_VALUE);
+    private static final String STR_LONG_MIN_VALUE = String.format(LOCALE_INTERNAL, "%,d", Long.MIN_VALUE);
 
     private static final char[] DIGITS = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DateHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DateHelper.java
@@ -22,7 +22,8 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Locale;
+
+import static com.hazelcast.util.StringUtil.LOCALE_INTERNAL;
 
 final class DateHelper {
 
@@ -79,19 +80,19 @@ final class DateHelper {
     }
 
     private static DateFormat getTimestampFormat() {
-        return new SimpleDateFormat(TIMESTAMP_FORMAT, Locale.US);
+        return new SimpleDateFormat(TIMESTAMP_FORMAT, LOCALE_INTERNAL);
     }
 
     private static DateFormat getSqlDateFormat() {
-        return new SimpleDateFormat(SQL_DATE_FORMAT, Locale.US);
+        return new SimpleDateFormat(SQL_DATE_FORMAT, LOCALE_INTERNAL);
     }
 
     private static DateFormat getUtilDateFormat() {
-        return new SimpleDateFormat(DATE_FORMAT, Locale.US);
+        return new SimpleDateFormat(DATE_FORMAT, LOCALE_INTERNAL);
     }
 
     private static DateFormat getSqlTimeFormat() {
-        return new SimpleDateFormat(SQL_TIME_FORMAT, Locale.US);
+        return new SimpleDateFormat(SQL_TIME_FORMAT, LOCALE_INTERNAL);
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -37,7 +37,11 @@ public final class StringUtil {
      */
     public static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
-    private static final Locale LOCALE_INTERNAL = Locale.ENGLISH;
+    /**
+     * LOCALE_INTERNAL is the default locale for string operations and number formatting. Initialized to
+     * {@code java.util.Locale.US} (US English).
+     */
+    public static final Locale LOCALE_INTERNAL = Locale.US;
 
     private StringUtil() {
     }


### PR DESCRIPTION
MutliLineDiagnosticsLogWriter test fails in el_GR.UTF-8 locale (and I guess other locales as well), because MutliLineDiagnosticsLogWriter.STR_LONG_MIN_VALUE is formatted with default platform locale and does not match expected value in MutliLineDiagnosticsLogWriterTest:116