### PR TITLE
Fix hanging invocation during shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
@@ -119,10 +119,28 @@ class MigrationThread extends Thread implements Runnable {
         return activeTask;
     }
 
+    /**
+     * Interrupts the migration thread and joins on it.
+     * <strong>Must not be called on the migration thread itself</strong> because it will result in infinite blocking.
+     */
     void stopNow() {
+        assert currentThread() != this : "stopNow must not be called on the migration thread";
         running = false;
         queue.clear();
         interrupt();
+        boolean currentThreadInterrupted = false;
+        while (true) {
+            try {
+                join();
+            } catch (InterruptedException e) {
+                currentThreadInterrupted = true;
+                continue;
+            }
+            break;
+        }
+        if (currentThreadInterrupted) {
+            currentThread().interrupt();
+        }
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
@@ -39,6 +39,7 @@ class MigrationThread extends Thread implements Runnable {
     private final long sleepTime;
 
     private volatile MigrationRunnable activeTask;
+    private volatile boolean running = true;
 
     MigrationThread(MigrationManager migrationManager, HazelcastThreadGroup hazelcastThreadGroup, ILogger logger,
                     MigrationQueue queue) {
@@ -54,7 +55,7 @@ class MigrationThread extends Thread implements Runnable {
     @Override
     public void run() {
         try {
-            while (!isInterrupted()) {
+            while (running) {
                 doRun();
             }
         } catch (InterruptedException e) {
@@ -98,7 +99,7 @@ class MigrationThread extends Thread implements Runnable {
 
     private boolean processTask(MigrationRunnable runnable) {
         try {
-            if (runnable == null || isInterrupted()) {
+            if (runnable == null || !running) {
                 return false;
             }
 
@@ -119,6 +120,7 @@ class MigrationThread extends Thread implements Runnable {
     }
 
     void stopNow() {
+        running = false;
         queue.clear();
         interrupt();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -49,12 +49,6 @@ public abstract class Operation implements DataSerializable {
      */
     public static final int GENERIC_PARTITION_ID = -1;
 
-    /**
-     * A call id for an invocation that is skipping local registration. For example, a local call without backups
-     * doesn't need to have its call id registered since it won't receive a response from a remote system.
-     */
-    public static final long CALL_ID_LOCAL_SKIPPED = Long.MAX_VALUE;
-
     static final int BITMASK_VALIDATE_TARGET = 1;
     static final int BITMASK_CALLER_UUID_SET = 1 << 1;
     static final int BITMASK_REPLICA_INDEX_SET = 1 << 2;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -426,10 +426,10 @@ public class NodeEngineImpl implements NodeEngine {
     public void shutdown(final boolean terminate) {
         logger.finest("Shutting down services...");
         waitNotifyService.shutdown();
+        operationService.shutdown();
         proxyService.shutdown();
         serviceManager.shutdown(terminate);
         eventService.shutdown();
-        operationService.shutdown();
         wanReplicationService.shutdown();
         executionService.shutdown();
         metricsRegistry.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -60,7 +60,6 @@ import java.util.logging.Level;
 import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.nio.IOUtil.extractOperationCallId;
-import static com.hazelcast.spi.Operation.CALL_ID_LOCAL_SKIPPED;
 import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
 import static com.hazelcast.spi.OperationAccessor.setConnection;
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
@@ -409,7 +408,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
 
     private void setOperationResponseHandler(Operation op) {
         OperationResponseHandler handler = remoteResponseHandler;
-        if (op.getCallId() == 0 || op.getCallId() == CALL_ID_LOCAL_SKIPPED) {
+        if (op.getCallId() == 0) {
             if (op.returnsResponse()) {
                 throw new HazelcastException(
                         "Op: " + op + " can not return response without call-id!");

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithoutBackpressureTest.java
@@ -24,8 +24,6 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
 
     private static boolean LOCAL = false;
     private static boolean REMOTE = true;
-    private static boolean SKIPPED = true;
-    private static boolean NOT_SKIPPED = false;
 
     private HazelcastInstance hz;
     private NodeEngineImpl nodeEngine;
@@ -74,19 +72,19 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
     @Test
     public void next() {
         // regular operation
-        next(new DummyOperation(), REMOTE, NOT_SKIPPED);
-        next(new DummyOperation(), LOCAL, SKIPPED);
+        next(new DummyOperation(), REMOTE);
+        next(new DummyOperation(), LOCAL);
 
         // backup-aware operation
-        next(new DummyBackupAwareOperation(), LOCAL, NOT_SKIPPED);
-        next(new DummyBackupAwareOperation(), REMOTE, NOT_SKIPPED);
+        next(new DummyBackupAwareOperation(), LOCAL);
+        next(new DummyBackupAwareOperation(), REMOTE);
 
         //urgent operation
-        next(new DummyPriorityOperation(), LOCAL, SKIPPED);
-        next(new DummyPriorityOperation(), REMOTE, NOT_SKIPPED);
+        next(new DummyPriorityOperation(), LOCAL);
+        next(new DummyPriorityOperation(), REMOTE);
     }
 
-    public void next(Operation operation, boolean remote, boolean skipped) {
+    public void next(Operation operation, boolean remote) {
         CallIdSequence.CallIdSequenceWithoutBackpressure sequence = new CallIdSequence.CallIdSequenceWithoutBackpressure();
 
         Invocation invocation = newInvocation(operation);
@@ -95,13 +93,8 @@ public class CallIdSequenceWithoutBackpressureTest extends HazelcastTestSupport 
 
         long result = sequence.next(invocation);
 
-        if (skipped) {
-            assertEquals(Operation.CALL_ID_LOCAL_SKIPPED, result);
-            assertEquals(oldSequence, sequence.getLastCallId());
-        } else {
-            assertEquals(oldSequence + 1, result);
-            assertEquals(oldSequence + 1, sequence.getLastCallId());
-        }
+        assertEquals(oldSequence + 1, result);
+        assertEquals(oldSequence + 1, sequence.getLastCallId());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -53,19 +53,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     // ====================== register ===============================
 
     @Test
-    public void register_whenSkippableInvocation() {
-        Operation op = new DummyOperation();
-        Invocation invocation = newInvocation(op);
-        invocation.remote = false;
-
-        invocationRegistry.register(invocation);
-
-        assertEquals(Operation.CALL_ID_LOCAL_SKIPPED, invocation.op.getCallId());
-        assertNull(invocationRegistry.get(op.getCallId()));
-    }
-
-    @Test
-    public void register_whenNoneSkippableInvocation() {
+    public void register_Invocation() {
         Operation op = new DummyBackupAwareOperation();
         Invocation invocation = newInvocation(op);
         long oldCallId = invocationRegistry.getLastCallId();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
@@ -3,12 +3,16 @@ package com.hazelcast.spi.impl.operationservice.impl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -16,13 +20,19 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -105,6 +115,91 @@ public class Invocation_RetryTest extends HazelcastTestSupport {
         });
     }
 
+    @Test
+    public void invocationShouldComplete_whenRetried_DuringShutdown() throws InterruptedException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+
+        final int numberOfInvocations = 100;
+        Future[] futures = new Future[numberOfInvocations];
+
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+        waitAllForSafeState(hz1, hz2, hz3);
+
+        InternalOperationService operationService = getNodeEngineImpl(hz1).getOperationService();
+        for (int k = 0; k < numberOfInvocations; k++) {
+            int partitionId = getRandomPartitionId(hz2);
+
+            Future<Object> future =
+                    operationService.createInvocationBuilder(null, new RetryingOperation(), partitionId)
+                            .setTryCount(Integer.MAX_VALUE).setCallTimeout(Long.MAX_VALUE).invoke();
+            futures[k] = future;
+        }
+
+        hz3.getLifecycleService().terminate();
+        hz1.getLifecycleService().terminate();
+
+        for (int k = 0; k < numberOfInvocations; k++) {
+            Future future = futures[k];
+            try {
+                future.get(2, TimeUnit.MINUTES);
+            } catch (ExecutionException ignored) {
+            } catch (TimeoutException e) {
+                Assert.fail(e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void invocationShouldComplete_whenOperationsPending_DuringShutdown() throws InterruptedException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+        InternalOperationService operationService = nodeEngine.getOperationService();
+
+        operationService.invokeOnPartition(new SleepingOperation(Long.MAX_VALUE).setPartitionId(0));
+        sleepSeconds(1);
+
+        final int numberOfInvocations = 100;
+        Future[] futures = new Future[numberOfInvocations];
+
+        for (int i = 0; i < numberOfInvocations; i++) {
+            Future<Object> future =
+                    operationService.createInvocationBuilder(null, new RetryingOperation(), 0)
+                            .setTryCount(Integer.MAX_VALUE).setCallTimeout(Long.MAX_VALUE).invoke();
+            futures[i]  = future;
+        }
+
+        hz.getLifecycleService().terminate();
+
+        for (int k = 0; k < numberOfInvocations; k++) {
+            Future future = futures[k];
+            try {
+                future.get(2, TimeUnit.MINUTES);
+            } catch (ExecutionException ignored) {
+            } catch (TimeoutException e) {
+                Assert.fail(e.getMessage());
+            }
+        }
+    }
+
+    private static int getRandomPartitionId(HazelcastInstance hz) {
+        warmUpPartitions(hz);
+
+        InternalPartitionService partitionService = getPartitionService(hz);
+        IPartition[] partitions = partitionService.getPartitions();
+        Collections.shuffle(Arrays.asList(partitions));
+
+        for (IPartition p : partitions) {
+            if (p.isLocal()) {
+                return p.getPartitionId();
+            }
+        }
+        throw new RuntimeException("No local partitions are found for hz: " + hz.getName());
+    }
+
     /**
      * Non-responsive operation.
      */
@@ -139,6 +234,31 @@ public class Invocation_RetryTest extends HazelcastTestSupport {
         @Override
         public void run() throws InterruptedException {
             Thread.sleep(5000);
+        }
+    }
+
+    private static class RetryingOperation extends Operation implements AllowedDuringPassiveState {
+
+        @Override
+        public void run() throws Exception {
+            throw new RetryableHazelcastException();
+        }
+    }
+
+    private static class SleepingOperation extends Operation implements AllowedDuringPassiveState {
+
+        private long sleepMillis;
+
+        public SleepingOperation() {
+        }
+
+        public SleepingOperation(long sleepMillis) {
+            this.sleepMillis = sleepMillis;
+        }
+
+        @Override
+        public void run() throws Exception {
+            Thread.sleep(sleepMillis);
         }
     }
 }


### PR DESCRIPTION
When an invocation is submitted or retried during node shutdown,
that invocation may not be notified with `HazelcastInstanceNotActiveException`
as expected. Because, there's no mechanism that prevents registering a new invocation
after `InvocationRegistry` is shutdown.

Also, `OperationService` (and all invocation infrastructure) should be shutdown before
any other service, since a service like `InternalPartitionService` may depend on an invocation
to complete (with either success or failure) during shutdown.

Another problem is, currently as an optimization, a local invocation without backup
is not registered in `InvocationRegistry`. That means, we don't have a reference to
that invocation during `OperationService` shutdown and we can't notify/complete it `HazelcastInstanceNotActiveException`.
Since, that invocation won't get notified, it will eventually timeout with `OperationTimeoutException`.
Worse scenario is, that invocation will hang forever if an infinite timeout is given,
like `PromotionCommitOperation` or `MigrationCommitOperation` in migration system.
A user invocation, like `map.get()`, can get an `OperationTimeoutException` if it's invoked
during shutdown.

To fix these issues

- An `alive` flag is introduced in `InvocationRegistry` which is set to false during shutdown.
When a new invocation is requested to be registered, `InvocationRegistry.register()` will return
value of `alive` flag. So, requester should stop there and complete invocation with failure.

- `OperationService.shutdown()` is shifted up in shutdown sequence.

- Optimization of skipping registration of a backup-less & local invocations is removed.

Fixes #8560
Cherry picked @mtopolnik's commit from #8565