### PR TITLE
Do not pick the node's own address to join in MockJoiner

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -113,6 +113,10 @@ class MockJoiner extends AbstractJoiner {
 
             Assert.assertEquals(address, foundNode.getThisAddress());
 
+            if (foundNode.getThisAddress().equals(node.getThisAddress())) {
+                continue;
+            }
+
             if (!foundNode.isRunning()) {
                 logger.fine("Node for " + address + " is not running. -> " + foundNode.getState());
                 continue;


### PR DESCRIPTION
 A node registers itself into MockJoiner registry and scans the registry to pick a node to send a join request. It should avoid picking itself.