### PR TITLE
[DONT MERGE] Fixed a performance regression in IMap.putAll()

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -124,7 +124,6 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.CollectionUtil;
-import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.MapUtil;
 import com.hazelcast.util.Preconditions;
@@ -146,6 +145,7 @@ import static com.hazelcast.cluster.memberselector.MemberSelectors.LITE_MEMBER_S
 import static com.hazelcast.map.impl.ListenerAdapters.createListenerAdapter;
 import static com.hazelcast.map.impl.MapListenerFlagOperator.setAndGetListenerFlags;
 import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.SortingUtil.getSortedQueryResultSet;
 import static java.util.Collections.emptyMap;
@@ -326,7 +326,7 @@ public class ClientMapProxy<K, V>
             return new ClientDelegatingFuture<V>(future, serializationService, GET_ASYNC_RESPONSE_DECODER);
 
         } catch (Exception e) {
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -359,7 +359,7 @@ public class ClientMapProxy<K, V>
             return new ClientDelegatingFuture<V>(future, getContext().getSerializationService(),
                     PUT_ASYNC_RESPONSE_DECODER);
         } catch (Exception e) {
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -386,7 +386,7 @@ public class ClientMapProxy<K, V>
             return new ClientDelegatingFuture<Void>(future, getContext().getSerializationService(),
                     SET_ASYNC_RESPONSE_DECODER);
         } catch (Exception e) {
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -404,7 +404,7 @@ public class ClientMapProxy<K, V>
             return new ClientDelegatingFuture<V>(future, getContext().getSerializationService(),
                     REMOVE_ASYNC_RESPONSE_DECODER);
         } catch (Exception e) {
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -1055,7 +1055,7 @@ public class ClientMapProxy<K, V>
 
                 responses.add(resultParameters);
             } catch (Exception e) {
-                ExceptionUtil.rethrow(e);
+                throw rethrow(e);
             }
         }
         return responses;
@@ -1245,7 +1245,7 @@ public class ClientMapProxy<K, V>
                     SUBMIT_TO_KEY_RESPONSE_DECODER);
             clientDelegatingFuture.andThen(callback);
         } catch (Exception e) {
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -1264,7 +1264,7 @@ public class ClientMapProxy<K, V>
             final ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);
             return new ClientDelegatingFuture(future, getContext().getSerializationService(), SUBMIT_TO_KEY_RESPONSE_DECODER);
         } catch (Exception e) {
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -1399,10 +1399,9 @@ public class ClientMapProxy<K, V>
 
     protected void putAllInternal(Map<Integer, List<Map.Entry<Data, Data>>> entryMap) {
         List<Future<?>> futures = new ArrayList<Future<?>>(entryMap.size());
-        for (final Entry<Integer, List<Map.Entry<Data, Data>>> entry : entryMap.entrySet()) {
-            final Integer partitionId = entry.getKey();
-            //If there is only one entry, consider how we can use MapPutRequest
-            //without having to get back the return value.
+        for (Entry<Integer, List<Map.Entry<Data, Data>>> entry : entryMap.entrySet()) {
+            Integer partitionId = entry.getKey();
+            // if there is only one entry, consider how we can use MapPutRequest without having to get back the return value
             ClientMessage request = MapPutAllCodec.encodeRequest(name, entry.getValue());
             futures.add(new ClientInvocation(getClient(), request, partitionId).invoke());
         }
@@ -1412,7 +1411,7 @@ public class ClientMapProxy<K, V>
                 future.get();
             }
         } catch (Exception e) {
-            ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -33,6 +33,7 @@ import com.hazelcast.internal.eviction.EvictionStrategy;
 import com.hazelcast.internal.eviction.EvictionStrategyProvider;
 import com.hazelcast.internal.eviction.impl.EvictionConfigHelper;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventRegistration;
@@ -99,9 +100,8 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     protected final boolean disablePerEntryInvalidationEvents;
     protected boolean primary;
 
-    //CHECKSTYLE:OFF
-    public AbstractCacheRecordStore(String name, int partitionId, NodeEngine nodeEngine,
-                                    AbstractCacheService cacheService) {
+    @SuppressWarnings({"checkstyle:executablestatementcount", "checkstyle:npathcomplexity"})
+    public AbstractCacheRecordStore(String name, int partitionId, NodeEngine nodeEngine, AbstractCacheService cacheService) {
         this.name = name;
         this.partitionId = partitionId;
         this.nodeEngine = nodeEngine;
@@ -155,7 +155,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         registerResourceIfItIsClosable(defaultExpiryPolicy);
         init();
     }
-    //CHECKSTYLE:ON
 
     private boolean isPrimary() {
         IPartition partition = nodeEngine.getPartitionService().getPartition(partitionId, false);
@@ -196,8 +195,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected abstract CRM createRecordCacheMap();
 
-    protected abstract CacheEntryProcessorEntry createCacheEntryProcessorEntry(Data key, R record,
-                                                                               long now, int completionId);
+    protected abstract CacheEntryProcessorEntry createCacheEntryProcessorEntry(Data key, R record, long now, int completionId);
 
     protected abstract R createRecord(Object value, long creationTime, long expiryTime);
 
@@ -1311,7 +1309,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     @Override
     public MapEntries getAll(Set<Data> keySet, ExpiryPolicy expiryPolicy) {
         expiryPolicy = getExpiryPolicy(expiryPolicy);
-        MapEntries result = new MapEntries(keySet.size());
+        MapEntries result = new MapEntriesImpl(keySet.size());
         for (Data key : keySet) {
             Object value = get(key, expiryPolicy);
             if (value != null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapPutAllCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesLegacyImpl;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.nio.Connection;
@@ -32,8 +33,7 @@ import java.security.Permission;
 import java.util.HashMap;
 import java.util.Map;
 
-public class MapPutAllMessageTask
-        extends AbstractMapPartitionMessageTask<MapPutAllCodec.RequestParameters> {
+public class MapPutAllMessageTask extends AbstractMapPartitionMessageTask<MapPutAllCodec.RequestParameters> {
 
     public MapPutAllMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -41,7 +41,8 @@ public class MapPutAllMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        MapEntries mapEntries = new MapEntries(parameters.entries);
+        // we have to use MapEntriesLegacyImpl here to avoid a performance regression
+        MapEntries mapEntries = new MapEntriesLegacyImpl(parameters.entries);
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
         return operationProvider.createPutAllOperation(parameters.name, mapEntries);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -110,7 +110,7 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         };
         constructors[MAP_ENTRIES] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MapEntries();
+                return new MapEntriesImpl();
             }
         };
         constructors[ENTRY_VIEW] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntries.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntries.java
@@ -16,140 +16,34 @@
 
 package com.hazelcast.map.impl;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.serialization.SerializationService;
 
-import java.io.IOException;
-import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 /**
  * MapEntries is a collection of {@link Data} instances for keys and values of a {@link java.util.Map.Entry}.
  */
-public final class MapEntries implements IdentifiedDataSerializable {
+public interface MapEntries extends IdentifiedDataSerializable {
 
-    private List<Data> keys;
-    private List<Data> values;
+    void add(Data key, Data value);
 
-    public MapEntries() {
-    }
+    List<Map.Entry<Data, Data>> entries();
 
-    public MapEntries(int initialSize) {
-        keys = new ArrayList<Data>(initialSize);
-        values = new ArrayList<Data>(initialSize);
-    }
+    Data getKey(int index);
 
-    public MapEntries(List<Map.Entry<Data, Data>> entries) {
-        int initialSize = entries.size();
-        keys = new ArrayList<Data>(initialSize);
-        values = new ArrayList<Data>(initialSize);
-        for (Map.Entry<Data, Data> entry : entries) {
-            keys.add(entry.getKey());
-            values.add(entry.getValue());
-        }
-    }
+    Data getValue(int index);
 
-    public void add(Data key, Data value) {
-        ensureEntriesCreated();
-        keys.add(key);
-        values.add(value);
-    }
+    int size();
 
-    public List<Map.Entry<Data, Data>> entries() {
-        ArrayList<Map.Entry<Data, Data>> entries = new ArrayList<Map.Entry<Data, Data>>(keys.size());
-        putAllToList(entries);
-        return entries;
-    }
+    boolean isEmpty();
 
-    public Data getKey(int index) {
-        return keys.get(index);
-    }
+    void clear();
 
-    public Data getValue(int index) {
-        return values.get(index);
-    }
+    void putAllToList(Collection<Map.Entry<Data, Data>> targetList);
 
-    public int size() {
-        return (keys == null ? 0 : keys.size());
-    }
-
-    public boolean isEmpty() {
-        return (keys == null || keys.size() == 0);
-    }
-
-    public void clear() {
-        if (keys != null) {
-            keys.clear();
-            values.clear();
-        }
-    }
-
-    public void putAllToList(Collection<Map.Entry<Data, Data>> targetList) {
-        if (keys == null) {
-            return;
-        }
-        Iterator<Data> keyIterator = keys.iterator();
-        Iterator<Data> valueIterator = values.iterator();
-        while (keyIterator.hasNext()) {
-            targetList.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(keyIterator.next(), valueIterator.next()));
-        }
-    }
-
-    public <K, V> void putAllToMap(SerializationService serializationService, Map<K, V> map) {
-        if (keys == null) {
-            return;
-        }
-        Iterator<Data> keyIterator = keys.iterator();
-        Iterator<Data> valueIterator = values.iterator();
-        while (keyIterator.hasNext()) {
-            K key = serializationService.toObject(keyIterator.next());
-            V value = serializationService.toObject(valueIterator.next());
-            map.put(key, value);
-        }
-    }
-
-    private void ensureEntriesCreated() {
-        if (keys == null) {
-            keys = new ArrayList<Data>();
-            values = new ArrayList<Data>();
-        }
-    }
-
-    @Override
-    public int getFactoryId() {
-        return MapDataSerializerHook.F_ID;
-    }
-
-    @Override
-    public int getId() {
-        return MapDataSerializerHook.MAP_ENTRIES;
-    }
-
-    @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
-        int size = size();
-        out.writeInt(size);
-        for (int i = 0; i < size; i++) {
-            out.writeData(keys.get(i));
-            out.writeData(values.get(i));
-        }
-    }
-
-    @Override
-    public void readData(ObjectDataInput in) throws IOException {
-        int size = in.readInt();
-        keys = new ArrayList<Data>(size);
-        values = new ArrayList<Data>(size);
-        for (int i = 0; i < size; i++) {
-            keys.add(in.readData());
-            values.add(in.readData());
-        }
-    }
+    <K, V> void putAllToMap(SerializationService serializationService, Map<K, V> map);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntriesImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntriesImpl.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of {@link MapEntries} which reduces litter by not wrapping each key/value pair in a {@link java.util.Map.Entry}.
+ */
+public class MapEntriesImpl implements MapEntries {
+
+    private List<Data> keys;
+    private List<Data> values;
+
+    public MapEntriesImpl() {
+    }
+
+    public MapEntriesImpl(int initialSize) {
+        keys = new ArrayList<Data>(initialSize);
+        values = new ArrayList<Data>(initialSize);
+    }
+
+    @Override
+    public void add(Data key, Data value) {
+        ensureEntriesCreated();
+        keys.add(key);
+        values.add(value);
+    }
+
+    @Override
+    public List<Map.Entry<Data, Data>> entries() {
+        ArrayList<Map.Entry<Data, Data>> entries = new ArrayList<Map.Entry<Data, Data>>(keys.size());
+        putAllToList(entries);
+        return entries;
+    }
+
+    @Override
+    public Data getKey(int index) {
+        return keys.get(index);
+    }
+
+    @Override
+    public Data getValue(int index) {
+        return values.get(index);
+    }
+
+    @Override
+    public int size() {
+        return (keys == null ? 0 : keys.size());
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return (keys == null || keys.isEmpty());
+    }
+
+    @Override
+    public void clear() {
+        if (keys != null) {
+            keys.clear();
+            values.clear();
+        }
+    }
+
+    @Override
+    public void putAllToList(Collection<Map.Entry<Data, Data>> targetList) {
+        if (keys == null) {
+            return;
+        }
+        Iterator<Data> keyIterator = keys.iterator();
+        Iterator<Data> valueIterator = values.iterator();
+        while (keyIterator.hasNext()) {
+            targetList.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(keyIterator.next(), valueIterator.next()));
+        }
+    }
+
+    @Override
+    public <K, V> void putAllToMap(SerializationService serializationService, Map<K, V> map) {
+        if (keys == null) {
+            return;
+        }
+        Iterator<Data> keyIterator = keys.iterator();
+        Iterator<Data> valueIterator = values.iterator();
+        while (keyIterator.hasNext()) {
+            K key = serializationService.toObject(keyIterator.next());
+            V value = serializationService.toObject(valueIterator.next());
+            map.put(key, value);
+        }
+    }
+
+    private void ensureEntriesCreated() {
+        if (keys == null) {
+            keys = new ArrayList<Data>();
+            values = new ArrayList<Data>();
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.MAP_ENTRIES;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        int size = size();
+        out.writeInt(size);
+        for (int i = 0; i < size; i++) {
+            out.writeData(keys.get(i));
+            out.writeData(values.get(i));
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        int size = in.readInt();
+        keys = new ArrayList<Data>(size);
+        values = new ArrayList<Data>(size);
+        for (int i = 0; i < size; i++) {
+            keys.add(in.readData());
+            values.add(in.readData());
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntriesLegacyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntriesLegacyImpl.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Legacy implementation of {@link MapEntries} for the old client {@link com.hazelcast.core.IMap#putAll(Map)} implementation,
+ * which avoids copying of the whole data set, when the data is already a {@link Collection}.
+ *
+ * Will be de-serialized as {@link MapEntriesImpl}.
+ */
+public final class MapEntriesLegacyImpl implements MapEntries {
+
+    private List<Map.Entry<Data, Data>> entries;
+
+    public MapEntriesLegacyImpl(Collection<Map.Entry<Data, Data>> entries) {
+        this.entries = new ArrayList<Map.Entry<Data, Data>>(entries);
+    }
+
+    @Override
+    public void add(Data key, Data value) {
+        ensureEntriesCreated();
+        entries.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(key, value));
+    }
+
+    @Override
+    public List<Map.Entry<Data, Data>> entries() {
+        return entries;
+    }
+
+    @Override
+    public Data getKey(int index) {
+        return entries.get(index).getKey();
+    }
+
+    @Override
+    public Data getValue(int index) {
+        return entries.get(index).getValue();
+    }
+
+    @Override
+    public int size() {
+        return (entries == null ? 0 : entries.size());
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return (entries == null || entries.isEmpty());
+    }
+
+    @Override
+    public void clear() {
+        if (entries != null) {
+            entries.clear();
+        }
+    }
+
+    @Override
+    public void putAllToList(Collection<Map.Entry<Data, Data>> targetList) {
+        if (entries == null) {
+            return;
+        }
+        targetList.addAll(entries);
+    }
+
+    @Override
+    public <K, V> void putAllToMap(SerializationService serializationService, Map<K, V> map) {
+        if (entries == null) {
+            return;
+        }
+        for (Map.Entry<Data, Data> entry : entries) {
+            K key = serializationService.toObject(entry.getKey());
+            V value = serializationService.toObject(entry.getValue());
+            map.put(key, value);
+        }
+    }
+
+    private void ensureEntriesCreated() {
+        if (entries == null) {
+            entries = new ArrayList<Map.Entry<Data, Data>>();
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.MAP_ENTRIES;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        int size = size();
+        out.writeInt(size);
+        if (size > 0) {
+            for (Map.Entry<Data, Data> entry : entries) {
+                out.writeData(entry.getKey());
+                out.writeData(entry.getValue());
+            }
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        throw new UnsupportedOperationException("This class should be de-serialized as MapEntriesImpl");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
-import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -56,7 +56,7 @@ public class MultipleEntryOperation extends AbstractMultipleEntryOperation imple
     @Override
     public void run() throws Exception {
         long now = getNow();
-        responses = new MapEntries(keys.size());
+        responses = new MapEntriesImpl(keys.size());
         for (Data key : keys) {
             if (!isKeyProcessable(key)) {
                 continue;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
-import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -61,7 +61,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
     public void run() {
         long now = getNow();
 
-        responses = new MapEntries(recordStore.size());
+        responses = new MapEntriesImpl(recordStore.size());
         Iterator<Record> iterator = recordStore.iterator(now, false);
         while (iterator.hasNext()) {
             Record record = iterator.next();
@@ -152,5 +152,4 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
         super.writeInternal(out);
         out.writeObject(entryProcessor);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.nio.ObjectDataInput;
@@ -86,7 +87,7 @@ public class PutAllBackupOperation extends MapOperation implements PartitionAwar
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
 
-        entries = new MapEntries();
+        entries = new MapEntriesImpl();
         entries.readData(in);
         int size = entries.size();
         recordInfos = new ArrayList<RecordInfo>(size);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.nio.ObjectDataInput;
@@ -181,7 +182,7 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        mapEntries = new MapEntries();
+        mapEntries = new MapEntriesImpl();
         mapEntries.readData(in);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactory.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.NodeEngine;
@@ -88,9 +89,9 @@ public class PutAllPartitionAwareOperationFactory implements PartitionAwareOpera
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readUTF();
         partitions = in.readIntArray();
-        mapEntries = new MapEntries[partitions.length];
+        mapEntries = new MapEntriesImpl[partitions.length];
         for (int i = 0; i < partitions.length; i++) {
-            MapEntries entry = new MapEntries();
+            MapEntries entry = new MapEntriesImpl();
             entry.readData(in);
             mapEntries[i] = entry;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -39,6 +39,7 @@ import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.EntryEventFilter;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.PartitionContainer;
@@ -779,7 +780,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
             }
 
             // fill entriesPerPartition
-            MapEntries[] entriesPerPartition = new MapEntries[partitionCount];
+            MapEntries[] entriesPerPartition = new MapEntriesImpl[partitionCount];
             for (Entry entry : map.entrySet()) {
                 checkNotNull(entry.getKey(), NULL_KEY_IS_NOT_ALLOWED);
                 checkNotNull(entry.getValue(), NULL_VALUE_IS_NOT_ALLOWED);
@@ -788,7 +789,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
                 int partitionId = partitionService.getPartitionId(keyData);
                 MapEntries entries = entriesPerPartition[partitionId];
                 if (entries == null) {
-                    entries = new MapEntries(initialSize);
+                    entries = new MapEntriesImpl(initialSize);
                     entriesPerPartition[partitionId] = entries;
                 }
 
@@ -832,7 +833,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         }
 
         index = 0;
-        MapEntries[] entries = new MapEntries[size];
+        MapEntries[] entries = new MapEntriesImpl[size];
         long totalSize = 0;
         for (int partitionId : partitions) {
             int batchSize = entriesPerPartition[partitionId].size();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -25,6 +25,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.EntryViews;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.map.impl.MapKeyLoader;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -636,7 +637,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         checkIfLoaded();
         final long now = getNow();
 
-        final MapEntries mapEntries = new MapEntries(keys.size());
+        final MapEntries mapEntries = new MapEntriesImpl(keys.size());
 
         final Iterator<Data> iterator = keys.iterator();
         while (iterator.hasNext()) {

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWrongTargetForPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPutAllWrongTargetForPartitionTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.PutAllPartitionAwareOperationFactory;
 import com.hazelcast.nio.Address;
@@ -148,9 +149,9 @@ public class MapPutAllWrongTargetForPartitionTest extends HazelcastTestSupport {
                                                                         HazelcastInstance hz,
                                                                         SerializationService serializationService) {
         int[] partitions = new int[INSTANCE_COUNT];
-        MapEntries[] entries = new MapEntries[INSTANCE_COUNT];
+        MapEntries[] entries = new MapEntriesImpl[INSTANCE_COUNT];
         for (int partitionId = 0; partitionId < INSTANCE_COUNT; partitionId++) {
-            MapEntries mapEntries = new MapEntries(entriesPerPartition);
+            MapEntries mapEntries = new MapEntriesImpl(entriesPerPartition);
 
             for (int i = 0; i < entriesPerPartition; i++) {
                 String key = generateKeyForPartition(hz, partitionId);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegatorTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -100,9 +101,9 @@ public class MapOperationProviderDelegatorTest extends HazelcastTestSupport {
             } else if (parameterType.equals(boolean[].class)) {
                 parameters[i] = new boolean[0];
             } else if (parameterType.isAssignableFrom(MapEntries.class)) {
-                parameters[i] = new MapEntries();
+                parameters[i] = new MapEntriesImpl();
             } else if (parameterType.equals(MapEntries[].class)) {
-                parameters[i] = new MapEntries[0];
+                parameters[i] = new MapEntriesImpl[0];
             } else {
                 try {
                     parameters[i] = mock(parameterType);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PutAllPartitionAwareOperationFactoryTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.MapEntriesImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -20,7 +21,7 @@ public class PutAllPartitionAwareOperationFactoryTest extends HazelcastTestSuppo
     public void setUp() throws Exception {
         String name = randomMapName();
         int[] partitions = new int[0];
-        MapEntries[] mapEntries = new MapEntries[0];
+        MapEntries[] mapEntries = new MapEntriesImpl[0];
         factory = getFactory(name, partitions, mapEntries);
     }
 


### PR DESCRIPTION
Fixed a performance regression in `IMap.putAll()` due to copying the whole data set, which occurred on the client code path.