### PR TITLE
Fixed a possible NPE in PartitionWideEntryWithPredicateOperationFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.CollectionUtil.isEmpty;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
+import static com.hazelcast.util.MapUtil.isNullOrEmpty;
 
 public class PartitionWideEntryWithPredicateOperationFactory implements PartitionAwareOperationFactory {
 
@@ -72,7 +73,7 @@ public class PartitionWideEntryWithPredicateOperationFactory implements Partitio
     }
 
     private void queryIndex() {
-        // Do not use index in this case, because it requires full-table-scan.
+        // do not use index in this case, because it requires full-table-scan
         if (predicate == TruePredicate.INSTANCE) {
             return;
         }
@@ -104,12 +105,13 @@ public class PartitionWideEntryWithPredicateOperationFactory implements Partitio
 
     @Override
     public Operation createPartitionOperation(int partition) {
-        if (hasIndex) {
+        if (hasIndex && !isNullOrEmpty(partitionIdToKeys)) {
             List<Data> keys = partitionIdToKeys.get(partition);
-            InflatableSet<Data> keySet = InflatableSet.newBuilder(keys).build();
-            return new MultipleEntryWithPredicateOperation(name, keySet, entryProcessor, predicate);
+            if (keys != null) {
+                InflatableSet<Data> keySet = InflatableSet.newBuilder(keys).build();
+                return new MultipleEntryWithPredicateOperation(name, keySet, entryProcessor, predicate);
+            }
         }
-
         return createOperation();
     }
 


### PR DESCRIPTION
Fixed a possible NPE in `PartitionWideEntryWithPredicateOperationFactory` on bouncing members.

BTW: There is still no code coverage on the serialization part of `MultipleEntryWithPredicateOperation`, even with the bouncing test.