### PR TITLE
Fixed IllegalStateException in PutAllPartitionAwareOperationFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.map.impl.operation.PutAllPartitionAwareOperationFactory;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation.PartitionResponse;
 
@@ -124,8 +124,8 @@ final class InvokeOnPartitions {
 
         for (Integer failedPartition : failedPartitions) {
             Operation operation;
-            if (operationFactory instanceof PartitionAwareOperationFactory) {
-                operation = ((PartitionAwareOperationFactory) operationFactory).createPartitionOperation(failedPartition);
+            if (operationFactory instanceof PutAllPartitionAwareOperationFactory) {
+                operation = ((PutAllPartitionAwareOperationFactory) operationFactory).createPartitionOperation(failedPartition);
             } else {
                 operation = operationFactory.createOperation();
             }


### PR DESCRIPTION
Fixed `IllegalStateException` in `PutAllPartitionAwareOperationFactory` on bouncing members, without creating thread-safety issues in `PartitionWideEntryWithPredicateOperationFactory`.

This solution is a bit more hacky on the first view, since we make an exception for the `PutAllPartitionAwareOperationFactory`. But @jerrinot pointed out, that the other solution (https://github.com/hazelcast/hazelcast/pull/8624) has at least visibility issues between threads which modify the state of the `PartitionWideEntryWithPredicateOperationFactory`. So this solution is more safe.