### PR TITLE
Split OperationService.shutdown into two separate methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -426,10 +426,11 @@ public class NodeEngineImpl implements NodeEngine {
     public void shutdown(final boolean terminate) {
         logger.finest("Shutting down services...");
         waitNotifyService.shutdown();
-        operationService.shutdown();
+        operationService.shutdownInvocations();
         proxyService.shutdown();
         serviceManager.shutdown(terminate);
         eventService.shutdown();
+        operationService.shutdownOperationExecutor();
         wanReplicationService.shutdown();
         executionService.shutdown();
         metricsRegistry.shutdown();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -485,14 +485,17 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         slowOperationDetector.start();
     }
 
-    public void shutdown() {
-        logger.finest("Shutting down OperationService");
+    /**
+     * Shuts down invocation infrastructure.
+     * New invocation requests will be rejected after shutdown and all pending invocations
+     * will be notified with a failure response.
+     */
+    public void shutdownInvocations() {
+        logger.finest("Shutting down invocations");
 
         invocationRegistry.shutdown();
         invocationMonitor.shutdown();
-        operationExecutor.shutdown();
         asyncResponseHandler.shutdown();
-        slowOperationDetector.shutdown();
 
         try {
             invocationMonitor.awaitTermination(TERMINATION_TIMEOUT_MILLIS);
@@ -502,5 +505,12 @@ public final class OperationServiceImpl implements InternalOperationService, Met
             Thread.currentThread().interrupt();
             EmptyStatement.ignore(e);
         }
+    }
+
+    public void shutdownOperationExecutor() {
+        logger.finest("Shutting down operation executors");
+
+        operationExecutor.shutdown();
+        slowOperationDetector.shutdown();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -81,7 +81,8 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
             return;
         }
         OperationServiceImpl operationService = (OperationServiceImpl) getOperationService(instance);
-        operationService.shutdown();
+        operationService.shutdownInvocations();
+        operationService.shutdownOperationExecutor();
     }
 
     static Collection<SlowOperationLog.Invocation> getInvocations(SlowOperationLog log) {


### PR DESCRIPTION
Before `OperationService.shutdown()` was shutting down invocations
and operation executors at once.
In a previous commit, `OperationService.shutdown()` call was shifted up
in shutdown sequence to be able notify all pending invocations while
services were shutting down.
But on EE side, some services are submitting local tasks/operations during
service shutdown (like cleanup tasks) and they started to fail after that change.

As a fix, `OperationService.shutdown()` is split into two methods; first one
will shutdown only invocations (invocation infrastructure), second one will shutdown
operation executors (and operation threads etc).

See PR https://github.com/hazelcast/hazelcast/pull/8610