### PR TITLE
Implement MemcacheEntry.getKey

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheEntry.java
@@ -94,6 +94,16 @@ public class MemcacheEntry implements DataSerializable {
         return bytes;
     }
 
+    public String getKey() {
+        final int start = TextCommandConstants.VALUE_SPACE.length;
+        for (int i = start; i < bytes.length; ++i) {
+            if (bytes[i] == ' ') {
+                return bytesToString(Arrays.copyOfRange(bytes, start, i));
+            }
+        }
+        return null;
+    }
+
     public byte[] getValue() {
         return value;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcacheTest.java
@@ -166,6 +166,7 @@ public class MemcacheTest extends HazelcastTestSupport {
                 final MemcacheEntry memcacheEntry = (MemcacheEntry) map.get(String.valueOf(i));
                 final MemcacheEntry expected = new MemcacheEntry(prefix + String.valueOf(i), String.valueOf(i * 10).getBytes(), 0);
                 assertEquals(expected, memcacheEntry);
+                assertEquals(prefix + String.valueOf(i), memcacheEntry.getKey());
             }
             final OperationFuture<Boolean> future = client.delete(prefix);
             future.get();


### PR DESCRIPTION
zalora/zcast@6aedda5 implements a MapInterceptor that partially compresses/decompresses MemcachedEntry payloads on the fly using LZ4 during IMap.get/put operations. It does this by extracting the fields from an intercepted MemcachedEntry and creating a new one with a compressed value and extra lz4 metadata added to flags.

One of the challenges implementing this MapInterceptor is extracting the key from the original MemcachedEntry. @wolframite has hence requested that the key is made available via a getter, which is implemented in this PR. The first and last bytes of the key are determined respectively using dead reckoning, and locating the space character between the key and flags.