### PR TITLE
Retrying on timeout when invoking PutResultOperation

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableLongRunningTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableLongRunningTaskTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class DurableLongRunningTaskTest extends HazelcastTestSupport {
 
-    private static final int CALL_TIMEOUT = 1000;
+    private static final int CALL_TIMEOUT = 2000;
 
     private HazelcastInstance hz;
 


### PR DESCRIPTION
Fix #8584
Reasoning: Result of the invocation is not passed into user-code. Any kind of timeout here
means a result is lost. The operation is idempotent -> overly eager retrying (in the case of
heart beat timeout) will not cause any harm. There is no limit on number of retry attempt,
however given we are retrying only on timeout I don't see this as an issue.

Alternatively we could just increase call timeout for this operation, but it would still cause issues
in the case of hogged operation thread.

I also increased global calltime of the test as the new invocation system does not play nicely
with too low timeouts.

Credits for this discovering the root cause of the failure go to @tombujok