### PR TITLE
Set call-timeout to Long.MAX_VALUE for PutResultOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorContainer.java
@@ -26,6 +26,8 @@ import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
+import static com.hazelcast.durableexecutor.impl.DistributedDurableExecutorService.SERVICE_NAME;
+
 public class DurableExecutorContainer {
 
     private final String name;
@@ -142,8 +144,10 @@ public class DurableExecutorContainer {
 
         private void setResponse(Object response) {
             OperationService operationService = nodeEngine.getOperationService();
-            Operation op = new PutResultOperation(name, sequence, response).setPartitionId(partitionId);
-            operationService.invokeOnPartition(op);
+            Operation op = new PutResultOperation(name, sequence, response);
+            operationService.createInvocationBuilder(SERVICE_NAME, op, partitionId)
+                    .setCallTimeout(Long.MAX_VALUE)
+                    .invoke();
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableLongRunningTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableLongRunningTaskTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class DurableLongRunningTaskTest extends HazelcastTestSupport {
 
-    private static final int CALL_TIMEOUT = 1000;
+    private static final int CALL_TIMEOUT = 3000;
 
     private HazelcastInstance hz;
 
@@ -39,7 +39,7 @@ public class DurableLongRunningTaskTest extends HazelcastTestSupport {
     @Test
     public void test() {
         final String response = "foobar";
-        SleepingCallable task = new SleepingCallable(response, 10 * CALL_TIMEOUT);
+        SleepingCallable task = new SleepingCallable(response, 6 * CALL_TIMEOUT);
         final Future<String> f = hz.getDurableExecutorService("e").submit(task);
         assertTrueEventually(new AssertTask() {
             @Override


### PR DESCRIPTION
fixes #8584 
Also increased call-timeout of the DurableLongRunningTest.