### PR TITLE
Remove a block of entries from suppressions.xml

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -23,9 +23,8 @@
     <suppress checks="JavadocVariable" files="/impl/"/>
 
     <!-- Exclude internal packages from JavaDoc checks -->
-    <suppress checks="JavadocMethod" files="com/hazelcast/internal/"/>
-    <suppress checks="JavadocType" files="com/hazelcast/internal/"/>
-    <suppress checks="JavadocVariable" files="com/hazelcast/internal/"/>
+    <suppress checks="Javadoc(Method|Type|Variable)" files="com/hazelcast/internal/"/>
+    <suppress checks="Javadoc(Method|Type|Variable)" files="com/hazelcast/util/executor/"/>
 
     <!-- SerializerHook -->
     <suppress checks="MethodCount|MethodLength|ReturnCount|AnonInnerLength" files="SerializerHook\.java$"/>
@@ -310,19 +309,7 @@
     <suppress checks="MethodCount" files="com/hazelcast/map/impl/query/MapQueryEngineImpl"/>
     <suppress checks="NPathComplexity|CyclomaticComplexity" files="com/hazelcast/map/impl/SimpleEntryView"/>
 
-    <!-- Util (written by Doug Lea, Agrona backport etc.) -->
-    <suppress checks="MethodCount" files="com/hazelcast/collection/impl/collection/CollectionContainer"/>
-    <suppress checks="MagicNumber" files="com/hazelcast/util/QuickMath"/>
-    <suppress checks="MagicNumber" files="com/hazelcast/util/collection/"/>
-    <suppress checks="JavadocType" files="com/hazelcast/util/collection/\w*2ObjectHashMap"/>
-    <suppress checks="MethodCount" files="com/hazelcast/util/collection/\w*Hash\w*"/>
-    <suppress checks="SuperClone" files="com/hazelcast/util/collection/InflatableSet"/>
-    <suppress checks="NPathComplexity|CyclomaticComplexity" files="com/hazelcast/client/util/ClientDelegatingFuture"/>
-    <suppress checks="IllegalImport|InnerAssignment" files="com/hazelcast/internal/util/counters/SwCounter"/>
-    <suppress checks="JavadocMethod" files="com/hazelcast/util/executor/"/>
-    <suppress checks="JavadocType" files="com/hazelcast/util/executor/"/>
-    <suppress checks="JavadocVariable" files="com/hazelcast/util/executor/"/>
-    <suppress checks="NPathComplexity" files="com/hazelcast/util/executor/DelegatingFuture"/>
+    <!-- Adopted public domain code with different style -->
     <suppress checks="MagicNumber|DeclarationOrder|ConstantName|MultipleVariableDeclarations|NeedBracesCheck|Whitespace"
               files="com/hazelcast/internal/util/ThreadLocalRandom"/>
     <suppress checks="MagicNumber|FileLength|DeclarationOrder|RedundantModifier|InnerAssignment|NPath|Cyclomatic"

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -112,6 +112,7 @@ public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity"})
     public V get(long timeout, TimeUnit unit) throws InterruptedException,
             ExecutionException, TimeoutException {
         if (!done || !isResponseSet()) {

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainer.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@SuppressWarnings("checkstyle:methodcount")
 public abstract class CollectionContainer implements DataSerializable {
 
     protected final Map<Long, TxCollectionItem> txMap = new HashMap<Long, TxCollectionItem>();

--- a/hazelcast/src/main/java/com/hazelcast/util/QuickMath.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/QuickMath.java
@@ -23,6 +23,7 @@ package com.hazelcast.util;
  * Methods are <b>not</b> required to perform validation of input arguments, but they have to indicate the constraints
  * in theirs contract.
  */
+@SuppressWarnings("checkstyle:magicnumber")
 public final class QuickMath {
 
     private QuickMath() {

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/BiInt2ObjectMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/BiInt2ObjectMap.java
@@ -30,6 +30,10 @@ import java.util.Map;
  * @param <V> type of the object stored in the map.
  */
 public class BiInt2ObjectMap<V> {
+
+    @SuppressWarnings("checkstyle:magicnumber")
+    private static final long LOWER_INT_MASK = (1L << Integer.SIZE) - 1;
+
     /**
      * Handler for a map entry
      *
@@ -131,8 +135,8 @@ public class BiInt2ObjectMap<V> {
     public void forEach(final EntryConsumer<V> consumer) {
         for (Map.Entry<Long, V> entry : map.entrySet()) {
             Long compoundKey = entry.getKey();
-            final int keyPartA = (int) (compoundKey >>> 32);
-            final int keyPartB = (int) (compoundKey & 0xFFFFFFFFL);
+            final int keyPartA = (int) (compoundKey >>> Integer.SIZE);
+            final int keyPartB = (int) (compoundKey & LOWER_INT_MASK);
             consumer.accept(keyPartA, keyPartB, entry.getValue());
         }
     }
@@ -167,6 +171,6 @@ public class BiInt2ObjectMap<V> {
     }
 
     private static long compoundKey(final int keyPartA, final int keyPartB) {
-        return ((long) keyPartA << 32) | keyPartB;
+        return ((long) keyPartA << Integer.SIZE) | keyPartB;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
@@ -179,7 +179,8 @@ public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Se
      * @return a shallow copy of this set
      */
     @Override
-    @SuppressFBWarnings("CN_IDIOM")
+    @SuppressFBWarnings(value = "CN_IDIOM", justification = "Deliberate, documented contract violation")
+    @SuppressWarnings({"checkstyle:superclone", "CloneDoesntCallSuperClone"})
     protected Object clone() {
         return new InflatableSet<T>(this);
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Int2ObjectHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Int2ObjectHashMap.java
@@ -34,19 +34,19 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.collection.Hashing.intHash;
 
 /**
- * {@link java.util.Map} implementation specialised for int keys using open addressing and
- * linear probing for cache efficient access.
- *
- * NOTE: This map doesn't support {@code null} keys and values!
+ * {@link java.util.Map} implementation specialized for int keys using open addressing and
+ * linear probing for cache-efficient access.
+ * <p>
+ * <strong>NOTE: This map doesn't support {@code null} keys and values.</strong>
  *
  * @param <V> values stored in the {@link java.util.Map}
  */
 public class Int2ObjectHashMap<V> implements Map<Integer, V> {
 
-    /**
-     * The default load factor for constructors not explicitly supplying it
-     */
+    /** The default load factor for constructors not explicitly supplying it. */
     public static final double DEFAULT_LOAD_FACTOR = 0.6;
+    /** The default initial capacity for constructors not explicitly supplying it. */
+    public static final int DEFAULT_INITIAL_CAPACITY = 8;
 
     private final double loadFactor;
     private int resizeThreshold;
@@ -63,7 +63,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
     private final EntrySet entrySet = new EntrySet();
 
     public Int2ObjectHashMap() {
-        this(8, DEFAULT_LOAD_FACTOR);
+        this(DEFAULT_INITIAL_CAPACITY, DEFAULT_LOAD_FACTOR);
     }
 
     public Int2ObjectHashMap(int initialCapacity) {
@@ -114,23 +114,17 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
         return resizeThreshold;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int size() {
         return size;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean isEmpty() {
         return 0 == size;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean containsKey(final Object key) {
         checkNotNull(key, "Null keys are not permitted");
         return containsKey(((Integer) key).intValue());
@@ -153,9 +147,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean containsValue(final Object value) {
         checkNotNull(value, "Null values are not permitted");
         for (final Object v : values) {
@@ -166,9 +158,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public V get(final Object key) {
         return get(((Integer) key).intValue());
     }
@@ -212,9 +202,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
         return value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public V put(final Integer key, final V value) {
         return put(key.intValue(), value);
     }
@@ -249,9 +237,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
         return oldValue;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public V remove(final Object key) {
         return remove(((Integer) key).intValue());
     }
@@ -278,9 +264,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void clear() {
         size = 0;
         Arrays.fill(values, null);
@@ -295,25 +279,19 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
         rehash(QuickMath.nextPowerOfTwo(idealCapacity));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void putAll(final Map<? extends Integer, ? extends V> map) {
         for (final Entry<? extends Integer, ? extends V> entry : map.entrySet()) {
             put(entry.getKey(), entry.getValue());
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public KeySet keySet() {
         return keySet;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Collection<V> values() {
         return valueCollection;
     }
@@ -326,13 +304,12 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
      * makes the set unusable wherever the returned entries are
      * retained (such as <code>coll.addAll(entrySet)</code>.
      */
+    @Override
     public Set<Entry<Integer, V>> entrySet() {
         return entrySet;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
         sb.append('{');
@@ -404,36 +381,45 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
     // Internal Sets and Collections
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
+    /** Adds non-boxing methods to the standard Set interface. */
     public class KeySet extends AbstractSet<Integer> {
 
+        @Override
         public int size() {
             return Int2ObjectHashMap.this.size();
         }
 
+        @Override
         public boolean isEmpty() {
             return Int2ObjectHashMap.this.isEmpty();
         }
 
+        @Override
         public boolean contains(final Object o) {
             return Int2ObjectHashMap.this.containsKey(o);
         }
 
+        /** Non-boxing variant of contains(). */
         public boolean contains(final int key) {
             return Int2ObjectHashMap.this.containsKey(key);
         }
 
+        @Override
         public KeyIterator iterator() {
             return new KeyIterator();
         }
 
+        @Override
         public boolean remove(final Object o) {
             return null != Int2ObjectHashMap.this.remove(o);
         }
 
+        /** Non-boxing variant of remove(). */
         public boolean remove(final int key) {
             return null != Int2ObjectHashMap.this.remove(key);
         }
 
+        @Override
         public void clear() {
             Int2ObjectHashMap.this.clear();
         }
@@ -441,22 +427,27 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
 
     private class ValueCollection extends AbstractCollection<V> {
 
+        @Override
         public int size() {
             return Int2ObjectHashMap.this.size();
         }
 
+        @Override
         public boolean isEmpty() {
             return Int2ObjectHashMap.this.isEmpty();
         }
 
+        @Override
         public boolean contains(final Object o) {
             return Int2ObjectHashMap.this.containsValue(o);
         }
 
+        @Override
         public ValueIterator<V> iterator() {
             return new ValueIterator<V>();
         }
 
+        @Override
         public void clear() {
             Int2ObjectHashMap.this.clear();
         }
@@ -464,18 +455,22 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
 
     private class EntrySet extends AbstractSet<Entry<Integer, V>> {
 
+        @Override
         public int size() {
             return Int2ObjectHashMap.this.size();
         }
 
+        @Override
         public boolean isEmpty() {
             return Int2ObjectHashMap.this.isEmpty();
         }
 
+        @Override
         public Iterator<Entry<Integer, V>> iterator() {
             return new EntryIterator();
         }
 
+        @Override
         public void clear() {
             Int2ObjectHashMap.this.clear();
         }
@@ -511,6 +506,7 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
             return posCounter & mask;
         }
 
+        @Override
         public boolean hasNext() {
             for (int i = posCounter - 1; i >= stopCounter; i--) {
                 final int index = i & mask;
@@ -534,8 +530,10 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
             throw new NoSuchElementException();
         }
 
+        @Override
         public abstract T next();
 
+        @Override
         public void remove() {
             if (isPositionValid) {
                 final int position = getPosition();
@@ -549,7 +547,8 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
         }
     }
 
-    public class ValueIterator<T> extends AbstractIterator<T> {
+    private class ValueIterator<T> extends AbstractIterator<T> {
+        @Override
         @SuppressWarnings("unchecked")
         public T next() {
             findNext();
@@ -557,12 +556,15 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
         }
     }
 
+    /** Adds an unboxed next() method to the standard Iterator interface. */
     public class KeyIterator extends AbstractIterator<Integer> {
 
+        @Override
         public Integer next() {
             return nextInt();
         }
 
+        /** Non-boxing variant of next(). */
         public int nextInt() {
             findNext();
             return keys[getPosition()];
@@ -574,19 +576,23 @@ public class Int2ObjectHashMap<V> implements Map<Integer, V> {
             justification = "deliberate, documented choice")
     private class EntryIterator extends AbstractIterator<Entry<Integer, V>> implements Entry<Integer, V> {
 
+        @Override
         public Entry<Integer, V> next() {
             findNext();
             return this;
         }
 
+        @Override
         public Integer getKey() {
             return keys[getPosition()];
         }
 
+        @Override
         public V getValue() {
             return (V) values[getPosition()];
         }
 
+        @Override
         public V setValue(final V value) {
             checkNotNull(value);
             final int pos = getPosition();

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/IntHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/IntHashSet.java
@@ -32,6 +32,7 @@ import static com.hazelcast.util.collection.Hashing.intHash;
 /**
  * Simple fixed-size int hashset.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public final class IntHashSet implements Set<Integer> {
     /** Maximum supported capacity */
     @SuppressWarnings("checkstyle:magicnumber")
@@ -58,9 +59,7 @@ public final class IntHashSet implements Set<Integer> {
         iterator = new IntIterator(missingValue, values);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean add(final Integer value) {
         return add(value.intValue());
     }
@@ -91,9 +90,7 @@ public final class IntHashSet implements Set<Integer> {
         return true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean remove(final Object value) {
         return value instanceof Integer && remove(((Integer) value).intValue());
     }
@@ -144,16 +141,11 @@ public final class IntHashSet implements Set<Integer> {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean contains(final Object value) {
         return value instanceof Integer && contains(((Integer) value).intValue());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public boolean contains(final int value) {
         int index = intHash(value, mask);
 
@@ -168,23 +160,17 @@ public final class IntHashSet implements Set<Integer> {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int size() {
         return size;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean isEmpty() {
         return size() == 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void clear() {
         final int[] values = this.values;
         final int length = values.length;
@@ -194,9 +180,7 @@ public final class IntHashSet implements Set<Integer> {
         size = 0;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean addAll(final Collection<? extends Integer> coll) {
         return addAllCapture(coll);
     }
@@ -211,9 +195,7 @@ public final class IntHashSet implements Set<Integer> {
         return conjunction(coll, p);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean containsAll(final Collection<?> coll) {
         return containsAllCapture(coll);
     }
@@ -271,9 +253,7 @@ public final class IntHashSet implements Set<Integer> {
         return difference;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean removeAll(final Collection<?> coll) {
         return removeAllCapture(coll);
     }
@@ -298,17 +278,12 @@ public final class IntHashSet implements Set<Integer> {
         return acc;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public IntIterator iterator() {
         iterator.reset();
         return iterator;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public void copy(final IntHashSet obj) {
         // NB: mask also implies the length is the same
         if (this.mask != obj.mask) {
@@ -323,9 +298,7 @@ public final class IntHashSet implements Set<Integer> {
         this.size = obj.size;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public String toString() {
         final StringBuilder b = new StringBuilder(size() * 3 + 2);
         b.append('{');
@@ -337,9 +310,7 @@ public final class IntHashSet implements Set<Integer> {
         return b.append('}').toString();
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Object[] toArray() {
         final int[] values = this.values;
         final Object[] array = new Object[this.size];
@@ -352,9 +323,7 @@ public final class IntHashSet implements Set<Integer> {
         return array;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     @SuppressWarnings("unchecked")
     public <T> T[] toArray(T[] into) {
         checkNotNull(into);
@@ -376,9 +345,6 @@ public final class IntHashSet implements Set<Integer> {
         return (T[]) ret;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public boolean equals(final Object other) {
         if (other == this) {
             return true;
@@ -392,9 +358,6 @@ public final class IntHashSet implements Set<Integer> {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public int hashCode() {
         final IntIterator iterator = iterator();
         int total = 0;
@@ -407,6 +370,7 @@ public final class IntHashSet implements Set<Integer> {
 
     // --- Unimplemented below here
 
+    @Override
     public boolean retainAll(final Collection<?> coll) {
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2ObjectHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2ObjectHashMap.java
@@ -43,10 +43,10 @@ import static com.hazelcast.util.collection.Hashing.longHash;
  */
 public class Long2ObjectHashMap<V> implements Map<Long, V> {
 
-    /**
-     * The default load factor for constructors not explicitly supplying it
-     */
+    /** The default load factor for constructors not explicitly supplying it */
     public static final double DEFAULT_LOAD_FACTOR = 0.6;
+    /** The default initial capacity for constructors not explicitly supplying it */
+    public static final int DEFAULT_INITIAL_CAPACITY = 8;
 
     private final double loadFactor;
     private int resizeThreshold;
@@ -63,7 +63,7 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
     private final EntrySet entrySet = new EntrySet();
 
     public Long2ObjectHashMap() {
-        this(8, DEFAULT_LOAD_FACTOR);
+        this(DEFAULT_INITIAL_CAPACITY, DEFAULT_LOAD_FACTOR);
     }
 
     public Long2ObjectHashMap(int initialCapacity) {
@@ -114,23 +114,17 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
         return resizeThreshold;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public int size() {
         return size;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean isEmpty() {
         return 0 == size;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean containsKey(final Object key) {
         checkNotNull(key, "Null keys are not permitted");
         return containsKey(((Long) key).longValue());
@@ -153,9 +147,7 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public boolean containsValue(final Object value) {
         checkNotNull(value, "Null values are not permitted");
         for (final Object v : values) {
@@ -166,9 +158,7 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public V get(final Object key) {
         return get(((Long) key).longValue());
     }
@@ -212,9 +202,7 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
         return value;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public V put(final Long key, final V value) {
         return put(key.longValue(), value);
     }
@@ -249,9 +237,7 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
         return oldValue;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public V remove(final Object key) {
         return remove(((Long) key).longValue());
     }
@@ -278,9 +264,7 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void clear() {
         size = 0;
         Arrays.fill(values, null);
@@ -295,25 +279,19 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
         rehash(QuickMath.nextPowerOfTwo(idealCapacity));
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public void putAll(final Map<? extends Long, ? extends V> map) {
         for (final Entry<? extends Long, ? extends V> entry : map.entrySet()) {
             put(entry.getKey(), entry.getValue());
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public KeySet keySet() {
         return keySet;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Collection<V> values() {
         return valueCollection;
     }
@@ -326,13 +304,11 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
      * makes the set unusable wherever the returned entries are
      * retained (such as <code>coll.addAll(entrySet)</code>.
      */
+    @Override
     public Set<Entry<Long, V>> entrySet() {
         return entrySet;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public String toString() {
         final StringBuilder sb = new StringBuilder();
         sb.append('{');
@@ -404,36 +380,45 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
     // Internal Sets and Collections
     ///////////////////////////////////////////////////////////////////////////////////////////////
 
+    /** Adds non-boxing methods to the standard Set interface. */
     public class KeySet extends AbstractSet<Long> {
 
+        @Override
         public int size() {
             return Long2ObjectHashMap.this.size();
         }
 
+        @Override
         public boolean isEmpty() {
             return Long2ObjectHashMap.this.isEmpty();
         }
 
+        @Override
         public boolean contains(final Object o) {
             return Long2ObjectHashMap.this.containsKey(o);
         }
 
+        /** Non-boxing variant of contains(). */
         public boolean contains(final long key) {
             return Long2ObjectHashMap.this.containsKey(key);
         }
 
+        @Override
         public KeyIterator iterator() {
             return new KeyIterator();
         }
 
+        @Override
         public boolean remove(final Object o) {
             return null != Long2ObjectHashMap.this.remove(o);
         }
 
+        /** Non-boxing variant of remove(). */
         public boolean remove(final long key) {
             return null != Long2ObjectHashMap.this.remove(key);
         }
 
+        @Override
         public void clear() {
             Long2ObjectHashMap.this.clear();
         }
@@ -441,22 +426,27 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
 
     private class ValueCollection extends AbstractCollection<V> {
 
+        @Override
         public int size() {
             return Long2ObjectHashMap.this.size();
         }
 
+        @Override
         public boolean isEmpty() {
             return Long2ObjectHashMap.this.isEmpty();
         }
 
+        @Override
         public boolean contains(final Object o) {
             return Long2ObjectHashMap.this.containsValue(o);
         }
 
-        public ValueIterator<V> iterator() {
+        @Override
+        public Iterator<V> iterator() {
             return new ValueIterator<V>();
         }
 
+        @Override
         public void clear() {
             Long2ObjectHashMap.this.clear();
         }
@@ -464,18 +454,22 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
 
     private class EntrySet extends AbstractSet<Entry<Long, V>> {
 
+        @Override
         public int size() {
             return Long2ObjectHashMap.this.size();
         }
 
+        @Override
         public boolean isEmpty() {
             return Long2ObjectHashMap.this.isEmpty();
         }
 
+        @Override
         public Iterator<Entry<Long, V>> iterator() {
             return new EntryIterator();
         }
 
+        @Override
         public void clear() {
             Long2ObjectHashMap.this.clear();
         }
@@ -511,6 +505,7 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
             return posCounter & mask;
         }
 
+        @Override
         public boolean hasNext() {
             for (int i = posCounter - 1; i >= stopCounter; i--) {
                 final int index = i & mask;
@@ -534,8 +529,10 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
             throw new NoSuchElementException();
         }
 
+        @Override
         public abstract T next();
 
+        @Override
         public void remove() {
             if (isPositionValid) {
                 final int position = getPosition();
@@ -549,7 +546,8 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
         }
     }
 
-    public class ValueIterator<T> extends AbstractIterator<T> {
+    private class ValueIterator<T> extends AbstractIterator<T> {
+        @Override
         @SuppressWarnings("unchecked")
         public T next() {
             findNext();
@@ -557,15 +555,17 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
         }
     }
 
+    /** Adds an unboxed next() method to the standard Iterator interface. */
     public class KeyIterator extends AbstractIterator<Long> {
 
+        @Override
         public Long next() {
             return nextLong();
         }
 
+        /** Non-boxing variant of next(). */
         public long nextLong() {
             findNext();
-
             return keys[getPosition()];
         }
     }
@@ -575,19 +575,23 @@ public class Long2ObjectHashMap<V> implements Map<Long, V> {
             justification = "deliberate, documented choice")
     private class EntryIterator extends AbstractIterator<Entry<Long, V>> implements Entry<Long, V> {
 
+        @Override
         public Entry<Long, V> next() {
             findNext();
             return this;
         }
 
+        @Override
         public Long getKey() {
             return keys[getPosition()];
         }
 
+        @Override
         public V getValue() {
             return (V) values[getPosition()];
         }
 
+        @Override
         public V setValue(final V value) {
             checkNotNull(value);
             final int pos = getPosition();

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/LongHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/LongHashSet.java
@@ -32,6 +32,7 @@ import static com.hazelcast.util.collection.Hashing.longHash;
 /**
  * Simple fixed-size long hashset.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public final class LongHashSet implements Set<Long> {
     /** Maximum supported capacity */
     @SuppressWarnings("checkstyle:magicnumber")

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
@@ -63,8 +63,9 @@ public class DelegatingFuture<V> implements ICompletableFuture<V> {
     }
 
 
-    @SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
     @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
+    @SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
     public final V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         if (!done || value == null) {
             synchronized (mutex) {

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/Long2LongHashMapTest.java
@@ -199,9 +199,9 @@ public class Long2LongHashMapTest {
 
         final Iterator<Entry<Long, Long>> it = entrySet.iterator();
         assertTrue(it.hasNext());
-        assertEntryIs(it.next(), 1L, 1L);
-        assertTrue(it.hasNext());
         assertEntryIs(it.next(), 2L, 3L);
+        assertTrue(it.hasNext());
+        assertEntryIs(it.next(), 1L, 1L);
         assertFalse(it.hasNext());
     }
 
@@ -257,7 +257,7 @@ public class Long2LongHashMapTest {
     public void toStringShouldReportAllEntries() {
         map.put(1, 2);
         map.put(3, 4);
-        assertEquals("{3->4 1->2}", map.toString());
+        assertEquals("{1->2 3->4}", map.toString());
     }
 
     private static void assertEntryIs(final Entry<Long, Long> entry, final long expectedKey, final long expectedValue) {


### PR DESCRIPTION
At some places the CheckStyle complaint was fixed and at others a local `@SuppressWarnings` was added.

Also IntelliJ warnings have been honored about missing `@Override`, and redundant `/** @inheritDoc */` was removed.