### PR TITLE
Move concurrent array queues from EE Hot Restart module

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -9,12 +9,15 @@
     <!-- Suppress strict duplicate code checking -->
     <suppress checks="StrictDuplicateCode" files="\.java" lines="1-15"/>
 
-    <!-- Suppress checking of copyright notice -->
+    <!-- Suppress checking of copyright notice where additional attributions are made -->
     <suppress checks="Header" files="com/hazelcast/buildutils/ElementParser"/>
     <suppress checks="Header" files="com/hazelcast/logging/Log4j2Factory"/>
     <suppress checks="Header" files="com/hazelcast/util/HashUtil"/>
     <suppress checks="Header" files="com/hazelcast/util/QuickMath"/>
     <suppress checks="Header" files="com/hazelcast/util/collection/"/>
+    <suppress checks="Header" files="com/hazelcast/internal/util/collection/.*ConcurrentArrayQueue"/>
+    <suppress checks="Header" files="com/hazelcast/internal/util/collection/Pipe"/>
+    <suppress checks="Header" files="com/hazelcast/internal/util/collection/QueuedPipe"/>
 
     <!-- Exclude implementation packages from JavaDoc checks -->
     <suppress checks="JavadocPackage" files="/impl/"/>
@@ -310,7 +313,8 @@
     <suppress checks="MethodCount" files="com/hazelcast/map/impl/query/MapQueryEngineImpl"/>
     <suppress checks="NPathComplexity|CyclomaticComplexity" files="com/hazelcast/map/impl/SimpleEntryView"/>
 
-    <!-- Util (written by Doug Lea, Agrona backport etc.) -->
+    <!-- Util (written by Doug Lea, Agrona, etc.) -->
+    <suppress checks="OuterTypeNumber" files="com/hazelcast/internal/util/collection/AbstractConcurrentArrayQueue\.java"/>
     <suppress checks="MethodCount" files="com/hazelcast/collection/impl/collection/CollectionContainer"/>
     <suppress checks="MagicNumber" files="com/hazelcast/util/QuickMath"/>
     <suppress checks="MagicNumber" files="com/hazelcast/util/collection/"/>

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/AbstractConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/AbstractConcurrentArrayQueue.java
@@ -1,0 +1,232 @@
+/*
+ * Original work Copyright 2016 Real Logic Ltd.
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import com.hazelcast.util.QuickMath;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/** Pad out a cacheline to the left of producer fields to prevent false sharing. */
+@SuppressFBWarnings(value = "UuF", justification = "Fields used for padding are unused programatically")
+class AbstractConcurrentArrayQueuePadding1 {
+    @SuppressWarnings({"unused", "checkstyle:multiplevariabledeclarations"})
+    protected long p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15;
+}
+
+/** Values for the producer that are expected to be padded. */
+class AbstractConcurrentArrayQueueProducer extends AbstractConcurrentArrayQueuePadding1 {
+    protected static final AtomicLongFieldUpdater<AbstractConcurrentArrayQueueProducer> TAIL =
+            AtomicLongFieldUpdater.newUpdater(AbstractConcurrentArrayQueueProducer.class, "tail");
+    protected static final AtomicLongFieldUpdater<AbstractConcurrentArrayQueueProducer> SHARED_HEAD_CACHE =
+            AtomicLongFieldUpdater.newUpdater(AbstractConcurrentArrayQueueProducer.class, "sharedHeadCache");
+
+    protected volatile long tail;
+    protected long headCache;
+    protected volatile long sharedHeadCache;
+}
+
+/** Pad out a cacheline between the producer and consumer fields to prevent false sharing. */
+@SuppressFBWarnings(value = "UuF", justification = "Fields used for padding are unused programatically")
+class AbstractConcurrentArrayQueuePadding2 extends AbstractConcurrentArrayQueueProducer {
+    @SuppressWarnings({"unused", "checkstyle:multiplevariabledeclarations"})
+    protected long p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30;
+}
+
+/** Values for the consumer that are expected to be padded. */
+class AbstractConcurrentArrayQueueConsumer extends AbstractConcurrentArrayQueuePadding2 {
+    protected static final AtomicLongFieldUpdater<AbstractConcurrentArrayQueueConsumer> HEAD =
+            AtomicLongFieldUpdater.newUpdater(AbstractConcurrentArrayQueueConsumer.class, "head");
+
+    protected volatile long head;
+}
+
+/** Pad out a cacheline to the right of consumer fields to prevent false sharing. */
+@SuppressFBWarnings(value = "UuF", justification = "Fields used for padding are unused programatically")
+class AbstractConcurrentArrayQueuePadding3 extends AbstractConcurrentArrayQueueConsumer {
+    @SuppressWarnings({"unused", "checkstyle:multiplevariabledeclarations"})
+    protected long p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45;
+}
+
+/**
+ * Abstract base class for concurrent array queues.
+ * @param <E> type of elements in the queue.
+ */
+abstract class AbstractConcurrentArrayQueue<E>
+extends AbstractConcurrentArrayQueuePadding3
+implements QueuedPipe<E> {
+
+    protected final int capacity;
+    protected final AtomicReferenceArray<E> buffer;
+
+    @SuppressWarnings("unchecked")
+    protected AbstractConcurrentArrayQueue(int requestedCapacity) {
+        capacity = QuickMath.nextPowerOfTwo(requestedCapacity);
+        buffer = new AtomicReferenceArray(capacity);
+    }
+
+    @Override
+    public long addedCount() {
+        return tail;
+    }
+
+    @Override
+    public long removedCount() {
+        return head;
+    }
+
+    @Override
+    public int capacity() {
+        return capacity;
+    }
+
+    @Override
+    public int remainingCapacity() {
+        return capacity() - size();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public E peek() {
+        return buffer.get(seqToArrayIndex(head, capacity - 1));
+    }
+
+    @Override
+    public boolean add(E e) {
+        if (offer(e)) {
+            return true;
+        }
+        throw new IllegalStateException("Queue is full");
+    }
+
+    @Override
+    public E remove() {
+        final E e = poll();
+        if (e == null) {
+            throw new NoSuchElementException("Queue is empty");
+        }
+        return e;
+    }
+
+    @Override
+    public E element() {
+        final E e = peek();
+        if (e == null) {
+            throw new NoSuchElementException("Queue is empty");
+        }
+        return e;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return peek() == null;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        if (o == null) {
+            return false;
+        }
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        long mask = capacity - 1;
+        for (long i = head, limit = tail; i < limit; i++) {
+            final Object e = buffer.get(seqToArrayIndex(i, mask));
+            if (o.equals(e)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object[] toArray() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        for (final Object o : c) {
+            if (!contains(o)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        for (E e : c) {
+            add(e);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        Object value;
+        do {
+            value = poll();
+        } while (value != null);
+    }
+
+    @Override
+    public int size() {
+        long currentHeadBefore;
+        long currentTail;
+        long currentHeadAfter = head;
+        do {
+            currentHeadBefore = currentHeadAfter;
+            currentTail = tail;
+            currentHeadAfter = head;
+        } while (currentHeadAfter != currentHeadBefore);
+        return (int) (currentTail - currentHeadAfter);
+    }
+
+    protected static int seqToArrayIndex(long sequence, long mask) {
+        return (int) (sequence & mask);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ManyToOneConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ManyToOneConcurrentArrayQueue.java
@@ -1,0 +1,117 @@
+/*
+ * Original work Copyright 2016 Real Logic Ltd.
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import com.hazelcast.util.function.Consumer;
+
+/**
+ * Many producers to single consumer concurrent queue backed by an array. Adapted from the Agrona project.
+ *
+ * @param <E> type of the elements stored in the queue.
+ */
+public class ManyToOneConcurrentArrayQueue<E> extends AbstractConcurrentArrayQueue<E> {
+    public ManyToOneConcurrentArrayQueue(int requestedCapacity) {
+        super(requestedCapacity);
+    }
+
+    @Override
+    public boolean offer(E e) {
+        assert e != null : "attempt to offer a null element";
+
+        final int capacity = this.capacity;
+
+        long acquiredHead = sharedHeadCache;
+        long bufferLimit = acquiredHead + capacity;
+        long acquiredTail;
+        do {
+            acquiredTail = tail;
+            if (acquiredTail >= bufferLimit) {
+                acquiredHead = head;
+                bufferLimit = acquiredHead + capacity;
+                if (acquiredTail >= bufferLimit) {
+                    return false;
+                }
+                SHARED_HEAD_CACHE.lazySet(this, acquiredHead);
+            }
+        } while (!TAIL.compareAndSet(this, acquiredTail, acquiredTail + 1));
+        buffer.lazySet(seqToArrayIndex(acquiredTail, capacity - 1), e);
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public E poll() {
+        final long head = this.head;
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final int arrayIndex = seqToArrayIndex(head, capacity - 1);
+        final E item = buffer.get(arrayIndex);
+        if (item != null) {
+            buffer.lazySet(arrayIndex, null);
+            HEAD.lazySet(this, head + 1);
+        }
+        return item;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public int drain(Consumer<E> elementHandler) {
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long mask = capacity - 1;
+        final long acquiredHead = head;
+        final long limit = acquiredHead + mask + 1;
+
+        long nextSequence = acquiredHead;
+        while (nextSequence < limit) {
+            final int arrayIndex = seqToArrayIndex(nextSequence, mask);
+            final E item = buffer.get(arrayIndex);
+            if (item == null) {
+                break;
+            }
+            buffer.lazySet(arrayIndex, null);
+            nextSequence++;
+            HEAD.lazySet(this, nextSequence);
+            elementHandler.accept(item);
+        }
+        return (int) (nextSequence - acquiredHead);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public int drainTo(Collection<? super E> target, int limit) {
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long mask = capacity - 1;
+
+        long nextSequence = head;
+        int count = 0;
+        while (count < limit) {
+            final int arrayIndex = seqToArrayIndex(nextSequence, mask);
+            final E item = buffer.get(arrayIndex);
+            if (item == null) {
+                break;
+            }
+            buffer.lazySet(arrayIndex, null);
+            nextSequence++;
+            HEAD.lazySet(this, nextSequence);
+            count++;
+            target.add(item);
+        }
+        return count;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/OneToOneConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/OneToOneConcurrentArrayQueue.java
@@ -1,0 +1,120 @@
+/*
+ * Original work Copyright 2016 Real Logic Ltd.
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import com.hazelcast.util.function.Consumer;
+
+
+/**
+ * Single producer to single consumer concurrent queue backed by an array. Adapted from the Agrona project.
+ *
+ * @param <E> type of the elements stored in the queue.
+ */
+public class OneToOneConcurrentArrayQueue<E> extends AbstractConcurrentArrayQueue<E> {
+    public OneToOneConcurrentArrayQueue(final int requestedCapacity) {
+        super(requestedCapacity);
+    }
+
+    @Override
+    public boolean offer(final E e) {
+        assert e != null : "Attempted to offer null to a concurrent array queue";
+
+        final int capacity = this.capacity;
+        final long currentTail = tail;
+
+        long acquiredHead = headCache;
+        long bufferLimit = acquiredHead + capacity;
+        if (currentTail >= bufferLimit) {
+            acquiredHead = head;
+            bufferLimit = acquiredHead + capacity;
+            if (currentTail >= bufferLimit) {
+                return false;
+            }
+            headCache = acquiredHead;
+        }
+        final int arrayIndex = seqToArrayIndex(currentTail, capacity - 1);
+        buffer.lazySet(arrayIndex, e);
+        TAIL.lazySet(this, currentTail + 1);
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public E poll() {
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long currentHead = head;
+        final int arrayIndex = seqToArrayIndex(currentHead, capacity - 1);
+        final E e = buffer.get(arrayIndex);
+        if (e != null) {
+            buffer.lazySet(arrayIndex, null);
+            HEAD.lazySet(this, currentHead + 1);
+        }
+        return e;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public int drain(Consumer<E> elementHandler) {
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long mask = this.capacity - 1;
+        final long acquiredHead = head;
+        final long limit = acquiredHead + mask + 1;
+
+        long nextSequence = acquiredHead;
+        while (nextSequence < limit) {
+            final int arrayIndex = seqToArrayIndex(nextSequence, mask);
+            final E item = buffer.get(arrayIndex);
+            if (item == null) {
+                break;
+            }
+            buffer.lazySet(arrayIndex, null);
+            nextSequence++;
+            HEAD.lazySet(this, nextSequence);
+            elementHandler.accept(item);
+        }
+        return (int) (nextSequence - acquiredHead);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public int drainTo(final Collection<? super E> target, final int limit) {
+        if (limit <= 0) {
+            return 0;
+        }
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long mask = capacity - 1;
+
+        long nextSequence = head;
+        int count = 0;
+        while (count < limit) {
+            final int arrayIndex = seqToArrayIndex(nextSequence, mask);
+            final E item = buffer.get(arrayIndex);
+            if (item == null) {
+                break;
+            }
+            buffer.lazySet(arrayIndex, null);
+            nextSequence++;
+            HEAD.lazySet(this, nextSequence);
+            count++;
+            target.add(item);
+        }
+        return count;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Pipe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/Pipe.java
@@ -1,0 +1,75 @@
+/*
+ * Original work Copyright 2016 Real Logic Ltd.
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import java.util.Collection;
+import com.hazelcast.util.function.Consumer;
+
+/**
+ * A container for items processed in sequence
+ */
+public interface Pipe<E> {
+    /**
+     * The number of items added to this container since creation.
+     *
+     * @return the number of items added.
+     */
+    long addedCount();
+
+    /**
+     * The number of items removed from this container since creation.
+     *
+     * @return the number of items removed.
+     */
+    long removedCount();
+
+    /**
+     * The maximum capacity of this container to hold items.
+     *
+     * @return the capacity of the container.
+     */
+    int capacity();
+
+    /**
+     * Get the remaining capacity for elements in the container given the current size.
+     *
+     * @return remaining capacity of the container
+     */
+    int remainingCapacity();
+
+    /**
+     * Invoke a {@link Consumer} callback on each elements to drain the collection of elements until it is empty.
+     *
+     * If possible, implementations should use smart batching to best handle burst traffic.
+     *
+     * @param elementHandler to callback for processing elements
+     * @return the number of elements drained
+     */
+    int drain(Consumer<E> elementHandler);
+
+    /**
+     * Drain available elements into the provided {@link java.util.Collection} up to a provided maximum limit of elements.
+     *
+     * If possible, implementations should use smart batching to best handle burst traffic.
+     *
+     * @param target in to which elements are drained.
+     * @param limit  of the maximum number of elements to drain.
+     * @return the number of elements actually drained.
+     */
+    int drainTo(Collection<? super E> target, int limit);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/QueuedPipe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/QueuedPipe.java
@@ -1,0 +1,28 @@
+/*
+ * Original work Copyright 2016 Real Logic Ltd.
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import java.util.Queue;
+
+/**
+ * Composed interface for concurrent queues and sequenced containers.
+ *
+ * @param <E> type of the elements stored in the {@link java.util.Queue}.
+ */
+public interface QueuedPipe<E> extends Queue<E>, Pipe<E> {
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/ConcurrentArrayQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/ConcurrentArrayQueueTest.java
@@ -1,0 +1,202 @@
+/*
+ * Original work Copyright 2016 Real Logic Ltd.
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConcurrentArrayQueueTest {
+    @Parameters(name = "manyToOne == {0}")
+    public static Collection<Object[]> params() {
+        return asList(new Object[][] { {false}, {true} });
+    }
+
+    @Parameter public boolean manyToOne;
+
+    private QueuedPipe<Integer> q;
+
+    @Before public void setup() {
+        this.q = manyToOne ? new ManyToOneConcurrentArrayQueue<Integer>(2)
+                           : new OneToOneConcurrentArrayQueue<Integer>(2);
+    }
+
+    @Test public void when_offer_then_pollInOrder() {
+        q.offer(1);
+        q.offer(2);
+        assertEquals(1, (Object) q.poll());
+        assertEquals(2, (Object) q.poll());
+    }
+
+    @Test public void when_offerTooMany_then_rejectWithFalse() {
+        assertTrue(q.offer(1));
+        assertTrue(q.offer(2));
+        assertFalse(q.offer(3));
+    }
+
+    @Test public void when_pollTooMany_then_getNull() {
+        q.offer(1);
+        assertNotNull(q.poll());
+        assertNull(q.poll());
+    }
+
+    @Test public void when_offer_then_drainToList() {
+        q.offer(1);
+        q.offer(2);
+        final List<Integer> drained = new ArrayList<Integer>();
+        q.drainTo(drained, 2);
+        assertEquals(drained, asList(1, 2));
+    }
+
+    @Test public void when_add_then_removeInOrder() {
+        q.add(1);
+        q.add(2);
+        assertEquals(1, (Object) q.remove());
+        assertEquals(2, (Object) q.remove());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void when_addTooMany_then_exception() {
+        q.add(1);
+        q.add(2);
+        q.add(3);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void when_removeTooMany_then_exception() {
+        q.add(1);
+        q.remove();
+        q.remove();
+    }
+
+    @Test public void when_addAndRemove_then_addedCountTracksTotalAdded() {
+        q.add(4);
+        q.remove();
+        q.add(3);
+        assertEquals(2, q.addedCount());
+    }
+
+    @Test public void when_instantiateWithCapacityX_then_capacityReportsX() {
+        assertEquals(2, q.capacity());
+    }
+
+    @Test public void when_clear_then_pollNull() {
+        q.add(1);
+        q.clear();
+        assertNull(q.poll());
+    }
+
+    @Test public void when_add_then_contains() {
+        q.add(1);
+        assertTrue(q.contains(1));
+    }
+
+    @Test public void when_addSome_thenContainsAll() {
+        q.add(1);
+        q.add(2);
+        assertTrue(q.containsAll(asList(1, 2)));
+    }
+
+    @Test public void when_add_then_elementGetsIt() {
+        q.add(1);
+        assertEquals(1, (Object) q.element());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void when_addAndRemove_then_elementThrows() {
+        q.add(1);
+        q.remove();
+        q.element();
+    }
+
+    @Test public void when_empty_then_isEmptyGetsTrue() {
+        assertTrue(q.isEmpty());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void when_iterator_thenUnsupportedException() {
+        q.iterator();
+    }
+
+    @Test public void when_add_then_peek() {
+        q.add(1);
+        assertEquals(1, (Object) q.peek());
+    }
+
+    @Test public void when_add_then_remaningCapacityReduced() {
+        q.add(1);
+        assertEquals(1, q.remainingCapacity());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void when_removeSpecificObject_thenUnsupportedException() {
+        q.add(1);
+        q.remove(1);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void when_removeAll_thenUnsupportedException() {
+        q.add(1);
+        q.removeAll(singletonList(1));
+    }
+
+    @Test public void when_addAndRemove_thenRemovedCountTracksTotalRemoved() {
+        q.add(1);
+        q.remove();
+        assertEquals(1, q.removedCount());
+    }
+
+    @Test public void when_addAndRemove_thenSizeZero() {
+        q.add(1);
+        q.remove();
+        assertEquals(0, q.size());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void when_toArray_thenUnsupportedException() {
+        q.toArray();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void when_toArrayWithArg_thenUnsupportedException() {
+        q.toArray(null);
+    }
+}


### PR DESCRIPTION
1. Move the classes to OSS.
2. Catch up with Agrona's master, there were several performance touchups.
3. Remove the `Unsafe` dependency, instead code against `AtomicReferenceArray` and `AtomicLongFieldUpdater`.