### PR TITLE
[3.6.5] Use cluster time for operation heartbeat timeout checks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -509,7 +509,7 @@ abstract class Invocation implements OperationResponseHandler, Runnable {
         boolean hasWaitingThreads = invocationFuture.getWaitingThreadsCount() > 0;
         boolean notExpired = maxCallTimeout == Long.MAX_VALUE
                 || expirationTime < 0
-                || expirationTime >= Clock.currentTimeMillis();
+                || expirationTime >= nodeEngine.getClusterService().getClusterTime();
 
         if (hasResponse || hasWaitingThreads || notExpired || done) {
             return false;


### PR DESCRIPTION
Invocation is initiated with cluster time. Therefore, all timeout checks should be done using cluster time instead of local clock time. Otherwise, a clock shift that occurs after an invocation is initiated may cause premature operation timeouts.