### PR TITLE
[BACKPORT] Use cluster time for operation heartbeat timeout checks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -589,7 +589,7 @@ public abstract class Invocation implements OperationResponseHandler {
                 ? op.getInvocationTime() + callTimeoutMillis + heartbeatTimeoutMillis
                 : lastHeartbeatMillis + heartbeatTimeoutMillis;
 
-        if (heartbeatExpirationTimeMillis > Clock.currentTimeMillis()) {
+        if (heartbeatExpirationTimeMillis > context.clusterService.getClusterTime()) {
             return NO_TIMEOUT__HEARTBEAT_TIMEOUT_NOT_EXPIRED;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -36,7 +36,6 @@ import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
 import com.hazelcast.spi.impl.servicemanager.ServiceManager;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.util.Clock;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -403,7 +402,7 @@ class InvocationMonitor implements PacketHandler, MetricsProvider {
         @Override
         public void run0() {
             heartbeatPacketsReceived.inc();
-            long timeMillis = Clock.currentTimeMillis();
+            long timeMillis = nodeEngine.getClusterService().getClusterTime();
 
             updateMemberHeartbeat(timeMillis);
 


### PR DESCRIPTION
Invocation is initiated with cluster time. Therefore, all timeout checks should be done using cluster time instead of local clock time. Otherwise, a clock shift that occurs after an invocation is initiated may cause premature operation timeouts.