### PR TITLE
Backport of #8649 - Too many client cache Invalidation callbacks for a single ICache.clear call

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheClearTest;
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.CacheAddInvalidationListenerCodec;
+import com.hazelcast.client.impl.protocol.codec.CacheRemoveEntryListenerCodec;
+import com.hazelcast.client.spi.EventHandler;
+import com.hazelcast.client.spi.impl.ListenerMessageCodec;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientCacheClearTest
+        extends CacheClearTest {
+
+    private TestHazelcastFactory clientFactory;
+    private HazelcastInstance client;
+
+    @Override
+    protected TestHazelcastInstanceFactory getInstanceFactory(int instanceCount) {
+        clientFactory = new TestHazelcastFactory();
+        return clientFactory;
+    }
+
+    protected ClientConfig createClientConfig() {
+        final ClientConfig clientConfig = new ClientConfig();
+
+        NearCacheConfig nearCacheConfig = new NearCacheConfig("myCache");
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        nearCacheConfig.setCacheLocalEntries(false);
+        nearCacheConfig
+                .setEvictionConfig(new EvictionConfig(10000, EvictionConfig.MaxSizePolicy.ENTRY_COUNT, EvictionPolicy.LFU));
+        nearCacheConfig.setInvalidateOnChange(true);
+        nearCacheConfig.setLocalUpdatePolicy(NearCacheConfig.LocalUpdatePolicy.CACHE);
+        nearCacheConfig.setMaxIdleSeconds(600);
+        nearCacheConfig.setMaxSize(100);
+        nearCacheConfig.setTimeToLiveSeconds(60);
+
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+
+        return clientConfig;
+    }
+
+    @Override
+    protected void onSetup() {
+        super.onSetup();
+        ClientConfig clientConfig = createClientConfig();
+        client = clientFactory.newHazelcastClient(clientConfig);
+    }
+
+    @Test
+    public void testClientInvalidationListenerCallCount() {
+        ICache<String, String> cache = createCache();
+        Map<String, String> entries = createAndFillEntries();
+
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            cache.put(entry.getKey(), entry.getValue());
+        }
+
+        // Verify that put works
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            String key = entry.getKey();
+            String expectedValue = entries.get(key);
+            String actualValue = cache.get(key);
+            assertEquals(expectedValue, actualValue);
+        }
+
+        final AtomicInteger counter = new AtomicInteger(0);
+
+        CacheConfig config = cache.getConfiguration(CacheConfig.class);
+
+        registerInvalidationListener(new EventHandler() {
+            @Override
+            public void handle(Object event) {
+                counter.getAndIncrement();
+            }
+
+            @Override
+            public void beforeListenerRegister() {
+
+            }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
+        }, config.getNameWithPrefix());
+
+        cache.clear();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(1, counter.get());
+            }
+        }, 2);
+
+        // Make sure that the callback is not called for a while
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(counter.get() <= 1);
+            }
+        }, 3);
+
+    }
+
+    @Test
+    public void testClientInvalidationListenerCallCountWhenServerCacheClearUsed() {
+        ICache<String, String> cache = createCache();
+        Map<String, String> entries = createAndFillEntries();
+
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            cache.put(entry.getKey(), entry.getValue());
+        }
+
+        // Verify that put works
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            String key = entry.getKey();
+            String expectedValue = entries.get(key);
+            String actualValue = cache.get(key);
+            assertEquals(expectedValue, actualValue);
+        }
+
+        final AtomicInteger counter = new AtomicInteger(0);
+
+        CacheConfig config = cache.getConfiguration(CacheConfig.class);
+
+        registerInvalidationListener(new EventHandler() {
+            @Override
+            public void handle(Object event) {
+                counter.getAndIncrement();
+            }
+
+            @Override
+            public void beforeListenerRegister() {
+
+            }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
+        }, config.getNameWithPrefix());
+
+        CacheManager cacheManager = getCachingProvider(getHazelcastInstance()).getCacheManager();
+        Cache<Object, Object> serverCache = cacheManager.getCache(config.getName());
+        serverCache.clear();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(1, counter.get());
+            }
+        }, 2);
+
+        // Make sure that the callback is not called for a while
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(counter.get() <= 1);
+            }
+        }, 3);
+
+    }
+
+    @Override
+    protected void onTearDown() {
+        super.onTearDown();
+        // Client factory is already shutdown at this test's super class (`CachePutAllTest`)
+        // because it is returned instance factory from overriden `getInstanceFactory` method.
+        client = null;
+    }
+
+    @Override
+    protected CachingProvider getCachingProvider() {
+        return HazelcastClientCachingProvider.createCachingProvider(client);
+    }
+
+    private void registerInvalidationListener(EventHandler handler, String nameWithPrefix) {
+        ListenerMessageCodec listenerCodec = createInvalidationListenerCodec(nameWithPrefix);
+        HazelcastClientProxy hzClient = (HazelcastClientProxy) client;
+        final HazelcastClientInstanceImpl clientInstance = hzClient.client;
+        clientInstance.getListenerService().registerListener(listenerCodec, handler);
+    }
+
+    private ListenerMessageCodec createInvalidationListenerCodec(final String nameWithPrefix) {
+        return new ListenerMessageCodec() {
+            @Override
+            public ClientMessage encodeAddRequest(boolean localOnly) {
+                return CacheAddInvalidationListenerCodec.encodeRequest(nameWithPrefix, localOnly);
+            }
+
+            @Override
+            public String decodeAddResponse(ClientMessage clientMessage) {
+                return CacheAddInvalidationListenerCodec.decodeResponse(clientMessage).response;
+            }
+
+            @Override
+            public ClientMessage encodeRemoveRequest(String realRegistrationId) {
+                return CacheRemoveEntryListenerCodec.encodeRequest(nameWithPrefix, realRegistrationId);
+            }
+
+            @Override
+            public boolean decodeRemoveResponse(ClientMessage clientMessage) {
+                return CacheRemoveEntryListenerCodec.decodeResponse(clientMessage).response;
+            }
+        };
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -113,6 +113,9 @@ abstract class AbstractCacheProxyBase<K, V> {
         }
         loadAllTasks.clear();
 
+        // send invalidation event
+        cacheService.sendInvalidationEvent(nameWithPrefix, null, AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE);
+
         closeListeners();
         if (caughtException != null) {
             throw new CacheException("Problem while waiting for loadAll tasks to complete", caughtException);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -75,8 +75,8 @@ import static com.hazelcast.cache.impl.record.CacheRecordFactory.isExpiredAt;
 public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extends SampleableCacheRecordMap<Data, R>>
         implements ICacheRecordStore, EvictionListener<Data, R> {
 
+    public static final String SOURCE_NOT_AVAILABLE = "<NA>";
     protected static final int DEFAULT_INITIAL_CAPACITY = 256;
-    protected static final String SOURCE_NOT_AVAILABLE = "<NA>";
 
     protected final String name;
     protected final int partitionId;
@@ -1223,7 +1223,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         R record = records.get(key);
         int hitCount = 0;
         boolean removed = false;
-
         try {
             if (recordNotExistOrExpired(record, now)) {
                 if (isStatisticsEnabled()) {
@@ -1280,7 +1279,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         R record = records.get(key);
         final Object obj;
         boolean removed = false;
-
         try {
             if (recordNotExistOrExpired(record, now)) {
                 obj = null;
@@ -1451,11 +1449,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     @Override
     public void clear() {
         records.clear();
-        onClear();
-    }
-
-    protected void onClear() {
-        invalidateAllEntries();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -132,6 +132,10 @@ public abstract class AbstractCacheService
                 }
             }
         }
+
+        for (String objectName : configs.keySet()) {
+            sendInvalidationEvent(objectName, null, AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -72,12 +72,13 @@ abstract class AbstractInternalCacheProxy<K, V>
         implements ICacheInternal<K, V>, CacheSyncListenerCompleter {
 
     private static final long MAX_COMPLETION_LATCH_WAIT_TIME = TimeUnit.MINUTES.toMillis(5);
+
     private static final long COMPLETION_LATCH_WAIT_TIME_STEP = TimeUnit.SECONDS.toMillis(1);
-
     private final ConcurrentMap<CacheEntryListenerConfiguration, String> asyncListenerRegistrations;
-    private final ConcurrentMap<CacheEntryListenerConfiguration, String> syncListenerRegistrations;
 
+    private final ConcurrentMap<CacheEntryListenerConfiguration, String> syncListenerRegistrations;
     private final ConcurrentMap<Integer, CountDownLatch> syncLocks;
+
     private final AtomicInteger completionIdCounter = new AtomicInteger();
 
     protected AbstractInternalCacheProxy(CacheConfig cacheConfig, NodeEngine nodeEngine,
@@ -222,6 +223,9 @@ abstract class AbstractInternalCacheProxy<K, V>
             }
         } catch (Throwable t) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(t, CacheException.class);
+        } finally {
+            // send single invalidation event
+            cacheService.sendInvalidationEvent(nameWithPrefix, null, AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandler.java
@@ -31,6 +31,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.HashMap;
@@ -43,7 +44,6 @@ import java.util.concurrent.TimeUnit;
  * Handles split-brain functionality for cache.
  */
 class CacheSplitBrainHandler {
-
     private final NodeEngine nodeEngine;
     private final Map<String, CacheConfig> configs;
     private final CachePartitionSegment[] segments;
@@ -85,6 +85,12 @@ class CacheSplitBrainHandler {
                     }
                     // Clear all records either owned or backup
                     cacheRecordStore.clear();
+
+                    // send the cache invalidation event regardless if any actually cleared or not (no need to know how many
+                    // actually cleared)
+                    NodeEngineImpl node = (NodeEngineImpl) this.nodeEngine;
+                    final CacheService cacheService = node.getService(CacheService.SERVICE_NAME);
+                    cacheService.sendInvalidationEvent(cacheName, null, AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheClearRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/client/CacheClearRequest.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.cache.impl.client;
 
+import com.hazelcast.cache.impl.AbstractCacheRecordStore;
 import com.hazelcast.cache.impl.CacheOperationProvider;
 import com.hazelcast.cache.impl.CachePortableHook;
+import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cache.impl.operation.CacheClearOperationFactory;
 import com.hazelcast.client.impl.client.RetryableRequest;
@@ -122,6 +124,10 @@ public class CacheClearRequest
 
     @Override
     protected Object reduce(Map<Integer, Object> map) {
+        // send the invalidation event
+        CacheService cacheService = getService();
+        cacheService.sendInvalidationEvent(name, null, AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE);
+
         return map;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceProxy.java
@@ -255,7 +255,7 @@ public final class HazelcastInstanceProxy implements HazelcastInstance, Serializ
         return getOriginal().getSerializationService();
     }
 
-    private HazelcastInstanceImpl getOriginal() {
+    public HazelcastInstanceImpl getOriginal() {
         final HazelcastInstanceImpl hazelcastInstance = original;
         if (hazelcastInstance == null) {
             throw new HazelcastInstanceNotActiveException();

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheCloseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheCloseTest.java
@@ -1,0 +1,127 @@
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.CacheEventListener;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.client.CacheSingleInvalidationMessage;
+import com.hazelcast.cache.impl.operation.CacheDestroyOperation;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheCloseTest
+        extends CacheTestSupport {
+    private static final int INSTANCE_COUNT = 2;
+
+    private TestHazelcastInstanceFactory factory = getInstanceFactory(INSTANCE_COUNT);
+    private HazelcastInstance[] hazelcastInstances;
+    private HazelcastInstance hazelcastInstance;
+
+    protected TestHazelcastInstanceFactory getInstanceFactory(int instanceCount) {
+        return createHazelcastInstanceFactory(instanceCount);
+    }
+
+    @Override
+    protected void onSetup() {
+        Config config = createConfig();
+        hazelcastInstances = new HazelcastInstance[INSTANCE_COUNT];
+        for (int i = 0; i < INSTANCE_COUNT; i++) {
+            hazelcastInstances[i] = factory.newHazelcastInstance(config);
+        }
+        warmUpPartitions(hazelcastInstances);
+        waitAllForSafeState(hazelcastInstances);
+        hazelcastInstance = hazelcastInstances[0];
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.shutdownAll();
+        hazelcastInstances = null;
+        hazelcastInstance = null;
+    }
+
+
+    @Override
+    protected <K, V> CacheConfig<K, V> createCacheConfig() {
+        CacheConfig cacheConfig = super.createCacheConfig();
+        cacheConfig.setBackupCount(INSTANCE_COUNT - 1);
+        return cacheConfig;
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return hazelcastInstance;
+    }
+
+    @Test
+    public void testInvalidationListenerCallCount() {
+        final ICache<String, String> cache = createCache();
+
+        final AtomicInteger counter = new AtomicInteger(0);
+
+        final CacheConfig config = cache.getConfiguration(CacheConfig.class);
+
+        registerInvalidationListener(new CacheEventListener() {
+            @Override
+            public void handleEvent(Object eventObject) {
+                if (eventObject instanceof CacheSingleInvalidationMessage) {
+                    CacheSingleInvalidationMessage event = (CacheSingleInvalidationMessage) eventObject;
+                    if (null == event.getKey() && config.getNameWithPrefix().equals(event.getName())) {
+                        counter.incrementAndGet();
+                    }
+                }
+            }
+        }, config.getNameWithPrefix());
+
+        cache.close();
+
+        // Make sure that one event is received
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(1, counter.get());
+            }
+        }, 2);
+
+        // Make sure that the callback is not called for a while
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(counter.get() <= 1);
+            }
+        }, 3);
+
+    }
+
+    private void registerInvalidationListener(CacheEventListener cacheEventListener, String name) {
+        HazelcastInstanceProxy hzInstance = (HazelcastInstanceProxy) this.hazelcastInstance;
+        hzInstance.getOriginal().node.getNodeEngine().getEventService()
+                                     .registerListener(ICacheService.SERVICE_NAME, name, cacheEventListener);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
@@ -1,0 +1,160 @@
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.CacheEventListener;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.client.CacheSingleInvalidationMessage;
+import com.hazelcast.cache.impl.operation.CacheDestroyOperation;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheDestroyTest extends CacheTestSupport {
+    private static final int INSTANCE_COUNT = 2;
+
+    private TestHazelcastInstanceFactory factory = getInstanceFactory(INSTANCE_COUNT);
+    private HazelcastInstance[] hazelcastInstances;
+    private HazelcastInstance hazelcastInstance;
+
+    protected TestHazelcastInstanceFactory getInstanceFactory(int instanceCount) {
+        return createHazelcastInstanceFactory(instanceCount);
+    }
+
+    @Override
+    protected void onSetup() {
+        Config config = createConfig();
+        hazelcastInstances = new HazelcastInstance[INSTANCE_COUNT];
+        for (int i = 0; i < INSTANCE_COUNT; i++) {
+            hazelcastInstances[i] = factory.newHazelcastInstance(config);
+        }
+        warmUpPartitions(hazelcastInstances);
+        waitAllForSafeState(hazelcastInstances);
+        hazelcastInstance = hazelcastInstances[0];
+    }
+
+    @Override
+    protected void onTearDown() {
+        factory.shutdownAll();
+        hazelcastInstances = null;
+        hazelcastInstance = null;
+    }
+
+
+    @Override
+    protected <K, V> CacheConfig<K, V> createCacheConfig() {
+        CacheConfig cacheConfig = super.createCacheConfig();
+        cacheConfig.setBackupCount(INSTANCE_COUNT - 1);
+        return cacheConfig;
+    }
+
+    @Override
+    protected HazelcastInstance getHazelcastInstance() {
+        return hazelcastInstance;
+    }
+
+    @Test
+    public void test_cacheDestroyOperation() throws ExecutionException, InterruptedException {
+        final ICache<String, String> cache = createCache();
+
+        NodeEngineImpl nodeEngine1 = getNode(getHazelcastInstance()).getNodeEngine();
+        final ICacheService cacheService1 = nodeEngine1.getService(ICacheService.SERVICE_NAME);
+        InternalOperationService operationService1 = nodeEngine1.getOperationService();
+
+        NodeEngineImpl nodeEngine2 = getNode(hazelcastInstances[1]).getNodeEngine();
+        final ICacheService cacheService2 = nodeEngine2.getService(ICacheService.SERVICE_NAME);
+
+        final CacheConfig config = cache.getConfiguration(CacheConfig.class);
+        final String nameWithPrefix = config.getNameWithPrefix();
+        assertNotNull(cacheService1.getCacheConfig(nameWithPrefix));
+        assertNotNull(cacheService2.getCacheConfig(nameWithPrefix));
+
+        // Invoke on single node and the operation is also forward to others nodes by the operation itself
+        operationService1.invokeOnTarget(ICacheService.SERVICE_NAME,
+                                         new CacheDestroyOperation(nameWithPrefix),
+                                         nodeEngine1.getThisAddress());
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertNull(cacheService1.getCacheConfig(nameWithPrefix));
+                assertNull(cacheService2.getCacheConfig(nameWithPrefix));
+            }
+        });
+    }
+
+    @Test
+    public void testInvalidationListenerCallCount() {
+        final ICache<String, String> cache = createCache();
+
+        final AtomicInteger counter = new AtomicInteger(0);
+
+        final CacheConfig config = cache.getConfiguration(CacheConfig.class);
+
+        registerInvalidationListener(new CacheEventListener() {
+            @Override
+            public void handleEvent(Object eventObject) {
+                if (eventObject instanceof CacheSingleInvalidationMessage) {
+                    CacheSingleInvalidationMessage event = (CacheSingleInvalidationMessage) eventObject;
+                    if (null == event.getKey() && config.getNameWithPrefix().equals(event.getName())) {
+                        counter.incrementAndGet();
+                    }
+                }
+            }
+        }, config.getNameWithPrefix());
+
+        cache.destroy();
+
+        // Make sure that one event is received
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(1, counter.get());
+            }
+        }, 2);
+
+        // Make sure that the callback is not called for a while
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(counter.get() <= 1);
+            }
+        }, 3);
+
+    }
+
+    private void registerInvalidationListener(CacheEventListener cacheEventListener, String name) {
+        HazelcastInstanceProxy hzInstance = (HazelcastInstanceProxy) this.hazelcastInstance;
+        hzInstance.getOriginal().node.getNodeEngine().getEventService()
+                                     .registerListener(ICacheService.SERVICE_NAME, name, cacheEventListener);
+    }
+
+}


### PR DESCRIPTION
Fix for decreasing the cache clear callbacks for the client for a single clear request. Current implementation can cause up to parition count callbacks for a single clear request.

Added test for proving that the cache callback is only called one time during ICache.clear.

Added code for generating only one clear cache invalidation event when cache.clear is called. Test for ensuring only one clear cache invalidation event is sent for a cache.clear call is added.

Added invalidation event handling for other places where AbstractCacheRecordStore.clear is called.

Fixes issue #8593 