### PR TITLE
Diagnostics log file name change

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -150,7 +150,7 @@ public class NodeEngineImpl implements NodeEngine {
     private Diagnostics newDiagnostics() {
         Member localMember = node.getLocalMember();
         Address address = localMember.getAddress();
-        String addressString = address.getHost().replace(":", "_") + "#" + address.getPort();
+        String addressString = address.getHost().replace(":", "_") + "_" + address.getPort();
         String name = "diagnostics-" + addressString + "-" + currentTimeMillis();
 
         return new Diagnostics(


### PR DESCRIPTION
Customer had problem using '#' in name, so replaced by '_'