### PR TITLE
Clears member side local near cache after imap#clear call

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -220,6 +220,12 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
+    public void clearInternal() {
+        super.clearInternal();
+        nearCache.clear();
+    }
+
+    @Override
     public void loadAllInternal(boolean replaceExistingValues) {
         super.loadAllInternal(replaceExistingValues);
         if (replaceExistingValues) {


### PR DESCRIPTION
Problem does not likely happen in common case, because clear-operations also clear local near-caches on partition owners but for example when one sets partition count to 1 on 2 nodes, if member-near-cache is on the map#clear caller node and partition owner(assuming no backups also) is on other node, caller nodes' near cache will not be empty after map#clear call without this fix.