### PR TITLE
 Fix for decreasing the cache clear callbacks for the client for a single clear request - Forward Port of #8649

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache;
+
+import com.hazelcast.cache.CacheClearTest;
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.CacheAddInvalidationListenerCodec;
+import com.hazelcast.client.impl.protocol.codec.CacheRemoveEntryListenerCodec;
+import com.hazelcast.client.spi.EventHandler;
+import com.hazelcast.client.spi.impl.ListenerMessageCodec;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.spi.CachingProvider;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientCacheClearTest
+        extends CacheClearTest {
+
+    private TestHazelcastFactory clientFactory;
+    private HazelcastInstance client;
+
+    @Override
+    protected TestHazelcastInstanceFactory getInstanceFactory(int instanceCount) {
+        clientFactory = new TestHazelcastFactory();
+        return clientFactory;
+    }
+
+    protected ClientConfig createClientConfig() {
+        final ClientConfig clientConfig = new ClientConfig();
+
+        NearCacheConfig nearCacheConfig = new NearCacheConfig("myCache");
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        nearCacheConfig.setCacheLocalEntries(false);
+        nearCacheConfig
+                .setEvictionConfig(new EvictionConfig(10000, EvictionConfig.MaxSizePolicy.ENTRY_COUNT, EvictionPolicy.LFU));
+        nearCacheConfig.setInvalidateOnChange(true);
+        nearCacheConfig.setLocalUpdatePolicy(NearCacheConfig.LocalUpdatePolicy.CACHE);
+        nearCacheConfig.setMaxIdleSeconds(600);
+        nearCacheConfig.setMaxSize(100);
+        nearCacheConfig.setTimeToLiveSeconds(60);
+
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+
+        return clientConfig;
+    }
+
+    @Override
+    protected void onSetup() {
+        super.onSetup();
+        ClientConfig clientConfig = createClientConfig();
+        client = clientFactory.newHazelcastClient(clientConfig);
+    }
+
+    @Test
+    public void testClientInvalidationListenerCallCount() {
+        ICache<String, String> cache = createCache();
+        Map<String, String> entries = createAndFillEntries();
+
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            cache.put(entry.getKey(), entry.getValue());
+        }
+
+        // Verify that put works
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            String key = entry.getKey();
+            String expectedValue = entries.get(key);
+            String actualValue = cache.get(key);
+            assertEquals(expectedValue, actualValue);
+        }
+
+        final AtomicInteger counter = new AtomicInteger(0);
+
+        CacheConfig config = cache.getConfiguration(CacheConfig.class);
+
+        registerInvalidationListener(new EventHandler() {
+            @Override
+            public void handle(Object event) {
+                counter.getAndIncrement();
+            }
+
+            @Override
+            public void beforeListenerRegister() {
+
+            }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
+        }, config.getNameWithPrefix());
+
+        cache.clear();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(1, counter.get());
+            }
+        }, 2);
+
+        // Make sure that the callback is not called for a while
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(counter.get() <= 1);
+            }
+        }, 3);
+
+    }
+
+    @Test
+    public void testClientInvalidationListenerCallCountWhenServerCacheClearUsed() {
+        ICache<String, String> cache = createCache();
+        Map<String, String> entries = createAndFillEntries();
+
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            cache.put(entry.getKey(), entry.getValue());
+        }
+
+        // Verify that put works
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            String key = entry.getKey();
+            String expectedValue = entries.get(key);
+            String actualValue = cache.get(key);
+            assertEquals(expectedValue, actualValue);
+        }
+
+        final AtomicInteger counter = new AtomicInteger(0);
+
+        CacheConfig config = cache.getConfiguration(CacheConfig.class);
+
+        registerInvalidationListener(new EventHandler() {
+            @Override
+            public void handle(Object event) {
+                counter.getAndIncrement();
+            }
+
+            @Override
+            public void beforeListenerRegister() {
+
+            }
+
+            @Override
+            public void onListenerRegister() {
+
+            }
+        }, config.getNameWithPrefix());
+
+        ICache<Object, Object> serverCache = getHazelcastInstance().getCacheManager().getCache(config.getName());
+        serverCache.clear();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(1, counter.get());
+            }
+        }, 2);
+
+        // Make sure that the callback is not called for a while
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(counter.get() <= 1);
+            }
+        }, 3);
+
+    }
+
+    @Override
+    protected void onTearDown() {
+        super.onTearDown();
+        // Client factory is already shutdown at this test's super class (`CachePutAllTest`)
+        // because it is returned instance factory from overriden `getInstanceFactory` method.
+        client = null;
+    }
+
+    @Override
+    protected CachingProvider getCachingProvider() {
+        return HazelcastClientCachingProvider.createCachingProvider(client);
+    }
+
+    private void registerInvalidationListener(EventHandler handler, String nameWithPrefix) {
+        ListenerMessageCodec listenerCodec = createInvalidationListenerCodec(nameWithPrefix);
+        HazelcastClientProxy hzClient = (HazelcastClientProxy) client;
+        final HazelcastClientInstanceImpl clientInstance = hzClient.client;
+        clientInstance.getListenerService().registerListener(listenerCodec, handler);
+    }
+
+    private ListenerMessageCodec createInvalidationListenerCodec(final String nameWithPrefix) {
+        return new ListenerMessageCodec() {
+            @Override
+            public ClientMessage encodeAddRequest(boolean localOnly) {
+                return CacheAddInvalidationListenerCodec.encodeRequest(nameWithPrefix, localOnly);
+            }
+
+            @Override
+            public String decodeAddResponse(ClientMessage clientMessage) {
+                return CacheAddInvalidationListenerCodec.decodeResponse(clientMessage).response;
+            }
+
+            @Override
+            public ClientMessage encodeRemoveRequest(String realRegistrationId) {
+                return CacheRemoveEntryListenerCodec.encodeRequest(nameWithPrefix, realRegistrationId);
+            }
+
+            @Override
+            public boolean decodeRemoveResponse(ClientMessage clientMessage) {
+                return CacheRemoveEntryListenerCodec.decodeResponse(clientMessage).response;
+            }
+        };
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -141,6 +141,9 @@ abstract class AbstractCacheProxyBase<K, V>
         }
         loadAllTasks.clear();
 
+        // send invalidation event
+        cacheService.sendInvalidationEvent(nameWithPrefix, null, AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE);
+
         closeListeners();
         if (caughtException != null) {
             throw new CacheException("Problem while waiting for loadAll tasks to complete", caughtException);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -72,8 +72,8 @@ import static com.hazelcast.cache.impl.record.CacheRecordFactory.isExpiredAt;
 public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extends SampleableCacheRecordMap<Data, R>>
         implements ICacheRecordStore, EvictionListener<Data, R> {
 
+    public static final String SOURCE_NOT_AVAILABLE = "<NA>";
     protected static final int DEFAULT_INITIAL_CAPACITY = 256;
-    protected static final String SOURCE_NOT_AVAILABLE = "<NA>";
 
     protected final String name;
     protected final int partitionId;
@@ -1221,7 +1221,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         R record = records.get(key);
         int hitCount = 0;
         boolean removed = false;
-
         try {
             if (recordNotExistOrExpired(record, now)) {
                 if (isStatisticsEnabled()) {
@@ -1278,7 +1277,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         R record = records.get(key);
         Object obj;
         boolean removed = false;
-
         try {
             if (recordNotExistOrExpired(record, now)) {
                 obj = null;
@@ -1455,11 +1453,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     @Override
     public void clear() {
         records.clear();
-        onClear();
-    }
-
-    protected void onClear() {
-        invalidateAllEntries();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -138,6 +138,10 @@ public abstract class AbstractCacheService
                 }
             }
         }
+
+        for (String objectName : configs.keySet()) {
+            sendInvalidationEvent(objectName, null, AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -72,12 +72,13 @@ abstract class AbstractInternalCacheProxy<K, V>
         implements ICacheInternal<K, V>, CacheSyncListenerCompleter {
 
     private static final long MAX_COMPLETION_LATCH_WAIT_TIME = TimeUnit.MINUTES.toMillis(5);
+
     private static final long COMPLETION_LATCH_WAIT_TIME_STEP = TimeUnit.SECONDS.toMillis(1);
-
     private final ConcurrentMap<CacheEntryListenerConfiguration, String> asyncListenerRegistrations;
-    private final ConcurrentMap<CacheEntryListenerConfiguration, String> syncListenerRegistrations;
 
+    private final ConcurrentMap<CacheEntryListenerConfiguration, String> syncListenerRegistrations;
     private final ConcurrentMap<Integer, CountDownLatch> syncLocks;
+
     private final AtomicInteger completionIdCounter = new AtomicInteger();
 
     private HazelcastServerCacheManager cacheManager;
@@ -240,6 +241,9 @@ abstract class AbstractInternalCacheProxy<K, V>
             }
         } catch (Throwable t) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(t, CacheException.class);
+        } finally {
+            // send single invalidation event
+            cacheService.sendInvalidationEvent(nameWithPrefix, null, AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandler.java
@@ -43,7 +43,6 @@ import java.util.concurrent.TimeUnit;
  * Handles split-brain functionality for cache.
  */
 class CacheSplitBrainHandler {
-
     private final NodeEngine nodeEngine;
     private final Map<String, CacheConfig> configs;
     private final CachePartitionSegment[] segments;
@@ -85,6 +84,11 @@ class CacheSplitBrainHandler {
                     }
                     // Clear all records either owned or backup
                     cacheRecordStore.clear();
+
+                    // send the cache invalidation event regardless if any actually cleared or not (no need to know how many
+                    // actually cleared)
+                    final CacheService cacheService = nodeEngine.getService(CacheService.SERVICE_NAME);
+                    cacheService.sendInvalidationEvent(cacheName, null, AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE);
                 }
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheClearTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheClearTest.java
@@ -16,15 +16,19 @@
 
 package com.hazelcast.cache;
 
+import com.hazelcast.cache.impl.CacheEventListener;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.client.CacheSingleInvalidationMessage;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -35,10 +39,12 @@ import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -57,10 +63,7 @@ public class CacheClearTest extends CacheTestSupport {
     @Override
     protected void onSetup() {
         Config config = createConfig();
-        hazelcastInstances = new HazelcastInstance[INSTANCE_COUNT];
-        for (int i = 0; i < INSTANCE_COUNT; i++) {
-            hazelcastInstances[i] = factory.newHazelcastInstance(config);
-        }
+        hazelcastInstances = factory.newInstances(config, INSTANCE_COUNT);
         warmUpPartitions(hazelcastInstances);
         waitAllForSafeState(hazelcastInstances);
         hazelcastInstance = hazelcastInstances[0];
@@ -85,7 +88,7 @@ public class CacheClearTest extends CacheTestSupport {
         return hazelcastInstance;
     }
 
-    private Map<String, String> createAndFillEntries() {
+    protected Map<String, String> createAndFillEntries() {
         final int ENTRY_COUNT_PER_PARTITION = 3;
         Node node = getNode(hazelcastInstance);
         int partitionCount = node.getPartitionService().getPartitionCount();
@@ -165,4 +168,64 @@ public class CacheClearTest extends CacheTestSupport {
         }
     }
 
+    @Test
+    public void testInvalidationListenerCallCount() {
+        final ICache<String, String> cache = createCache();
+        Map<String, String> entries = createAndFillEntries();
+
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            cache.put(entry.getKey(), entry.getValue());
+        }
+
+        // Verify that put works
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            String key = entry.getKey();
+            String expectedValue = entries.get(key);
+            String actualValue = cache.get(key);
+            assertEquals(expectedValue, actualValue);
+        }
+
+        final AtomicInteger counter = new AtomicInteger(0);
+
+        final CacheConfig config = cache.getConfiguration(CacheConfig.class);
+
+        registerInvalidationListener(new CacheEventListener() {
+            @Override
+            public void handleEvent(Object eventObject) {
+                if (eventObject instanceof CacheSingleInvalidationMessage) {
+                    CacheSingleInvalidationMessage event = (CacheSingleInvalidationMessage) eventObject;
+                    if (null == event.getKey() && config.getNameWithPrefix().equals(event.getName())) {
+                        counter.incrementAndGet();
+                    }
+                }
+            }
+        }, config.getNameWithPrefix());
+
+        cache.clear();
+
+        // Make sure that one event is received
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(1, counter.get());
+            }
+        }, 2);
+
+        // Make sure that the callback is not called for a while
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertTrue(counter.get() <= 1);
+            }
+        }, 3);
+
+    }
+
+    private void registerInvalidationListener(CacheEventListener cacheEventListener, String name) {
+        HazelcastInstanceProxy hzInstance = (HazelcastInstanceProxy) this.hazelcastInstance;
+        hzInstance.getOriginal().node.getNodeEngine().getEventService()
+                                     .registerListener(ICacheService.SERVICE_NAME, name, cacheEventListener);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheCloseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheCloseTest.java
@@ -13,19 +13,15 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.cache.CacheManager;
 import javax.cache.spi.CachingProvider;
-
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -36,7 +32,8 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class CacheDestroyTest extends CacheTestSupport {
+public class CacheCloseTest
+        extends CacheTestSupport {
     private static final int INSTANCE_COUNT = 2;
 
     private TestHazelcastInstanceFactory factory = getInstanceFactory(INSTANCE_COUNT);
@@ -132,7 +129,7 @@ public class CacheDestroyTest extends CacheTestSupport {
             }
         }, config.getNameWithPrefix());
 
-        cache.destroy();
+        cache.close();
 
         // Make sure that one event is received
         assertTrueEventually(new AssertTask() {


### PR DESCRIPTION
Fix for decreasing the cache clear callbacks for the client for a single clear request. Current implementation can cause up to partition count callbacks for a single clear request.  Added code for generating only one clear cache invalidation event when  cache.clear is called. New tests are added to test this behaviour. (Forward port of #8649)