### PR TITLE
Makes imap#clear and imap#evictAll to send only one clear event to cl…

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -968,6 +968,10 @@ public class ClientMapProxy<K, V>
     public void loadAll(boolean replaceExistingValues) {
         ClientMessage request = MapLoadAllCodec.encodeRequest(name, replaceExistingValues);
         invoke(request);
+
+        if (replaceExistingValues) {
+            clearNearCachesOnLiteMembers();
+        }
     }
 
     @Override
@@ -979,6 +983,10 @@ public class ClientMapProxy<K, V>
 
         Collection<Data> dataKeys = CollectionUtil.objectToDataCollection(keys, getSerializationService());
         loadAllInternal(replaceExistingValues, dataKeys);
+
+        if (replaceExistingValues) {
+            clearNearCachesOnLiteMembers();
+        }
     }
 
     protected void loadAllInternal(boolean replaceExistingValues, Collection<Data> dataKeys) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.map.impl.nearcache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddNearCacheEntryListenerCodec;
+import com.hazelcast.client.proxy.NearCachedClientMapProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
@@ -55,11 +56,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -77,7 +81,7 @@ public class ClientMapNearCacheTest {
 
     @Parameterized.Parameters(name = "batchInvalidationEnabled:{0}")
     public static Iterable<Object[]> parameters() {
-        return Arrays.asList(new Object[]{Boolean.TRUE}, new Object[]{Boolean.FALSE});
+        return Arrays.asList(new Object[]{TRUE}, new Object[]{FALSE});
     }
 
     protected static final int MAX_TTL_SECONDS = 3;
@@ -983,6 +987,176 @@ public class ClientMapNearCacheTest {
     }
 
     @Test
+    public void receives_one_clearEvent_after_mapClear_call_from_client() throws ExecutionException, InterruptedException {
+        // populate near-cache
+        IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(newNearCacheConfig());
+        populateNearCache(clientMap, 1000);
+
+        // add test listener to count clear events
+        final ClearEventCounterEventHandler handler = new ClearEventCounterEventHandler();
+        ((NearCachedClientMapProxy) clientMap).addNearCacheInvalidateListener(handler);
+
+        // create a new client to send events
+        HazelcastInstance anotherClient = hazelcastFactory.newHazelcastClient(newClientConfig());
+        IMap<Object, Object> anotherClientMap = anotherClient.getMap(clientMap.getName());
+        anotherClientMap.clear();
+
+        // sleep for a while to see there is another clear event coming
+        sleepSeconds(2);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("Expecting only 1 clear event", 1, handler.getClearEventCount());
+            }
+        });
+    }
+
+    @Test
+    public void receives_one_clearEvent_after_mapClear_call_from_member() throws ExecutionException, InterruptedException {
+        // populate near-cache
+        IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(newNearCacheConfig());
+        populateNearCache(clientMap, 1000);
+
+        // member comes
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(newConfig());
+
+        // add test listener to count clear events
+        final ClearEventCounterEventHandler handler = new ClearEventCounterEventHandler();
+        ((NearCachedClientMapProxy) clientMap).addNearCacheInvalidateListener(handler);
+
+        // call map#clear
+        IMap<Object, Object> memberMap = member.getMap(clientMap.getName());
+        memberMap.clear();
+
+        // sleep for a while to see there is another clear event coming
+        sleepSeconds(2);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("Expecting only 1 clear event", 1, handler.getClearEventCount());
+            }
+        });
+    }
+
+    @Test
+    public void receives_one_clearEvent_after_mapEvictAll_call_from_client() throws ExecutionException, InterruptedException {
+        // populate near-cache
+        IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(newNearCacheConfig());
+        populateNearCache(clientMap, 1000);
+
+        // add test listener to count clear events
+        final ClearEventCounterEventHandler handler = new ClearEventCounterEventHandler();
+        ((NearCachedClientMapProxy) clientMap).addNearCacheInvalidateListener(handler);
+
+        // call evictAll
+        HazelcastInstance anotherClient = hazelcastFactory.newHazelcastClient(newClientConfig());
+        IMap<Object, Object> anotherClientMap = anotherClient.getMap(clientMap.getName());
+        anotherClientMap.evictAll();
+
+        // sleep for a while to see there is another clear event coming
+        sleepSeconds(2);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("Expecting only 1 clear event", 1, handler.getClearEventCount());
+            }
+        });
+    }
+
+    @Test
+    public void receives_one_clearEvent_after_mapEvictAll_call_from_member() throws ExecutionException, InterruptedException {
+        // populate near-cache
+        IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(newNearCacheConfig());
+        populateNearCache(clientMap, 1000);
+
+        // member comes
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(newConfig());
+
+        // add test listener to count clear events
+        final ClearEventCounterEventHandler handler = new ClearEventCounterEventHandler();
+        ((NearCachedClientMapProxy) clientMap).addNearCacheInvalidateListener(handler);
+
+        // call evictAll
+        IMap memberMap = member.getMap(clientMap.getName());
+        memberMap.evictAll();
+
+        // sleep for a while to see there is another clear event coming
+        sleepSeconds(2);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("Expecting only 1 clear event", 1, handler.getClearEventCount());
+            }
+        });
+    }
+
+    @Test
+    public void receives_one_clearEvent_after_mapLoadAll_call_from_client() throws ExecutionException, InterruptedException {
+        // configure map-store
+        Config config = newConfig();
+        config.getMapConfig("default").getMapStoreConfig().setEnabled(true).setImplementation(new SimpleMapStore());
+
+        // populate near-cache
+        IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(config, newNearCacheConfig());
+        populateNearCache(clientMap, 1000);
+
+        // add test listener to count clear events
+        final ClearEventCounterEventHandler handler = new ClearEventCounterEventHandler();
+        ((NearCachedClientMapProxy) clientMap).addNearCacheInvalidateListener(handler);
+
+        // create a new client to send events
+        HazelcastInstance anotherClient = hazelcastFactory.newHazelcastClient(newClientConfig());
+        IMap<Object, Object> anotherClientMap = anotherClient.getMap(clientMap.getName());
+        anotherClientMap.loadAll(true);
+
+        // sleep for a while to see there is another clear event coming
+        sleepSeconds(2);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("Expecting only 1 clear event", 1, handler.getClearEventCount());
+            }
+        });
+    }
+
+    @Test
+    public void receives_one_clearEvent_after_mapLoadAll_call_from_member() throws ExecutionException, InterruptedException {
+        // configure map-store
+        Config config = newConfig();
+        config.getMapConfig("default").getMapStoreConfig().setEnabled(true).setImplementation(new SimpleMapStore());
+
+        // member comes
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
+
+        // populate near-cache
+        IMap<Integer, Integer> clientMap = getNearCachedMapFromClient(config, newNearCacheConfig());
+        populateNearCache(clientMap, 1000);
+
+        // add test listener to count clear events
+        final ClearEventCounterEventHandler handler = new ClearEventCounterEventHandler();
+        ((NearCachedClientMapProxy) clientMap).addNearCacheInvalidateListener(handler);
+
+        // create a new client to send events
+        IMap<Object, Object> memberMap = member.getMap(clientMap.getName());
+        memberMap.loadAll(true);
+
+        // sleep for a while to see there is another clear event coming
+        sleepSeconds(2);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals("Expecting only 1 clear event", 1, handler.getClearEventCount());
+            }
+        });
+    }
+
+    @Test
     public void testNearCacheInvalidation_WithLFU_whenMaxSizeExceeded() throws Exception {
         assertNearCacheInvalidation_whenMaxSizeExceeded(newLFUMaxSizeNearCacheConfig());
     }
@@ -1080,6 +1254,42 @@ public class ClientMapNearCacheTest {
         map.getAsync(1).get();
         Thread.sleep(1000);
         assertNull(map.getAsync(1).get());
+    }
+
+
+    private static final class ClearEventCounterEventHandler
+            extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler implements EventHandler<ClientMessage> {
+
+        private final AtomicInteger clearEventCount = new AtomicInteger();
+
+        public ClearEventCounterEventHandler() {
+        }
+
+        @Override
+        public void handle(Data data) {
+            if (data == null) {
+                clearEventCount.incrementAndGet();
+            }
+        }
+
+        @Override
+        public void handle(Collection<Data> collection) {
+
+        }
+
+        @Override
+        public void beforeListenerRegister() {
+
+        }
+
+        @Override
+        public void onListenerRegister() {
+
+        }
+
+        public int getClearEventCount() {
+            return clearEventCount.get();
+        }
     }
 
     protected void populateNearCache(IMap<Integer, Integer> map, int size) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAllPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAllPartitionsMessageTask.java
@@ -21,8 +21,12 @@ import com.hazelcast.client.impl.protocol.task.AbstractAllPartitionsMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.nearcache.NearCacheInvalidator;
+import com.hazelcast.map.impl.nearcache.NearCacheProvider;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.nio.Connection;
+
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 abstract class AbstractMapAllPartitionsMessageTask<P> extends AbstractAllPartitionsMessageTask<P> {
 
@@ -31,8 +35,16 @@ abstract class AbstractMapAllPartitionsMessageTask<P> extends AbstractAllPartiti
     }
 
     protected final MapOperationProvider getOperationProvider(String mapName) {
-        MapService mapService = getService(MapService.SERVICE_NAME);
+        MapService mapService = getService(SERVICE_NAME);
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         return mapServiceContext.getMapOperationProvider(mapName);
+    }
+
+    protected final void sendClientNearCacheClearEvent(String mapName) {
+        MapService mapService = getService(SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        NearCacheProvider nearCacheProvider = mapServiceContext.getNearCacheProvider();
+        NearCacheInvalidator nearCacheInvalidator = nearCacheProvider.getNearCacheInvalidator();
+        nearCacheInvalidator.sendClientNearCacheClearEvent(mapName, nodeEngine.getLocalMember().getUuid());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/AbstractNearCacheInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/AbstractNearCacheInvalidator.java
@@ -72,7 +72,8 @@ public abstract class AbstractNearCacheInvalidator implements NearCacheInvalidat
         }
     }
 
-    public void clearLocal(String mapName) {
+    @Override
+    public void clearLocalNearCache(String mapName) {
         if (!isMemberNearCacheInvalidationEnabled(mapName)) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchInvalidator.java
@@ -94,13 +94,8 @@ public class BatchInvalidator extends AbstractNearCacheInvalidator {
     }
 
     @Override
-    public void clear(String mapName, boolean owner, String sourceUuid) {
-        if (owner) {
-            // only send invalidation event to clients, server near-caches are cleared by ClearOperation.
-            invalidateClient(new CleaningNearCacheInvalidation(mapName, sourceUuid));
-        }
-
-        clearLocal(mapName);
+    public void sendClientNearCacheClearEvent(String mapName, String sourceUuid) {
+        invalidateClient(new CleaningNearCacheInvalidation(mapName, sourceUuid));
     }
 
     private void invalidateInternal(String mapName, Data key, List<Data> keys, String sourceUuid) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
@@ -51,14 +51,20 @@ public interface NearCacheInvalidator {
 
 
     /**
-     * Clears local and remote near-caches.
-     * Local near-caches are node local, remote near-caches can be exist on remote members or clients.
+     * Clears local members near-cache.
+     *
+     * @param mapName name of the map.
+     */
+    void clearLocalNearCache(String mapName);
+
+
+    /**
+     * Send clear event to client-side near-cache invalidation listeners.
      *
      * @param mapName    name of the map.
-     * @param owner      <code>true</code> if this method is called from partition owner, otherwise <code>false</code>.
      * @param sourceUuid caller uuid
      */
-    void clear(String mapName, boolean owner, String sourceUuid);
+    void sendClientNearCacheClearEvent(String mapName, String sourceUuid);
 
     /**
      * Removes supplied maps invalidation queue and flushes its content.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NonStopInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NonStopInvalidator.java
@@ -50,13 +50,8 @@ public class NonStopInvalidator extends AbstractNearCacheInvalidator {
     }
 
     @Override
-    public void clear(String mapName, boolean owner, String sourceUuid) {
-        if (owner) {
-            // only send invalidation event to clients, server near-caches are cleared by ClearOperation.
-            invalidateClient(mapName, null, null, sourceUuid);
-        }
-
-        clearLocal(mapName);
+    public void sendClientNearCacheClearEvent(String mapName, String sourceUuid) {
+        invalidateClient(mapName, null, null, sourceUuid);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -35,7 +35,7 @@ public class ClearBackupOperation extends MapOperation implements BackupOperatio
     public void run() {
         // clear near-cache also on this backup operation, there is a possibility that no owner partition exists on this
         // node but a near-cache exists.
-        clearNearCache(false);
+        clearLocalNearCache();
 
         if (recordStore != null) {
             recordStore.clear();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearNearCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearNearCacheOperation.java
@@ -29,7 +29,7 @@ public class ClearNearCacheOperation extends MapOperation implements MutatingOpe
 
     @Override
     public void run() {
-        clearNearCache(false);
+        clearLocalNearCache();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -43,7 +43,7 @@ public class ClearOperation extends MapOperation implements BackupAwareOperation
     public void run() {
         // near-cache clear will be called multiple times by each clear operation,
         // but it's still preferred to send a separate operation to clear near-cache.
-        clearNearCache(true);
+        clearLocalNearCache();
 
         if (recordStore == null) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllBackupOperation.java
@@ -37,7 +37,7 @@ public class EvictAllBackupOperation extends MapOperation implements BackupOpera
 
     @Override
     public void run() throws Exception {
-        clearNearCache(false);
+        clearLocalNearCache();
 
         if (recordStore == null) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -48,7 +48,7 @@ public class EvictAllOperation extends MapOperation implements BackupAwareOperat
     public void run() throws Exception {
 
         // TODO this also clears locked keys from near cache which should be preserved.
-        clearNearCache(true);
+        clearLocalNearCache();
 
         if (recordStore == null) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
@@ -61,6 +61,15 @@ public class LoadAllOperation extends MapOperation implements PartitionAwareOper
         recordStore.loadAllFromStore(keys);
     }
 
+    @Override
+    public void afterRun() throws Exception {
+        if (replaceExistingValues) {
+            clearLocalNearCache();
+        }
+
+        super.afterRun();
+    }
+
     private void removeExistingKeys(Collection<Data> keys) {
         if (keys == null || keys.isEmpty()) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -116,12 +116,12 @@ public abstract class MapOperation extends AbstractNamedOperation {
         nearCacheProvider.getNearCacheInvalidator().invalidate(name, key, getCallerUuid());
     }
 
-    protected final void clearNearCache(boolean owner) {
+    protected final void clearLocalNearCache() {
         if (!mapContainer.isInvalidationEnabled()) {
             return;
         }
         NearCacheProvider nearCacheProvider = mapServiceContext.getNearCacheProvider();
-        nearCacheProvider.getNearCacheInvalidator().clear(name, owner, getCallerUuid());
+        nearCacheProvider.getNearCacheInvalidator().clearLocalNearCache(name);
     }
 
     protected void evict(Data excludedKey) {


### PR DESCRIPTION
…ients near-cache-invalidation-listener

backport of https://github.com/hazelcast/hazelcast/pull/8697