### PR TITLE
Backport #8737 Missing client near cache invalidation test for ICache.loadAll

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -90,6 +90,18 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
+    public void testLoadAllNearCacheInvalidationBinary()
+            throws InterruptedException {
+        testLoadAllNearCacheInvalidation(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void testLoadAllNearCacheInvalidationObject()
+            throws InterruptedException {
+        testLoadAllNearCacheInvalidation(InMemoryFormat.OBJECT);
+    }
+
+    @Test
     public void putToCacheAndClearOrDestroyThenCantGetAnyRecordFromClientNearCacheWithBinaryInMemoryFormat() {
         putToCacheAndClearOrDestroyThenCantGetAnyRecordFromClientNearCache(InMemoryFormat.BINARY);
     }


### PR DESCRIPTION
Backports #8737
Added test to verify that near cache invalidations work for ICache.loadAll as expected.