### PR TITLE
Small cleanup of NearCache related classes.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -54,6 +54,7 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.executor.CompletedFuture;
 
@@ -168,7 +169,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
 
         if (nearCache != null) {
             statistics = new ClientCacheStatisticsImpl(System.currentTimeMillis(),
-                                                       nearCache.getNearCacheStats());
+                    nearCache.getNearCacheStats());
         } else {
             statistics = new ClientCacheStatisticsImpl(System.currentTimeMillis());
         }
@@ -503,11 +504,11 @@ abstract class AbstractClientInternalCacheProxy<K, V>
 
     private Object putInternalAsync(final V value, final boolean isGet, final long start, final Data keyData,
                                     final Data valueData, ClientInvocationFuture future) {
-        OneShotExecutionCallback oneShotExecutionCallback = null;
+        OneShotExecutionCallback<V> oneShotExecutionCallback = null;
         if (nearCache != null || statisticsEnabled) {
-            oneShotExecutionCallback = new OneShotExecutionCallback() {
+            oneShotExecutionCallback = new OneShotExecutionCallback<V>() {
                 @Override
-                protected void onResponseInternal(Object responseData) {
+                protected void onResponseInternal(V responseData) {
                     if (nearCache != null) {
                         if (cacheOnUpdate) {
                             storeInNearCache(keyData, valueData, value);
@@ -525,24 +526,21 @@ abstract class AbstractClientInternalCacheProxy<K, V>
                 }
             };
         }
-        ClientDelegatingFuture delegatingFuture;
-        if (oneShotExecutionCallback != null) {
-            delegatingFuture =
-                    new CallbackAwareClientDelegatingFuture(future, clientContext.getSerializationService(),
-                            PUT_RESPONSE_DECODER, oneShotExecutionCallback);
-            delegatingFuture.andThen(oneShotExecutionCallback);
-        } else {
-            delegatingFuture =
-                    new ClientDelegatingFuture(future, clientContext.getSerializationService(), PUT_RESPONSE_DECODER);
+        SerializationService serializationService = clientContext.getSerializationService();
+        if (oneShotExecutionCallback == null) {
+            return new ClientDelegatingFuture<V>(future, serializationService, PUT_RESPONSE_DECODER);
         }
+        ClientDelegatingFuture<V> delegatingFuture = new CallbackAwareClientDelegatingFuture<V>(future,
+                serializationService, PUT_RESPONSE_DECODER, oneShotExecutionCallback);
+        delegatingFuture.andThen(oneShotExecutionCallback);
         return delegatingFuture;
     }
 
     private Object putInternalSync(V value, boolean isGet, long start, Data keyData, Data valueData,
                                    ClientInvocationFuture future) {
         try {
-            ClientDelegatingFuture delegatingFuture = new ClientDelegatingFuture(future, clientContext.getSerializationService(),
-                    PUT_RESPONSE_DECODER);
+            ClientDelegatingFuture delegatingFuture = new ClientDelegatingFuture(future,
+                    clientContext.getSerializationService(), PUT_RESPONSE_DECODER);
             Object response = delegatingFuture.get();
             if (nearCache != null) {
                 if (cacheOnUpdate) {
@@ -574,7 +572,8 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         }
     }
 
-    protected Object putIfAbsentInternal(K key, V value, ExpiryPolicy expiryPolicy, boolean withCompletionEvent, boolean async) {
+    protected Object putIfAbsentInternal(K key, V value, ExpiryPolicy expiryPolicy, boolean withCompletionEvent,
+                                         boolean async) {
         long start = System.nanoTime();
         ensureOpen();
         validateNotNull(key, value);
@@ -984,5 +983,4 @@ abstract class AbstractClientInternalCacheProxy<K, V>
             }
         }
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CallbackAwareClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CallbackAwareClientDelegatingFuture.java
@@ -31,22 +31,22 @@ import java.util.concurrent.TimeoutException;
  * A specific {@link ClientDelegatingFuture} implementation
  * which calls given {@link OneShotExecutionCallback} as sync on get.
  */
-class CallbackAwareClientDelegatingFuture extends ClientDelegatingFuture {
+class CallbackAwareClientDelegatingFuture<V> extends ClientDelegatingFuture<V> {
 
-    private final OneShotExecutionCallback callback;
+    private final OneShotExecutionCallback<V> callback;
 
     CallbackAwareClientDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
                                         SerializationService serializationService,
                                         ClientMessageDecoder clientMessageDecoder,
-                                        OneShotExecutionCallback callback) {
+                                        OneShotExecutionCallback<V> callback) {
         super(clientInvocationFuture, serializationService, clientMessageDecoder);
         this.callback = callback;
     }
 
     @Override
-    public Object get() throws InterruptedException, ExecutionException {
+    public V get() throws InterruptedException, ExecutionException {
         try {
-            Object result = super.get();
+            V result = super.get();
             /*
              * - If it has not been called yet, it will be called and it will be waited to finish.
              * - If it has been called but not finished yet, it will be waited to finish.
@@ -61,7 +61,7 @@ class CallbackAwareClientDelegatingFuture extends ClientDelegatingFuture {
     }
 
     @Override
-    public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         long finishTime = (timeout == Long.MAX_VALUE)
                 ? Long.MAX_VALUE
                 : Clock.currentTimeMillis() + unit.toMillis(timeout);
@@ -69,7 +69,7 @@ class CallbackAwareClientDelegatingFuture extends ClientDelegatingFuture {
             finishTime = Long.MAX_VALUE;
         }
         try {
-            Object result = super.get(timeout, unit);
+            V result = super.get(timeout, unit);
             /*
              * - If it has not been called yet, it will be called and it will be waited to finish.
              * - If it has been called but not finished yet, it will be waited to finish.
@@ -82,5 +82,4 @@ class CallbackAwareClientDelegatingFuture extends ClientDelegatingFuture {
             return ExceptionUtil.sneakyThrow(t);
         }
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -231,7 +231,7 @@ public class ClientConfig {
     /**
      * please use {@link ClientConfig#addNearCacheConfig(NearCacheConfig)}
      *
-     * @param name            name of the IMap / ICache that near cache config will be applied to
+     * @param name            name of the IMap / ICache that Near Cache config will be applied to
      * @param nearCacheConfig nearCacheConfig
      * @return configured {@link com.hazelcast.client.config.ClientConfig} for chaining
      */

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/ClientNearCacheType.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/ClientNearCacheType.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.map.impl.nearcache;
 
 /**
- * Legal near cache types
+ * Legal Near Cache types.
  */
 public enum ClientNearCacheType {
     /**

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -60,7 +60,6 @@ import com.hazelcast.util.IterationType;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +69,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.cache.impl.nearcache.NearCache.NULL_OBJECT;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.util.Collections.sort;
 
 /**
  * The replicated map client side proxy implementation proxying all requests to a member node
@@ -375,8 +375,8 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
 
     @Override
     public Collection<V> values(Comparator<V> comparator) {
-        List values = (List) values();
-        Collections.sort(values, comparator);
+        List<V> values = (List<V>) values();
+        sort(values, comparator);
         return values;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -56,7 +56,7 @@ import static java.util.Collections.EMPTY_MAP;
 import static java.util.Collections.emptyMap;
 
 /**
- * A Client-side {@code IMap} implementation which is fronted by a near-cache.
+ * A Client-side {@code IMap} implementation which is fronted by a Near Cache.
  *
  * @param <K> the key type for this {@code IMap} proxy.
  * @param <V> the value type for this {@code IMap} proxy.
@@ -68,7 +68,6 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
     protected volatile String invalidationListenerId;
     private boolean invalidateOnChange;
-
 
     public NearCachedClientMapProxy(String serviceName, String name) {
         super(serviceName, name);
@@ -90,7 +89,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         nearCache = wrapAsStaleReadPreventerNearCache(clientHeapNearCache, partitionCount);
         keyStateMarker = getKeyStateMarker();
 
-        invalidateOnChange = this.nearCache.isInvalidatedOnChange();
+        invalidateOnChange = nearCache.isInvalidatedOnChange();
         if (invalidateOnChange) {
             addNearCacheInvalidateListener();
         }
@@ -105,7 +104,6 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
         return super.containsKeyInternal(keyData);
     }
-
 
     @Override
     protected V getInternal(Data key) {
@@ -242,7 +240,6 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         V v = super.replaceInternal(keyData, valueData);
         invalidateNearCache(keyData);
         return v;
-
     }
 
     @Override
@@ -495,7 +492,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
         @Override
         public void handle(Data key) {
-            // null key means near cache has to remove all entries in it.
+            // null key means Near Cache has to remove all entries in it.
             // see MapAddNearCacheEntryListenerMessageTask.
             if (key == null) {
                 nearCache.clear();
@@ -515,5 +512,4 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     public KeyStateMarker getKeyStateMarker() {
         return ((StaleReadPreventerNearCacheWrapper) nearCache).getKeyStateMarker();
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -469,7 +469,8 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = client.getMap(mapName);
 
         map.put("a", "b");
-        map.get("a"); //put to nearCache
+        // populate Near Cache
+        map.get("a");
 
         instance.shutdown();
         hazelcastFactory.newHazelcastInstance();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheInvalidationTest.java
@@ -59,7 +59,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test that near cache invalidation events are delivered when a cache is:
+ * Test that Near Cache invalidation events are delivered when a cache is:
  * <ul>
  * <li><code>clear</code>ed</li>
  * <li><code>destroy</code>ed (with <code>Cache.destroy()</code></li>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -235,7 +235,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         // get updated records from client-2
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             final int key = i;
-            // records are stored in the near-cache will be invalidated eventually, since cache records are updated
+            // records are stored in the Near Cache will be invalidated eventually, since cache records are updated
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
@@ -285,7 +285,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             keyAndValues.put(key, value);
         }
 
-        // verify that records are exist at near-cache of client-1 because `local-update-policy` is `CACHE`
+        // verify that records are exist at Near Cache of client-1 because `local-update-policy` is `CACHE`
         for (Map.Entry<String, String> entry : keyAndValues.entrySet()) {
             String key = entry.getKey();
             String exceptedValue = entry.getValue();
@@ -294,7 +294,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         }
 
         // remove records through client-2 so there will be invalidation events
-        // to send to client to invalidate its near-cache
+        // to send to client to invalidate its Near Cache
         for (Map.Entry<String, String> entry : keyAndValues.entrySet()) {
             nearCacheTestContext2.cache.remove(entry.getKey());
         }
@@ -308,7 +308,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         ((LifecycleServiceImpl) instanceToShutdown.getLifecycleService())
                 .fireLifecycleEvent(LifecycleEvent.LifecycleState.SHUTTING_DOWN);
 
-        // verify that records in the near-cache of client-1 are invalidated eventually when instance shutdown
+        // verify that records in the Near Cache of client-1 are invalidated eventually when instance shutdown
         for (Map.Entry<String, String> entry : keyAndValues.entrySet()) {
             final String key = entry.getKey();
             assertTrueEventually(new AssertTask() {
@@ -354,7 +354,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         // can't get deleted records from client-2
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             final int key = i;
-            // records are stored in the near-cache will be invalidated eventually, since cache records are updated.
+            // records are stored in the Near Cache will be invalidated eventually, since cache records are updated.
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
@@ -402,7 +402,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         // can't get replaced keys from client-2
         for (int i : loadKeys) {
             final int key = i;
-            // records are stored in the near-cache will be invalidated eventually, since cache records are updated
+            // records are stored in the Near Cache will be invalidated eventually, since cache records are updated
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
@@ -443,7 +443,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         // can't get expired records from client-2
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             final int key = i;
-            // records are stored in the near-cache will be invalidated eventually, since cache records are cleared
+            // records are stored in the Near Cache will be invalidated eventually, since cache records are cleared
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
@@ -463,13 +463,13 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            // get records so they will be stored in near-cache
+            // get records so they will be stored in Near Cache
             nearCacheTestContext.cache.get(i);
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             Data keyData = nearCacheTestContext.serializationService.toData(i);
-            // check if same reference to verify data coming from near cache
+            // check if same reference to verify data coming from Near Cache
             assertSame(nearCacheTestContext.cache.get(i), nearCacheTestContext.nearCache.get(keyData));
         }
     }
@@ -526,7 +526,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         // can't get expired records from client-2
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             final int key = i;
-            // records are stored in the near-cache will be invalidated eventually, since cache records are cleared
+            // records are stored in the Near Cache will be invalidated eventually, since cache records are cleared
             // because we just disable per entry invalidation events, not full-flush events
             assertTrueEventually(new AssertTask() {
                 @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/NearCacheTestContext.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/NearCacheTestContext.java
@@ -26,7 +26,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 
 /**
- * Context for client near cache tests.
+ * Context for client Near Cache tests.
  */
 public class NearCacheTestContext {
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapTest.java
@@ -538,11 +538,11 @@ public class ClientReplicatedMapTest extends HazelcastTestSupport {
         final ReplicatedMap<Integer, Integer> replicatedMap1 = client1.getReplicatedMap(mapName);
 
         replicatedMap1.put(1, 1);
-        // puts key 1 to near cache
+        // puts key 1 to Near Cache
         replicatedMap1.get(1);
 
         ReplicatedMap<Integer, Integer> replicatedMap2 = client2.getReplicatedMap(mapName);
-        // this should invalidate near cache of replicatedMap1
+        // this should invalidate Near Cache of replicatedMap1
         replicatedMap2.put(1, 2);
 
         assertTrueEventually(new AssertTask() {
@@ -564,11 +564,11 @@ public class ClientReplicatedMapTest extends HazelcastTestSupport {
         final ReplicatedMap<Integer, Integer> replicatedMap1 = client1.getReplicatedMap(mapName);
 
         replicatedMap1.put(1, 1);
-        // puts key 1 to near cache
+        // puts key 1 to Near Cache
         replicatedMap1.get(1);
 
         ReplicatedMap replicatedMap2 = client2.getReplicatedMap(mapName);
-        // this should invalidate near cache of replicatedMap1
+        // this should invalidate Near Cache of replicatedMap1
         replicatedMap2.clear();
 
         assertTrueEventually(new AssertTask() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheStatistics.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheStatistics.java
@@ -199,10 +199,9 @@ public interface CacheStatistics {
     float getAverageRemoveTime();
 
     /**
-     * Gets the near-cache statistics.
+     * Gets the Near Cache statistics.
      *
-     * @return the near-cache statistics
+     * @return the Near Cache statistics
      */
     NearCacheStats getNearCacheStatistics();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventType.java
@@ -51,7 +51,7 @@ public enum CacheEventType {
     EVICTED(5),
 
     /**
-     * An event type indicating that the cache entry has invalidated for near cache invalidation.
+     * An event type indicating that the cache entry has invalidated for Near Cache invalidation.
      */
     INVALIDATED(6),
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCache.java
@@ -44,22 +44,22 @@ public interface NearCache<K, V> {
     Object NULL_OBJECT = new Object();
 
     /**
-     * Gets the name of the <code>this</code> {@link com.hazelcast.cache.impl.nearcache.NearCache} instance.
+     * Gets the name of this {@link com.hazelcast.cache.impl.nearcache.NearCache} instance.
      *
-     * @return the name of the <code>this</code> {@link com.hazelcast.cache.impl.nearcache.NearCache} instance
+     * @return the name of this {@link com.hazelcast.cache.impl.nearcache.NearCache} instance
      */
     String getName();
 
     /**
-     * Gets the value associated with the given <code>key</code>.
+     * Gets the value associated with the given {@code key}.
      *
      * @param key the key of the requested value
-     * @return the value associated with the given <code>key</code>
+     * @return the value associated with the given {@code key}
      */
     V get(K key);
 
     /**
-     * Puts (associates) a value with the given <code>key</code>.
+     * Puts (associates) a value with the given {@code key}.
      *
      * @param key   the key of the value will be stored
      * @param value the value will be stored
@@ -67,14 +67,16 @@ public interface NearCache<K, V> {
     void put(K key, V value);
 
     /**
-     * Removes the value associated with the given <code>key</code>.
+     * Removes the value associated with the given {@code key}.
      *
      * @param key the key of the value will be removed
      */
     boolean remove(K key);
 
     /**
-     * @return
+     * Checks if values are invalidated on changes.
+     *
+     * @return {@code true} if values are invalidated on changes, {@code false} otherwise
      */
     boolean isInvalidatedOnChange();
 
@@ -103,10 +105,10 @@ public interface NearCache<K, V> {
     NearCacheStats getNearCacheStats();
 
     /**
-     * Selects the best candidate object to store from the given <code>candidates</code>.
+     * Selects the best candidate object to store from the given {@code candidates}.
      *
      * @param candidates the candidates from which the best candidate object will be selected.
-     * @return the best candidate object to store, selected from the given <code>candidates</code>.
+     * @return the best candidate object to store, selected from the given {@code candidates}.
      */
     Object selectToSave(Object... candidates);
 
@@ -116,5 +118,4 @@ public interface NearCache<K, V> {
      * @return the count of stored records
      */
     int size();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheContext.java
@@ -64,5 +64,4 @@ public class NearCacheContext {
     public ClassLoader getClassLoader() {
         return classLoader;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheExecutor.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Contract point for executing near-cache specific tasks.
+ * Contract point for executing Near Cache specific tasks.
  *
  * @see java.lang.Runnable
  * @see java.util.concurrent.ScheduledFuture
@@ -30,16 +30,14 @@ public interface NearCacheExecutor {
     /**
      * Creates and executes a periodic action that becomes enabled first after the given initial delay.
      *
-     * @param command       the task to execute.
-     * @param initialDelay  the time to delay the first execution of the task.
-     * @param delay         the delay between the termination of one task and the commencement of the next task.
-     * @param unit          the time unit of the <code>initialDelay</code> and <code>delay</code> parameters.
-     *
+     * @param command      the task to execute.
+     * @param initialDelay the time to delay the first execution of the task.
+     * @param delay        the delay between the termination of one task and the commencement of the next task.
+     * @param unit         the time unit of the {@code initialDelay} and {@code delay} parameters.
      * @return the {@link ScheduledFuture} instance representing the pending completion of the task.
      */
     ScheduledFuture<?> scheduleWithRepetition(Runnable command,
                                               long initialDelay,
                                               long delay,
                                               TimeUnit unit);
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheManager.java
@@ -28,13 +28,13 @@ public interface NearCacheManager {
 
     /**
      * Gets the {@link com.hazelcast.cache.impl.nearcache.NearCache} instance
-     * associated with given <code>name</code>.
+     * associated with given {@code name}.
      *
      * @param name the name of the {@link com.hazelcast.cache.impl.nearcache.NearCache} instance will be got
-     * @param <K> the type of the key for Near Cache
-     * @param <V> the type of the value for Near Cache
+     * @param <K>  the type of the key for Near Cache
+     * @param <V>  the type of the value for Near Cache
      * @return the {@link com.hazelcast.cache.impl.nearcache.NearCache} instance
-     *         associated with given <code>name</code>
+     * associated with given {@code name}
      */
     <K, V> NearCache<K, V> getNearCache(String name);
 
@@ -42,16 +42,16 @@ public interface NearCacheManager {
      * Creates a new {@link com.hazelcast.cache.impl.nearcache.NearCache} with given configurations
      * or returns existing one.
      *
-     * @param name              the name of the {@link com.hazelcast.cache.impl.nearcache.NearCache}
-     *                          to be created or existing one
-     * @param nearCacheConfig   the {@link com.hazelcast.config.NearCacheConfig} of the
-     *                          {@link com.hazelcast.cache.impl.nearcache.NearCache} to be created
-     * @param nearCacheContext  the {@link com.hazelcast.cache.impl.nearcache.NearCacheContext} of the
-     *                          {@link com.hazelcast.cache.impl.nearcache.NearCache} to be created
-     * @param <K> the key type of the {@link com.hazelcast.cache.impl.nearcache.NearCache}
-     * @param <V> the value type of the {@link com.hazelcast.cache.impl.nearcache.NearCache}
+     * @param name             the name of the {@link com.hazelcast.cache.impl.nearcache.NearCache}
+     *                         to be created or existing one
+     * @param nearCacheConfig  the {@link com.hazelcast.config.NearCacheConfig} of the
+     *                         {@link com.hazelcast.cache.impl.nearcache.NearCache} to be created
+     * @param nearCacheContext the {@link com.hazelcast.cache.impl.nearcache.NearCacheContext} of the
+     *                         {@link com.hazelcast.cache.impl.nearcache.NearCache} to be created
+     * @param <K>              the key type of the {@link com.hazelcast.cache.impl.nearcache.NearCache}
+     * @param <V>              the value type of the {@link com.hazelcast.cache.impl.nearcache.NearCache}
      * @return the created or existing {@link com.hazelcast.cache.impl.nearcache.NearCache} instance
-     *         associated with given <code>name</code>
+     * associated with given {@code name}
      */
     <K, V> NearCache<K, V> getOrCreateNearCache(String name, NearCacheConfig nearCacheConfig,
                                                 NearCacheContext nearCacheContext);
@@ -64,12 +64,12 @@ public interface NearCacheManager {
     Collection<NearCache> listAllNearCaches();
 
     /**
-     * Clears {@link com.hazelcast.cache.impl.nearcache.NearCache} instance associated with given <code>name</code>
+     * Clears {@link com.hazelcast.cache.impl.nearcache.NearCache} instance associated with given {@code name}
      * but not removes it.
      *
      * @param name name of the {@link com.hazelcast.cache.impl.nearcache.NearCache} to be cleared
-     * @return <code>true</code> if {@link com.hazelcast.cache.impl.nearcache.NearCache}
-     *         was found and cleared, otherwise <code>false</code>
+     * @return {@code true} if {@link com.hazelcast.cache.impl.nearcache.NearCache}
+     * was found and cleared, otherwise {@code false}
      */
     boolean clearNearCache(String name);
 
@@ -79,12 +79,12 @@ public interface NearCacheManager {
     void clearAllNearCaches();
 
     /**
-     * Destroys {@link com.hazelcast.cache.impl.nearcache.NearCache} instance associated with given <code>name</code>
+     * Destroys {@link com.hazelcast.cache.impl.nearcache.NearCache} instance associated with given {@code name}
      * and also removes it.
      *
      * @param name name of the {@link com.hazelcast.cache.impl.nearcache.NearCache} to be destroyed
-     * @return <code>true</code> if {@link com.hazelcast.cache.impl.nearcache.NearCache}
-     *         was found and destroyed, otherwise <code>false</code>
+     * @return {@code true} if {@link com.hazelcast.cache.impl.nearcache.NearCache}
+     * was found and destroyed, otherwise {@code false}
      */
     boolean destroyNearCache(String name);
 
@@ -92,5 +92,4 @@ public interface NearCacheManager {
      * Destroys all defined {@link com.hazelcast.cache.impl.nearcache.NearCache} instances.
      */
     void destroyAllNearCaches();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheRecord.java
@@ -20,15 +20,13 @@ import com.hazelcast.internal.eviction.Evictable;
 import com.hazelcast.internal.eviction.Expirable;
 
 /**
- * <p>
- * An expirable and evictable data object which represents a near cache entry.
- * </p>
+ * An expirable and evictable data object which represents a Near Cache entry.
+ *
  * Record of {@link com.hazelcast.cache.impl.nearcache.NearCacheRecordStore}.
  *
+ * @param <V> the type of the value stored by this {@link NearCacheRecord}
  * @see com.hazelcast.internal.eviction.Expirable
  * @see com.hazelcast.internal.eviction.Evictable
- *
- * @param <V> the type of the value stored by this {@link NearCacheRecord}
  */
 public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
 
@@ -63,23 +61,22 @@ public interface NearCacheRecord<V> extends Expirable, Evictable<V> {
     void setAccessHit(int hit);
 
     /**
-     * Increases the access hit count of this {@link Evictable} as <code>1</code>.
+     * Increases the access hit count of this {@link Evictable} by {@code 1}.
      */
     void incrementAccessHit();
 
     /**
-     * Resets the access hit count of this {@link Evictable} to <code>0</code>.
+     * Resets the access hit count of this {@link Evictable} to {@code 0}.
      */
     void resetAccessHit();
 
     /**
      * Checks whether the maximum idle time is passed with respect to the provided time
-     * without any access during this time period as <code>maxIdleSeconds</code>.
+     * without any access during this time period as {@code maxIdleSeconds}.
      *
-     * @param maxIdleMilliSeconds   maximum idle time in milliseconds
-     * @param now                   current time in milliseconds
-     * @return <code>true</code> if exceeds max idle seconds, otherwise <code>false</code>
+     * @param maxIdleMilliSeconds maximum idle time in milliseconds
+     * @param now                 current time in milliseconds
+     * @return {@code true} if exceeds max idle seconds, otherwise {@code false}
      */
     boolean isIdleAt(long maxIdleMilliSeconds, long now);
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheRecordStore.java
@@ -28,15 +28,15 @@ import com.hazelcast.monitor.NearCacheStats;
 public interface NearCacheRecordStore<K, V> {
 
     /**
-     * Gets the value associated with the given <code>key</code>.
+     * Gets the value associated with the given {@code key}.
      *
      * @param key the key from which to get the associated value.
-     * @return the value associated with the given <code>key</code>.
+     * @return the value associated with the given {@code key}.
      */
     V get(K key);
 
     /**
-     * Puts (associates) a value with the given <code>key</code>.
+     * Puts (associates) a value with the given {@code key}.
      *
      * @param key   the key to which the given value will be associated.
      * @param value the value that will be associated with the key.
@@ -44,10 +44,10 @@ public interface NearCacheRecordStore<K, V> {
     void put(K key, V value);
 
     /**
-     * Removes the value associated with the given <code>key</code>.
+     * Removes the value associated with the given {@code key}.
      *
      * @param key the key from which the value will be removed.
-     * @return <code>true</code> if the value was removed, otherwise <code>false</code>.
+     * @return {@code true} if the value was removed, otherwise {@code false}.
      */
     boolean remove(K key);
 
@@ -69,10 +69,10 @@ public interface NearCacheRecordStore<K, V> {
     NearCacheStats getNearCacheStats();
 
     /**
-     * Selects the best candidate object to store from the given <code>candidates</code>.
+     * Selects the best candidate object to store from the given {@code candidates}.
      *
      * @param candidates the candidates from which the best candidate object will be selected.
-     * @return the best candidate object to store, selected from the given <code>candidates</code>.
+     * @return the best candidate object to store, selected from the given {@code candidates}.
      */
     Object selectToSave(Object... candidates);
 
@@ -99,5 +99,4 @@ public interface NearCacheRecordStore<K, V> {
      * in {@link com.hazelcast.config.NearCacheConfig} regardless from the max-size policy.
      */
     void doEviction();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheType.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheType.java
@@ -25,5 +25,4 @@ public enum NearCacheType {
 
     // Maybe CLIENT in the future
     // Maybe SERVER in the future
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/DefaultNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/DefaultNearCacheManager.java
@@ -99,5 +99,4 @@ public class DefaultNearCacheManager implements NearCacheManager {
             nearCache.destroy();
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/NearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/NearCacheRecordMap.java
@@ -22,15 +22,13 @@ import com.hazelcast.internal.eviction.EvictableStore;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * Contract point for all record maps to be used for storage in near-cache.
+ * Contract point for all record maps to be used for storage in Near Cache.
  *
  * @param <K> type of the key
  * @param <V> type of the {@link com.hazelcast.cache.impl.nearcache.NearCacheRecord} to be stored
- *
  * @see com.hazelcast.cache.impl.nearcache.NearCacheRecord
  * @see com.hazelcast.internal.eviction.EvictableStore
  */
 public interface NearCacheRecordMap<K, V extends NearCacheRecord>
         extends ConcurrentMap<K, V>, EvictableStore<K, V> {
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/SampleableNearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/SampleableNearCacheRecordMap.java
@@ -20,16 +20,14 @@ import com.hazelcast.cache.impl.nearcache.NearCacheRecord;
 import com.hazelcast.internal.eviction.impl.strategy.sampling.SampleableEvictableStore;
 
 /**
- * Contract point for all record maps these supports entry sampling to be used for storage in near-cache.
+ * Contract point for all record maps these supports entry sampling to be used for storage in Near Cache.
  *
  * @param <K> type of the key
  * @param <V> type of the {@link com.hazelcast.cache.impl.nearcache.NearCacheRecord} to be stored
- *
  * @see com.hazelcast.cache.impl.nearcache.NearCacheRecord
  * @see com.hazelcast.cache.impl.nearcache.impl.NearCacheRecordMap
  * @see com.hazelcast.internal.eviction.impl.strategy.sampling.SampleableEvictableStore
  */
 public interface SampleableNearCacheRecordMap<K, V extends NearCacheRecord>
         extends NearCacheRecordMap<K, V>, SampleableEvictableStore<K, V> {
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/maxsize/EntryCountNearCacheMaxSizeChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/maxsize/EntryCountNearCacheMaxSizeChecker.java
@@ -20,9 +20,9 @@ import com.hazelcast.cache.impl.maxsize.MaxSizeChecker;
 import com.hazelcast.cache.impl.nearcache.impl.NearCacheRecordMap;
 
 /**
- * Near-Cache max-size policy implementation for
- * {@link com.hazelcast.config.EvictionConfig.MaxSizePolicy#ENTRY_COUNT}.
- * Check if near-cache size is reached to max-size or not.
+ * Near Cache max-size policy implementation for {@link com.hazelcast.config.EvictionConfig.MaxSizePolicy#ENTRY_COUNT}.
+ *
+ * Checks if the Near Cache size is reached to max-size or not.
  *
  * @see com.hazelcast.cache.impl.maxsize.MaxSizeChecker
  */
@@ -41,5 +41,4 @@ public class EntryCountNearCacheMaxSizeChecker implements MaxSizeChecker {
     public boolean isReachedToMaxSize() {
         return nearCacheRecordMap.size() >= maxSize;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/maxsize/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/maxsize/package-info.java
@@ -15,8 +15,6 @@
  */
 
 /**
- * <p>
- *     Max-Size policy implementations for near-cache.
- * </p>
+ * Max-Size policy implementations for Near Cache.
  */
 package com.hazelcast.cache.impl.nearcache.impl.maxsize;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/package-info.java
@@ -15,8 +15,6 @@
  */
 
 /**
- * <p>
- *     Near cache implementations.
- * </p>
+ * Near Cache implementations.
  */
 package com.hazelcast.cache.impl.nearcache.impl;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/AbstractNearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/AbstractNearCacheRecord.java
@@ -120,5 +120,4 @@ public abstract class AbstractNearCacheRecord<V> implements NearCacheRecord<V> {
             return false;
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/NearCacheDataRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/NearCacheDataRecord.java
@@ -28,5 +28,4 @@ public class NearCacheDataRecord extends AbstractNearCacheRecord<Data> {
         super(value, creationTime, expiryTime);
         this.value = value;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/NearCacheObjectRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/NearCacheObjectRecord.java
@@ -28,5 +28,4 @@ public class NearCacheObjectRecord<V> extends AbstractNearCacheRecord<V> {
         super(value, creationTime, expiryTime);
         this.value = value;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/record/package-info.java
@@ -15,8 +15,6 @@
  */
 
 /**
- * <p>
- *     Near cache record implementations.
- * </p>
+ * Near Cache record implementations.
  */
 package com.hazelcast.cache.impl.nearcache.impl.record;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -26,10 +26,8 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.internal.eviction.EvictionChecker;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.eviction.EvictionPolicyEvaluator;
-import com.hazelcast.internal.eviction.EvictionPolicyEvaluatorProvider;
 import com.hazelcast.internal.eviction.EvictionPolicyType;
 import com.hazelcast.internal.eviction.EvictionStrategy;
-import com.hazelcast.internal.eviction.EvictionStrategyProvider;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.nio.serialization.Data;
@@ -37,6 +35,8 @@ import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ExceptionUtil;
 
+import static com.hazelcast.internal.eviction.EvictionPolicyEvaluatorProvider.getEvictionPolicyEvaluator;
+import static com.hazelcast.internal.eviction.EvictionStrategyProvider.getEvictionStrategy;
 import static com.hazelcast.internal.memory.GlobalMemoryAccessorRegistry.MEM;
 import static com.hazelcast.internal.memory.GlobalMemoryAccessorRegistry.MEM_AVAILABLE;
 
@@ -124,7 +124,7 @@ public abstract class AbstractNearCacheRecordStore<
 
     protected void checkAvailable() {
         if (!isAvailable()) {
-            throw new IllegalStateException(nearCacheConfig.getName() + " named near cache record store is not available");
+            throw new IllegalStateException(nearCacheConfig.getName() + " named Near Cache record store is not available");
         }
     }
 
@@ -133,15 +133,15 @@ public abstract class AbstractNearCacheRecordStore<
         if (evictionPolicyType == null) {
             throw new IllegalArgumentException("Eviction policy cannot be null");
         }
-        return EvictionPolicyEvaluatorProvider.getEvictionPolicyEvaluator(evictionConfig, classLoader);
+        return getEvictionPolicyEvaluator(evictionConfig, classLoader);
+    }
+
+    protected EvictionStrategy<KS, R, NCRM> createEvictionStrategy(EvictionConfig evictionConfig) {
+        return getEvictionStrategy(evictionConfig);
     }
 
     protected EvictionChecker createEvictionChecker(NearCacheConfig nearCacheConfig) {
         return new MaxSizeEvictionChecker();
-    }
-
-    protected EvictionStrategy<KS, R, NCRM> createEvictionStrategy(EvictionConfig evictionConfig) {
-        return EvictionStrategyProvider.getEvictionStrategy(evictionConfig);
     }
 
     protected boolean isAvailable() {
@@ -331,7 +331,7 @@ public abstract class AbstractNearCacheRecordStore<
 
     protected void destroyStore() {
         clearRecords();
-        // Clear reference so GC can collect it
+        // clear reference so GC can collect it
         records = null;
     }
 
@@ -358,19 +358,6 @@ public abstract class AbstractNearCacheRecordStore<
         return nearCacheStats;
     }
 
-    protected class MaxSizeEvictionChecker implements EvictionChecker {
-
-        @Override
-        public boolean isEvictionRequired() {
-            if (maxSizeChecker != null) {
-                return maxSizeChecker.isReachedToMaxSize();
-            } else {
-                return false;
-            }
-        }
-
-    }
-
     @Override
     public void doEvictionIfRequired() {
         checkAvailable();
@@ -386,6 +373,18 @@ public abstract class AbstractNearCacheRecordStore<
 
         if (isEvictionEnabled()) {
             evictionStrategy.evict(records, evictionPolicyEvaluator, null, this);
+        }
+    }
+
+    protected class MaxSizeEvictionChecker implements EvictionChecker {
+
+        @Override
+        public boolean isEvictionRequired() {
+            if (maxSizeChecker != null) {
+                return maxSizeChecker.isReachedToMaxSize();
+            } else {
+                return false;
+            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -52,7 +52,7 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
     @Override
     protected HeapNearCacheRecordMap<K, R> createNearCacheRecordMap(NearCacheConfig nearCacheConfig,
                                                                     NearCacheContext nearCacheContext) {
-        return new HeapNearCacheRecordMap(nearCacheContext.getSerializationService(), DEFAULT_INITIAL_CAPACITY);
+        return new HeapNearCacheRecordMap<K, R>(nearCacheContext.getSerializationService(), DEFAULT_INITIAL_CAPACITY);
     }
 
     @Override
@@ -69,7 +69,7 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
 
     @Override
     protected R removeRecord(K key) {
-        R removedRecord =  records.remove(key);
+        R removedRecord = records.remove(key);
         if (removedRecord != null) {
             nearCacheStats.decrementOwnedEntryMemoryCost(getTotalStorageMemoryCost(key, removedRecord));
         }
@@ -93,5 +93,4 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
             }
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/HeapNearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/HeapNearCacheRecordMap.java
@@ -83,7 +83,6 @@ public class HeapNearCacheRecordMap<K, V extends NearCacheRecord>
         public long getAccessHit() {
             return value.getAccessHit();
         }
-
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/NearCacheDataRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/NearCacheDataRecordStore.java
@@ -36,17 +36,17 @@ public class NearCacheDataRecordStore<K, V>
     protected long getKeyStorageMemoryCost(K key) {
         if (key instanceof Data) {
             return
-                // Reference to this key data inside map ("store" field)
-                REFERENCE_SIZE
-                // Heap cost of this key data
-                + ((Data) key).getHeapCost();
+                    // reference to this key data inside map ("store" field)
+                    REFERENCE_SIZE
+                            // heap cost of this key data
+                            + ((Data) key).getHeapCost();
         } else {
-            // Memory cost for non-data typed instance is not supported.
+            // memory cost for non-data typed instance is not supported
             return 0L;
         }
     }
 
-    // TODO We don't handle object header (mark, class definition) for heap memory cost
+    // TODO: we don't handle object header (mark, class definition) for heap memory cost
     @Override
     protected long getRecordStorageMemoryCost(NearCacheDataRecord record) {
         if (record == null) {
@@ -54,18 +54,18 @@ public class NearCacheDataRecordStore<K, V>
         }
         Data value = record.getValue();
         return
-            // Reference to this record inside map ("store" field)
-            REFERENCE_SIZE
-            // Reference to "value" field
-            + REFERENCE_SIZE
-            // Heap cost of this value data
-            + (value != null ? value.getHeapCost() : 0)
-            // 3 primitive long typed fields: "creationTime", "expirationTime" and "accessTime"
-            + (3 * (Long.SIZE / Byte.SIZE))
-            // Reference to "accessHit" field
-            + REFERENCE_SIZE
-            // Primitive int typed "value" field in "AtomicInteger" typed "accessHit" field
-            + (Integer.SIZE / Byte.SIZE);
+                // reference to this record inside map ("store" field)
+                REFERENCE_SIZE
+                        // reference to "value" field
+                        + REFERENCE_SIZE
+                        // heap cost of this value data
+                        + (value != null ? value.getHeapCost() : 0)
+                        // 3 primitive long typed fields: "creationTime", "expirationTime" and "accessTime"
+                        + (3 * (Long.SIZE / Byte.SIZE))
+                        // reference to "accessHit" field
+                        + REFERENCE_SIZE
+                        // primitive int typed "value" field in "AtomicInteger" typed "accessHit" field
+                        + (Integer.SIZE / Byte.SIZE);
     }
 
     @Override
@@ -99,8 +99,7 @@ public class NearCacheDataRecordStore<K, V>
         Object selectedCandidate = null;
         if (candidates != null && candidates.length > 0) {
             for (Object candidate : candidates) {
-                // Give priority to Data typed candidate.
-                // So there will be no extra convertion from Object to Data.
+                // give priority to Data typed candidate, so there will be no extra conversion from Object to Data
                 if (candidate instanceof Data) {
                     selectedCandidate = candidate;
                     break;
@@ -109,7 +108,7 @@ public class NearCacheDataRecordStore<K, V>
             if (selectedCandidate != null) {
                 return selectedCandidate;
             } else {
-                // Select a non-null candidate
+                // select a non-null candidate
                 for (Object candidate : candidates) {
                     if (candidate != null) {
                         selectedCandidate = candidate;
@@ -120,7 +119,4 @@ public class NearCacheDataRecordStore<K, V>
         }
         return selectedCandidate;
     }
-
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/NearCacheObjectRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/NearCacheObjectRecordStore.java
@@ -32,15 +32,13 @@ public class NearCacheObjectRecordStore<K, V>
 
     @Override
     protected long getKeyStorageMemoryCost(K key) {
-        // Memory cost for "OBJECT" in memory format is totally not supported.
-        // So just return zero.
+        // memory cost for "OBJECT" in memory format is totally not supported, so just return zero
         return 0L;
     }
 
     @Override
     protected long getRecordStorageMemoryCost(NearCacheObjectRecord record) {
-        // Memory cost for "OBJECT" in memory format is totally not supported.
-        // So just return zero.
+        // memory cost for "OBJECT" in memory format is totally not supported, so just return zero
         return 0L;
     }
 
@@ -49,9 +47,9 @@ public class NearCacheObjectRecordStore<K, V>
         value = toValue(value);
         long creationTime = Clock.currentTimeMillis();
         if (timeToLiveMillis > 0) {
-            return new NearCacheObjectRecord(value, creationTime, creationTime + timeToLiveMillis);
+            return new NearCacheObjectRecord<V>(value, creationTime, creationTime + timeToLiveMillis);
         } else {
-            return new NearCacheObjectRecord(value, creationTime, NearCacheRecord.TIME_NOT_SET);
+            return new NearCacheObjectRecord<V>(value, creationTime, NearCacheRecord.TIME_NOT_SET);
         }
     }
 
@@ -70,8 +68,7 @@ public class NearCacheObjectRecordStore<K, V>
         Object selectedCandidate = null;
         if (candidates != null && candidates.length > 0) {
             for (Object candidate : candidates) {
-                // Give priority to non Data typed candidate.
-                // So there will be no extra convertion from Data to Object.
+                // give priority to non Data typed candidate, so there will be no extra conversion from Data to Object
                 if (!(candidate instanceof Data)) {
                     selectedCandidate = candidate;
                     break;
@@ -80,7 +77,7 @@ public class NearCacheObjectRecordStore<K, V>
             if (selectedCandidate != null) {
                 return selectedCandidate;
             } else {
-                // Select a non-null candidate
+                // select a non-null candidate
                 for (Object candidate : candidates) {
                     if (candidate != null) {
                         selectedCandidate = candidate;
@@ -91,5 +88,4 @@ public class NearCacheObjectRecordStore<K, V>
         }
         return selectedCandidate;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/package-info.java
@@ -15,8 +15,6 @@
  */
 
 /**
- * <p>
- *     Near cache store implementations.
- * </p>
+ * Near Cache store implementations.
  */
 package com.hazelcast.cache.impl.nearcache.impl.store;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/package-info.java
@@ -15,8 +15,6 @@
  */
 
 /**
- * <p>
- *     Near cache support.
- * </p>
+ * Near Cache support.
  */
 package com.hazelcast.cache.impl.nearcache;

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -511,18 +511,18 @@ public class MapConfig {
     }
 
     /**
-     * Returns the near cache configuration
+     * Returns the Near Cache configuration
      *
-     * @return the near cache configuration
+     * @return the Near Cache configuration
      */
     public NearCacheConfig getNearCacheConfig() {
         return nearCacheConfig;
     }
 
     /**
-     * Sets the near cache configuration
+     * Sets the Near Cache configuration
      *
-     * @param nearCacheConfig the near cache configuration
+     * @param nearCacheConfig the Near Cache configuration
      * @return the updated map configuration
      */
     public MapConfig setNearCacheConfig(NearCacheConfig nearCacheConfig) {
@@ -731,9 +731,9 @@ public class MapConfig {
     }
 
     /**
-     * Checks if near cache is enabled
+     * Checks if Near Cache is enabled
      *
-     * @return true if near cache is enabled, false otherwise
+     * @return true if Near Cache is enabled, false otherwise
      */
     public boolean isNearCacheEnabled() {
         return nearCacheConfig != null;

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -28,7 +28,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.isNotNull;
 
 /**
- * Contains configuration for an NearCache.
+ * Contains the configuration for a Near Cache.
  */
 public class NearCacheConfig
         implements DataSerializable, Serializable {
@@ -143,19 +143,19 @@ public class NearCacheConfig
     }
 
     /**
-     * Gets the name of the near cache.
+     * Gets the name of the Near Cache.
      *
-     * @return The name of the near cache.
+     * @return The name of the Near Cache.
      */
     public String getName() {
         return name;
     }
 
     /**
-     * Sets the name of the near cache.
+     * Sets the name of the Near Cache.
      *
-     * @param name The name of the near cache.
-     * @return This near cache config instance.
+     * @param name The name of the Near Cache.
+     * @return This Near Cache config instance.
      */
     public NearCacheConfig setName(String name) {
         this.name = name;
@@ -163,22 +163,22 @@ public class NearCacheConfig
     }
 
     /**
-     * Gets the maximum number of seconds for each entry to stay in the near cache. Entries that are
-     * older than time-to-live-seconds will get automatically evicted from the near cache.
+     * Gets the maximum number of seconds for each entry to stay in the Near Cache. Entries that are
+     * older than time-to-live-seconds will get automatically evicted from the Near Cache.
      *
-     * @return The maximum number of seconds for each entry to stay in the near cache.
+     * @return The maximum number of seconds for each entry to stay in the Near Cache.
      */
     public int getTimeToLiveSeconds() {
         return timeToLiveSeconds;
     }
 
     /**
-     * Sets the maximum number of seconds for each entry to stay in the near cache. Entries that are
-     * older than time-to-live-seconds will get automatically evicted from the near cache.
+     * Sets the maximum number of seconds for each entry to stay in the Near Cache. Entries that are
+     * older than time-to-live-seconds will get automatically evicted from the Near Cache.
      * Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
      *
-     * @param timeToLiveSeconds The maximum number of seconds for each entry to stay in the near cache.
-     * @return This near cache config instance.
+     * @param timeToLiveSeconds The maximum number of seconds for each entry to stay in the Near Cache.
+     * @return This Near Cache config instance.
      */
     public NearCacheConfig setTimeToLiveSeconds(int timeToLiveSeconds) {
         this.timeToLiveSeconds = checkNotNegative(timeToLiveSeconds, "TTL seconds cannot be negative !");
@@ -186,23 +186,23 @@ public class NearCacheConfig
     }
 
     /**
-     * Gets the maximum size of the near cache. When max size is reached,
+     * Gets the maximum size of the Near Cache. When max size is reached,
      * cache is evicted based on the policy defined.
      *
-     * @return The maximum size of the near cache.
+     * @return The maximum size of the Near Cache.
      */
     public int getMaxSize() {
         return maxSize;
     }
 
     /**
-     * Sets the maximum size of the near cache. When max size is reached,
+     * Sets the maximum size of the Near Cache. When max size is reached,
      * cache is evicted based on the policy defined.
      * Any integer between 0 and Integer.MAX_VALUE. 0 means
      * Integer.MAX_VALUE. Default is 0.
      *
-     * @param maxSize The maximum number of seconds for each entry to stay in the near cache.
-     * @return This near cache config instance.
+     * @param maxSize The maximum number of seconds for each entry to stay in the Near Cache.
+     * @return This Near Cache config instance.
      */
     public NearCacheConfig setMaxSize(int maxSize) {
         this.maxSize = (maxSize == 0) ? Integer.MAX_VALUE : checkNotNegative(maxSize, "Max-Size cannot be negative !");
@@ -210,7 +210,7 @@ public class NearCacheConfig
     }
 
     /**
-     * The eviction policy for the near cache.
+     * The eviction policy for the Near Cache.
      * Valid values are:
      * NONE (no extra eviction, time-to-live-seconds may still apply),
      * LRU  (Least Recently Used),
@@ -218,7 +218,7 @@ public class NearCacheConfig
      * NONE is the default.
      * Regardless of the eviction policy used, time-to-live-seconds will still apply.
      *
-     * @return TThe eviction policy for the near cache.
+     * @return TThe eviction policy for the Near Cache.
      */
     public String getEvictionPolicy() {
         return evictionPolicy;
@@ -232,8 +232,8 @@ public class NearCacheConfig
      * NONE is the default.
      * Regardless of the eviction policy used, time-to-live-seconds will still apply.
      *
-     * @param evictionPolicy The eviction policy for the near cache.
-     * @return This near cache config instance.
+     * @param evictionPolicy The eviction policy for the Near Cache.
+     * @return This Near Cache config instance.
      */
     public NearCacheConfig setEvictionPolicy(String evictionPolicy) {
         this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null !");
@@ -241,11 +241,11 @@ public class NearCacheConfig
     }
 
     /**
-     * Maximum number of seconds each entry can stay in the near cache as untouched (not-read).
+     * Maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
      * Entries that are not read (touched) more than max-idle-seconds value will get removed
-     * from the near cache.
+     * from the Near Cache.
      *
-     * @return Maximum number of seconds each entry can stay in the near cache as
+     * @return Maximum number of seconds each entry can stay in the Near Cache as
      * untouched (not-read).
      */
     public int getMaxIdleSeconds() {
@@ -253,14 +253,14 @@ public class NearCacheConfig
     }
 
     /**
-     * Maximum number of seconds each entry can stay in the near cache as untouched (not-read).
+     * Maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
      * Entries that are not read (touched) more than max-idle-seconds value will get removed
-     * from the near cache.
+     * from the Near Cache.
      * Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
      *
-     * @param maxIdleSeconds Maximum number of seconds each entry can stay in the near cache as
+     * @param maxIdleSeconds Maximum number of seconds each entry can stay in the Near Cache as
      *                       untouched (not-read).
-     * @return This near cache config instance.
+     * @return This Near Cache config instance.
      */
     public NearCacheConfig setMaxIdleSeconds(int maxIdleSeconds) {
         this.maxIdleSeconds = checkNotNegative(maxIdleSeconds, "Max-Idle seconds cannot be negative !");
@@ -273,7 +273,7 @@ public class NearCacheConfig
      * When true, the member listens for cluster-wide changes on the entries and invalidates
      * them on change. Changes done on the local member always invalidate the cache.
      *
-     * @return This near cache config instance.
+     * @return This Near Cache config instance.
      */
     public boolean isInvalidateOnChange() {
         return invalidateOnChange;
@@ -287,7 +287,7 @@ public class NearCacheConfig
      *
      * @param invalidateOnChange True to evict the cached entries if the entries are
      *                           changed (updated or removed), false otherwise.
-     * @return This near cache config instance.
+     * @return This Near Cache config instance.
      */
     public NearCacheConfig setInvalidateOnChange(boolean invalidateOnChange) {
         this.invalidateOnChange = invalidateOnChange;
@@ -315,7 +315,7 @@ public class NearCacheConfig
      * NATIVE: keys and values are stored in native memory.
      *
      * @param inMemoryFormat The data type used to store entries.
-     * @return This near cache config instance.
+     * @return This Near Cache config instance.
      */
     public NearCacheConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
         this.inMemoryFormat = isNotNull(inMemoryFormat, "In-Memory format cannot be null !");
@@ -324,7 +324,7 @@ public class NearCacheConfig
 
     /**
      * If true, cache local entries also.
-     * This is useful when in-memory-format for near cache is different than the map's one.
+     * This is useful when in-memory-format for Near Cache is different than the map's one.
      *
      * @return True if local entries are cached also.
      */
@@ -334,10 +334,10 @@ public class NearCacheConfig
 
     /**
      * True to cache local entries also.
-     * This is useful when in-memory-format for near cache is different than the map's one.
+     * This is useful when in-memory-format for Near Cache is different than the map's one.
      *
      * @param cacheLocalEntries True to cache local entries also.
-     * @return This near cache config instance.
+     * @return This Near Cache config instance.
      */
     public NearCacheConfig setCacheLocalEntries(boolean cacheLocalEntries) {
         this.cacheLocalEntries = cacheLocalEntries;
@@ -383,7 +383,7 @@ public class NearCacheConfig
      * Regardless of the eviction policy used, time-to-live-seconds will still apply.
      *
      * @param evictionConfig The eviction policy.
-     * @return This near cache config instance.
+     * @return This Near Cache config instance.
      */
     public NearCacheConfig setEvictionConfig(EvictionConfig evictionConfig) {
         this.evictionConfig = checkNotNull(evictionConfig, "Eviction config cannot be null !");

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 /**
- * Contains configuration for an NearCache(Read-Only).
+ * Contains configuration for a Near Cache (read-only).
  *
  * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionStrategyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionStrategyProvider.java
@@ -34,7 +34,6 @@ public final class EvictionStrategyProvider {
     }
 
     private EvictionStrategyProvider() {
-
     }
 
     private static void init() {
@@ -45,10 +44,10 @@ public final class EvictionStrategyProvider {
      * Gets the {@link EvictionStrategy} implementation specified with <code>evictionStrategyType</code>.
      *
      * @param evictionConfig {@link EvictionConfiguration} for the requested {@link EvictionStrategy} implementation
-     *
      * @return the requested {@link EvictionStrategy} implementation
      */
-    public static EvictionStrategy getEvictionStrategy(EvictionConfiguration evictionConfig) {
+    public static <A, E extends Evictable, S extends EvictableStore<A, E>> EvictionStrategy<A, E, S> getEvictionStrategy(
+            EvictionConfiguration evictionConfig) {
         if (evictionConfig == null) {
             return null;
         }
@@ -56,6 +55,7 @@ public final class EvictionStrategyProvider {
         if (evictionStrategyType == null) {
             return null;
         }
+        //noinspection unchecked
         return EVICTION_STRATEGY_MAP.get(evictionStrategyType);
 
         // TODO "evictionStrategyFactory" can be handled here from a single point
@@ -71,5 +71,4 @@ public final class EvictionStrategyProvider {
     public static EvictionStrategy getDefaultEvictionStrategy() {
         return EVICTION_STRATEGY_MAP.get(EvictionStrategyType.DEFAULT_EVICTION_STRATEGY);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/MapMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/MapMBean.java
@@ -180,11 +180,10 @@ public class MapMBean extends HazelcastMBean<IMap> {
     }
 
     @ManagedAnnotation("localHeapCost")
-    @ManagedDescription("the total heap cost of map, near cache and heap cost")
+    @ManagedDescription("the total heap cost of map, Near Cache and heap cost")
     public long localHeapCost() {
         return localMapStatsDelegate.getLocalStats().getHeapCost();
     }
-
 
     @ManagedAnnotation("name")
     @ManagedDescription("name of the map")

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -232,7 +232,7 @@ public class LocalMapStatsProvider {
     }
 
     /**
-     * Adds near cache stats.
+     * Adds Near Cache stats.
      */
     protected void addNearCacheStats(LocalMapStatsImpl stats,
                                      LocalMapOnDemandCalculatedStats onDemandStats, MapContainer mapContainer) {
@@ -256,7 +256,7 @@ public class LocalMapStatsProvider {
         protected long ownedEntryMemoryCost;
         protected long backupEntryMemoryCost;
         /**
-         * Holds total heap cost of map & near-cache & backups.
+         * Holds total heap cost of map & Near Cache & backups.
          */
         protected long heapCost;
         protected long lockedEntryCount;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/AbstractNearCacheInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/AbstractNearCacheInvalidator.java
@@ -32,7 +32,6 @@ import java.util.List;
 
 import static com.hazelcast.util.CollectionUtil.isEmpty;
 
-
 /**
  * Contains common functionality of a {@code NearCacheInvalidator}
  */
@@ -53,7 +52,6 @@ public abstract class AbstractNearCacheInvalidator implements NearCacheInvalidat
         this.operationService = nodeEngine.getOperationService();
         this.clusterService = nodeEngine.getClusterService();
     }
-
 
     public void invalidateLocal(String mapName, Data key, List<Data> keys) {
         if (!isMemberNearCacheInvalidationEnabled(mapName)) {
@@ -94,7 +92,6 @@ public abstract class AbstractNearCacheInvalidator implements NearCacheInvalidat
         return mapContainer.hasInvalidationListener();
     }
 
-
     protected Data toHeapData(Data key) {
         return mapServiceContext.toData(key);
     }
@@ -120,5 +117,4 @@ public abstract class AbstractNearCacheInvalidator implements NearCacheInvalidat
 
         throw new IllegalArgumentException("One of key or keys should be provided for invalidation");
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchInvalidator.java
@@ -50,7 +50,7 @@ import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static java.util.Collections.EMPTY_LIST;
 
 /**
- * Sends invalidations to near-caches in batches.
+ * Sends invalidations to Near Cache in batches.
  */
 public class BatchInvalidator extends AbstractNearCacheInvalidator {
 
@@ -154,7 +154,7 @@ public class BatchInvalidator extends AbstractNearCacheInvalidator {
         if (invalidationQueue == null) {
             return;
         }
-        // If still in progress, no need to another attempt. So just return.
+        // if still in progress, no need to another attempt, so just return
         if (!invalidationQueue.tryAcquire()) {
             return;
         }
@@ -234,7 +234,6 @@ public class BatchInvalidator extends AbstractNearCacheInvalidator {
         return keyList == null ? EMPTY_LIST : keyList;
     }
 
-
     private void handleBatchesOnNodeShutdown() {
         HazelcastInstance node = nodeEngine.getHazelcastInstance();
         LifecycleService lifecycleService = node.getLifecycleService();
@@ -256,7 +255,6 @@ public class BatchInvalidator extends AbstractNearCacheInvalidator {
         ExecutionService executionService = nodeEngine.getExecutionService();
         executionService.scheduleWithRepetition(INVALIDATION_EXECUTOR_NAME,
                 new MapBatchInvalidationEventSender(), periodSeconds, periodSeconds, TimeUnit.SECONDS);
-
     }
 
     private int getBatchSize() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/BatchNearCacheInvalidation.java
@@ -55,7 +55,6 @@ public class BatchNearCacheInvalidation extends Invalidation {
         for (SingleNearCacheInvalidation singleNearCacheInvalidation : invalidations) {
             singleNearCacheInvalidation.writeData(out);
         }
-
     }
 
     @Override
@@ -74,5 +73,4 @@ public class BatchNearCacheInvalidation extends Invalidation {
             this.invalidations = invalidations;
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/CleaningNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/CleaningNearCacheInvalidation.java
@@ -17,8 +17,8 @@
 package com.hazelcast.map.impl.nearcache;
 
 /**
- * Used when invalidating client near-caches.
- * When a client near-cache invalidation listener receives this data, it clears its near-cache.
+ * Used when invalidating client Near Caches.
+ * When a client Near Cache invalidation listener receives this data, it clears its Near Cache.
  */
 public class CleaningNearCacheInvalidation extends Invalidation {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/Invalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/Invalidation.java
@@ -26,7 +26,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import java.io.IOException;
 
 /**
- * Root interface for near-cache invalidation data.
+ * Root interface for Near Cache invalidation data.
  */
 public abstract class Invalidation implements IMapEvent, DataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/InvalidationListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/InvalidationListener.java
@@ -21,7 +21,7 @@ import com.hazelcast.map.listener.MapListener;
 /**
  * Used to receive invalidation events from an {@link com.hazelcast.core.IMap IMap}
  * <p/>
- * For example, a client near-cache implementation can listen changes in IMap data and
+ * For example, a client Near Cache implementation can listen changes in IMap data and
  * can remove stale data in its own cache.
  *
  * @since 3.6

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/KeyStateMarker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/KeyStateMarker.java
@@ -19,9 +19,9 @@ package com.hazelcast.map.impl.nearcache;
 /**
  * Used to assign a {@link STATE} to a key.
  *
- * That {@link STATE} is used when deciding whether or not a key can be puttable to a near-cache.
+ * That {@link STATE} is used when deciding whether or not a key can be puttable to a Near Cache.
  * Because there is a possibility that an invalidation for a key can be received before putting that
- * key into near-cache, in that case, key should not be put into near-cache.
+ * key into Near Cache, in that case, key should not be put into Near Cache.
  */
 public interface KeyStateMarker {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/KeyStateMarkerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/KeyStateMarkerImpl.java
@@ -28,6 +28,7 @@ import static com.hazelcast.util.HashUtil.hashToIndex;
 public class KeyStateMarkerImpl implements KeyStateMarker {
 
     private final int markCount;
+
     private volatile AtomicLongArray marks;
 
     public KeyStateMarkerImpl(int markCount) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheImpl.java
@@ -72,7 +72,7 @@ public class NearCacheImpl implements NearCache<Data, Object> {
     private volatile long lastExpiration;
 
     /**
-     * @param mapName    name of the map which owns near cache.
+     * @param mapName    name of the map which owns Near Cache.
      * @param nodeEngine node engine.
      */
     public NearCacheImpl(String mapName, NodeEngine nodeEngine, SizeEstimator<NearCacheRecord> nearCacheSizeEstimator) {
@@ -97,7 +97,7 @@ public class NearCacheImpl implements NearCache<Data, Object> {
         this.lastExpiration = Clock.currentTimeMillis();
     }
 
-    // TODO this operation returns the given value in near-cache memory format (data or object)?
+    // TODO this operation returns the given value in Near Cache memory format (data or object)?
     @Override
     public void put(Data key, Object value) {
         fireCacheExpiration();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheInvalidator.java
@@ -22,44 +22,42 @@ import com.hazelcast.spi.ManagedService;
 import java.util.List;
 
 /**
- * Responsible for local and remote near-cache invalidation.
- * Local near-caches are node local, remote near-caches can be exist on remote nodes or clients.
+ * Responsible for local and remote Near Cache invalidation.
+ * Local Near Caches are node local, remote Near Caches can be exist on remote nodes or clients.
  *
  * @since 3.6
  */
 public interface NearCacheInvalidator {
 
     /**
-     * Invalidates local and remote near-caches.
-     * Local near-caches are node local, remote near-caches can be exist on remote members or clients.
+     * Invalidates local and remote Near Caches.
+     * Local Near Caches are node local, remote Near Caches can be exist on remote members or clients.
      *
      * @param mapName    name of the map.
-     * @param key        key of the entry to be removed from near-cache.
+     * @param key        key of the entry to be removed from Near Cache.
      * @param sourceUuid caller uuid
      */
     void invalidate(String mapName, Data key, String sourceUuid);
 
     /**
-     * Invalidates local and remote near-caches.
-     * Local near-caches are node local, remote near-caches can be exist on remote members or clients.
+     * Invalidates local and remote Near Caches.
+     * Local Near Caches are node local, remote Near Caches can be exist on remote members or clients.
      *
      * @param mapName    name of the map.
-     * @param keys       keys of the entries to be removed from near-cache.
+     * @param keys       keys of the entries to be removed from Near Cache.
      * @param sourceUuid caller uuid
      */
     void invalidate(String mapName, List<Data> keys, String sourceUuid);
 
-
     /**
-     * Clears local members near-cache.
+     * Clears local members Near Cache.
      *
      * @param mapName name of the map.
      */
     void clearLocalNearCache(String mapName);
 
-
     /**
-     * Send clear event to client-side near-cache invalidation listeners.
+     * Send clear event to client-side Near Cache invalidation listeners.
      *
      * @param mapName    name of the map.
      * @param sourceUuid caller uuid
@@ -68,7 +66,7 @@ public interface NearCacheInvalidator {
 
     /**
      * Removes supplied maps invalidation queue and flushes its content.
-     * This method is called when removing a near-cache with
+     * This method is called when removing a Near Cache with
      * {@link com.hazelcast.map.impl.MapRemoteService#destroyDistributedObject(String)}
      *
      * @param mapName name of the map.
@@ -80,7 +78,7 @@ public interface NearCacheInvalidator {
      * Resets this invalidator back to its initial state.
      * Aimed to call with {@link ManagedService#reset()}
      *
-     * @see {@link ManagedService#reset()}
+     * @see ManagedService#reset()
      */
     void reset();
 
@@ -88,7 +86,7 @@ public interface NearCacheInvalidator {
      * Shuts down this invalidator and releases used resources.
      * Aimed to call with {@link com.hazelcast.spi.ManagedService#shutdown(boolean)}
      *
-     * @see {@link com.hazelcast.spi.ManagedService#shutdown(boolean)}
+     * @see ManagedService#shutdown(boolean)
      */
     void shutdown();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheRecord.java
@@ -28,9 +28,10 @@ import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.util.JVMUtil.REFERENCE_COST_IN_BYTES;
 
 /**
- * Entry holder to be used in Client and Node side Near cache
+ * Entry holder to be used in client and member side Near Cache implementations.
  */
 public class NearCacheRecord {
+
     private static final Comparator<NearCacheRecord> LRU_COMPARATOR = new Comparator<NearCacheRecord>() {
         public int compare(NearCacheRecord o1, NearCacheRecord o2) {
             final int result = QuickMath.compareLongs(o1.lastAccessTime, o2.lastAccessTime);
@@ -125,6 +126,4 @@ public class NearCacheRecord {
             return NearCacheRecord.DEFAULT_COMPARATOR;
         }
     }
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheSizeEstimator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheSizeEstimator.java
@@ -23,14 +23,14 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 
 /**
- * Size estimator for near cache.
+ * Size estimator for Near Cache.
  */
-public class NearCacheSizeEstimator
-        implements SizeEstimator<NearCacheRecord> {
+public class NearCacheSizeEstimator implements SizeEstimator<NearCacheRecord> {
 
     private static final AtomicLongFieldUpdater<NearCacheSizeEstimator> SIZE = AtomicLongFieldUpdater
             .newUpdater(NearCacheSizeEstimator.class, "size");
 
+    @SuppressWarnings("unused")
     private volatile long size;
 
     public NearCacheSizeEstimator() {
@@ -43,8 +43,7 @@ public class NearCacheSizeEstimator
             return 0;
         }
         final long cost = record.getCost();
-        // if  cost is zero, type of cached object is not Data.
-        // then omit.
+        // if cost is zero, type of cached object is not Data (then omit)
         if (cost == 0) {
             return 0;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NonStopInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NonStopInvalidator.java
@@ -31,7 +31,7 @@ import static com.hazelcast.core.EntryEventType.INVALIDATION;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 
 /**
- * Sends invalidations to near-caches immediately.
+ * Sends invalidations to Near Cache immediately.
  */
 public class NonStopInvalidator extends AbstractNearCacheInvalidator {
 
@@ -56,17 +56,17 @@ public class NonStopInvalidator extends AbstractNearCacheInvalidator {
 
     @Override
     public void destroy(String mapName) {
-        // nop.
+        // nop
     }
 
     @Override
     public void reset() {
-        // nop.
+        // nop
     }
 
     @Override
     public void shutdown() {
-        // nop.
+        // nop
     }
 
     private void invalidateInternal(String mapName, Data key, List<Data> keys, String sourceUuid) {
@@ -108,7 +108,7 @@ public class NonStopInvalidator extends AbstractNearCacheInvalidator {
             return batch;
         }
 
-        // if key and keys are null, that means a cleaning invalidation must be created.
+        // if key and keys are null, that means a cleaning invalidation must be created
         return new CleaningNearCacheInvalidation(mapName, sourceUuid);
     }
 
@@ -131,7 +131,4 @@ public class NonStopInvalidator extends AbstractNearCacheInvalidator {
             operationService.send(operation, member.getAddress());
         }
     }
-
 }
-
-

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/StaleReadPreventerNearCacheWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/StaleReadPreventerNearCacheWrapper.java
@@ -25,18 +25,19 @@ import com.hazelcast.monitor.NearCacheStats;
  *
  * @see KeyStateMarker
  */
-public final class StaleReadPreventerNearCacheWrapper implements NearCache {
+public final class StaleReadPreventerNearCacheWrapper<K, V> implements NearCache<K, V> {
 
-    private final NearCache nearCache;
+    private final NearCache<K, V> nearCache;
     private final KeyStateMarker keyStateMarker;
 
-    private StaleReadPreventerNearCacheWrapper(NearCache nearCache, int markerCount) {
+    private StaleReadPreventerNearCacheWrapper(NearCache<K, V> nearCache, int markerCount) {
         this.nearCache = nearCache;
         this.keyStateMarker = new KeyStateMarkerImpl(markerCount);
     }
 
-    public static NearCache wrapAsStaleReadPreventerNearCache(NearCache nearCache, int markerCount) {
-        return new StaleReadPreventerNearCacheWrapper(nearCache, markerCount);
+    public static <KEY, VALUE> NearCache<KEY, VALUE> wrapAsStaleReadPreventerNearCache(NearCache<KEY, VALUE> nearCache,
+                                                                                       int markerCount) {
+        return new StaleReadPreventerNearCacheWrapper<KEY, VALUE>(nearCache, markerCount);
     }
 
     @Override
@@ -45,17 +46,17 @@ public final class StaleReadPreventerNearCacheWrapper implements NearCache {
     }
 
     @Override
-    public Object get(Object key) {
+    public V get(K key) {
         return nearCache.get(key);
     }
 
     @Override
-    public void put(Object key, Object value) {
+    public void put(K key, V value) {
         nearCache.put(key, value);
     }
 
     @Override
-    public boolean remove(Object key) {
+    public boolean remove(K key) {
         keyStateMarker.tryRemove(key);
         return nearCache.remove(key);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Contains near-cache specific classes.
+ * Contains Near Cache specific classes.
  */
 package com.hazelcast.map.impl.nearcache;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearBackupOperation.java
@@ -33,8 +33,8 @@ public class ClearBackupOperation extends MapOperation implements BackupOperatio
 
     @Override
     public void run() {
-        // clear near-cache also on this backup operation, there is a possibility that no owner partition exists on this
-        // node but a near-cache exists.
+        // clear Near Cache also on this backup operation, since  there is a possibility
+        // that no owner partition exists on this node, but a Near Cache exists
         clearLocalNearCache();
 
         if (recordStore != null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -41,8 +41,8 @@ public class ClearOperation extends MapOperation implements BackupAwareOperation
 
     @Override
     public void run() {
-        // near-cache clear will be called multiple times by each clear operation,
-        // but it's still preferred to send a separate operation to clear near-cache.
+        // Near Cache clear will be called multiple times by each clear operation,
+        // but it's still preferred to send a separate operation to clear Near Cache.
         clearLocalNearCache();
 
         if (recordStore == null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictAllOperation.java
@@ -46,8 +46,7 @@ public class EvictAllOperation extends MapOperation implements BackupAwareOperat
 
     @Override
     public void run() throws Exception {
-
-        // TODO this also clears locked keys from near cache which should be preserved.
+        // TODO: this also clears locked keys from Near Cache which should be preserved
         clearLocalNearCache();
 
         if (recordStore == null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheBatchInvalidationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheBatchInvalidationOperation.java
@@ -49,7 +49,7 @@ public class NearCacheBatchInvalidationOperation extends MapOperation implements
             NearCacheInvalidator nearCacheInvalidator = nearCacheProvider.getNearCacheInvalidator();
             ((AbstractNearCacheInvalidator) nearCacheInvalidator).invalidateLocal(name, null, keys);
         } else {
-            getLogger().warning("Cache clear operation has been accepted while near cache is not enabled for "
+            getLogger().warning("Cache clear operation has been accepted while Near Cache is not enabled for "
                     + name + " map. Possible configuration conflict among nodes.");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheSingleInvalidationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheSingleInvalidationOperation.java
@@ -45,7 +45,7 @@ public class NearCacheSingleInvalidationOperation extends MapOperation implement
             NearCacheInvalidator nearCacheInvalidator = nearCacheProvider.getNearCacheInvalidator();
             ((AbstractNearCacheInvalidator) nearCacheInvalidator).invalidateLocal(name, key, null);
         } else {
-            getLogger().warning("Cache clear operation has been accepted while near cache is not enabled for "
+            getLogger().warning("Cache clear operation has been accepted while Near Cache is not enabled for "
                     + name + " map. Possible configuration conflict among nodes.");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -44,7 +44,7 @@ import static com.hazelcast.cache.impl.nearcache.NearCache.NULL_OBJECT;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
- * A server-side {@code IMap} implementation which is fronted by a near-cache.
+ * A server-side {@code IMap} implementation which is fronted by a Near Cache.
  *
  * @param <K> the key type for this {@code IMap} proxy.
  * @param <V> the value type for this {@code IMap} proxy.
@@ -75,7 +75,7 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     // this operation returns the object in data format,
-    // except when it is retrieved from near-cache and near-cache memory format is object
+    // except when it is retrieved from Near Cache and Near Cache memory format is object
     @Override
     protected Object getInternal(Data key) {
         Object value = getCachedValue(key);

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
@@ -191,7 +191,7 @@ public interface LocalMapStats extends LocalInstanceStats {
     long total();
 
     /**
-     * Cost of map & near cache  & backup in bytes
+     * Cost of map & Near Cache & backup in bytes
      * todo in object mode object size is zero.
      *
      * @return heap cost

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -83,7 +83,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
     private volatile long ownedEntryMemoryCost;
     private volatile long backupEntryMemoryCost;
     /**
-     * Holds total heap cost of map & near-cache & backups.
+     * Holds total heap cost of map & Near Cache & backups.
      */
     private volatile long heapCost;
     private volatile long lockedEntryCount;

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -443,19 +443,19 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.cache.invalidation.batchfrequency.seconds", 10, SECONDS);
 
     /**
-     * Defines near-cache invalidation event batch sending is enabled or not.
+     * Defines Near Cache invalidation event batch sending is enabled or not.
      */
     public static final HazelcastProperty MAP_INVALIDATION_MESSAGE_BATCH_ENABLED
             = new HazelcastProperty("hazelcast.map.invalidation.batch.enabled", true);
 
     /**
-     * Defines the maximum number of near-cache invalidation events to be drained and sent to the event near-caches in a batch.
+     * Defines the maximum number of Near Cache invalidation events to be drained and sent to the event Near Cache in a batch.
      */
     public static final HazelcastProperty MAP_INVALIDATION_MESSAGE_BATCH_SIZE
             = new HazelcastProperty("hazelcast.map.invalidation.batch.size", 100);
 
     /**
-     * Defines the near-cache invalidation event batch sending frequency in seconds.
+     * Defines the Near Cache invalidation event batch sending frequency in seconds.
      * <p/>
      * When the number of events do not come up to {@link #MAP_INVALIDATION_MESSAGE_BATCH_SIZE} in the given time period (which
      * is defined by this property); those events are gathered into a batch and sent to target.

--- a/hazelcast/src/main/resources/hazelcast-config-3.5.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.5.xsd
@@ -2108,7 +2108,7 @@
             <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
 	            <xs:annotation>
 	                <xs:documentation>
-	                    Maximum size of the near cache. When max size is reached,
+	                    Maximum size of the Near Cache. When max size is reached,
 						cache is evicted based on the policy defined.
 						Any integer between 0 and Integer.MAX_VALUE. 0 means
 						Integer.MAX_VALUE. Default is 0.
@@ -2118,8 +2118,8 @@
             <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
 	            <xs:annotation>
 	                <xs:documentation>
-	                    Maximum number of seconds for each entry to stay in the near cache. Entries that are
-						older than time-to-live-seconds will get automatically evicted from the near cache.
+	                    Maximum number of seconds for each entry to stay in the Near Cache. Entries that are
+						older than time-to-live-seconds will get automatically evicted from the Near Cache.
 						Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
 	                </xs:documentation>
 	            </xs:annotation>
@@ -2127,9 +2127,9 @@
             <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
 	            <xs:annotation>
 	                <xs:documentation>
-	                    Maximum number of seconds each entry can stay in the near cache as untouched (not-read).
+	                    Maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
 				        Entries that are not read (touched) more than max-idle-seconds value will get removed
-				        from the near cache.
+				        from the Near Cache.
 				        Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
 	                </xs:documentation>
 	            </xs:annotation>
@@ -2169,7 +2169,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         True to cache local entries also.
-						This is useful when in-memory-format for near cache is different than the map's one.
+						This is useful when in-memory-format for Near Cache is different than the map's one.
 						Default value is false.
                     </xs:documentation>
                 </xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.6.xsd
@@ -2221,7 +2221,7 @@
             <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
 	            <xs:annotation>
 	                <xs:documentation>
-	                    Maximum size of the near cache. When max size is reached,
+	                    Maximum size of the Near Cache. When max size is reached,
 						cache is evicted based on the policy defined.
 						Any integer between 0 and Integer.MAX_VALUE. 0 means
 						Integer.MAX_VALUE. Default is 0.
@@ -2231,8 +2231,8 @@
             <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
 	            <xs:annotation>
 	                <xs:documentation>
-	                    Maximum number of seconds for each entry to stay in the near cache. Entries that are
-						older than time-to-live-seconds will get automatically evicted from the near cache.
+	                    Maximum number of seconds for each entry to stay in the Near Cache. Entries that are
+						older than time-to-live-seconds will get automatically evicted from the Near Cache.
 						Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
 	                </xs:documentation>
 	            </xs:annotation>
@@ -2240,9 +2240,9 @@
             <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
 	            <xs:annotation>
 	                <xs:documentation>
-	                    Maximum number of seconds each entry can stay in the near cache as untouched (not-read).
+	                    Maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
 				        Entries that are not read (touched) more than max-idle-seconds value will get removed
-				        from the near cache.
+				        from the Near Cache.
 				        Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
 	                </xs:documentation>
 	            </xs:annotation>
@@ -2282,7 +2282,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         True to cache local entries also.
-						This is useful when in-memory-format for near cache is different than the map's one.
+						This is useful when in-memory-format for Near Cache is different than the map's one.
 						Default value is false.
                     </xs:documentation>
                 </xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-config-3.7.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.7.xsd
@@ -2266,7 +2266,7 @@
             <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Maximum size of the near cache. When max size is reached,
+                        Maximum size of the Near Cache. When max size is reached,
                         cache is evicted based on the policy defined.
                         Any integer between 0 and Integer.MAX_VALUE. 0 means
                         Integer.MAX_VALUE. Default is 0.
@@ -2276,8 +2276,8 @@
             <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Maximum number of seconds for each entry to stay in the near cache. Entries that are
-                        older than time-to-live-seconds will get automatically evicted from the near cache.
+                        Maximum number of seconds for each entry to stay in the Near Cache. Entries that are
+                        older than time-to-live-seconds will get automatically evicted from the Near Cache.
                         Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
                     </xs:documentation>
                 </xs:annotation>
@@ -2285,9 +2285,9 @@
             <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Maximum number of seconds each entry can stay in the near cache as untouched (not-read).
+                        Maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
                         Entries that are not read (touched) more than max-idle-seconds value will get removed
-                        from the near cache.
+                        from the Near Cache.
                         Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
                     </xs:documentation>
                 </xs:annotation>
@@ -2327,7 +2327,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         True to cache local entries also.
-                        This is useful when in-memory-format for near cache is different than the map's one.
+                        This is useful when in-memory-format for Near Cache is different than the map's one.
                         Default value is false.
                     </xs:documentation>
                 </xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -2266,7 +2266,7 @@
             <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Maximum size of the near cache. When max size is reached,
+                        Maximum size of the Near Cache. When max size is reached,
                         cache is evicted based on the policy defined.
                         Any integer between 0 and Integer.MAX_VALUE. 0 means
                         Integer.MAX_VALUE. Default is 0.
@@ -2276,8 +2276,8 @@
             <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Maximum number of seconds for each entry to stay in the near cache. Entries that are
-                        older than time-to-live-seconds will get automatically evicted from the near cache.
+                        Maximum number of seconds for each entry to stay in the Near Cache. Entries that are
+                        older than time-to-live-seconds will get automatically evicted from the Near Cache.
                         Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
                     </xs:documentation>
                 </xs:annotation>
@@ -2285,9 +2285,9 @@
             <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Maximum number of seconds each entry can stay in the near cache as untouched (not-read).
+                        Maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
                         Entries that are not read (touched) more than max-idle-seconds value will get removed
-                        from the near cache.
+                        from the Near Cache.
                         Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
                     </xs:documentation>
                 </xs:annotation>
@@ -2327,7 +2327,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         True to cache local entries also.
-                        This is useful when in-memory-format for near cache is different than the map's one.
+                        This is useful when in-memory-format for Near Cache is different than the map's one.
                         Default value is false.
                     </xs:documentation>
                 </xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -656,21 +656,21 @@ https://hazelcast.org/documentation/.
 		While you are implementing MapStore or MapLoader you can define specific properties to be configured.
 		It can be your store's URL, credentials, etc. Please see the example map configuration snippet below.
     * <near-cache>:
-	Configuration options when you want to use a near cache for your map.
+	Configuration options when you want to use a Near Cache for your map.
 	It has the following attributes:
-	- name: You can give a name for your near cache. It is optional and its default value is "default".
+	- name: You can give a name for your Near Cache. It is optional and its default value is "default".
 	
 	It has the following sub-elements:
     	- <max-size>:
-    		Maximum size of the near cache. When this is reached, near cache is evicted based on the policy defined.
+    		Maximum size of the Near Cache. When this is reached, Near Cache is evicted based on the policy defined.
 			Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Its default value is 0.
     	- <time-to-live-seconds>:
-    		Maximum number of seconds for each entry to stay in the near cache. Entries that are older than this 
-    		period are automatically evicted from the near cache. Any integer between 0 and Integer.MAX_VALUE. 
+    		Maximum number of seconds for each entry to stay in the Near Cache. Entries that are older than this 
+    		period are automatically evicted from the Near Cache. Any integer between 0 and Integer.MAX_VALUE. 
     		0 means infinite. Its default value is 0.
     	- <max-idle-seconds>:
-    		Maximum number of seconds each entry can stay in the near cache as untouched (not read). Entries that 
-    		are not read more than this period are removed from the near cache. Any integer between 0 and 
+    		Maximum number of seconds each entry can stay in the Near Cache as untouched (not read). Entries that 
+    		are not read more than this period are removed from the Near Cache. Any integer between 0 and 
     		Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Its default value is 0.
     	- <eviction-policy>:
     		Eviction policy configuration. Its default values is NONE. Available values are as follows:
@@ -683,26 +683,26 @@ https://hazelcast.org/documentation/.
     		Specifies whether the cached entries are evicted when the entries are updated or removed. Its default 
     		value is true.
     	- <in-memory-format>:
-		Specifies in which format data will be stored in your near cache. Note that a map's in-memory format
-		can be different from that of its near cache.
+		Specifies in which format data will be stored in your Near Cache. Note that a map's in-memory format
+		can be different from that of its Near Cache.
 		Available values are as follows:
 		- BINARY:
 			Data will be stored in serialized binary format. It is the default option.
 		- OBJECT:
 			Data will be stored in deserialized form.
 		- NATIVE:
-			Data will be stored in the near cache that uses Hazelcast's High-Density Memory Store feature. 
-			This option is available only in Hazelcast Enterprise HD. Note that a map and its near cache 
+			Data will be stored in the Near Cache that uses Hazelcast's High-Density Memory Store feature. 
+			This option is available only in Hazelcast Enterprise HD. Note that a map and its Near Cache 
 			can independently use High-Density Memory Store. For example, while your map does not use 
-			High-Density Memory Store, its near cache can use it.
+			High-Density Memory Store, its Near Cache can use it.
     	- <cache-local-entries>:
     		Specifies whether the local entries will be cached. It can be useful when in-memory format for 
-    		near cache is different from that of the map. By default, it is disabled.
+    		Near Cache is different from that of the map. By default, it is disabled.
     	- <eviction>:
-    		Configuration for the eviction when the in-memory format of the near cache is NATIVE. It has the 
+    		Configuration for the eviction when the in-memory format of the Near Cache is NATIVE. It has the 
     		following attributes:
-    		- size: Maximum size (entry count) of the near cache.
-    		- max-size-policy: Maximum size policy for eviction of the near cache. Available values are as follows:
+    		- size: Maximum size (entry count) of the Near Cache.
+    		- max-size-policy: Maximum size policy for eviction of the Near Cache. Available values are as follows:
     			* ENTRY_COUNT: Maximum entry count per member.
          		* USED_NATIVE_MEMORY_SIZE: Maximum used native memory size in megabytes.
          		* USED_NATIVE_MEMORY_PERCENTAGE: Maximum used native memory percentage.

--- a/hazelcast/src/test/java/com/hazelcast/cache/nearcache/NearCacheManagerTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/nearcache/NearCacheManagerTestSupport.java
@@ -79,12 +79,12 @@ public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSup
         }
 
         Collection<NearCache> nearCaches2 = nearCacheManager.listAllNearCaches();
-        // clear doesn't remove near cache, just clears it
+        // clear doesn't remove Near Cache, just clears it
         assertEquals(DEFAULT_NEAR_CACHE_COUNT, nearCaches2.size());
 
         nearCacheManager.clearAllNearCaches();
         Collection<NearCache> nearCaches3 = nearCacheManager.listAllNearCaches();
-        // clear all doesn't remove near caches, just clears them
+        // clear all doesn't remove Near Caches, just clears them
         assertEquals(DEFAULT_NEAR_CACHE_COUNT, nearCaches3.size());
 
         assertFalse(nearCacheManager.clearNearCache(DEFAULT_NEAR_CACHE_NAME + "-" + DEFAULT_NEAR_CACHE_COUNT));
@@ -105,7 +105,7 @@ public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSup
         }
 
         Collection<NearCache> nearCaches2 = nearCacheManager.listAllNearCaches();
-        // destroy also removes near cache
+        // destroy also removes Near Cache
         assertEquals(0, nearCaches2.size());
 
         assertFalse(nearCacheManager.clearNearCache(DEFAULT_NEAR_CACHE_NAME + "-" + DEFAULT_NEAR_CACHE_COUNT));
@@ -119,7 +119,7 @@ public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSup
 
         nearCacheManager.destroyAllNearCaches();
         Collection<NearCache> nearCaches4 = nearCacheManager.listAllNearCaches();
-        // destroy all also removes near caches
+        // destroy all also removes Near Caches
         assertEquals(0, nearCaches4.size());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionStrategyTest.java
@@ -19,6 +19,9 @@ import org.junit.runner.RunWith;
 
 import java.util.Collections;
 
+import static com.hazelcast.internal.eviction.EvictionChecker.EVICT_ALWAYS;
+import static com.hazelcast.internal.eviction.EvictionListener.NO_LISTENER;
+import static com.hazelcast.internal.eviction.EvictionStrategyProvider.getEvictionStrategy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -26,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class EvictionStrategyTest extends HazelcastTestSupport {
+public class EvictionStrategyTest<K, V extends Evictable, S extends EvictableStore<K, V>> extends HazelcastTestSupport {
 
     private HazelcastInstance instance;
 
@@ -35,7 +38,7 @@ public class EvictionStrategyTest extends HazelcastTestSupport {
         instance = createHazelcastInstance();
     }
 
-    private class SimpleEvictionCandidate<K, V extends Evictable> implements EvictionCandidate<K, V> {
+    private class SimpleEvictionCandidate implements EvictionCandidate<K, V> {
 
         private K key;
         private V value;
@@ -79,7 +82,6 @@ public class EvictionStrategyTest extends HazelcastTestSupport {
         public long getAccessHit() {
             return getEvictable().getAccessHit();
         }
-
     }
 
     @Test
@@ -115,8 +117,7 @@ public class EvictionStrategyTest extends HazelcastTestSupport {
                 return null;
             }
         };
-        EvictionStrategy evictionStrategy =
-                EvictionStrategyProvider.getEvictionStrategy(evictionConfig);
+        EvictionStrategy<K, V, S> evictionStrategy = getEvictionStrategy(evictionConfig);
         CacheRecordHashMap cacheRecordMap = new CacheRecordHashMap(serializationService, 1000, cacheContext);
         CacheObjectRecord expectedEvictedRecord = null;
         Data expectedData = null;
@@ -134,10 +135,10 @@ public class EvictionStrategyTest extends HazelcastTestSupport {
         assertNotNull(expectedEvictedRecord);
         assertNotNull(expectedData);
 
-        final SimpleEvictionCandidate evictionCandidate =
-                new SimpleEvictionCandidate(expectedData, expectedEvictedRecord);
-        // Mock "EvictionPolicyEvaluator", since we are testing it in other tests.
-        // In this test, we are testing "EvictionStrategy".
+        final SimpleEvictionCandidate evictionCandidate
+                = new SimpleEvictionCandidate((K) expectedData, (V) expectedEvictedRecord);
+        // we are testing "EvictionStrategy" in this test, so we mock "EvictionPolicyEvaluator"
+        // (it's tested in another test)
         EvictionPolicyEvaluator evictionPolicyEvaluator =
                 new EvictionPolicyEvaluator() {
                     @Override
@@ -155,12 +156,10 @@ public class EvictionStrategyTest extends HazelcastTestSupport {
         assertTrue(cacheRecordMap.containsKey(expectedData));
         assertTrue(cacheRecordMap.containsValue(expectedEvictedRecord));
 
-        int evictedCount = evictionStrategy.evict(cacheRecordMap, evictionPolicyEvaluator,
-                EvictionChecker.EVICT_ALWAYS, EvictionListener.NO_LISTENER);
+        int evictedCount = evictionStrategy.evict((S) cacheRecordMap, evictionPolicyEvaluator, EVICT_ALWAYS, NO_LISTENER);
         assertEquals(EXPECTED_EVICTED_COUNT, evictedCount);
         assertEquals(RECORD_COUNT - EXPECTED_EVICTED_COUNT, cacheRecordMap.size());
         assertFalse(cacheRecordMap.containsKey(expectedData));
         assertFalse(cacheRecordMap.containsValue(expectedEvictedRecord));
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheBatchInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheBatchInvalidationTest.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package com.hazelcast.map.impl.nearcache;
 
 import com.hazelcast.cache.impl.nearcache.NearCache;
@@ -71,17 +70,17 @@ public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
             map1.put(i, i);
         }
 
-        // fill near-cache on node-1
+        // fill Near Cache on node-1
         for (int i = 0; i < size; i++) {
             map1.get(i);
         }
 
-        // fill near-cache on node-2
+        // fill Near Cache on node-2
         for (int i = 0; i < size; i++) {
             map2.get(i);
         }
 
-        // generate invalidation data.
+        // generate invalidation data
         for (int i = 0; i < size; i++) {
             map1.put(i, i);
         }
@@ -94,9 +93,7 @@ public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
                 assertEquals(0, nearCache1.size() + nearCache2.size());
             }
         });
-
     }
-
 
     @Test
     public void testHigherBatchSize_shouldNotCauseAnyInvalidation_onRemoteNode() throws Exception {
@@ -111,7 +108,6 @@ public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
         IMap<String, Integer> map1 = node1.getMap(mapName);
         IMap<String, Integer> map2 = node2.getMap(mapName);
 
-
         int size = 1000;
 
         List<String> keys = new ArrayList<String>();
@@ -119,23 +115,22 @@ public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
             keys.add(generateKeyOwnedBy(node1));
         }
 
-
         // fill map-1
         for (int i = 0; i < size; i++) {
             map1.put(keys.get(i), i);
         }
 
-        // fill near-cache on node-1
+        // fill Near Cache on node-1
         for (int i = 0; i < size; i++) {
             map1.get(keys.get(i));
         }
 
-        // fill near-cache on node-2
+        // fill Near Cache on node-2
         for (int i = 0; i < size; i++) {
             map2.get(keys.get(i));
         }
 
-        // generate invalidation data.
+        // generate invalidation data
         for (int i = 0; i < size; i++) {
             map1.put(keys.get(i), i);
         }
@@ -143,7 +138,7 @@ public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
         NearCache nearCache1 = ((NearCachedMapProxyImpl) map1).getNearCache();
         NearCache nearCache2 = ((NearCachedMapProxyImpl) map2).getNearCache();
 
-        // Near-cache on one node should be invalidated wholly, other node should not receive any event.
+        // Near Cache on one node should be invalidated wholly, other node should not receive any event.
         // Due to the higher batch-size to sent invalidation.
         assertEquals(size, nearCache1.size() + nearCache2.size());
     }
@@ -169,12 +164,12 @@ public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
             map1.put(i, i);
         }
 
-        // fill near-cache on node-1
+        // fill Near Cache on node-1
         for (int i = 0; i < size; i++) {
             map1.get(i);
         }
 
-        // fill near-cache on node-2
+        // fill Near Cache on node-2
         for (int i = 0; i < size; i++) {
             map2.get(i);
         }
@@ -189,9 +184,7 @@ public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
                 assertEquals(0, nearCache1.size() + nearCache2.size());
             }
         });
-
     }
-
 
     @Test
     public void testMapEvictAll_shouldClearNearCaches_onOwnerAndBackupNodes() throws Exception {
@@ -214,12 +207,12 @@ public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
             map1.put(i, i);
         }
 
-        // fill near-cache on node-1
+        // fill Near Cache on node-1
         for (int i = 0; i < size; i++) {
             map1.get(i);
         }
 
-        // fill near-cache on node-2
+        // fill Near Cache on node-2
         for (int i = 0; i < size; i++) {
             map2.get(i);
         }
@@ -234,7 +227,6 @@ public class NearCacheBatchInvalidationTest extends HazelcastTestSupport {
                 assertEquals(0, nearCache1.size() + nearCache2.size());
             }
         });
-
     }
 
     protected Config newConfig(String mapName) {

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLiteMemberTest.java
@@ -471,7 +471,7 @@ public class NearCacheLiteMemberTest {
     private static void assertLiteMemberNearCacheNonEmpty(HazelcastInstance instance, String mapName) {
         NearCache nearCache = getNearCache(instance, mapName);
         int sizeAfterPut = nearCache.size();
-        assertTrue("NearCache size should be > 0 but was " + sizeAfterPut, sizeAfterPut > 0);
+        assertTrue("Near Cache size should be > 0 but was " + sizeAfterPut, sizeAfterPut > 0);
     }
 
     private static void assertNearCacheIsEmptyEventually(HazelcastInstance instance, String mapName) {

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLocalImmediateInvalidateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLocalImmediateInvalidateTest.java
@@ -101,7 +101,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String value = "merhaba-" + key;
 
             String value0 = map.put(key, value);
-            // this brings the value into the NearCache
+            // this brings the value into the Near Cache
             String value1 = map.get(key);
             map.delete(key);
             // here we _might_ still see the value
@@ -121,7 +121,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String value = "merhaba-" + key;
 
             String value0 = map.put(key, value);
-            // this brings the value into the NearCache
+            // this brings the value into the Near Cache
             String value1 = map.get(key);
             map.remove(key, value);
             // here we _might_ still see the value
@@ -141,7 +141,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String value = "merhaba-" + key;
 
             String value0 = map.put(key, value);
-            // this brings the value into the NearCache
+            // this brings the value into the Near Cache
             String value1 = map.get(key);
             map.tryRemove(key, TIMEOUT, TIME_UNIT);
             // here we _might_ still see the value
@@ -161,7 +161,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String value = "merhaba-" + key;
 
             String value0 = map.put(key, value);
-            // this brings the value into the NearCache
+            // this brings the value into the Near Cache
             String value1 = map.get(key);
             Future<String> future = map.removeAsync(key);
             String value2 = null;
@@ -189,7 +189,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String key = "put_" + String.valueOf(k);
             String value = "merhaba-" + key;
 
-            // this brings the NULL_OBJECT into the NearCache
+            // this brings the NULL_OBJECT into the Near Cache
             String value0 = map.get(key);
             String value1 = map.put(key, value);
             // here we _might_ still see the NULL_OBJECT
@@ -208,7 +208,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String key = "tryput_" + String.valueOf(k);
             String value = "merhaba-" + key;
 
-            // this brings the NULL_OBJECT into the NearCache
+            // this brings the NULL_OBJECT into the Near Cache
             String value0 = map.get(key);
             map.tryPut(key, value, TIMEOUT, TIME_UNIT);
             // here we _might_ still see the NULL_OBJECT
@@ -226,7 +226,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String key = "putifabsent_" + String.valueOf(k);
             String value = "merhaba-" + key;
 
-            // this brings the NULL_OBJECT into the NearCache
+            // this brings the NULL_OBJECT into the Near Cache
             String value0 = map.get(key);
             String value1 = map.putIfAbsent(key, value);
             // here we _might_ still see the NULL_OBJECT
@@ -245,7 +245,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String key = "puttransient_" + String.valueOf(k);
             String value = "merhaba-" + key;
 
-            // this brings the NULL_OBJECT into the NearCache
+            // this brings the NULL_OBJECT into the Near Cache
             String value0 = map.get(key);
             map.putTransient(key, value, 0, TIME_UNIT);
             // here we _might_ still see the NULL_OBJECT
@@ -289,7 +289,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String value = "merhaba-" + key;
 
             String value0 = map.put(key, value);
-            // this brings the value into the NearCache
+            // this brings the value into the Near Cache
             String value1 = map.get(key);
             map.evict(key);
             // here we _might_ still see the value
@@ -328,7 +328,7 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
             String valueNew = "merhaba-new" + key;
 
             map.put(key, value);
-            // this brings the NULL_OBJECT into the NearCache
+            // this brings the NULL_OBJECT into the Near Cache
             String value0 = map.get(key);
             map.replace(key, valueNew);
             // here we _might_ still see the NULL_OBJECT


### PR DESCRIPTION
* renamed `NearChache.isInvalidateOnChange()` to `NearCache.isInvalidatedOnChange()`
* added missing generics to reduce warnings and make clearer which types are expected in which implementation
* unified naming of Near Cache (according to our documentation)
* fixed and improved some JavaDoc
* improved some comments
* whitespace formatting

The only modified classes which are not in an `impl` or `internal` package are:
* `ClientReplicatedMapProxy`
* `NearCachedClientMapProxy`
* `NearCacheTestSupport`

I didn't change any method interface in those classes, so there should be no compatibility issues.