### PR TITLE
Always populate proxy info in post join operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -86,20 +86,17 @@ public final class ProxyRegistry {
     }
 
     /**
-     * Gets the ProxyInfo of all proxies in this registry. The result is written into 'result'.
+     * Gets the ProxyInfo of all fully initialized proxies in this registry.
+     * The result is written into 'result'.
      *
      * @param result The ProxyInfo of all proxies in this registry.
      */
     public void getProxyInfos(Collection<ProxyInfo> result) {
         for (Map.Entry<String, DistributedObjectFuture> entry : proxies.entrySet()) {
-            final DistributedObjectFuture future = entry.getValue();
-            if (!future.isSet()) {
-                continue;
-            }
-            final DistributedObject distributedObject = future.get();
-
-            if (distributedObject instanceof InitializingObject) {
-                result.add(new ProxyInfo(serviceName, entry.getKey()));
+            DistributedObjectFuture future = entry.getValue();
+            if (future.isSet()) {
+                String proxyName = entry.getKey();
+                result.add(new ProxyInfo(serviceName, proxyName));
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/core/ProxySplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/ProxySplitBrainTest.java
@@ -1,0 +1,43 @@
+package com.hazelcast.core;
+
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.SplitBrainTestSupport;
+
+import static org.junit.Assert.assertEquals;
+
+public class ProxySplitBrainTest extends SplitBrainTestSupport {
+
+    @Override
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+        HazelcastInstance isolatedInstance = firstBrain[0];
+        isolatedInstance.getLock("isolatedLock");
+        assertDistributedObjectCountEventually(1, isolatedInstance);
+
+        for (HazelcastInstance hz : secondBrain) {
+            String name = generateKeyOwnedBy(hz);
+            hz.getLock(name);
+        }
+
+        for (HazelcastInstance hz : secondBrain) {
+            int expectedCount = secondBrain.length;
+            assertDistributedObjectCountEventually(expectedCount, hz);
+        }
+    }
+
+    @Override
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] allInstances) {
+        for (HazelcastInstance hz : allInstances) {
+            assertDistributedObjectCountEventually(allInstances.length, hz);
+        }
+    }
+
+    private static void assertDistributedObjectCountEventually(final int expectedCount, final HazelcastInstance hz) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                int actualSize = hz.getDistributedObjects().size();
+                assertEquals(expectedCount, actualSize);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Reasoning:
Even when a proxy does not need any initialization it has to be send
all other members during merge. Otherwise some objects won't be
visible in `getDistributedObjects()`

Fixes #8743
