### PR TITLE
[BACKPORT] Fix wrong client defaults when configured via Spring

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.7.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.7.xsd
@@ -2119,9 +2119,9 @@
             <xs:element name="aws" type="aws-client" minOccurs="0" maxOccurs="1"/>
             <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
-        <xs:attribute name="smart-routing" use="optional" type="parameterized-boolean" default="false"/>
+        <xs:attribute name="smart-routing" use="optional" type="parameterized-boolean" default="true"/>
         <xs:attribute name="redo-operation" use="optional" type="parameterized-boolean" default="false"/>
-        <xs:attribute name="connection-timeout" use="optional" type="parameterized-positive-integer" default="60000"/>
+        <xs:attribute name="connection-timeout" use="optional" type="parameterized-positive-integer" default="5000"/>
         <xs:attribute name="connection-attempt-period" use="optional" type="parameterized-positive-integer" default="3000"/>
         <xs:attribute name="connection-attempt-limit" use="optional" type="parameterized-non-negative-integer" default="2"/>
     </xs:complexType>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientConfigAndSpringDefaults.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientConfigAndSpringDefaults.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+
+import javax.annotation.Resource;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(CustomSpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"client-network-defaults-context.xml"})
+@Category(QuickTest.class)
+public class TestClientConfigAndSpringDefaults {
+
+    private ClientConfig clientConfig;
+
+    @Resource(name = "client")
+    private HazelcastClientProxy client;
+
+    @BeforeClass
+    @AfterClass
+    public static void start() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Before
+    public void before() throws IllegalAccessException {
+        clientConfig = client.getClientConfig();
+    }
+
+    @Test
+    public void testDefaults() {
+        ClientConfig defaults = new ClientConfig();
+
+        assertEquals(defaults.isSmartRouting(), clientConfig.isSmartRouting());
+        assertEquals(defaults.getNetworkConfig().isSmartRouting(), clientConfig.getNetworkConfig().isSmartRouting());
+        assertEquals(defaults.getNetworkConfig().getConnectionTimeout(), clientConfig.getNetworkConfig().getConnectionTimeout());
+    }
+}

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.hazelcast.com/schema/spring
+		http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
+
+    <hz:hazelcast id="instance"/>
+
+    <hz:client id="client">
+        <hz:network/>
+    </hz:client>
+
+</beans>


### PR DESCRIPTION
Fix #8746, Backport of #8747
It would be great to  just use equals() on the config objects,
however a lot of our *Config(s) do not override equals()/hashcode()
and moreover the config objects are mutated in some cases - e.g.
  https://github.com/hazelcast/hazelcast/blob/eef987b9920f3f7b4c506e433b0d067cab9ba93c/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java#L207-L207

(cherry picked from commit 939c25c)