### PR TITLE
Client mocked connections uses the same local Address

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -366,9 +366,11 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
     @Override
     public void destroyConnection(final Connection connection, final String reason, final Throwable cause) {
-        Address endpoint = connection.getEndPoint();
+        Address endPoint = connection.getEndPoint();
         ClientConnection conn = (ClientConnection) connection;
-        if (endpoint != null && connections.remove(endpoint, conn)) {
+        if (endPoint != null && connections.remove(endPoint, conn)) {
+            logger.info("Removed connection to endpoint: " + endPoint + ", connection: " + connection);
+
             conn.close(reason, cause);
             for (ConnectionListener connectionListener : connectionListeners) {
                 connectionListener.connectionRemoved(conn);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 public class TestClientRegistry {
@@ -67,17 +68,17 @@ public class TestClientRegistry {
         this.nodeRegistry = nodeRegistry;
     }
 
-
-    ClientConnectionManagerFactory createClientServiceFactory(Address clientAddress) {
-        return new MockClientConnectionManagerFactory(clientAddress);
+    public ClientConnectionManagerFactory createClientServiceFactory(String host, AtomicInteger ports) {
+        return new MockClientConnectionManagerFactory(host, ports);
     }
 
     private class MockClientConnectionManagerFactory implements ClientConnectionManagerFactory {
+        private final String host;
+        private final AtomicInteger ports;
 
-        private final Address clientAddress;
-
-        public MockClientConnectionManagerFactory(Address clientAddress) {
-            this.clientAddress = clientAddress;
+        public MockClientConnectionManagerFactory(String host, AtomicInteger ports) {
+            this.host = host;
+            this.ports = ports;
         }
 
         @Override
@@ -94,26 +95,29 @@ public class TestClientRegistry {
                     throw e;
                 }
             } else if (discoveryService != null) {
-                addressTranslator = new DiscoveryAddressTranslator(discoveryService, client.getProperties().getBoolean(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED));
+                addressTranslator = new DiscoveryAddressTranslator(discoveryService,
+                        client.getProperties().getBoolean(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED));
             } else {
                 addressTranslator = new DefaultAddressTranslator();
             }
-            return new MockClientConnectionManager(client, addressTranslator, clientAddress);
+            return new MockClientConnectionManager(client, addressTranslator, host, ports);
         }
     }
 
 
     public class MockClientConnectionManager extends ClientConnectionManagerImpl {
 
-        private final Address clientAddress;
+        private final String host;
+        private final AtomicInteger ports;
         private final HazelcastClientInstanceImpl client;
         private final Map<Address, State> stateMap = new ConcurrentHashMap<Address, State>();
 
         public MockClientConnectionManager(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
-                                           Address clientAddress) {
+                                           String host, AtomicInteger ports) {
             super(client, addressTranslator);
             this.client = client;
-            this.clientAddress = clientAddress;
+            this.host = host;
+            this.ports = ports;
         }
 
         @Override
@@ -142,8 +146,9 @@ public class TestClientRegistry {
                     throw new IOException("Can not connected to " + address + ": instance does not exist");
                 }
                 Node node = TestUtil.getNode(instance);
+                Address localAddress = new Address(host, ports.incrementAndGet());
                 return new MockedClientConnection(client, connectionIdGen.incrementAndGet(),
-                        node.nodeEngine, address, clientAddress, stateMap);
+                        node.nodeEngine, address, localAddress, stateMap);
             } catch (Exception e) {
                 throw ExceptionUtil.rethrow(e, IOException.class);
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -147,8 +147,10 @@ public class TestClientRegistry {
                 }
                 Node node = TestUtil.getNode(instance);
                 Address localAddress = new Address(host, ports.incrementAndGet());
-                return new MockedClientConnection(client, connectionIdGen.incrementAndGet(),
-                        node.nodeEngine, address, localAddress, stateMap);
+                MockedClientConnection connection = new MockedClientConnection(client,
+                        connectionIdGen.incrementAndGet(), node.nodeEngine, address, localAddress, stateMap);
+                LOGGER.info("Created connection to endpoint: " + address + ", connection: " + connection);
+                return connection;
             } catch (Exception e) {
                 throw ExceptionUtil.rethrow(e, IOException.class);
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -68,7 +68,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
                 Thread.currentThread().setContextClassLoader(HazelcastClient.class.getClassLoader());
             }
             ClientConnectionManagerFactory clientConnectionManagerFactory =
-                    clientRegistry.createClientServiceFactory(createAddress("127.0.0.1", clientPorts.incrementAndGet()));
+                    clientRegistry.createClientServiceFactory("127.0.0.1", clientPorts);
             AddressProvider testAddressProvider = createAddressProvider(config);
             HazelcastClientInstanceImpl client =
                     new HazelcastClientInstanceImpl(config, clientConnectionManagerFactory, testAddressProvider);

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
@@ -28,12 +28,14 @@ import com.hazelcast.util.ExceptionUtil;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class DroppingConnection implements Connection {
 
     final Address endpoint;
     final long timestamp = Clock.currentTimeMillis();
     private final ConnectionManager connectionManager;
+    private AtomicBoolean isClosing = new AtomicBoolean(false);
 
     DroppingConnection(Address endpoint, ConnectionManager connectionManager) {
         this.endpoint = endpoint;
@@ -73,7 +75,9 @@ class DroppingConnection implements Connection {
     @Override
     public void close(String msg, Throwable cause) {
         if (connectionManager instanceof MockConnectionManager) {
-            ((MockConnectionManager)connectionManager).destroyConnection(this);
+            if (isClosing.compareAndSet(false, true)) {
+                ((MockConnectionManager)connectionManager).destroyConnection(this);
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -165,25 +165,27 @@ public class MockConnectionManager implements ConnectionManager {
 
     public void destroyConnection(final Connection connection) {
         final Address endPoint = connection.getEndPoint();
-        final boolean removed = mapConnections.remove(endPoint, connection);
-        if (!removed) {
-            return;
-        }
+        if (null != endPoint && mapConnections.remove(endPoint, connection)) {
+            logger.info("Removed connection to endpoint: " + endPoint + ", connection: " + connection);
 
-        logger.info("Removed connection to endpoint: " + endPoint + ", connection: " + connection);
-        ioService.getEventService().executeEventCallback(new StripedRunnable() {
-            @Override
-            public void run() {
-                for (ConnectionListener listener : connectionListeners) {
-                    listener.connectionRemoved(connection);
+            connection.close(null, null);
+
+            ioService.getEventService().executeEventCallback(new StripedRunnable() {
+                @Override
+                public void run() {
+                    for (ConnectionListener listener : connectionListeners) {
+                        listener.connectionRemoved(connection);
+                    }
                 }
-            }
 
-            @Override
-            public int getKey() {
-                return endPoint.hashCode();
-            }
-        });
+                @Override
+                public int getKey() {
+                    return endPoint.hashCode();
+                }
+            });
+        } else {
+            connection.close(null, null);
+        }
     }
 
     @Override


### PR DESCRIPTION
Modified the mock connection manager so that each new client gets a different local Address. Previously they were getting the same ip port (this confuses the logs and at some places the address is used as key to the connection maps) but their connection id was different, hence this usually did not cause any problems. The fix assigns unique port numbers for each mocked client connection.