### PR TITLE
Added eviction and expiration count to NearCacheStats

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -131,4 +131,34 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     public void putAsyncToCacheAndThenGetFromClientNearCacheImmediatelyWithObjectInMemoryFormat() throws Exception {
         putAsyncToCacheAndThenGetFromClientNearCacheImmediately(InMemoryFormat.OBJECT);
     }
+
+    @Test
+    public void testNearCacheEviction_withObjectInMemoryFormat() {
+        testNearCacheEviction(InMemoryFormat.OBJECT);
+    }
+
+    @Test
+    public void testNearCacheEviction_withBinaryInMemoryFormat() {
+        testNearCacheEviction(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void testNearCacheTTLRecordsExpired_withObjectInMemoryFormat() {
+        testNearCacheExpiration_withTTL(InMemoryFormat.OBJECT);
+    }
+
+    @Test
+    public void testNearCacheTTLRecordsExpired_withBinaryInMemoryFormat() {
+        testNearCacheExpiration_withTTL(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void testNearCacheIdleRecordsExpired_withObjectInMemoryFormat() {
+        testNearCacheExpiration_withMaxIdle(InMemoryFormat.OBJECT);
+    }
+
+    @Test
+    public void testNearCacheIdleRecordsExpired_withBinaryInMemoryFormat() {
+        testNearCacheExpiration_withMaxIdle(InMemoryFormat.BINARY);
+    }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -26,12 +26,15 @@ import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.instance.LifecycleServiceImpl;
+import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
@@ -53,14 +56,18 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.spi.properties.GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
+import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
     protected static final String DEFAULT_CACHE_NAME = "ClientCache";
     protected static final int DEFAULT_RECORD_COUNT = 100;
+    protected static final int MAX_TTL_SECONDS = 2;
+    protected static final int MAX_IDLE_SECONDS = 1;
 
     protected HazelcastInstance serverInstance;
 
@@ -86,6 +93,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
 
     protected CacheConfig createCacheConfig(InMemoryFormat inMemoryFormat) {
         CacheConfig cacheConfig = new CacheConfig().setName(DEFAULT_CACHE_NAME).setInMemoryFormat(inMemoryFormat);
+        //noinspection unchecked
         cacheConfig.setCacheLoaderFactory(FactoryBuilder.factoryOf(ClientNearCacheTestSupport.TestCacheLoader.class));
         return cacheConfig;
     }
@@ -109,6 +117,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         CachingProvider provider = HazelcastClientCachingProvider.createCachingProvider(client);
         HazelcastClientCacheManager cacheManager = (HazelcastClientCacheManager) provider.getCacheManager();
 
+        //noinspection unchecked
         ICache<Object, String> cache = cacheManager.createCache(cacheName, cacheConfig);
 
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(cacheManager.getCacheNameWithPrefix(cacheName));
@@ -209,7 +218,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             final Integer key = i;
             final String value = nearCacheTestContext2.cache.get(key);
             // records are stored in the cache as async not sync, so these records will be there in cache eventually
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -227,7 +236,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             final int key = i;
             // records are stored in the near-cache will be invalidated eventually, since cache records are updated
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -241,7 +250,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             final Integer key = i;
             final String value = nearCacheTestContext2.cache.get(key);
             // records are stored in the cache as async not sync, so these records will be there in cache eventually
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -302,7 +311,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         // verify that records in the near-cache of client-1 are invalidated eventually when instance shutdown
         for (Map.Entry<String, String> entry : keyAndValues.entrySet()) {
             final String key = entry.getKey();
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext1.serializationService.toData(key);
@@ -328,7 +337,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             final Integer key = i;
             final String value = nearCacheTestContext2.cache.get(key);
             // records are stored in the cache as async not sync, so these records will be there in cache eventually
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -346,7 +355,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             final int key = i;
             // records are stored in the near-cache will be invalidated eventually, since cache records are updated.
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -394,7 +403,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         for (int i : loadKeys) {
             final int key = i;
             // records are stored in the near-cache will be invalidated eventually, since cache records are updated
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -420,7 +429,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             final Integer key = i;
             final String value = nearCacheTestContext2.cache.get(key);
             // records are stored in the cache as async not sync, so these records will be there in cache eventually
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -435,7 +444,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             final int key = i;
             // records are stored in the near-cache will be invalidated eventually, since cache records are cleared
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -461,7 +470,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             Data keyData = nearCacheTestContext.serializationService.toData(i);
             // check if same reference to verify data coming from near cache
-            assertTrue(nearCacheTestContext.cache.get(i) == nearCacheTestContext.nearCache.get(keyData));
+            assertSame(nearCacheTestContext.cache.get(i), nearCacheTestContext.nearCache.get(keyData));
         }
     }
 
@@ -484,7 +493,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             final Integer key = i;
             final String value = nearCacheTestContext2.cache.get(key);
             // records are stored in the cache as async not sync, so these records will be there in cache eventually
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -519,7 +528,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             final int key = i;
             // records are stored in the near-cache will be invalidated eventually, since cache records are cleared
             // because we just disable per entry invalidation events, not full-flush events
-            HazelcastTestSupport.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     Data keyData = nearCacheTestContext2.serializationService.toData(key);
@@ -527,6 +536,112 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                 }
             });
         }
+    }
+
+    protected void testNearCacheEviction(InMemoryFormat inMemoryFormat) {
+        int size = 100;
+        int expectedEvictions = 1;
+
+        EvictionConfig evictionConfig = new EvictionConfig()
+                .setEvictionPolicy(EvictionPolicy.LRU)
+                .setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT)
+                .setSize(size);
+
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+        nearCacheConfig.setEvictionConfig(evictionConfig);
+
+        NearCacheTestContext context = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
+
+        // populate map with an extra entry
+        for (int i = 0; i < size + 1; i++) {
+            context.cache.put(i, "value-" + i);
+        }
+
+        // populate Near Caches
+        for (int i = 0; i < size; i++) {
+            context.cache.get(i);
+        }
+
+        NearCacheStats statsBeforeEviction = getNearCacheStats(context.cache);
+
+        // trigger eviction via fetching the extra entry
+        context.cache.get(size);
+
+        waitForNearCacheEvictions(context.cache, expectedEvictions);
+
+        // we expect (size + the extra entry - the expectedEvictions) entries in the Near Cache
+        int expectedOwnedEntryCount = size + 1 - expectedEvictions;
+
+        NearCacheStats stats = getNearCacheStats(context.cache);
+        assertEquals("got the wrong ownedEntryCount", expectedOwnedEntryCount, stats.getOwnedEntryCount());
+        assertEquals("got the wrong eviction count", expectedEvictions, stats.getEvictions());
+        assertEquals("got the wrong expiration count", 0, stats.getExpirations());
+        assertEquals("we expect the same hits", statsBeforeEviction.getHits(), stats.getHits());
+        assertEquals("we expect the same misses", statsBeforeEviction.getMisses(), stats.getMisses());
+    }
+
+    protected void testNearCacheExpiration_withTTL(InMemoryFormat inMemoryFormat) {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+        nearCacheConfig.setTimeToLiveSeconds(MAX_TTL_SECONDS);
+
+        testNearCacheExpiration(nearCacheConfig, MAX_TTL_SECONDS);
+    }
+
+    protected void testNearCacheExpiration_withMaxIdle(InMemoryFormat inMemoryFormat) {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+        nearCacheConfig.setTimeToLiveSeconds(MAX_IDLE_SECONDS);
+
+        testNearCacheExpiration(nearCacheConfig, MAX_IDLE_SECONDS);
+    }
+
+    private void testNearCacheExpiration(NearCacheConfig nearCacheConfig, int expireSeconds) {
+        final int size = 147;
+
+        final NearCacheTestContext context = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
+
+        for (int i = 0; i < size; i++) {
+            context.cache.put(i, "value-" + i);
+            context.cache.get(i);
+        }
+
+        final NearCacheStats statsBeforeExpiration = getNearCacheStats(context.cache);
+        assertEquals(format("we expected to have all map entries in the Near Cache (%s)", statsBeforeExpiration),
+                size, statsBeforeExpiration.getOwnedEntryCount() + statsBeforeExpiration.getExpirations());
+
+        sleepSeconds(expireSeconds + 1);
+
+        assertTrueEventually(new AssertTask() {
+            public void run() {
+                // map.get() triggers Near Cache eviction/expiration process,
+                // but we need to call this on every assert since the Near Cache has a cooldown for TTL cleanups
+                context.cache.get(0);
+
+                NearCacheStats stats = getNearCacheStats(context.cache);
+                assertEquals("we expect the same hits", statsBeforeExpiration.getHits(), stats.getHits());
+                assertEquals("we expect the same misses", statsBeforeExpiration.getMisses(), stats.getMisses());
+                assertEquals("we expect all entries beside the 'trigger entry' to be deleted from the Near Cache",
+                        1, stats.getOwnedEntryCount());
+                assertEquals("we did not expect any entries to be evicted from the Near Cache",
+                        0, stats.getEvictions());
+                assertTrue(format("we expect at least %d entries to be expired from the Near Cache", size),
+                        stats.getExpirations() >= size);
+            }
+        });
+    }
+
+    protected NearCacheStats getNearCacheStats(ICache cache) {
+        return cache.getLocalCacheStatistics().getNearCacheStatistics();
+    }
+
+    protected void waitForNearCacheEvictions(final ICache cache, final int evictionCount) {
+        assertTrueEventually(new AssertTask() {
+            public void run() {
+                long evictions = getNearCacheStats(cache).getEvictions();
+                assertTrue(
+                        format("Near Cache eviction count didn't reach the desired value (%d vs. %d)", evictions, evictionCount),
+                        evictions >= evictionCount);
+            }
+        });
     }
 
     public static class TestCacheLoader implements CacheLoader<Integer, String> {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -363,7 +363,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     @Override
-    public void onEvict(Data key, R record) {
+    public void onEvict(Data key, R record, boolean wasExpired) {
         invalidateEntry(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -77,8 +77,8 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
     }
 
     @Override
-    public void onEvict(K key, R record) {
-        super.onEvict(key, record);
+    public void onEvict(K key, R record, boolean wasExpired) {
+        super.onEvict(key, record, wasExpired);
         nearCacheStats.decrementOwnedEntryMemoryCost(getTotalStorageMemoryCost(key, record));
     }
 
@@ -89,6 +89,7 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
             R value = entry.getValue();
             if (isRecordExpired(value)) {
                 remove(key);
+                onExpire(key, value);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/HeapNearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/HeapNearCacheRecordMap.java
@@ -102,7 +102,7 @@ public class HeapNearCacheRecordMap<K, V extends NearCacheRecord>
             if (remove(evictionCandidate.getAccessor()) != null) {
                 actualEvictedCount++;
                 if (evictionListener != null) {
-                    evictionListener.onEvict(evictionCandidate.getAccessor(), evictionCandidate.getEvictable());
+                    evictionListener.onEvict(evictionCandidate.getAccessor(), evictionCandidate.getEvictable(), false);
                 }
             }
         }
@@ -113,5 +113,4 @@ public class HeapNearCacheRecordMap<K, V extends NearCacheRecord>
     public Iterable<NearCacheEvictableSamplingEntry> sample(int sampleCount) {
         return super.getRandomSamples(sampleCount);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -203,7 +203,7 @@ public class CacheRecordHashMap
             if (remove(evictionCandidate.getAccessor()) != null) {
                 actualEvictedCount++;
                 if (evictionListener != null) {
-                    evictionListener.onEvict(evictionCandidate.getAccessor(), evictionCandidate.getEvictable());
+                    evictionListener.onEvict(evictionCandidate.getAccessor(), evictionCandidate.getEvictable(), false);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionListener.java
@@ -32,10 +32,9 @@ public interface EvictionListener<A, E extends Evictable> {
     /**
      * Called when an {@link Evictable} entry is evicted.
      *
-     * @param evictedEntryAccessor  Accessor of the {@link Evictable} entry
-     *                              that is evicted.
-     * @param evictedEntry          {@link Evictable} entry that is evicted.
+     * @param evictedEntryAccessor Accessor of the {@link Evictable} entry that is evicted.
+     * @param evictedEntry         {@link Evictable} entry that is evicted.
+     * @param wasExpired           {@code true} if the entry was evicted due to expiration, {@code false} otherwise
      */
-    void onEvict(A evictedEntryAccessor, E evictedEntry);
-
+    void onEvict(A evictedEntryAccessor, E evictedEntry, boolean wasExpired);
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/NearCacheStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/NearCacheStats.java
@@ -19,44 +19,58 @@ package com.hazelcast.monitor;
 public interface NearCacheStats extends LocalInstanceStats {
 
     /**
-     * Returns the creation time of this NearCache on this member
+     * Returns the creation time of this Near Cache on this member.
      *
-     * @return creation time of this NearCache on this member
+     * @return creation time of this Near Cache on this member.
      */
     long getCreationTime();
 
     /**
-     * Returns the number of entries owned by this member.
+     * Returns the number of Near Cache entries owned by this member.
      *
-     * @return number of entries owned by this member.
+     * @return number of Near Cache entries owned by this member.
      */
     long getOwnedEntryCount();
 
     /**
-     * Returns memory cost (number of bytes) of entries in this cache.
+     * Returns memory cost (number of bytes) of Near Cache entries owned by this member.
      *
-     * @return memory cost (number of bytes) of entries in this cache.
+     * @return memory cost (number of bytes) of Near Cache entries owned by this member.
      */
     long getOwnedEntryMemoryCost();
 
     /**
-     * Returns the number of hits (reads) of the locally owned entries.
+     * Returns the number of hits (reads) of Near Cache entries owned by this member.
      *
-     * @return number of hits (reads) of the locally owned entries.
+     * @return number of hits (reads) of Near Cache entries owned by this member.
      */
     long getHits();
 
     /**
-     * Returns the number of misses of the locally owned entries.
+     * Returns the number of misses of Near Cache entries owned by this member.
      *
-     * @return number of misses of the locally owned entries.
+     * @return number of misses of Near Cache entries owned by this member.
      */
     long getMisses();
 
     /**
-     * Returns the hit/miss ratio of the locally owned entries.
+     * Returns the hit/miss ratio of Near Cache entries owned by this member.
      *
-     * @return hit/miss ratio of the locally owned entries.
+     * @return hit/miss ratio of Near Cache entries owned by this member.
      */
     double getRatio();
+
+    /**
+     * Returns the number of evictions of Near Cache entries owned by this member.
+     *
+     * @return number of evictions of Near Cache entries owned by this member.
+     */
+    long getEvictions();
+
+    /**
+     * Returns the number of TTL and max-idle expirations of Near Cache entries owned by this member.
+     *
+     * @return number of TTL and max-idle expirations of Near Cache entries owned by this member.
+     */
+    long getExpirations();
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
@@ -37,12 +37,18 @@ public class NearCacheStatsImpl implements NearCacheStats {
             newUpdater(NearCacheStatsImpl.class, "hits");
     private static final AtomicLongFieldUpdater<NearCacheStatsImpl> MISSES =
             newUpdater(NearCacheStatsImpl.class, "misses");
+    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> EVICTIONS =
+            newUpdater(NearCacheStatsImpl.class, "evictions");
+    private static final AtomicLongFieldUpdater<NearCacheStatsImpl> EXPIRATIONS =
+            newUpdater(NearCacheStatsImpl.class, "expirations");
 
     private volatile long creationTime;
     private volatile long ownedEntryCount;
     private volatile long ownedEntryMemoryCost;
     private volatile long hits;
     private volatile long misses;
+    private volatile long evictions;
+    private volatile long expirations;
 
     public NearCacheStatsImpl() {
         this.creationTime = Clock.currentTimeMillis();
@@ -92,12 +98,13 @@ public class NearCacheStatsImpl implements NearCacheStats {
         return hits;
     }
 
-    public void incrementHits() {
-        HITS.incrementAndGet(this);
+    // just for testing
+    void setHits(long hits) {
+        HITS.set(this, hits);
     }
 
-    public void setHits(long hits) {
-        HITS.set(this, hits);
+    public void incrementHits() {
+        HITS.incrementAndGet(this);
     }
 
     @Override
@@ -105,7 +112,8 @@ public class NearCacheStatsImpl implements NearCacheStats {
         return misses;
     }
 
-    public void setMisses(long misses) {
+    // just for testing
+    void setMisses(long misses) {
         MISSES.set(this, misses);
     }
 
@@ -127,6 +135,34 @@ public class NearCacheStatsImpl implements NearCacheStats {
     }
 
     @Override
+    public long getEvictions() {
+        return evictions;
+    }
+
+    // just for testing
+    void setEvictions(long evictions) {
+        EVICTIONS.set(this, evictions);
+    }
+
+    public void incrementEvictions() {
+        EVICTIONS.incrementAndGet(this);
+    }
+
+    @Override
+    public long getExpirations() {
+        return expirations;
+    }
+
+    // just for testing
+    void setExpirations(long expirations) {
+        EXPIRATIONS.set(this, expirations);
+    }
+
+    public void incrementExpirations() {
+        EXPIRATIONS.incrementAndGet(this);
+    }
+
+    @Override
     public JsonObject toJson() {
         JsonObject root = new JsonObject();
         root.add("ownedEntryCount", ownedEntryCount);
@@ -134,6 +170,8 @@ public class NearCacheStatsImpl implements NearCacheStats {
         root.add("creationTime", creationTime);
         root.add("hits", hits);
         root.add("misses", misses);
+        root.add("evictions", evictions);
+        root.add("expirations", expirations);
         return root;
     }
 
@@ -144,6 +182,8 @@ public class NearCacheStatsImpl implements NearCacheStats {
         creationTime = getLong(json, "creationTime", -1L);
         hits = getLong(json, "hits", -1L);
         misses = getLong(json, "misses", -1L);
+        evictions = getLong(json, "evictions", -1L);
+        expirations = getLong(json, "expirations", -1L);
     }
 
     @Override
@@ -155,6 +195,8 @@ public class NearCacheStatsImpl implements NearCacheStats {
                 + ", hits=" + hits
                 + ", misses=" + misses
                 + ", ratio=" + String.format("%.1f%%", getRatio())
+                + ", evictions=" + evictions
+                + ", expirations=" + expirations
                 + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTestSupport.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.nearcache;
+
+import com.hazelcast.cache.impl.nearcache.NearCache;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapStoreAdapter;
+import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastTestSupport;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class NearCacheTestSupport extends HazelcastTestSupport {
+
+    protected static final int MAX_CACHE_SIZE = 50000;
+    protected static final int MAX_TTL_SECONDS = 2;
+    protected static final int MAX_IDLE_SECONDS = 1;
+
+    /**
+     * The OS Near Caches evict 20% + 1 of the Near Cache.
+     */
+    protected int getExpectedEvictionCount(int size) {
+        return (int) (size * 0.2) + 1;
+    }
+
+    protected void testNearCacheEviction(IMap<Integer, Integer> map, int size) {
+        int expectedEvictions = getExpectedEvictionCount(size);
+
+        // populate map with an extra entry
+        populateMap(map, size + 1);
+
+        // populate Near Caches
+        populateNearCache(map, size);
+
+        NearCacheStats statsBeforeEviction = getNearCacheStats(map);
+
+        // trigger eviction via fetching the extra entry
+        map.get(size);
+
+        waitForNearCacheEvictions(map, expectedEvictions);
+
+        // we expect (size + the extra entry - the expectedEvictions) entries in the Near Cache
+        int expectedOwnedEntryCount = size + 1 - expectedEvictions;
+
+        NearCacheStats stats = getNearCacheStats(map);
+        assertEquals("got the wrong ownedEntryCount", expectedOwnedEntryCount, stats.getOwnedEntryCount());
+        assertEquals("got the wrong eviction count", expectedEvictions, stats.getEvictions());
+        assertEquals("got the wrong expiration count", 0, stats.getExpirations());
+        assertEquals("we expect the same hits", statsBeforeEviction.getHits(), stats.getHits());
+        assertEquals("we expect the same misses", statsBeforeEviction.getMisses(), stats.getMisses());
+    }
+
+    protected void testNearCacheExpiration(final IMap<Integer, Integer> map, final int size, int expireSeconds) {
+        populateMap(map, size);
+        populateNearCache(map, size);
+
+        final NearCacheStats statsBeforeExpiration = getNearCacheStats(map);
+        assertEquals(format("we expected to have all map entries in the Near Cache (%s)", statsBeforeExpiration),
+                size, statsBeforeExpiration.getOwnedEntryCount() + statsBeforeExpiration.getExpirations());
+
+        sleepSeconds(expireSeconds + 1);
+
+        assertTrueEventually(new AssertTask() {
+            public void run() {
+                // map.get() triggers Near Cache eviction/expiration process,
+                // but we need to call this on every assert since the Near Cache has a cooldown for expiration cleanups
+                map.get(0);
+
+                NearCacheStats stats = getNearCacheStats(map);
+                assertEquals("we expect the same hits", statsBeforeExpiration.getHits(), stats.getHits());
+                assertEquals("we expect the same misses", statsBeforeExpiration.getMisses(), stats.getMisses());
+                assertEquals("we expect all entries beside the 'trigger entry' to be deleted from the Near Cache",
+                        1, stats.getOwnedEntryCount());
+                assertEquals("we did not expect any entries to be evicted from the Near Cache",
+                        0, stats.getEvictions());
+                assertTrue(format("we expect at least %d entries to be expired from the Near Cache", size),
+                        stats.getExpirations() >= size);
+            }
+        });
+    }
+
+    protected NearCacheConfig newNearCacheConfigWithEntryCountEviction(EvictionPolicy evictionPolicy, int size) {
+        return newNearCacheConfig()
+                .setCacheLocalEntries(true)
+                .setMaxSize(size)
+                .setEvictionPolicy(evictionPolicy.name());
+    }
+
+    protected NearCacheConfig newNearCacheConfig() {
+        return new NearCacheConfig();
+    }
+
+    protected void triggerEviction(IMap<Integer, Integer> map) {
+        map.put(0, 0);
+    }
+
+    /**
+     * There is a time-window in that an "is Near Cache evictable?" check may return {@code false},
+     * although the Near Cache size is bigger than the configured Near Cache max-size.
+     * This can happen because eviction process is offloaded to a different thread
+     * and there is no synchronization between the thread that puts the entry to the Near Cache
+     * and the thread which sweeps the entries from the Near Cache.
+     * This method continuously triggers the eviction to bring the Near Cache size under the configured max-size.
+     * Only needed for testing purposes.
+     */
+    protected void triggerNearCacheEviction(IMap<Integer, Integer> map) {
+        populateMap(map, 1);
+        populateNearCache(map, 1);
+    }
+
+    protected void waitForNearCacheEvictions(final IMap map, final int evictionCount) {
+        assertTrueEventually(new AssertTask() {
+            public void run() {
+                long evictions = getNearCacheStats(map).getEvictions();
+                assertTrue(
+                        format("Near Cache eviction count didn't reach the desired value (%d vs. %d)", evictions, evictionCount),
+                        evictions >= evictionCount);
+            }
+        });
+    }
+
+    protected void waitUntilEvictionEventsReceived(CountDownLatch latch) {
+        assertOpenEventually(latch);
+    }
+
+    protected void addEntryEvictedListener(IMap<Integer, Integer> map, final CountDownLatch latch) {
+        map.addLocalEntryListener(new EntryEvictedListener<Integer, Integer>() {
+            @Override
+            public void entryEvicted(EntryEvent<Integer, Integer> event) {
+                latch.countDown();
+            }
+        });
+    }
+
+    protected void populateMapWithExpirableEntries(IMap<Integer, Integer> map, int mapSize, long ttl, TimeUnit timeunit) {
+        for (int i = 0; i < mapSize; i++) {
+            map.put(i, i, ttl, timeunit);
+        }
+    }
+
+    protected void populateMap(Map<Integer, Integer> map, int mapSize) {
+        for (int i = 0; i < mapSize; i++) {
+            map.put(i, i);
+        }
+    }
+
+    protected void populateNearCache(IMap<Integer, ?> map, int mapSize) {
+        for (int i = 0; i < mapSize; i++) {
+            map.get(i);
+        }
+    }
+
+    protected Config createNearCachedMapConfig(String mapName) {
+        Config config = getConfig();
+
+        NearCacheConfig nearCacheConfig = newNearCacheConfig();
+        nearCacheConfig.setCacheLocalEntries(true);
+
+        MapConfig mapConfig = config.getMapConfig(mapName);
+        mapConfig.setNearCacheConfig(nearCacheConfig);
+
+        return config;
+    }
+
+    protected Config createNearCachedMapConfigWithMapStoreConfig(String mapName) {
+        SimpleMapStore store = new SimpleMapStore();
+
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setEnabled(true);
+        mapStoreConfig.setImplementation(store);
+
+        Config config = createNearCachedMapConfig(mapName);
+        config.getMapConfig(mapName).setMapStoreConfig(mapStoreConfig);
+
+        return config;
+    }
+
+    protected NearCache getNearCache(String mapName, HazelcastInstance instance) {
+        NodeEngineImpl nodeEngine = getNode(instance).nodeEngine;
+        MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
+
+        return service.getMapServiceContext().getNearCacheProvider().getOrCreateNearCache(mapName);
+    }
+
+    protected int getNearCacheSize(IMap map) {
+        return ((NearCachedMapProxyImpl) map).getNearCache().size();
+    }
+
+    protected NearCacheStats getNearCacheStats(IMap map) {
+        return map.getLocalMapStats().getNearCacheStats();
+    }
+
+    protected void assertThatOwnedEntryCountEquals(IMap<Integer, Integer> clientMap, long expected) {
+        assertEquals(expected, getNearCacheStats(clientMap).getOwnedEntryCount());
+    }
+
+    protected void assertThatOwnedEntryCountIsSmallerThan(IMap<Integer, Integer> clientMap, long expected) {
+        long ownedEntryCount = getNearCacheStats(clientMap).getOwnedEntryCount();
+        assertTrue(format("ownedEntryCount should be smaller than %d, but was %d", expected, ownedEntryCount),
+                ownedEntryCount < expected);
+    }
+
+    public static class SimpleMapStore<K, V> extends MapStoreAdapter<K, V> {
+
+        private final Map<K, V> store = new ConcurrentHashMap<K, V>();
+
+        private boolean loadAllKeys = true;
+
+        @Override
+        public void delete(final K key) {
+            store.remove(key);
+        }
+
+        @Override
+        public V load(final K key) {
+            return store.get(key);
+        }
+
+        @Override
+        public void store(final K key, final V value) {
+            store.put(key, value);
+        }
+
+        public Set<K> loadAllKeys() {
+            if (loadAllKeys) {
+                return store.keySet();
+            }
+            return null;
+        }
+
+        public void setLoadAllKeys(boolean loadAllKeys) {
+            this.loadAllKeys = loadAllKeys;
+        }
+
+        @Override
+        public void storeAll(final Map<K, V> kvMap) {
+            store.putAll(kvMap);
+        }
+    }
+
+    public static class IncrementEntryProcessor extends AbstractEntryProcessor<Integer, Integer> {
+        @Override
+        public Object process(Map.Entry<Integer, Integer> entry) {
+            int currentValue = entry.getValue();
+            int newValue = currentValue + 1000;
+            entry.setValue(newValue);
+            return newValue;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/NearCacheStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/NearCacheStatsImplTest.java
@@ -38,6 +38,12 @@ public class NearCacheStatsImplTest {
 
         nearCacheStats.setMisses(304);
         nearCacheStats.incrementMisses();
+
+        nearCacheStats.setEvictions(222);
+        nearCacheStats.incrementEvictions();
+
+        nearCacheStats.setExpirations(123);
+        nearCacheStats.incrementExpirations();
     }
 
     @Test
@@ -47,6 +53,8 @@ public class NearCacheStatsImplTest {
         assertEquals(1280, nearCacheStats.getOwnedEntryMemoryCost());
         assertEquals(602, nearCacheStats.getHits());
         assertEquals(305, nearCacheStats.getMisses());
+        assertEquals(223, nearCacheStats.getEvictions());
+        assertEquals(124, nearCacheStats.getExpirations());
         assertNotNull(nearCacheStats.toString());
     }
 
@@ -61,6 +69,8 @@ public class NearCacheStatsImplTest {
         assertEquals(1280, deserialized.getOwnedEntryMemoryCost());
         assertEquals(602, deserialized.getHits());
         assertEquals(305, deserialized.getMisses());
+        assertEquals(223, deserialized.getEvictions());
+        assertEquals(124, deserialized.getExpirations());
         assertNotNull(deserialized.toString());
     }
 


### PR DESCRIPTION
* Added eviction and expiration counts to the `NearCacheStats`
* Added the parameter `wasExpired` to `EvictionListener.onEvict()` to distinguish if an entry was evicted due to expiration or a max-size policy eviction, to pick the correct `NearCacheStats`
* Added missing eviction/expiration tests to `NearCacheTest`, `ClientMapNearCacheTest` and `ClientNearCacheTest`
* Fixed `NearCacheTest` and `ClientMapNearCacheTest` regarding tests with `max-size` or `eviction-policy` (which were ignored in extended EE tests)
* Pulled out commonly used `NearCacheTestSupport` for `IMap` Near Cache tests
* Cleanup of `NearCacheImpl` and `ClientHeapNearCache` to distinct better between eviction and expiration

Added evictions and expiration counts to the `NearCacheStats` helped me a lot to verify if the Near Cache eviction or expiration was triggered (and of course to see how many entries were evicted). This will be useful for the Near Cache unification and code samples.