### PR TITLE
Cleanup of queue related tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAbstractTest.java
@@ -26,11 +26,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.test.AbstractHazelcastClassRunner.getTestMethodName;
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -85,18 +87,20 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void testOffer_whenNullArgument() {
         try {
             queue.offer(null);
             fail();
         } catch (NullPointerException expected) {
+            ignore(expected);
         }
 
         assertTrue(queue.isEmpty());
     }
 
     @Test
-    public void testOfferWithTimeout() throws InterruptedException {
+    public void testOfferWithTimeout() {
         OfferThread offerThread = new OfferThread(queue);
         for (int i = 0; i < queueConfig.getMaxSize(); i++) {
             queue.offer("item" + i);
@@ -179,6 +183,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
             queue.remove(null);
             fail();
         } catch (NullPointerException expected) {
+            ignore(expected);
         }
 
         assertEquals(1, queue.size());
@@ -191,7 +196,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
         for (int i = 0; i < 10; i++) {
             queue.offer("item" + i);
         }
-        List list = new ArrayList(10);
+        List<String> list = new ArrayList<String>(10);
 
         assertEquals(10, queue.drainTo(list));
         assertEquals(10, list.size());
@@ -202,12 +207,13 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
 
     @Test
     public void testDrainTo_whenQueueEmpty() {
-        List list = new ArrayList();
+        List<String> list = new ArrayList<String>();
 
         assertEquals(0, queue.drainTo(list));
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void testDrainTo_whenCollectionNull() {
         for (int i = 0; i < 10; i++) {
             queue.offer("item" + i);
@@ -217,6 +223,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
             queue.drainTo(null);
             fail();
         } catch (NullPointerException expected) {
+            ignore(expected);
         }
         assertEquals(10, queue.size());
     }
@@ -226,7 +233,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
         for (int i = 0; i < 10; i++) {
             queue.offer("item" + i);
         }
-        List list = new ArrayList(10);
+        List<String> list = new ArrayList<String>(10);
 
         queue.drainTo(list, 4);
         assertEquals(4, list.size());
@@ -235,6 +242,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void testDrainToWithMaxElement_whenCollectionNull() {
         for (int i = 0; i < 10; i++) {
             queue.offer("item" + i);
@@ -244,6 +252,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
             queue.drainTo(null, 4);
             fail();
         } catch (NullPointerException expected) {
+            ignore(expected);
         }
 
         assertEquals(10, queue.size());
@@ -254,7 +263,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
         for (int i = 0; i < 10; i++) {
             queue.offer("item" + i);
         }
-        List list = new ArrayList();
+        List<String> list = new ArrayList<String>();
 
         assertEquals(10, queue.drainTo(list, -4));
         assertEquals(0, queue.size());
@@ -296,7 +305,8 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
         try {
             queue.addAll(list);
             fail();
-        } catch (NullPointerException e) {
+        } catch (NullPointerException expected) {
+            ignore(expected);
         }
     }
 
@@ -341,6 +351,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
     }
 
     @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
     public void testContainsAll_whenNull() {
         queue.containsAll(null);
     }
@@ -359,11 +370,13 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void testAddAll_whenNullCollection() {
         try {
             queue.addAll(null);
             fail();
         } catch (NullPointerException expected) {
+            ignore(expected);
         }
 
         assertEquals(0, queue.size());
@@ -374,10 +387,8 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
         for (int i = 0; i < 10; i++) {
             queue.offer("item" + i);
         }
-        List<String> list = new ArrayList<String>();
-
         assertEquals(10, queue.size());
-        assertTrue(queue.addAll(list));
+        assertTrue(queue.addAll(Collections.<String>emptyList()));
         assertEquals(10, queue.size());
     }
 
@@ -411,6 +422,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
     }
 
     @Test
+    @SuppressWarnings("ConstantConditions")
     public void testRetainAll_whenCollectionNull() {
         queue.add("item3");
         queue.add("item4");
@@ -419,7 +431,8 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
         try {
             queue.retainAll(null);
             fail();
-        } catch (NullPointerException e) {
+        } catch (NullPointerException expected) {
+            ignore(expected);
         }
         assertEquals(3, queue.size());
     }
@@ -429,9 +442,8 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
         queue.add("item3");
         queue.add("item4");
         queue.add("item5");
-        List list = new ArrayList();
 
-        assertTrue(queue.retainAll(list));
+        assertTrue(queue.retainAll(emptyList()));
         assertEquals(0, queue.size());
     }
 
@@ -440,7 +452,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
         queue.add("item3");
         queue.add("item4");
         queue.add("item5");
-        List list = new ArrayList();
+        List<String> list = new ArrayList<String>();
         list.add(null);
 
         assertTrue(queue.retainAll(list));
@@ -464,6 +476,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
     }
 
     @Test(expected = NullPointerException.class)
+    @SuppressWarnings("ConstantConditions")
     public void testRemoveAll_whenCollectionNull() {
         queue.removeAll(null);
     }
@@ -473,9 +486,8 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
         queue.add("item3");
         queue.add("item4");
         queue.add("item5");
-        List<String> list = new ArrayList<String>();
 
-        assertFalse(queue.removeAll(list));
+        assertFalse(queue.removeAll(Collections.<String>emptyList()));
         assertEquals(3, queue.size());
     }
 
@@ -510,9 +522,10 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
     }
 
     private static class OfferThread extends Thread {
-        IQueue queue;
 
-        OfferThread(IQueue queue) {
+        IQueue<String> queue;
+
+        OfferThread(IQueue<String> queue) {
             this.queue = queue;
         }
 
@@ -527,6 +540,7 @@ public abstract class QueueAbstractTest extends HazelcastTestSupport {
     }
 
     private static class PollThread extends Thread {
+
         IQueue queue;
 
         PollThread(IQueue queue) {

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
@@ -24,16 +24,13 @@ import com.hazelcast.core.IQueue;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.TestThread;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.util.EmptyStatement;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -609,7 +606,7 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testTakeInterruption() throws InterruptedException {
+    public void testTakeInterruption() {
         Config config = new Config()
                 .setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "10000");
 
@@ -634,7 +631,7 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutInterruption() throws InterruptedException {
+    public void testPutInterruption() {
         Config config = new Config()
                 .setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "10000");
         config.getQueueConfig("default").setMaxSize(1);

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBasicDistributedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueBasicDistributedTest.java
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class QueueBasicDistributedTest extends QueueAbstractTest {
+
     @Override
     protected HazelcastInstance[] newInstances(Config config) {
         return createHazelcastInstanceFactory(2).newInstances(config);

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueIteratorTest.java
@@ -21,10 +21,6 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class QueueIteratorTest extends HazelcastTestSupport {
-    protected IQueue newQueue() {
-        HazelcastInstance instance = createHazelcastInstance();
-        return instance.getQueue(randomString());
-    }
 
     @Test
     public void testIterator() {
@@ -50,6 +46,7 @@ public class QueueIteratorTest extends HazelcastTestSupport {
             assertNull(iterator.next());
             fail();
         } catch (NoSuchElementException e) {
+            ignore(e);
         }
     }
 
@@ -66,8 +63,14 @@ public class QueueIteratorTest extends HazelcastTestSupport {
             iterator.remove();
             fail();
         } catch (UnsupportedOperationException e) {
+            ignore(e);
         }
 
         assertEquals(10, queue.size());
+    }
+
+    private IQueue<String> newQueue() {
+        HazelcastInstance instance = createHazelcastInstance();
+        return instance.getQueue(randomString());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueMigrationTest.java
@@ -22,14 +22,13 @@ import static org.junit.Assert.assertEquals;
 public class QueueMigrationTest extends HazelcastTestSupport {
 
     private IQueue<Object> queue;
-    private HazelcastInstance local;
     private HazelcastInstance remote1;
     private HazelcastInstance remote2;
 
     @Before
     public void setup() {
         HazelcastInstance[] cluster = createHazelcastInstanceFactory(3).newInstances();
-        local = cluster[0];
+        HazelcastInstance local = cluster[0];
         remote1 = cluster[1];
         remote2 = cluster[2];
 
@@ -40,9 +39,9 @@ public class QueueMigrationTest extends HazelcastTestSupport {
     @Test
     public void test() {
         List<Object> expectedItems = new LinkedList<Object>();
-        for (int k = 0; k < 100; k++) {
-            queue.add(k);
-            expectedItems.add(k);
+        for (int i = 0; i < 100; i++) {
+            queue.add(i);
+            expectedItems.add(i);
         }
 
         remote1.shutdown();

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.Assert.assertFalse;
@@ -32,17 +31,18 @@ public class QueueSplitBrainTest extends HazelcastTestSupport {
 
     @Before
     @After
-    public void killAllHazelcastInstances() throws IOException {
+    public void killAllHazelcastInstances() {
         HazelcastInstanceFactory.shutdownAll();
     }
 
     @Test
-    public void testQueueSplitBrain() throws InterruptedException {
+    public void testQueueSplitBrain() {
         Config config = newConfig();
         HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
         HazelcastInstance h3 = Hazelcast.newHazelcastInstance(config);
-        final String name = generateKeyOwnedBy(h1);
+
+        String name = generateKeyOwnedBy(h1);
         IQueue<Object> queue = h1.getQueue(name);
 
         TestMemberShipListener memberShipListener = new TestMemberShipListener(2);
@@ -120,7 +120,6 @@ public class QueueSplitBrainTest extends HazelcastTestSupport {
 
         @Override
         public void memberAdded(MembershipEvent membershipEvent) {
-
         }
 
         @Override
@@ -130,7 +129,6 @@ public class QueueSplitBrainTest extends HazelcastTestSupport {
 
         @Override
         public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-
         }
     }
 }


### PR DESCRIPTION
* Improved some test names (e.g. `testQueueEviction2()` to `testQueueEviction_whenTtlIsZero_thenListenersAreNeverthelessExecuted()`)
* Removed warnings