### PR TITLE
[Backport] https://github.com/hazelcast/hazelcast/pull/8765 - Mock connection local address needs to be different

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -68,7 +68,7 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
                 Thread.currentThread().setContextClassLoader(HazelcastClient.class.getClassLoader());
             }
             ClientConnectionManagerFactory clientConnectionManagerFactory =
-                    clientRegistry.createClientServiceFactory(createAddress("127.0.0.1", clientPorts.incrementAndGet()));
+                    clientRegistry.createClientServiceFactory("127.0.0.1", clientPorts);
             AddressProvider testAddressProvider = createAddressProvider(config);
             HazelcastClientInstanceImpl client =
                     new HazelcastClientInstanceImpl(config, clientConnectionManagerFactory, testAddressProvider);

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
@@ -28,12 +28,14 @@ import com.hazelcast.util.ExceptionUtil;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class DroppingConnection implements Connection {
 
     final Address endpoint;
     final long timestamp = Clock.currentTimeMillis();
     private final ConnectionManager connectionManager;
+    private AtomicBoolean isClosing = new AtomicBoolean(false);
 
     DroppingConnection(Address endpoint, ConnectionManager connectionManager) {
         this.endpoint = endpoint;
@@ -73,7 +75,9 @@ class DroppingConnection implements Connection {
     @Override
     public void close(String msg, Throwable cause) {
         if (connectionManager instanceof MockConnectionManager) {
-            ((MockConnectionManager)connectionManager).destroyConnection(this);
+            if (isClosing.compareAndSet(false, true)) {
+                ((MockConnectionManager)connectionManager).destroyConnection(this);
+            }
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -165,25 +165,27 @@ public class MockConnectionManager implements ConnectionManager {
 
     public void destroyConnection(final Connection connection) {
         final Address endPoint = connection.getEndPoint();
-        final boolean removed = mapConnections.remove(endPoint, connection);
-        if (!removed) {
-            return;
-        }
+        if (null != endPoint && mapConnections.remove(endPoint, connection)) {
+            logger.info("Removed connection to endpoint: " + endPoint + ", connection: " + connection);
 
-        logger.info("Removed connection to endpoint: " + endPoint + ", connection: " + connection);
-        ioService.getEventService().executeEventCallback(new StripedRunnable() {
-            @Override
-            public void run() {
-                for (ConnectionListener listener : connectionListeners) {
-                    listener.connectionRemoved(connection);
+            connection.close(null, null);
+
+            ioService.getEventService().executeEventCallback(new StripedRunnable() {
+                @Override
+                public void run() {
+                    for (ConnectionListener listener : connectionListeners) {
+                        listener.connectionRemoved(connection);
+                    }
                 }
-            }
 
-            @Override
-            public int getKey() {
-                return endPoint.hashCode();
-            }
-        });
+                @Override
+                public int getKey() {
+                    return endPoint.hashCode();
+                }
+            });
+        } else {
+            connection.close(null, null);
+        }
     }
 
     @Override


### PR DESCRIPTION
Backports https://github.com/hazelcast/hazelcast/pull/8765 

* Modified the mock connection manager so that each new client gets a different local Address. Previously they were getting the same ip port (this confuses the logs and at some places the address is used as key to the connection maps) but their connection id was different. The fix assigns unique port numbers for each mocked client connection.

* Fix preventing DroppingConnection.close to call itself.

* Added same level of logging as at the server side mock connection creation.