### PR TITLE
[BACKPORT] Fixed eviction of max-idle expired entries in IMap client Near Cache

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/ClientHeapNearCache.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/ClientHeapNearCache.java
@@ -194,7 +194,6 @@ public class ClientHeapNearCache<K> implements NearCache<K, Object> {
         fireTtlCleanup();
         NearCacheRecord record = cache.get(key);
         if (record != null) {
-            record.access();
             if (record.isExpired(maxIdleMillis, timeToLiveMillis)) {
                 cache.remove(key);
                 stats.incrementMisses();
@@ -205,6 +204,7 @@ public class ClientHeapNearCache<K> implements NearCache<K, Object> {
                 return NULL_OBJECT;
             }
             stats.incrementHits();
+            record.access();
             return inMemoryFormat.equals(InMemoryFormat.BINARY)
                     ? context.getSerializationService().toObject(record.getValue()) : record.getValue();
         } else {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -67,6 +67,7 @@ import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -862,6 +863,7 @@ public class ClientMapNearCacheTest {
 
         NearCacheStats stats = map.getLocalMapStats().getNearCacheStats();
         long hitsBeforeIdleExpire = stats.getHits();
+        long missesBeforeIdleExpire = stats.getMisses();
 
         sleepSeconds(MAX_IDLE_SECONDS + 1);
 
@@ -870,8 +872,10 @@ public class ClientMapNearCacheTest {
         }
         stats = map.getLocalMapStats().getNearCacheStats();
 
-        assertEquals("as the hits are not equal, the entries were not cleared from near cash after MAX_IDLE_SECONDS",
-                hitsBeforeIdleExpire, stats.getHits(), size);
+        assertEquals("as the hits are not equal, the entries were not cleared from Near Cache after MAX_IDLE_SECONDS",
+                hitsBeforeIdleExpire, stats.getHits());
+        assertNotEquals("as the misses are equal, the entries were not cleared from Near Cache after MAX_IDLE_SECONDS",
+                missesBeforeIdleExpire, stats.getMisses());
     }
 
     @Test


### PR DESCRIPTION
* Fixed eviction of max-idle expired entries in IMap client Near Cache
* Fixed test which covered that bug

Backport of https://github.com/hazelcast/hazelcast/pull/8778