### PR TITLE
Small cleanup of ReplicatedMap tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAbstractTest.java
@@ -22,7 +22,7 @@ import java.util.Set;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public abstract class ReplicatedMapBaseTest extends HazelcastTestSupport {
+public abstract class ReplicatedMapAbstractTest extends HazelcastTestSupport {
 
     protected static Field REPLICATED_MAP_SERVICE;
 
@@ -87,8 +87,8 @@ public abstract class ReplicatedMapBaseTest extends HazelcastTestSupport {
 
     public List<ReplicatedMap> createMapOnEachInstance(HazelcastInstance[] instances, String replicatedMapName) {
         ArrayList<ReplicatedMap> maps = new ArrayList<ReplicatedMap>();
-        for (int i = 0; i < instances.length; i++) {
-            ReplicatedMap<Object, Object> replicatedMap = instances[i].getReplicatedMap(replicatedMapName);
+        for (HazelcastInstance instance : instances) {
+            ReplicatedMap<Object, Object> replicatedMap = instance.getReplicatedMap(replicatedMapName);
             maps.add(replicatedMap);
         }
         return maps;

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(value = {QuickTest.class, ParallelTest.class})
-public class ReplicatedMapAntiEntropyTest extends ReplicatedMapBaseTest {
+public class ReplicatedMapAntiEntropyTest extends ReplicatedMapAbstractTest {
 
     @After
     public void cleanup() {

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapHitsAndLastAccessTimeTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ReplicatedMapHitsAndLastAccessTimeTest extends ReplicatedMapBaseTest {
+public class ReplicatedMapHitsAndLastAccessTimeTest extends ReplicatedMapAbstractTest {
 
     @Test
     public void test_hitsAndLastAccessTimeSetToAnyValueAfterStartTime_object() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLoadingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLoadingTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(value = {QuickTest.class, ParallelTest.class})
-public class ReplicatedMapLoadingTest extends ReplicatedMapBaseTest {
+public class ReplicatedMapLoadingTest extends ReplicatedMapAbstractTest {
 
     @Test
     public void testAsyncFillUp() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(value = {QuickTest.class, ParallelTest.class})
-public class ReplicatedMapReadYourWritesTest extends ReplicatedMapBaseTest {
+public class ReplicatedMapReadYourWritesTest extends ReplicatedMapAbstractTest {
 
     @Test
     public void testReadYourWritesBySize() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class ReplicatedMapTest extends ReplicatedMapBaseTest {
+public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
     @Test
     public void testEmptyMapIsEmpty() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
-public class ReplicatedMapTtlTest extends ReplicatedMapBaseTest {
+public class ReplicatedMapTtlTest extends ReplicatedMapAbstractTest {
 
     @Test
     public void testPutWithTTL_withMigration() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(Parameterized.class)
-public class ReplicatedMapWriteOrderTest extends ReplicatedMapBaseTest {
+public class ReplicatedMapWriteOrderTest extends ReplicatedMapAbstractTest {
 
     int nodeCount;
     int operations;


### PR DESCRIPTION
Fixed names of `ReplicatedMap` tests, so that class names containing abstract are not executable and class names containing basic are executable test classes (e.g. `@RunWith`). Doesn't require an EE change.