### PR TITLE
Minor rename in diagnostics log file; customer had issue with #, so replaced by _'

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -150,7 +150,7 @@ public class NodeEngineImpl implements NodeEngine {
     private Diagnostics newDiagnostics() {
         Member localMember = node.getLocalMember();
         Address address = localMember.getAddress();
-        String addressString = address.getHost().replace(":", "_") + "#" + address.getPort();
+        String addressString = address.getHost().replace(":", "_") + "_" + address.getPort();
         String name = "diagnostics-" + addressString + "-" + currentTimeMillis();
 
         return new Diagnostics(


### PR DESCRIPTION
This was already merged into master, v3.7, but it was missing in maintanance-3.x
(cherry picked from commit dd40d77)