### PR TITLE
Pass ClassType into a constructor when creating a new instance of Serializer

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializerHookLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializerHookLoaderTest.java
@@ -5,6 +5,7 @@ import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.SampleIdentifiedDataSerializable;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -16,11 +17,12 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * SerializerHookLoader Tester.
  */
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class SerializerHookLoaderTest extends HazelcastTestSupport {
 
@@ -56,6 +58,33 @@ public class SerializerHookLoaderTest extends HazelcastTestSupport {
         TestSerializerHook.TestSerializerWithTypeConstructor serializer = (TestSerializerHook.TestSerializerWithTypeConstructor)
                 serializers.get(SampleIdentifiedDataSerializable.class);
         assertEquals(SampleIdentifiedDataSerializable.class, serializer.getClazz());
+    }
+
+    @Test
+    public void testLoad_withParametrizedConstructorAndCompatibilitySwitchOn() throws Exception {
+        String propName = "hazelcast.compat.serializers.use.default.constructor.only";
+        String origProperty = System.getProperty(propName);
+        try {
+            System.setProperty(propName, "true");
+            SerializerConfig serializerConfig = new SerializerConfig();
+            serializerConfig.setClassName("com.hazelcast.internal.serialization.impl.TestSerializerHook$TestSerializerWithTypeConstructor");
+            serializerConfig.setTypeClassName("com.hazelcast.nio.serialization.SampleIdentifiedDataSerializable");
+
+            SerializationConfig serializationConfig = getConfig().getSerializationConfig();
+            serializationConfig.addSerializerConfig(serializerConfig);
+
+            SerializerHookLoader hook = new SerializerHookLoader(serializationConfig, classLoader);
+            Map<Class, Object> serializers = hook.getSerializers();
+
+            TestSerializerHook.TestSerializerWithTypeConstructor serializer = (TestSerializerHook.TestSerializerWithTypeConstructor)
+                    serializers.get(SampleIdentifiedDataSerializable.class);
+            assertNull(serializer.getClazz());
+        } finally {
+            if (origProperty != null) {
+                System.setProperty(propName, origProperty);
+            } else
+                System.clearProperty(propName);
+        }
     }
 
     @Test(expected = HazelcastSerializationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializerHookLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/SerializerHookLoaderTest.java
@@ -3,6 +3,7 @@ package com.hazelcast.internal.serialization.impl;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.nio.serialization.SampleIdentifiedDataSerializable;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -13,6 +14,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -26,7 +28,7 @@ public class SerializerHookLoaderTest extends HazelcastTestSupport {
     private ClassLoader classLoader = getClass().getClassLoader();
 
     @Test
-    public void testLoad() throws Exception {
+    public void testLoad_withDefaultConstructor() throws Exception {
         SerializerConfig serializerConfig = new SerializerConfig();
         serializerConfig.setClassName("com.hazelcast.internal.serialization.impl.TestSerializerHook$TestSerializer");
         serializerConfig.setTypeClassName("com.hazelcast.nio.serialization.SampleIdentifiedDataSerializable");
@@ -37,6 +39,23 @@ public class SerializerHookLoaderTest extends HazelcastTestSupport {
         SerializerHookLoader hook = new SerializerHookLoader(serializationConfig, classLoader);
         Map<Class, Object> serializers = hook.getSerializers();
         assertNotNull(serializers);
+    }
+
+    @Test
+    public void testLoad_withParametrizedConstructor() throws Exception {
+        SerializerConfig serializerConfig = new SerializerConfig();
+        serializerConfig.setClassName("com.hazelcast.internal.serialization.impl.TestSerializerHook$TestSerializerWithTypeConstructor");
+        serializerConfig.setTypeClassName("com.hazelcast.nio.serialization.SampleIdentifiedDataSerializable");
+
+        SerializationConfig serializationConfig = getConfig().getSerializationConfig();
+        serializationConfig.addSerializerConfig(serializerConfig);
+
+        SerializerHookLoader hook = new SerializerHookLoader(serializationConfig, classLoader);
+        Map<Class, Object> serializers = hook.getSerializers();
+
+        TestSerializerHook.TestSerializerWithTypeConstructor serializer = (TestSerializerHook.TestSerializerWithTypeConstructor)
+                serializers.get(SampleIdentifiedDataSerializable.class);
+        assertEquals(SampleIdentifiedDataSerializable.class, serializer.getClazz());
     }
 
     @Test(expected = HazelcastSerializationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
@@ -54,5 +54,37 @@ public class TestSerializerHook implements SerializerHook {
         }
     }
 
-    ;
+    public static class TestSerializerWithTypeConstructor implements StreamSerializer {
+
+        private final Class<?> clazz;
+
+        public TestSerializerWithTypeConstructor(Class<?> clazz) {
+            this.clazz = clazz;
+        }
+
+        public Class<?> getClazz() {
+            return clazz;
+        }
+
+        @Override
+        public int getTypeId() {
+            return 1001;
+        }
+
+        @Override
+        public void destroy() {
+
+        }
+
+        @Override
+        public void write(ObjectDataOutput out, Object object) throws IOException {
+
+        }
+
+        @Override
+        public Object read(ObjectDataInput in) throws IOException {
+            return null;
+        }
+    }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/TestSerializerHook.java
@@ -56,10 +56,13 @@ public class TestSerializerHook implements SerializerHook {
 
     public static class TestSerializerWithTypeConstructor implements StreamSerializer {
 
-        private final Class<?> clazz;
+        private Class<?> clazz;
 
         public TestSerializerWithTypeConstructor(Class<?> clazz) {
             this.clazz = clazz;
+        }
+
+        public TestSerializerWithTypeConstructor() {
         }
 
         public Class<?> getClazz() {


### PR DESCRIPTION
When a serializer does not have a constructor accepting `Class` then a non-arg constructor will be used - the same as now. 

Reasoning:
This allows to use the same serializer class to (de-)serialize multiple domain classes. I stumbled upon this while working on the [SubZero](https://github.com/jerrinot/subzero) project. 