### PR TITLE
Aligned NearCacheImpl and ClientHeapNearCache

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -1258,6 +1258,14 @@ public class ClientMapNearCacheTest {
         assertNull(map.getAsync(1).get());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testNearCache_whenInMemoryFormatIsNative_thenThrowIllegalArgumentException() {
+        NearCacheConfig nearCacheConfig = newNearCacheConfig();
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.NATIVE);
+
+        getNearCachedMapFromClient(nearCacheConfig);
+    }
+
     protected void populateNearCache(IMap<Integer, Integer> map, int size) {
         for (int i = 0; i < size; i++) {
             map.put(i, i);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -27,6 +27,7 @@ import com.hazelcast.map.impl.eviction.EvictionChecker;
 import com.hazelcast.map.impl.eviction.Evictor;
 import com.hazelcast.map.impl.eviction.EvictorImpl;
 import com.hazelcast.map.impl.mapstore.MapStoreContext;
+import com.hazelcast.map.impl.nearcache.NearCacheRecord;
 import com.hazelcast.map.impl.query.QueryEntryFactory;
 import com.hazelcast.map.impl.record.DataRecordFactory;
 import com.hazelcast.map.impl.record.ObjectRecordFactory;
@@ -49,7 +50,7 @@ import com.hazelcast.wan.WanReplicationService;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.map.impl.SizeEstimators.createNearCacheSizeEstimator;
+import static com.hazelcast.map.impl.SizeEstimatorFactory.createNearCacheSizeEstimator;
 import static com.hazelcast.map.impl.eviction.Evictor.NULL_EVICTOR;
 import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
 import static java.lang.System.getProperty;
@@ -64,7 +65,7 @@ public class MapContainer {
     protected final MapServiceContext mapServiceContext;
     protected final Indexes indexes;
     protected final Extractors extractors;
-    protected final SizeEstimator nearCacheSizeEstimator;
+    protected final SizeEstimator<NearCacheRecord> nearCacheSizeEstimator;
     protected final PartitioningStrategy partitioningStrategy;
     protected final MapStoreContext mapStoreContext;
     protected final SerializationService serializationService;
@@ -226,7 +227,7 @@ public class MapContainer {
         return partitioningStrategy;
     }
 
-    public SizeEstimator getNearCacheSizeEstimator() {
+    public SizeEstimator<NearCacheRecord> getNearCacheSizeEstimator() {
         return nearCacheSizeEstimator;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SizeEstimatorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SizeEstimatorFactory.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.map.impl;
 
-
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.map.impl.nearcache.NearCacheRecord;
 import com.hazelcast.map.impl.nearcache.NearCacheSizeEstimator;
 
 import static com.hazelcast.config.InMemoryFormat.BINARY;
@@ -26,25 +26,25 @@ import static com.hazelcast.config.InMemoryFormat.BINARY;
 /**
  * Static factory methods for various size estimators.
  */
-public final class SizeEstimators {
+public final class SizeEstimatorFactory {
 
     /**
      * Returns zero for all estimations.
      */
     private static final SizeEstimator ZERO_SIZE_ESTIMATOR = new ZeroSizeEstimator();
 
-    private SizeEstimators() {
+    private SizeEstimatorFactory() {
     }
 
     public static SizeEstimator createMapSizeEstimator(InMemoryFormat inMemoryFormat) {
         if (BINARY.equals(inMemoryFormat)) {
             return new BinaryMapSizeEstimator();
-        } else {
-            return ZERO_SIZE_ESTIMATOR;
         }
+        return ZERO_SIZE_ESTIMATOR;
     }
 
-    public static SizeEstimator createNearCacheSizeEstimator(NearCacheConfig nearCacheConfig) {
+    @SuppressWarnings("unchecked")
+    public static SizeEstimator<NearCacheRecord> createNearCacheSizeEstimator(NearCacheConfig nearCacheConfig) {
         if (nearCacheConfig == null) {
             return ZERO_SIZE_ESTIMATOR;
         }
@@ -52,9 +52,8 @@ public final class SizeEstimators {
         InMemoryFormat inMemoryFormat = nearCacheConfig.getInMemoryFormat();
         if (BINARY.equals(inMemoryFormat)) {
             return new NearCacheSizeEstimator();
-        } else {
-            return ZERO_SIZE_ESTIMATOR;
         }
+        return ZERO_SIZE_ESTIMATOR;
     }
 
     private static class ZeroSizeEstimator implements SizeEstimator {
@@ -66,7 +65,6 @@ public final class SizeEstimators {
 
         @Override
         public void add(long size) {
-
         }
 
         @Override
@@ -76,8 +74,6 @@ public final class SizeEstimators {
 
         @Override
         public void reset() {
-
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
@@ -20,7 +20,6 @@ import com.hazelcast.cache.impl.nearcache.NearCache;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapManagedService;
 import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.map.impl.SizeEstimator;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -46,9 +45,7 @@ public class NearCacheProvider {
         @Override
         public NearCache createNew(String mapName) {
             MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-            SizeEstimator nearCacheSizeEstimator = mapContainer.getNearCacheSizeEstimator();
-            NearCacheImpl nearCache = new NearCacheImpl(mapName, nodeEngine);
-            nearCache.setNearCacheSizeEstimator(nearCacheSizeEstimator);
+            NearCacheImpl nearCache = new NearCacheImpl(mapName, nodeEngine, mapContainer.getNearCacheSizeEstimator());
 
             int partitionCount = mapServiceContext.getNodeEngine().getPartitionService().getPartitionCount();
             return wrapAsStaleReadPreventerNearCache(nearCache, partitionCount);
@@ -135,4 +132,3 @@ public class NearCacheProvider {
         return nearCacheInvalidator;
     }
 }
-

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import static com.hazelcast.map.impl.SizeEstimators.createMapSizeEstimator;
+import static com.hazelcast.map.impl.SizeEstimatorFactory.createMapSizeEstimator;
 
 /**
  * Default implementation of {@link Storage} layer used by a {@link RecordStore}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/SizeEstimatorFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/SizeEstimatorFactoryTest.java
@@ -16,18 +16,13 @@
 
 package com.hazelcast.map.impl;
 
-/**
- * Size estimator general contract.
- *
- * @param <T> the type of object which's size going to be estimated.
- */
-public interface SizeEstimator<T> {
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
 
-    long getSize();
+public class SizeEstimatorFactoryTest extends HazelcastTestSupport {
 
-    void add(long size);
-
-    long calculateSize(T object);
-
-    void reset();
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(SizeEstimatorFactory.class);
+    }
 }


### PR DESCRIPTION
* Aligned `NearCacheImpl` and `ClientHeapNearCache` implementations to make them easier to compare
* Fixed missing code coverage for `ClientHeapNearCache`
* Renamed `SizeEstimators` to `SizeEstimatorFactory`
* Fixed missing code coverage for `SizeEstimatorFactory`
* Fixed generics warning with Near Cache `SizeEstimator`