### PR TITLE
Fix for Hazelcast support for Spring Transaction API

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/HazelcastTransactionManager.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.TransactionSystemException;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.ResourceTransactionManager;
+import org.springframework.transaction.support.SmartTransactionObject;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
@@ -148,6 +149,12 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
     }
 
     @Override
+    protected void doSetRollbackOnly(DefaultTransactionStatus status) throws TransactionException {
+        HazelcastTransactionObject trx = (HazelcastTransactionObject) status.getTransaction();
+        trx.setRollbackOnly();
+    }
+
+    @Override
     protected void doRollback(DefaultTransactionStatus status) throws TransactionException {
         HazelcastTransactionObject txObject = (HazelcastTransactionObject) status.getTransaction();
         if (status.isDebug()) {
@@ -170,10 +177,11 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
         txObject.getTransactionContextHolder().clear();
     }
 
-    private static class HazelcastTransactionObject {
+    private static class HazelcastTransactionObject implements SmartTransactionObject {
 
         private TransactionContextHolder transactionContextHolder;
         private boolean newTransactionContextHolder;
+        private boolean rollbackOnly;
 
         public void setTransactionContextHolder(TransactionContextHolder transactionContextHolder,
                                                 boolean newTransactionContextHolder) {
@@ -191,6 +199,20 @@ public class HazelcastTransactionManager extends AbstractPlatformTransactionMana
 
         public boolean hasTransaction() {
             return this.transactionContextHolder != null && this.transactionContextHolder.isTransactionActive();
+        }
+
+        public void setRollbackOnly() {
+            this.rollbackOnly = true;
+        }
+
+        @Override
+        public boolean isRollbackOnly() {
+            return rollbackOnly;
+        }
+
+        @Override
+        public void flush() {
+            // no-op
         }
     }
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyException.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyException.java
@@ -1,0 +1,7 @@
+package com.hazelcast.spring.transaction;
+
+public class DummyException extends RuntimeException {
+    public DummyException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyObject.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyObject.java
@@ -32,4 +32,9 @@ public class DummyObject implements Serializable {
     public void setString(String string) {
         this.string = string;
     }
+
+    @Override
+    public String toString() {
+        return "DummyObject{" + "id=" + id + '}';
+    }
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
@@ -21,6 +21,12 @@ public class OtherServiceBeanWithTransactionalContext {
         transactionalContext.getMap("dummyObjectMap").put(object.getId(), object);
     }
 
+    @Transactional
+    public void putWithException(DummyObject object) {
+        put(object);
+        throw new DummyException("oops, let's rollback in other service!");
+    }
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void putInNewTransaction(DummyObject object) {
         put(object);

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
@@ -24,14 +24,28 @@ public class ServiceBeanWithTransactionalContext {
 
     public void putWithException(DummyObject object) {
         put(object);
-        throw new RuntimeException("oops, let's rollback!");
+        throw new DummyException("oops, let's rollback!");
     }
 
     public void putUsingOtherBean_sameTransaction(DummyObject object) {
         otherService.put(object);
     }
 
+    public void putUsingOtherBean_withExceptionInOtherBean_sameTransaction(DummyObject object,
+                                                                           DummyObject otherObject) {
+        put(object);
+        otherService.putWithException(otherObject);
+    }
+
+    public void putUsingOtherBean_withExceptionInThisBean_sameTransaction(DummyObject object,
+                                                                        DummyObject otherObject) {
+        otherService.put(otherObject);
+        putWithException(object);
+    }
+
     public void putUsingOtherBean_newTransaction(DummyObject object) {
         otherService.putInNewTransaction(object);
     }
+
+
 }


### PR DESCRIPTION
`HazelcastTransactionManager` does not properly handle transaction fallbacks that were initiated in nested `@Transactional` code. The issue was overlooked, because the unit tests covered only positive case: nested `@Transactional` blocks and successful transaction.

There are two commits in this pull request:
1. Missing unit tests for negative cases (exceptions in `@Transactional` blocks). They fail and expose the bug. Additionally, this commit also contains some minor improvements to existing unit tests.
2. Actual fix.

The bug looks as follows:
```
org.springframework.transaction.IllegalTransactionStateException: Participating in existing transactions is not supported - when 'isExistingTransaction' returns true, appropriate 'doSetRollbackOnly' behavior must be provided

	at org.springframework.transaction.support.AbstractPlatformTransactionManager.doSetRollbackOnly(AbstractPlatformTransactionManager.java:1228)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.processRollback(AbstractPlatformTransactionManager.java:860)
	at org.springframework.transaction.support.AbstractPlatformTransactionManager.rollback(AbstractPlatformTransactionManager.java:830)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.completeTransactionAfterThrowing(TransactionAspectSupport.java:503)
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:285)
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:96)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:179)
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:655)
	at com.hazelcast.spring.transaction.OtherServiceBeanWithTransactionalContext$$EnhancerBySpringCGLIB$$baa0c3b5.putWithException(<generated>)
```
