### PR TITLE
Avoid PartitioningStrategy clashes when running multiple members in same JVM

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -164,7 +164,8 @@ public class PartitionContainer {
         if (mapServiceContext.removeMapContainer(mapContainer)) {
             mapContainer.onDestroy();
         }
-        PartitioningStrategyFactory.removePartitioningStrategyFromCache(mapContainer.getName());
+        PartitioningStrategyFactory.removePartitioningStrategyFromCache(mapServiceContext.getNodeEngine(),
+                mapContainer.getName());
     }
 
     private void clearLockStore(String name) {


### PR DESCRIPTION
- PartitioningStrategy instances cache now uses member UUID as part of cache key
- Additional test coverage

Fixes #8634 