### PR TITLE
Fixed max-size value in NearCacheConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -205,7 +205,7 @@ public class NearCacheConfig
      * @return This near cache config instance.
      */
     public NearCacheConfig setMaxSize(int maxSize) {
-        this.maxSize = checkNotNegative(maxSize, "Max-Size cannot be negative !");
+        this.maxSize = (maxSize == 0) ? Integer.MAX_VALUE : checkNotNegative(maxSize, "Max-Size cannot be negative !");
         return this;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
@@ -23,9 +23,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class NearCacheConfigTest {
+
+    private NearCacheConfig config = new NearCacheConfig();
 
     /**
      * Test method for {@link com.hazelcast.config.NearCacheConfigReadOnly#setCacheLocalEntries(boolean)} .
@@ -33,5 +37,24 @@ public class NearCacheConfigTest {
     @Test(expected = UnsupportedOperationException.class)
     public void testReadOnlyNearCacheConfigSetCacheLocalEntries() {
         new NearCacheConfigReadOnly(new NearCacheConfig()).setCacheLocalEntries(true);
+    }
+
+    @Test
+    public void testMaxSize_whenValueIsZero_thenSetIntegerMax() {
+        config.setMaxSize(0);
+
+        assertEquals(Integer.MAX_VALUE, config.getMaxSize());
+    }
+
+    @Test
+    public void testMaxSize_whenValueIsPositive_thenSetValue() {
+        config.setMaxSize(4531);
+
+        assertEquals(4531, config.getMaxSize());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMaxSize_whenValueIsNegative_thenThrowException() {
+        config.setMaxSize(-1);
     }
 }


### PR DESCRIPTION
Fixed max-size value in `NearCacheConfig` when value was explicitly set to 0. According to the documentation we should set `Integer.MAX_VALUE` in this case, but it was set to 0.

@Serdaro Please add to the release notes for 3.8, that if you set
```
<near-cache>
  (...)
  <max-size>0</max-size>
  (...)
</near-cache>
```
or
```
NearCacheConfig config = new NearCacheConfig();
config.setMaxSize(0);
```
that this will set the max-size to `Integer.MAX_VALUE` now, as expected and documented?