### PR TITLE
Fix for NoSuchFieldException when running under non-HotSpot JVM

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/util/JVMUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/JVMUtilTest.java
@@ -16,4 +16,34 @@ public class JVMUtilTest extends HazelcastTestSupport {
     public void testConstructor() {
         assertUtilityConstructor(JVMUtil.class);
     }
+
+    // just invoke each JVMUtil static method to ensure no exception is thrown
+    @Test
+    public void testIsCompressedOops() {
+        JVMUtil.isCompressedOops();
+    }
+
+    @Test
+    public void testIsHotSpotCompressedOopsOrNull() {
+        JVMUtil.isHotSpotCompressedOopsOrNull();
+    }
+
+    @Test
+    public void testIsObjectLayoutCompressedOopsOrNull() {
+        JVMUtil.isObjectLayoutCompressedOopsOrNull();
+    }
+
+    @Test
+    public void testIs32bitJVM() {
+        JVMUtil.is32bitJVM();
+    }
+
+    // Prints the size of object reference as calculated by JVMUtil.
+    // When running under Hotspot 64-bit:
+    // - JDK 6u23+ should report 4 (CompressedOops enabled by default)
+    // - JDK 7 with -Xmx <= 32G or without any -Xmx specified should report 4 (CompressedOops enabled), otherwise 8
+    // - explicitly starting with -XX:+UseCompressedOops should report 4, otherwise 8
+    public static void main(String[] args) {
+        System.out.println("Size of reference: " + JVMUtil.REFERENCE_COST_IN_BYTES);
+    }
 }


### PR DESCRIPTION
In non-Hotspot JVMs `JVMUtil.isCompressedOopsOrNull` will attempt to determine the memory cost of reference by means of field location offset, however `getField` will only succeed if the field is public.

Also, instead of logging at `WARNING` level each exception, in this PR:
* log at `INFO` level in case all attempts to determine memory cost failed and we use default of 4 bytes
* log at `FINE` level the individual exceptions which may have occurred when attempting to determine the memory cost via Hotspot-specific and non-Hotspot methods.

closes https://github.com/hazelcast/hazelcast/issues/8835