### PR TITLE
Remember cluster state when the cluster is started after graceful cluster shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -220,7 +220,7 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
-    public void onClusterStateChange(ClusterState newState, boolean persistentChange) {
+    public void onClusterStateChange(ClusterState newState, boolean isTransient) {
         NodeEngineImpl nodeEngine = node.getNodeEngine();
         ServiceManager serviceManager = nodeEngine.getServiceManager();
         List<ClusterStateListener> listeners = serviceManager.getServices(ClusterStateListener.class);

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -175,10 +175,10 @@ public interface NodeExtension {
      * Called when cluster state is changed
      *
      * @param newState new state
-     * @param persistentChange status of the change. A cluster state change may be non-persistent if it has been done temporarily
+     * @param isTransient status of the change. A cluster state change may be transient if it has been done temporarily
      *                         during system operations such cluster start etc.
      */
-    void onClusterStateChange(ClusterState newState, boolean persistentChange);
+    void onClusterStateChange(ClusterState newState, boolean isTransient);
 
     /**
      * Registers given register if it's a known type.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -846,25 +846,22 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     @Override
     public void changeClusterState(ClusterState newState) {
+        changeClusterState(newState, false);
+    }
+
+    private void changeClusterState(ClusterState newState, boolean isTransient) {
         int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
-        clusterStateManager.changeClusterState(newState, getMembers(), partitionStateVersion);
+        clusterStateManager.changeClusterState(newState, getMembers(), partitionStateVersion, isTransient);
     }
 
     @Override
     public void changeClusterState(ClusterState newState, TransactionOptions options) {
-        int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
-        clusterStateManager.changeClusterState(newState, getMembers(), options, partitionStateVersion);
+        changeClusterState(newState, options, false);
     }
 
-    // for testing
-    void changeClusterState(ClusterState newState, Collection<Member> members) {
+    private void changeClusterState(ClusterState newState, TransactionOptions options, boolean isTransient) {
         int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
-        clusterStateManager.changeClusterState(newState, members, partitionStateVersion);
-    }
-
-    // for testing
-    void changeClusterState(ClusterState newState, int partitionStateVersion) {
-        clusterStateManager.changeClusterState(newState, getMembers(), partitionStateVersion);
+        clusterStateManager.changeClusterState(newState, getMembers(), options, partitionStateVersion, isTransient);
     }
 
     void addMembersRemovedInNotActiveState(Collection<Address> addresses) {
@@ -888,13 +885,13 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     @Override
     public void shutdown() {
-        changeClusterState(ClusterState.PASSIVE);
+        changeClusterState(ClusterState.PASSIVE, true);
         shutdownNodes();
     }
 
     @Override
     public void shutdown(TransactionOptions options) {
-        changeClusterState(ClusterState.PASSIVE, options);
+        changeClusterState(ClusterState.PASSIVE, options, true);
         shutdownNodes();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -43,12 +43,13 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
     private String txnId;
     private long leaseTime;
     private int partitionStateVersion;
+    private boolean isTransient;
 
     public ClusterStateTransactionLogRecord() {
     }
 
     public ClusterStateTransactionLogRecord(ClusterState newState, Address initiator, Address target,
-            String txnId, long leaseTime, int partitionStateVersion) {
+            String txnId, long leaseTime, int partitionStateVersion, boolean isTransient) {
         Preconditions.checkNotNull(newState);
         Preconditions.checkNotNull(initiator);
         Preconditions.checkNotNull(target);
@@ -61,6 +62,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         this.txnId = txnId;
         this.leaseTime = leaseTime;
         this.partitionStateVersion = partitionStateVersion;
+        this.isTransient = isTransient;
     }
 
     @Override
@@ -75,7 +77,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
 
     @Override
     public Operation newCommitOperation() {
-        return new ChangeClusterStateOperation(newState, initiator, txnId);
+        return new ChangeClusterStateOperation(newState, initiator, txnId, isTransient);
     }
 
     @Override
@@ -96,6 +98,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         out.writeUTF(txnId);
         out.writeLong(leaseTime);
         out.writeInt(partitionStateVersion);
+        out.writeBoolean(isTransient);
     }
 
     @Override
@@ -109,5 +112,6 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         txnId = in.readUTF();
         leaseTime = in.readLong();
         partitionStateVersion = in.readInt();
+        isTransient = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
@@ -40,14 +40,16 @@ public class ChangeClusterStateOperation extends Operation implements AllowedDur
     private Address initiator;
     private String txnId;
     private String stateName;
+    private boolean isTransient;
 
     public ChangeClusterStateOperation() {
     }
 
-    public ChangeClusterStateOperation(ClusterState newState, Address initiator, String txnId) {
+    public ChangeClusterStateOperation(ClusterState newState, Address initiator, String txnId, boolean isTransient) {
         this.newState = newState;
         this.initiator = initiator;
         this.txnId = txnId;
+        this.isTransient = isTransient;
     }
 
     @Override
@@ -61,8 +63,9 @@ public class ChangeClusterStateOperation extends Operation implements AllowedDur
     public void run() throws Exception {
         ClusterServiceImpl service = getService();
         ClusterStateManager clusterStateManager = service.getClusterStateManager();
-        getLogger().info("Changing cluster state state to " + newState + ", Initiator: " + initiator);
-        clusterStateManager.commitClusterState(newState, initiator, txnId);
+        getLogger().info("Changing cluster state state to " + newState + ", Initiator: " + initiator
+                + " transient: " + isTransient);
+        clusterStateManager.commitClusterState(newState, initiator, txnId, isTransient);
     }
 
     @Override
@@ -98,6 +101,7 @@ public class ChangeClusterStateOperation extends Operation implements AllowedDur
         out.writeUTF(newState.toString());
         initiator.writeData(out);
         out.writeUTF(txnId);
+        out.writeBoolean(isTransient);
     }
 
     @Override
@@ -112,6 +116,7 @@ public class ChangeClusterStateOperation extends Operation implements AllowedDur
         initiator = new Address();
         initiator.readData(in);
         txnId = in.readUTF();
+        isTransient = in.readBoolean();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterShutdownTest.java
@@ -108,7 +108,7 @@ public class ClusterShutdownTest extends HazelcastTestSupport {
         assertNodesShutDownEventually(nodes);
     }
 
-    private static Node[] getNodes(HazelcastInstance[] instances) {
+    public static Node[] getNodes(HazelcastInstance[] instances) {
         Node[] nodes = new Node[instances.length];
         for (int i = 0; i < instances.length; i++) {
             nodes[i] = getNode(instances[i]);
@@ -116,7 +116,7 @@ public class ClusterShutdownTest extends HazelcastTestSupport {
         return nodes;
     }
 
-    private static void assertNodesShutDownEventually(Node[] nodes) {
+    public static void assertNodesShutDownEventually(Node[] nodes) {
         for (final Node node : nodes) {
             assertTrueEventually(new AssertTask() {
                 @Override


### PR DESCRIPTION
If cluster.shutdown() is invoked when cluster is in the ACTIVE state, the final persisted state on disk will be still ACTIVE. Therefore, nodes will come back with ACTIVE state when they are restarted. The same rule also applies for the FROZEN state. Cluster still moves to PASSIVE state during the shutdown but now it is a transient state which is not persisted to disk.

EE PART: https://github.com/hazelcast/hazelcast-enterprise/pull/1037