### PR TITLE
PartitioningStrategyFactory no longer caching in static map

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -177,8 +177,7 @@ public class MapContainer {
     }
 
     private PartitioningStrategy createPartitioningStrategy() {
-        return PartitioningStrategyFactory.getPartitioningStrategy(mapServiceContext.getNodeEngine(),
-                mapConfig.getName(), mapConfig.getPartitioningStrategyConfig());
+        return mapServiceContext.getPartitioningStrategy(mapConfig.getName(), mapConfig.getPartitioningStrategyConfig());
     }
 
     public Indexes getIndexes() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
@@ -143,5 +144,9 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     void incrementOperationStats(long startTime, LocalMapStatsImpl localMapStats, String mapName, Operation operation);
 
     boolean removeMapContainer(MapContainer mapContainer);
+
+    PartitioningStrategy getPartitioningStrategy(String mapName, PartitioningStrategyConfig config);
+
+    void removePartitioningStrategyFromCache(String mapName);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.MapInterceptor;
@@ -104,6 +105,7 @@ class MapServiceContextImpl implements MapServiceContext {
     protected final MapQueryEngine mapQueryEngine;
     protected final QueryOptimizer queryOptimizer;
     protected final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
+    protected final PartitioningStrategyFactory partitioningStrategyFactory;
     protected MapEventPublisher mapEventPublisher;
     protected MapService mapService;
     protected EventService eventService;
@@ -123,6 +125,7 @@ class MapServiceContextImpl implements MapServiceContext {
         this.mapQueryEngine = createMapQueryEngine(queryOptimizer);
         this.eventService = nodeEngine.getEventService();
         this.operationProviders = createOperationProviders();
+        this.partitioningStrategyFactory = new PartitioningStrategyFactory(nodeEngine.getConfigClassLoader());
     }
 
     MapOperationProviders createOperationProviders() {
@@ -597,5 +600,15 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public boolean removeMapContainer(MapContainer mapContainer) {
         return mapContainers.remove(mapContainer.getName(), mapContainer);
+    }
+
+    @Override
+    public PartitioningStrategy getPartitioningStrategy(String mapName, PartitioningStrategyConfig config) {
+        return partitioningStrategyFactory.getPartitioningStrategy(mapName, config);
+    }
+
+    @Override
+    public void removePartitioningStrategyFromCache(String mapName) {
+        partitioningStrategyFactory.removePartitioningStrategyFromCache(mapName);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -164,7 +164,7 @@ public class PartitionContainer {
         if (mapServiceContext.removeMapContainer(mapContainer)) {
             mapContainer.onDestroy();
         }
-        PartitioningStrategyFactory.removePartitioningStrategyFromCache(mapContainer.getName());
+        mapServiceContext.removePartitioningStrategyFromCache(mapContainer.getName());
     }
 
     private void clearLockStore(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -42,7 +42,6 @@ import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.PartitionContainer;
-import com.hazelcast.map.impl.PartitioningStrategyFactory;
 import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.nearcache.NearCacheInvalidator;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
@@ -195,8 +194,8 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
 
         this.mapServiceContext = service.getMapServiceContext();
         this.mapConfig = mapConfig;
-        this.partitionStrategy = PartitioningStrategyFactory.getPartitioningStrategy(nodeEngine,
-                mapConfig.getName(), mapConfig.getPartitioningStrategyConfig());
+        this.partitionStrategy = mapServiceContext.getPartitioningStrategy(mapConfig.getName(),
+                mapConfig.getPartitioningStrategyConfig());
         this.localMapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(name);
         this.partitionService = getNodeEngine().getPartitionService();
         this.lockSupport = new LockProxySupport(new DefaultObjectNamespace(SERVICE_NAME, name),


### PR DESCRIPTION
A `PartitioningStrategyFactory` instance per Hazelcast node is constructed and used via `MapServiceContextImpl` to avoid potential clashes when running multiple nodes in same JVM.

Backport of #8833 for `maintenance-3.x` branch.