### PR TITLE
Made EvictionConfig the new default way to configure Near Caches

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -249,12 +249,14 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
             String value = getTextContent(child).trim();
             if ("max-size".equals(nodeName)) {
                 nearCacheConfig.setMaxSize(Integer.parseInt(value));
+                LOGGER.warning("The element <max-size/> for <near-cache/> is deprecated, please use <eviction/> instead!");
             } else if ("time-to-live-seconds".equals(nodeName)) {
                 nearCacheConfig.setTimeToLiveSeconds(Integer.parseInt(value));
             } else if ("max-idle-seconds".equals(nodeName)) {
                 nearCacheConfig.setMaxIdleSeconds(Integer.parseInt(value));
             } else if ("eviction-policy".equals(nodeName)) {
                 nearCacheConfig.setEvictionPolicy(value);
+                LOGGER.warning("The element <eviction-policy/> for <near-cache/> is deprecated, please use <eviction/> instead!");
             } else if ("in-memory-format".equals(nodeName)) {
                 nearCacheConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(value)));
             } else if ("invalidate-on-change".equals(nodeName)) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/ClientHeapNearCache.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/ClientHeapNearCache.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.map.impl.nearcache;
 import com.hazelcast.cache.impl.nearcache.NearCache;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.impl.ClientExecutionServiceImpl;
+import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
@@ -37,6 +38,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.hazelcast.config.EvictionConfigAccessor.initDefaultMaxSize;
 import static com.hazelcast.config.EvictionPolicy.NONE;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
@@ -85,11 +87,12 @@ public class ClientHeapNearCache<K> implements NearCache<K, Object> {
         if (inMemoryFormat != InMemoryFormat.BINARY && inMemoryFormat != InMemoryFormat.OBJECT) {
             throw new IllegalArgumentException("Illegal in-memory-format: " + inMemoryFormat);
         }
-        this.maxSize = nearCacheConfig.getMaxSize();
+        EvictionConfig evictionConfig = initDefaultMaxSize(nearCacheConfig.getEvictionConfig());
+        this.maxSize = evictionConfig.getSize();
         this.maxIdleMillis = TimeUnit.SECONDS.toMillis(nearCacheConfig.getMaxIdleSeconds());
         this.timeToLiveMillis = TimeUnit.SECONDS.toMillis(nearCacheConfig.getTimeToLiveSeconds());
         this.invalidateOnChange = nearCacheConfig.isInvalidateOnChange();
-        this.evictionPolicy = EvictionPolicy.valueOf(nearCacheConfig.getEvictionPolicy());
+        this.evictionPolicy = evictionConfig.getEvictionPolicy();
         this.canExpire = new AtomicBoolean(true);
         this.canEvict = new AtomicBoolean(true);
         this.stats = new NearCacheStatsImpl();

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.8.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.8.xsd
@@ -349,10 +349,22 @@
 
     <xs:complexType name="near-cache">
         <xs:all>
-            <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
+            <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated since 3.8, please use &lt;eviction/&gt;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
             <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
-            <xs:element name="eviction-policy" type="eviction-policy" minOccurs="0" maxOccurs="1" default="LRU"/>
+            <xs:element name="eviction-policy" type="eviction-policy" minOccurs="0" maxOccurs="1" default="LRU">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated since 3.8, please use &lt;eviction/&gt;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
             <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
             <xs:element name="local-update-policy" type="xs:string" default="INVALIDATE" minOccurs="0" maxOccurs="1"/>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionConfig.MaxSizePolicy;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
@@ -52,8 +53,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientCacheClearTest
-        extends CacheClearTest {
+public class ClientCacheClearTest extends CacheClearTest {
 
     private TestHazelcastFactory clientFactory;
     private HazelcastInstance client;
@@ -65,22 +65,17 @@ public class ClientCacheClearTest
     }
 
     protected ClientConfig createClientConfig() {
-        final ClientConfig clientConfig = new ClientConfig();
+        NearCacheConfig nearCacheConfig = new NearCacheConfig("myCache")
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+                .setCacheLocalEntries(false)
+                .setEvictionConfig(new EvictionConfig(10000, MaxSizePolicy.ENTRY_COUNT, EvictionPolicy.LFU))
+                .setInvalidateOnChange(true)
+                .setLocalUpdatePolicy(NearCacheConfig.LocalUpdatePolicy.CACHE)
+                .setMaxIdleSeconds(600)
+                .setTimeToLiveSeconds(60);
 
-        NearCacheConfig nearCacheConfig = new NearCacheConfig("myCache");
-        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
-        nearCacheConfig.setCacheLocalEntries(false);
-        nearCacheConfig
-                .setEvictionConfig(new EvictionConfig(10000, EvictionConfig.MaxSizePolicy.ENTRY_COUNT, EvictionPolicy.LFU));
-        nearCacheConfig.setInvalidateOnChange(true);
-        nearCacheConfig.setLocalUpdatePolicy(NearCacheConfig.LocalUpdatePolicy.CACHE);
-        nearCacheConfig.setMaxIdleSeconds(600);
-        nearCacheConfig.setMaxSize(100);
-        nearCacheConfig.setTimeToLiveSeconds(60);
-
-        clientConfig.addNearCacheConfig(nearCacheConfig);
-
-        return clientConfig;
+        return new ClientConfig()
+                .addNearCacheConfig(nearCacheConfig);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.spi.properties.GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -559,13 +560,8 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         int size = 100;
         int expectedEvictions = 1;
 
-        EvictionConfig evictionConfig = new EvictionConfig()
-                .setEvictionPolicy(EvictionPolicy.LRU)
-                .setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT)
-                .setSize(size);
-
-        NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat);
-        nearCacheConfig.setEvictionConfig(evictionConfig);
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat)
+                .setEvictionConfig(new EvictionConfig(size, ENTRY_COUNT, EvictionPolicy.LRU));
 
         NearCacheTestContext context = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -231,9 +231,11 @@ public class XmlClientConfigBuilderTest {
         final NearCacheConfig nearCacheConfig = clientConfig.getNearCacheConfig("asd");
 
         assertEquals(2000, nearCacheConfig.getMaxSize());
+        assertEquals(2000, nearCacheConfig.getEvictionConfig().getSize());
         assertEquals(90, nearCacheConfig.getTimeToLiveSeconds());
         assertEquals(100, nearCacheConfig.getMaxIdleSeconds());
         assertEquals("LFU", nearCacheConfig.getEvictionPolicy());
+        assertEquals(EvictionPolicy.LFU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
         assertTrue(nearCacheConfig.isInvalidateOnChange());
         assertEquals(InMemoryFormat.OBJECT, nearCacheConfig.getInMemoryFormat());
     }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -216,8 +216,8 @@ public class TestClientApplicationContext {
 
         assertEquals(1, nearCacheConfig.getTimeToLiveSeconds());
         assertEquals(70, nearCacheConfig.getMaxIdleSeconds());
-        assertEquals("LRU", nearCacheConfig.getEvictionPolicy());
-        assertEquals(4000, nearCacheConfig.getMaxSize());
+        assertEquals(EvictionPolicy.LRU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
+        assertEquals(4000, nearCacheConfig.getEvictionConfig().getSize());
         assertEquals(true, nearCacheConfig.isInvalidateOnChange());
     }
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -290,8 +290,8 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertNotNull(testNearCacheConfig);
         assertEquals(0, testNearCacheConfig.getTimeToLiveSeconds());
         assertEquals(60, testNearCacheConfig.getMaxIdleSeconds());
-        assertEquals("LRU", testNearCacheConfig.getEvictionPolicy());
-        assertEquals(5000, testNearCacheConfig.getMaxSize());
+        assertEquals(EvictionPolicy.LRU, testNearCacheConfig.getEvictionConfig().getEvictionPolicy());
+        assertEquals(5000, testNearCacheConfig.getEvictionConfig().getSize());
         assertTrue(testNearCacheConfig.isInvalidateOnChange());
 
         // Test that the testMapConfig2's mapStoreConfig implementation

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -52,6 +52,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
      */
     public static final EvictionPolicy DEFAULT_EVICTION_POLICY = EvictionPolicy.LRU;
 
+    protected boolean sizeConfigured;
     protected int size = DEFAULT_MAX_ENTRY_COUNT;
     protected MaxSizePolicy maxSizePolicy = DEFAULT_MAX_SIZE_POLICY;
     protected EvictionPolicy evictionPolicy = DEFAULT_EVICTION_POLICY;
@@ -71,6 +72,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
          * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
          */
 
+        this.sizeConfigured = true;
         this.size = checkPositive(size, "Size must be positive number!");
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
         this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
@@ -84,6 +86,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
          * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
          */
 
+        this.sizeConfigured = true;
         this.size = checkPositive(size, "Size must be positive number!");
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
         this.comparatorClassName = checkNotNull(comparatorClassName, "Comparator classname cannot be null!");
@@ -97,6 +100,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
          * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
          */
 
+        this.sizeConfigured = true;
         this.size = checkPositive(size, "Size must be positive number!");
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
         this.comparator = checkNotNull(comparator, "Comparator cannot be null!");
@@ -110,6 +114,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
          * cause "UnsupportedOperationException". So just set directly if value is valid.
          */
 
+        this.sizeConfigured = true;
         this.size = checkPositive(config.size, "Size must be positive number!");
         this.maxSizePolicy = checkNotNull(config.maxSizePolicy, "Max-Size policy cannot be null!");
         if (config.evictionPolicy != null) {
@@ -166,6 +171,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
     }
 
     public EvictionConfig setSize(int size) {
+        this.sizeConfigured = true;
         this.size = checkPositive(size, "Size must be positive number!");
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -35,8 +35,7 @@ import static com.hazelcast.util.Preconditions.checkPositive;
  * Configuration for eviction.
  * You can set a limit for number of entries or total memory cost of entries.
  */
-public class EvictionConfig
-        implements EvictionConfiguration, DataSerializable, Serializable {
+public class EvictionConfig implements EvictionConfiguration, DataSerializable, Serializable {
 
     /**
      * Default maximum entry count.
@@ -72,11 +71,8 @@ public class EvictionConfig
          * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
          */
 
-        // Size cannot be non-positive number
         this.size = checkPositive(size, "Size must be positive number!");
-        // Max-Size policy cannot be null
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
-        // Eviction policy cannot be null
         this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
     }
 
@@ -88,11 +84,8 @@ public class EvictionConfig
          * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
          */
 
-        // Size cannot be non-positive number
         this.size = checkPositive(size, "Size must be positive number!");
-        // Max-Size policy cannot be null
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
-        // Eviction policy comparator class name cannot be null
         this.comparatorClassName = checkNotNull(comparatorClassName, "Comparator classname cannot be null!");
     }
 
@@ -104,11 +97,8 @@ public class EvictionConfig
          * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
          */
 
-        // Size cannot be non-positive number
         this.size = checkPositive(size, "Size must be positive number!");
-        // Max-Size policy cannot be null
         this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
-        // Eviction policy comparator cannot be null
         this.comparator = checkNotNull(comparator, "Comparator cannot be null!");
     }
 
@@ -120,19 +110,16 @@ public class EvictionConfig
          * cause "UnsupportedOperationException". So just set directly if value is valid.
          */
 
-        // Size cannot be non-positive number
         this.size = checkPositive(config.size, "Size must be positive number!");
-        // Max-Size policy cannot be null
         this.maxSizePolicy = checkNotNull(config.maxSizePolicy, "Max-Size policy cannot be null!");
-        // Eviction policy cannot be null
         if (config.evictionPolicy != null) {
             this.evictionPolicy = config.evictionPolicy;
         }
-        // Eviction policy comparator class name cannot be null
+        // Eviction policy comparator class name is not allowed to be null
         if (config.comparatorClassName != null) {
             this.comparatorClassName = config.comparatorClassName;
         }
-        // Eviction policy comparator cannot be null
+        // Eviction policy comparator is not allowed to be null
         if (config.comparator != null) {
             this.comparator = config.comparator;
         }
@@ -179,7 +166,7 @@ public class EvictionConfig
     }
 
     public EvictionConfig setSize(int size) {
-        this.size = checkPositive(size, "Size must be positive number !");
+        this.size = checkPositive(size, "Size must be positive number!");
         return this;
     }
 
@@ -188,7 +175,7 @@ public class EvictionConfig
     }
 
     public EvictionConfig setMaximumSizePolicy(MaxSizePolicy maxSizePolicy) {
-        this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null !");
+        this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
         return this;
     }
 
@@ -197,9 +184,7 @@ public class EvictionConfig
     }
 
     public EvictionConfig setEvictionPolicy(EvictionPolicy evictionPolicy) {
-        checkNotNull(evictionPolicy, "Eviction policy cannot be null !");
-
-        this.evictionPolicy = evictionPolicy;
+        this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
         return this;
     }
 
@@ -209,9 +194,7 @@ public class EvictionConfig
     }
 
     public EvictionConfig setComparatorClassName(String comparatorClassName) {
-        checkNotNull(comparatorClassName, "Eviction policy comparator class name cannot be null !");
-
-        this.comparatorClassName = comparatorClassName;
+        this.comparatorClassName = checkNotNull(comparatorClassName, "Eviction policy comparator class name cannot be null!");
         return this;
     }
 
@@ -221,15 +204,13 @@ public class EvictionConfig
     }
 
     public EvictionConfig setComparator(EvictionPolicyComparator comparator) {
-        checkNotNull(comparator, "Eviction policy comparator cannot be null !");
-
-        this.comparator = comparator;
+        this.comparator = checkNotNull(comparator, "Eviction policy comparator cannot be null!");
         return this;
     }
 
     @Override
     public EvictionStrategyType getEvictionStrategyType() {
-        // TODO Add support for other/custom eviction strategies
+        // TODO: add support for other/custom eviction strategies
         return EvictionStrategyType.DEFAULT_EVICTION_STRATEGY;
     }
 
@@ -245,8 +226,7 @@ public class EvictionConfig
     }
 
     @Override
-    public void writeData(ObjectDataOutput out)
-            throws IOException {
+    public void writeData(ObjectDataOutput out) throws IOException {
         out.writeInt(size);
         out.writeUTF(maxSizePolicy.toString());
         out.writeUTF(evictionPolicy.toString());
@@ -255,8 +235,7 @@ public class EvictionConfig
     }
 
     @Override
-    public void readData(ObjectDataInput in)
-            throws IOException {
+    public void readData(ObjectDataInput in) throws IOException {
         size = in.readInt();
         maxSizePolicy = MaxSizePolicy.valueOf(in.readUTF());
         evictionPolicy = EvictionPolicy.valueOf(in.readUTF());
@@ -275,5 +254,4 @@ public class EvictionConfig
                 + ", readOnly=" + readOnly
                 + '}';
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigAccessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.spi.annotation.PrivateApi;
+
+/**
+ * Accessor for the {@link EvictionConfig} to initialize the old default max size, if no size was configured by the user.
+ */
+@PrivateApi
+public final class EvictionConfigAccessor {
+
+    private EvictionConfigAccessor() {
+    }
+
+    public static EvictionConfig initDefaultMaxSize(EvictionConfig evictionConfig) {
+        if (!evictionConfig.sizeConfigured) {
+            evictionConfig.setSize(NearCacheConfig.DEFAULT_MAX_SIZE);
+        }
+        return evictionConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import java.io.IOException;
 import java.io.Serializable;
 
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.isNotNull;
@@ -49,11 +50,15 @@ public class NearCacheConfig implements DataSerializable, Serializable {
 
     /**
      * Default value of the maximum size.
+     *
+     * @deprecated since 3.8, please use {@link EvictionConfig#DEFAULT_MAX_ENTRY_COUNT}
      */
     public static final int DEFAULT_MAX_SIZE = Integer.MAX_VALUE;
 
     /**
      * Default value for the eviction policy.
+     *
+     * @deprecated since 3.8, please use {@link EvictionConfig#DEFAULT_EVICTION_POLICY}
      */
     public static final String DEFAULT_EVICTION_POLICY = EvictionConfig.DEFAULT_EVICTION_POLICY.name();
 
@@ -122,6 +127,10 @@ public class NearCacheConfig implements DataSerializable, Serializable {
         // EvictionConfig is not allowed to be null
         if (evictionConfig != null) {
             this.evictionConfig = evictionConfig;
+        } else {
+            this.evictionConfig.setSize(maxSize);
+            this.evictionConfig.setEvictionPolicy(EvictionPolicy.valueOf(evictionPolicy));
+            this.evictionConfig.setMaximumSizePolicy(ENTRY_COUNT);
         }
     }
 
@@ -196,6 +205,7 @@ public class NearCacheConfig implements DataSerializable, Serializable {
      * cache is evicted based on the policy defined.
      *
      * @return The maximum size of the Near Cache.
+     * @deprecated since 3.8, use {@link #getEvictionConfig()} and {@link EvictionConfig#getSize()} instead
      */
     public int getMaxSize() {
         return maxSize;
@@ -209,9 +219,12 @@ public class NearCacheConfig implements DataSerializable, Serializable {
      *
      * @param maxSize The maximum number of seconds for each entry to stay in the Near Cache.
      * @return This Near Cache config instance.
+     * @deprecated since 3.8, use {@link #setEvictionConfig(EvictionConfig)} and {@link EvictionConfig#setSize(int)} instead
      */
     public NearCacheConfig setMaxSize(int maxSize) {
         this.maxSize = calculateMaxSize(maxSize);
+        this.evictionConfig.setSize(this.maxSize);
+        this.evictionConfig.setMaximumSizePolicy(ENTRY_COUNT);
         return this;
     }
 
@@ -227,6 +240,7 @@ public class NearCacheConfig implements DataSerializable, Serializable {
      * Regardless of the eviction policy used, time-to-live-seconds will still apply.
      *
      * @return TThe eviction policy for the Near Cache.
+     * @deprecated since 3.8, use {@link #getEvictionConfig()} and {@link EvictionConfig#getEvictionPolicy()} instead
      */
     public String getEvictionPolicy() {
         return evictionPolicy;
@@ -245,9 +259,13 @@ public class NearCacheConfig implements DataSerializable, Serializable {
      *
      * @param evictionPolicy The eviction policy for the Near Cache.
      * @return This Near Cache config instance.
+     * @deprecated since 3.8, use {@link #setEvictionConfig(EvictionConfig)}
+     * and {@link EvictionConfig#setEvictionPolicy(EvictionPolicy)} instead
      */
     public NearCacheConfig setEvictionPolicy(String evictionPolicy) {
         this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
+        this.evictionConfig.setEvictionPolicy(EvictionPolicy.valueOf(evictionPolicy));
+        this.evictionConfig.setMaximumSizePolicy(ENTRY_COUNT);
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1134,12 +1134,14 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             String value = getTextContent(child).trim();
             if ("max-size".equals(nodeName)) {
                 nearCacheConfig.setMaxSize(Integer.parseInt(value));
+                LOGGER.warning("The element <max-size/> for <near-cache/> is deprecated, please use <eviction/> instead!");
             } else if ("time-to-live-seconds".equals(nodeName)) {
                 nearCacheConfig.setTimeToLiveSeconds(Integer.parseInt(value));
             } else if ("max-idle-seconds".equals(nodeName)) {
                 nearCacheConfig.setMaxIdleSeconds(Integer.parseInt(value));
             } else if ("eviction-policy".equals(nodeName)) {
                 nearCacheConfig.setEvictionPolicy(value);
+                LOGGER.warning("The element <eviction-policy/> for <near-cache/> is deprecated, please use <eviction/> instead!");
             } else if ("in-memory-format".equals(nodeName)) {
                 nearCacheConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(value)));
             } else if ("invalidate-on-change".equals(nodeName)) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.nearcache;
 
 import com.hazelcast.cache.impl.nearcache.NearCache;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
@@ -39,6 +40,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.hazelcast.config.EvictionConfigAccessor.initDefaultMaxSize;
 import static com.hazelcast.config.EvictionPolicy.NONE;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
@@ -84,12 +86,13 @@ public class NearCacheImpl implements NearCache<Data, Object> {
 
         Config config = nodeEngine.getConfig();
         NearCacheConfig nearCacheConfig = config.findMapConfig(mapName).getNearCacheConfig();
+        EvictionConfig evictionConfig = initDefaultMaxSize(nearCacheConfig.getEvictionConfig());
         this.inMemoryFormat = nearCacheConfig.getInMemoryFormat();
-        this.maxSize = nearCacheConfig.getMaxSize() <= 0 ? Integer.MAX_VALUE : nearCacheConfig.getMaxSize();
+        this.maxSize = evictionConfig.getSize();
         this.maxIdleMillis = TimeUnit.SECONDS.toMillis(nearCacheConfig.getMaxIdleSeconds());
         this.timeToLiveMillis = TimeUnit.SECONDS.toMillis(nearCacheConfig.getTimeToLiveSeconds());
         this.invalidateOnChange = nearCacheConfig.isInvalidateOnChange();
-        this.evictionPolicy = EvictionPolicy.valueOf(nearCacheConfig.getEvictionPolicy());
+        this.evictionPolicy = evictionConfig.getEvictionPolicy();
         this.canExpire = new AtomicBoolean(true);
         this.canEvict = new AtomicBoolean(true);
         this.stats = new NearCacheStatsImpl();

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -111,7 +111,8 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="cache-deserialized-values" type="cache-deserialized-values" minOccurs="0" maxOccurs="1" default="INDEX-ONLY">
+            <xs:element name="cache-deserialized-values" type="cache-deserialized-values" minOccurs="0" maxOccurs="1"
+                        default="INDEX-ONLY">
                 <xs:annotation>
                     <xs:documentation>
                         Control caching of de-serialized values. Caching makes query evaluation faster, but it cost memory.
@@ -205,7 +206,8 @@
                                         cluster. Thus, for a small cluster, eviction of the entries will decrease
                                         performance (the number of entries is large).
                                         USED_HEAP_SIZE: Maximum used heap size in megabytes per map for each Hazelcast instance.
-                                        USED_HEAP_PERCENTAGE: Maximum used heap size percentage per map for each Hazelcast instance.
+                                        USED_HEAP_PERCENTAGE: Maximum used heap size percentage per map for each Hazelcast
+                                        instance.
                                         If, for example, JVM is configured to have 1000 MB and this value is 10, then the map
                                         entries will be evicted when used heap size exceeds 100 MB.
                                         FREE_HEAP_SIZE: Minimum free heap size in megabytes for each JVM.
@@ -231,7 +233,8 @@
                 <xs:annotation>
                     <xs:documentation>
                         This parameter is deprecated as of version 3.7 due to the eviction mechanism change.
-                        (New eviction mechanism uses a probabilistic algorithm based on sampling. Please see documentation for further details.)
+                        (New eviction mechanism uses a probabilistic algorithm based on sampling. Please see documentation for
+                        further details.)
 
                         When the map reaches maximum size, this specified percentage of the map will be evicted. Set to any
                         integer between 0 and 100.
@@ -250,7 +253,8 @@
                 <xs:annotation>
                     <xs:documentation>
                         This parameter is deprecated as of version 3.7 due to the eviction mechanism change.
-                        (New eviction mechanism uses a probabilistic algorithm based on sampling. Please see documentation for further details.)
+                        (New eviction mechanism uses a probabilistic algorithm based on sampling. Please see documentation for
+                        further details.)
 
                         Minimum time in milliseconds which should pass before checking
                         if a partition of this map is evictable or not.
@@ -288,7 +292,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1" />
+            <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1"/>
             <xs:element name="map-store" type="map-store" minOccurs="0" maxOccurs="1"/>
             <xs:element name="near-cache" type="near-cache" minOccurs="0" maxOccurs="1"/>
             <xs:element name="wan-replication-ref" type="wan-replication-ref" minOccurs="0" maxOccurs="1"/>
@@ -499,8 +503,10 @@
                         max-size-policy:
                         max-size-policy has these valid values:
                         ENTRY_COUNT (Maximum number of cache entries in the cache),
-                        USED_NATIVE_MEMORY_SIZE (Maximum used native memory size in megabytes per cache for each Hazelcast instance),
-                        USED_NATIVE_MEMORY_PERCENTAGE (Maximum used native memory size percentage per cache for each Hazelcast instance),
+                        USED_NATIVE_MEMORY_SIZE (Maximum used native memory size in megabytes per cache for each Hazelcast
+                        instance),
+                        USED_NATIVE_MEMORY_PERCENTAGE (Maximum used native memory size percentage per cache for each Hazelcast
+                        instance),
                         FREE_NATIVE_MEMORY_SIZE (Maximum free native memory size in megabytes for each Hazelcast instance),
                         FREE_NATIVE_MEMORY_PERCENTAGE (Maximum free native memory size percentage for each Hazelcast instance).
 
@@ -547,8 +553,9 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1" />
-            <xs:element name="disable-per-entry-invalidation-events" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+            <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="disable-per-entry-invalidation-events" type="xs:boolean" minOccurs="0" maxOccurs="1"
+                        default="false">
                 <xs:annotation>
                     <xs:documentation>
                         Disables invalidation events for per entry but full-flush invalidation events are still enabled.
@@ -1976,7 +1983,7 @@
     <xs:complexType name="map-attribute">
         <xs:simpleContent>
             <xs:extension base="xs:string">
-                <xs:attribute name="extractor" type="xs:string" />
+                <xs:attribute name="extractor" type="xs:string"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
@@ -2268,8 +2275,10 @@
                     <xs:documentation>
                         Maximum size of the Near Cache. When max size is reached,
                         cache is evicted based on the policy defined.
-                        Any integer between 0 and Integer.MAX_VALUE. 0 means
-                        Integer.MAX_VALUE. Default is 0.
+                        Any integer between 0 and Integer.MAX_VALUE.
+                        0 means Integer.MAX_VALUE. Default is 0.
+
+                        Deprecated since 3.8, please use &lt;eviction/&gt;
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -2297,10 +2306,12 @@
                     <xs:documentation>
                         Valid values are:
                         NONE (no extra eviction, time-to-live-seconds may still apply),
-                        LRU  (Least Recently Used),
-                        LFU  (Least Frequently Used).
+                        LRU (Least Recently Used),
+                        LFU (Least Frequently Used).
                         NONE is the default.
                         Regardless of the eviction policy used, time-to-live-seconds will still apply.
+
+                        Deprecated since 3.8, please use &lt;eviction/&gt;
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -121,7 +121,9 @@ public class ConfigXmlGeneratorTest {
         NearCacheConfig xmlNearCacheConfig = xmlConfig.getMapConfig("nearCacheTest").getNearCacheConfig();
         assertEquals(InMemoryFormat.NATIVE, xmlNearCacheConfig.getInMemoryFormat());
         assertEquals(23, xmlNearCacheConfig.getMaxSize());
+        assertEquals(23, xmlNearCacheConfig.getEvictionConfig().getSize());
         assertEquals("LRU", xmlNearCacheConfig.getEvictionPolicy());
+        assertEquals(EvictionPolicy.LRU, xmlNearCacheConfig.getEvictionConfig().getEvictionPolicy());
         assertEquals(42, xmlNearCacheConfig.getMaxIdleSeconds());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigAccessorTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
+
+public class EvictionConfigAccessorTest extends HazelcastTestSupport {
+
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(EvictionConfigAccessor.class);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLocalImmediateInvalidateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLocalImmediateInvalidateTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.map.nearcache;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.NearCacheConfig;
@@ -55,14 +56,14 @@ public class NearCacheLocalImmediateInvalidateTest extends HazelcastTestSupport 
     }
 
     protected Config createConfig() {
-        // create config
-        Config config = new Config();
-        // configure Near Cache
-        MapConfig mapConfig = config.getMapConfig(MAP_NAME + "*");
         NearCacheConfig nearCacheConfig = new NearCacheConfig();
-        nearCacheConfig.setEvictionPolicy("NONE");
         nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        nearCacheConfig.getEvictionConfig().setEvictionPolicy(EvictionPolicy.NONE);
+
+        Config config = new Config();
+        MapConfig mapConfig = config.getMapConfig(MAP_NAME + "*");
         mapConfig.setNearCacheConfig(nearCacheConfig);
+
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLocalInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLocalInvalidationTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.map.nearcache;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.NearCacheConfig;
@@ -43,16 +44,15 @@ public class NearCacheLocalInvalidationTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        // create config
-        Config config = new Config();
-        // configure Near Cache
-        MapConfig mapConfig = config.getMapConfig(MAP_NAME + "*");
         NearCacheConfig nearCacheConfig = new NearCacheConfig();
-        nearCacheConfig.setEvictionPolicy("NONE");
         nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
-        nearCacheConfig.setCacheLocalEntries(true); // this enables the local caching
+        nearCacheConfig.getEvictionConfig().setEvictionPolicy(EvictionPolicy.NONE);
+        nearCacheConfig.setCacheLocalEntries(true);
+
+        Config config = new Config();
+        MapConfig mapConfig = config.getMapConfig(MAP_NAME + "*");
         mapConfig.setNearCacheConfig(nearCacheConfig);
-        // create Hazelcast instance
+
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(INSTANCE_COUNT);
         hzInstance1 = factory.newHazelcastInstance(config);
         hzInstance2 = factory.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTestSupport.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.nearcache;
 
 import com.hazelcast.cache.impl.nearcache.NearCache;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
@@ -42,6 +43,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.instance.BuildInfoProvider.getBuildInfo;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -170,8 +172,7 @@ public class NearCacheTestSupport extends HazelcastTestSupport {
     protected NearCacheConfig newNearCacheConfigWithEntryCountEviction(EvictionPolicy evictionPolicy, int size) {
         return newNearCacheConfig()
                 .setCacheLocalEntries(true)
-                .setMaxSize(size)
-                .setEvictionPolicy(evictionPolicy.name());
+                .setEvictionConfig(new EvictionConfig(size, ENTRY_COUNT, evictionPolicy));
     }
 
     protected NearCacheConfig newNearCacheConfig() {


### PR DESCRIPTION
* Cleanup of `NearCacheConfig` and related classes
* Deprecated the old `max-size` and `eviction-policy` configuration
* Added functionality to return the new eviction configuration if the old configuration style was used
* Added fallback for old `max-size` default value if size was not configured explicitly

No EE adaption is needed.