### PR TITLE
Incrementing minimal-json version due to serialisation bug in 0.9.2

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -312,7 +312,7 @@
         <dependency>
             <groupId>com.eclipsesource.minimal-json</groupId>
             <artifactId>minimal-json</artifactId>
-            <version>0.9.2</version>
+            <version>0.9.4</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
Here's the issue description:
https://groups.google.com/forum/#!topic/hazelcast/uf81nXSlgNE