### PR TITLE
Fixed wrong calculation of Near Cache owned memory costs

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -161,4 +161,24 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     public void testNearCacheIdleRecordsExpired_withBinaryInMemoryFormat() {
         testNearCacheExpiration_withMaxIdle(InMemoryFormat.BINARY);
     }
+
+    @Test
+    public void testNearCacheMemoryCostCalculation_withObjectInMemoryFormat() {
+        testNearCacheMemoryCostCalculation(InMemoryFormat.OBJECT, 1);
+    }
+
+    @Test
+    public void testNearCacheMemoryCostCalculation_withConcurrentCacheMisses_withObjectInMemoryFormat() {
+        testNearCacheMemoryCostCalculation(InMemoryFormat.OBJECT, 10);
+    }
+
+    @Test
+    public void testNearCacheMemoryCostCalculation_withBinaryInMemoryFormat() {
+        testNearCacheMemoryCostCalculation(InMemoryFormat.BINARY, 1);
+    }
+
+    @Test
+    public void testNearCacheMemoryCostCalculation_withConcurrentCacheMisses_withBinaryInMemoryFormat() {
+        testNearCacheMemoryCostCalculation(InMemoryFormat.BINARY, 10);
+    }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -657,9 +657,11 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         assertOpenEventually(countDownLatch);
 
         // the Near Cache is filled, we should see some memory costs now
-        if (inMemoryFormat != InMemoryFormat.OBJECT) {
-            assertTrue("The Near Cache is filled, there should be some heap costs",
-                    context.cache.getLocalCacheStatistics().getNearCacheStatistics().getOwnedEntryMemoryCost() > 0);
+        long memoryCosts = context.cache.getLocalCacheStatistics().getNearCacheStatistics().getOwnedEntryMemoryCost();
+        if (inMemoryFormat == InMemoryFormat.OBJECT) {
+            assertEquals("There should be no Near Cache heap costs calculated for InMemoryFormat.OBJECT", 0, memoryCosts);
+        } else {
+            assertTrue("The Near Cache is filled, there should be some heap costs", memoryCosts > 0);
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -52,11 +52,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.spi.properties.GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
 import static java.lang.String.format;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -627,6 +629,46 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
                         stats.getExpirations() >= size);
             }
         });
+    }
+
+    protected void testNearCacheMemoryCostCalculation(InMemoryFormat inMemoryFormat, int threadCount) {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat).setCacheLocalEntries(true);
+        final NearCacheTestContext context = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            context.cache.put(i, "value-" + i);
+        }
+
+        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+                    context.cache.get(i);
+                }
+                countDownLatch.countDown();
+            }
+        };
+
+        ExecutorService executorService = newFixedThreadPool(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(task);
+        }
+        assertOpenEventually(countDownLatch);
+
+        // the Near Cache is filled, we should see some memory costs now
+        if (inMemoryFormat != InMemoryFormat.OBJECT) {
+            assertTrue("The Near Cache is filled, there should be some heap costs",
+                    context.cache.getLocalCacheStatistics().getNearCacheStatistics().getOwnedEntryMemoryCost() > 0);
+        }
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            context.cache.remove(i);
+        }
+
+        // the Near Cache is empty, we shouldn't see memory costs anymore
+        assertEquals("The Near Cache is empty, there should be no heap costs", 0,
+                context.cache.getLocalCacheStatistics().getNearCacheStatistics().getOwnedEntryMemoryCost());
     }
 
     protected NearCacheStats getNearCacheStats(ICache cache) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -875,6 +875,21 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
+    public void testNearCacheMemoryCostCalculation() {
+        testNearCacheMemoryCostCalculation(1);
+    }
+
+    @Test
+    public void testNearCacheMemoryCostCalculation_withConcurrentCacheMisses() {
+        testNearCacheMemoryCostCalculation(10);
+    }
+
+    private void testNearCacheMemoryCostCalculation(int threadCount) {
+        IMap<Integer, Integer> map = getNearCachedMapFromClient(newNearCacheConfig());
+        testNearCacheMemoryCostCalculation(map, false, threadCount);
+    }
+
+    @Test
     public void testNearCacheInvalidateOnChange() {
         String mapName = randomMapName();
         HazelcastInstance server = hazelcastFactory.newHazelcastInstance(newConfig());

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -286,7 +286,7 @@ public abstract class AbstractNearCacheRecordStore<
             if (oldRecord == null) {
                 nearCacheStats.incrementOwnedEntryCount();
             } else {
-                long oldRecordMemoryCost = getRecordStorageMemoryCost(oldRecord);
+                long oldRecordMemoryCost = getTotalStorageMemoryCost(key, oldRecord);
                 nearCacheStats.decrementOwnedEntryMemoryCost(oldRecordMemoryCost);
             }
             onPut(key, value, record, oldRecord);


### PR DESCRIPTION
* Added an additional tests for Near Cache memory cost calculation
* Fixed wrong calculation of Near Cache owned memory costs

All Near Caches implementations which are based on the `AbstractNearCacheRecordStore` suffer from a wrong calculation of owned memory costs. Whenever a record in the Near Cache is updated, we upfront add the memory costs for its key + value:
```
BaseHeapNearCacheRecordStore extends AbstractNearCacheRecordStore

@Override
protected R putRecord(K key, R record) {
    R oldRecord = records.put(key, record);
    nearCacheStats.incrementOwnedEntryMemoryCost(getTotalStorageMemoryCost(key, record));
    return oldRecord;
}
```
If `oldRecord` exists, we detract just the costs for the value, but not the key:
```
AbstractNearCacheRecordStore

oldRecord = putRecord(key, record);
if (oldRecord == null) {
    nearCacheStats.incrementOwnedEntryCount();
} else {
    long oldRecordMemoryCost = getRecordStorageMemoryCost(oldRecord);
    nearCacheStats.decrementOwnedEntryMemoryCost(oldRecordMemoryCost);
}
```
So in the end each record update piles up the costs of a key.

The new tests were failing like this before the fix was applied:
```
java.lang.AssertionError: The Near Cache is empty, there should be no owned entry memory costs 
Expected :0
Actual   :3696
```
The easiest fix is to detract the costs for key + value if an old record was found. So the upfront added key costs are removed again. We could also skip adding the key costs, but then we would have to duplicate this logic in all record store implementations (OS + EE). With the actual approach, it's just one line in the abstract base class.

There is no EE adaption needed, since the tests work for all scenarios.