### PR TITLE
Allow nested Spring transactions to be rolled back cleanly

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
@@ -21,6 +21,12 @@ public class OtherServiceBeanWithTransactionalContext {
         transactionalContext.getMap("dummyObjectMap").put(object.getId(), object);
     }
 
+    @Transactional
+    public void putWithException(DummyObject object) {
+        put(object);
+        throw new RuntimeException("oops, let's rollback in " + this.getClass().getSimpleName() + "!");
+    }
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void putInNewTransaction(DummyObject object) {
         put(object);

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
@@ -31,7 +31,21 @@ public class ServiceBeanWithTransactionalContext {
         otherService.put(object);
     }
 
+    public void putUsingOtherBean_sameTransaction_withException(DummyObject object) {
+        otherService.putWithException(object);
+    }
+
     public void putUsingOtherBean_newTransaction(DummyObject object) {
         otherService.putInNewTransaction(object);
+    }
+
+    public void putUsingSameBean_thenOtherBeanThrowingException_sameTransaction(DummyObject object, DummyObject otherObject) {
+        put(object);
+        otherService.putWithException(otherObject);
+    }
+
+    public void putUsingOtherBean_thenSameBeanThrowingException_sameTransaction(DummyObject object, DummyObject otherObject) {
+        otherService.put(otherObject);
+        putWithException(object);
     }
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -10,6 +10,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionalTaskContext;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +35,12 @@ public class TestSpringManagedHazelcastTransaction {
         Hazelcast.shutdownAll();
     }
 
+    @Before
+    public void setUp() {
+        //Clear all items from the dummyObjectMap used
+        //to test transactional object insertion
+        instance.getMap("dummyObjectMap").clear();
+    }
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -46,7 +53,6 @@ public class TestSpringManagedHazelcastTransaction {
 
     @Autowired
     HazelcastInstance instance;
-
 
     /**
      * Tests that transactionalContext cannot be accessed when there is no transaction.
@@ -95,6 +101,50 @@ public class TestSpringManagedHazelcastTransaction {
 
         try {
             service.putWithException(new DummyObject(1L, "magic"));
+        } catch (RuntimeException ex) {
+            expectedEx = ex;
+        } finally {
+            // then
+            Assert.assertNotNull(expectedEx);
+            Assert.assertEquals(0L, instance.getMap("dummyObjectMap").size());
+        }
+    }
+
+    /**
+     * Tests that transaction will be rollbacked when putting one object each 
+     * via two beans, one nested within the other,
+     * if there is an exception in the nested bean, but no exception in our own bean.
+     */
+    @Test
+    public void transactionalServiceBeanInvocation_withNestedBeanThrowingException_rollback() {
+        // when
+        RuntimeException expectedEx = null;
+
+        try {
+            service.putUsingSameBean_thenOtherBeanThrowingException_sameTransaction(
+                    new DummyObject(1L, "magic"), new DummyObject(2L, "magic2"));
+        } catch (RuntimeException ex) {
+            expectedEx = ex;
+        } finally {
+            // then
+            Assert.assertNotNull(expectedEx);
+            Assert.assertEquals(0L, instance.getMap("dummyObjectMap").size());
+        }
+    }
+
+    /**
+     * Tests that transaction will be rollbacked when putting one object each 
+     * via two beans, one nested within the other,
+     * if there is an exception in our own bean, but no exception in the other bean.
+     */
+    @Test
+    public void transactionalServiceBeanInvocation_withOwnBeanThrowingException_rollback() {
+        // when
+        RuntimeException expectedEx = null;
+
+        try {
+            service.putUsingOtherBean_thenSameBeanThrowingException_sameTransaction(
+                    new DummyObject(1L, "magic"), new DummyObject(2L, "magic2"));
         } catch (RuntimeException ex) {
             expectedEx = ex;
         } finally {


### PR DESCRIPTION
* HazelcastTransactionObject now implements Spring's
SmartTransactionObject, exposing the boolean field isRollbackOnly

* Make HazelcastTransactionManager override doSetRollbackOnly so that if
a transaction is participating in another one, and there is a rollback,
we force the participant to be rollback-only

* Add tests that verify that in the middle of persisting objects through several beans, even when one exception is thrown after some of the objects have been persisted, the
transaction gets fully rolled back, leaving behind an empty map.

Credit to @jrosiek for input

This PR supersedes #8806