### PR TITLE
Added missing tests for Near Cache Invalidation

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheLiteMemberTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.map.nearcache.NearCacheLiteMemberTest.createNearCachedMapConfigWithMapStoreConfig;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -22,16 +23,18 @@ public class ClientMapNearCacheLiteMemberTest {
 
     private TestHazelcastFactory factory;
 
-    private HazelcastInstance lite;
     private HazelcastInstance client;
+    private HazelcastInstance lite;
 
     @Before
     public void init() {
         mapName = randomMapName();
+
         factory = new TestHazelcastFactory();
         factory.newHazelcastInstance(NearCacheLiteMemberTest.createConfig(mapName, false));
-        lite = factory.newHazelcastInstance(NearCacheLiteMemberTest.createConfig(mapName, true));
+
         client = factory.newHazelcastClient();
+        lite = factory.newHazelcastInstance(NearCacheLiteMemberTest.createConfig(mapName, true));
     }
 
     @After
@@ -112,5 +115,27 @@ public class ClientMapNearCacheLiteMemberTest {
     @Test
     public void testExecuteOnKeys() {
         NearCacheLiteMemberTest.testExecuteOnKeys(client, lite, mapName);
+    }
+
+    @Test
+    public void testLoadAll() {
+        initWithMapStore();
+
+        NearCacheLiteMemberTest.testLoadAll(client, lite, mapName);
+    }
+
+    @Test
+    public void testLoadAllWithKeySet() {
+        initWithMapStore();
+
+        NearCacheLiteMemberTest.testLoadAllWithKeySet(client, lite, mapName);
+    }
+
+    private void initWithMapStore() {
+        factory.terminateAll();
+        factory.newHazelcastInstance(NearCacheLiteMemberTest.createNearCachedMapConfigWithMapStoreConfig(mapName, false));
+
+        client = factory.newHazelcastClient();
+        lite = factory.newHazelcastInstance(createNearCachedMapConfigWithMapStoreConfig(mapName, true));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheLiteMemberTest.java
@@ -2,6 +2,7 @@ package com.hazelcast.map.nearcache;
 
 import com.hazelcast.cache.impl.nearcache.NearCache;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -38,18 +39,19 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class NearCacheLiteMemberTest {
 
-    private TestHazelcastInstanceFactory factory;
-
     private String mapName;
 
-    private HazelcastInstance instance;
+    private TestHazelcastInstanceFactory factory;
 
+    private HazelcastInstance instance;
     private HazelcastInstance lite;
 
     @Before
     public void init() {
-        factory = new TestHazelcastInstanceFactory(2);
         mapName = randomMapName();
+
+        factory = new TestHazelcastInstanceFactory(2);
+
         instance = factory.newHazelcastInstance(createConfig(mapName, false));
         lite = factory.newHazelcastInstance(createConfig(mapName, true));
     }
@@ -132,6 +134,20 @@ public class NearCacheLiteMemberTest {
     @Test
     public void testExecuteOnKeys() {
         testExecuteOnKeys(instance, lite, mapName);
+    }
+
+    @Test
+    public void testLoadAll() {
+        initWithMapStore();
+
+        testLoadAll(instance, lite, mapName);
+    }
+
+    @Test
+    public void testLoadAllWithKeySet() {
+        initWithMapStore();
+
+        testLoadAllWithKeySet(instance, lite, mapName);
     }
 
     public static void testPut(HazelcastInstance instance, HazelcastInstance lite, String mapName) {
@@ -349,6 +365,38 @@ public class NearCacheLiteMemberTest {
         assertNearCacheIsEmptyEventually(lite, mapName);
     }
 
+    public static void testLoadAll(HazelcastInstance instance, HazelcastInstance lite, String mapName) {
+        IMap<Object, Object> map = instance.getMap(mapName);
+        map.put(1, 1);
+
+        IMap<Object, Object> liteMap = lite.getMap(mapName);
+        liteMap.get(1);
+
+        map.loadAll(true);
+
+        assertNearCacheIsEmptyEventually(lite, mapName);
+    }
+
+    public static void testLoadAllWithKeySet(HazelcastInstance instance, HazelcastInstance lite, String mapName) {
+        IMap<Object, Object> map = instance.getMap(mapName);
+        map.put(1, 1);
+
+        IMap<Object, Object> liteMap = lite.getMap(mapName);
+        liteMap.get(1);
+
+        Set<Object> keySet = map.keySet();
+        map.loadAll(keySet, true);
+
+        assertNearCacheIsEmptyEventually(lite, mapName);
+    }
+
+    private void initWithMapStore() {
+        factory.terminateAll();
+
+        instance = factory.newHazelcastInstance(createNearCachedMapConfigWithMapStoreConfig(mapName, false));
+        lite = factory.newHazelcastInstance(createNearCachedMapConfigWithMapStoreConfig(mapName, true));
+    }
+
     private static class DummyEntryProcessor implements EntryProcessor<Object, Object>, Serializable {
 
         private final Object newValue;
@@ -375,6 +423,25 @@ public class NearCacheLiteMemberTest {
         Config config = new Config();
         config.setLiteMember(liteMember);
         config.getMapConfig(mapName).setNearCacheConfig(nearCacheConfig);
+
+        return config;
+    }
+
+    public static Config createNearCachedMapConfigWithMapStoreConfig(String mapName, boolean liteMember) {
+        NearCacheTestSupport.SimpleMapStore store = new NearCacheTestSupport.SimpleMapStore();
+
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setEnabled(true);
+        mapStoreConfig.setImplementation(store);
+
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setInvalidateOnChange(true);
+
+        Config config = new Config();
+        config.setLiteMember(liteMember);
+        config.getMapConfig(mapName)
+                .setMapStoreConfig(mapStoreConfig)
+                .setNearCacheConfig(nearCacheConfig);
 
         return config;
     }


### PR DESCRIPTION
* Added tests for `IMap.loadAll(boolean)` and `IMap.loadAll(Set, boolean)`
* Added test for `IMap.evictAll()`

Adds missing tests for https://github.com/hazelcast/hazelcast/pull/8862