### PR TITLE
JUnit dependencies in MockJoiner and TestNodeRegistry

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1005,8 +1005,4 @@ public abstract class HazelcastTestSupport {
         Node node = getNode(instance);
         return (WaitNotifyServiceImpl) node.getNodeEngine().getWaitNotifyService();
     }
-
-    public static void verifyInvariant(boolean check, String msg) {
-        if (!check) throw new AssertionError(msg);
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1005,4 +1005,8 @@ public abstract class HazelcastTestSupport {
         Node node = getNode(instance);
         return (WaitNotifyServiceImpl) node.getNodeEngine().getWaitNotifyService();
     }
+
+    public static void verifyInvariant(boolean check, String msg) {
+        if (!check) throw new AssertionError(msg);
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -27,8 +27,6 @@ import com.hazelcast.util.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import static com.hazelcast.test.HazelcastTestSupport.verifyInvariant;
-
 class MockJoiner extends AbstractJoiner {
 
     private final TestNodeRegistry registry;
@@ -36,6 +34,10 @@ class MockJoiner extends AbstractJoiner {
     MockJoiner(Node node, TestNodeRegistry registry) {
         super(node);
         this.registry = registry;
+    }
+
+    private static void verifyInvariant(boolean check, String msg) {
+        if (!check) throw new AssertionError(msg);
     }
 
     public void doJoin() {

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -29,6 +29,10 @@ import java.util.Collection;
 
 class MockJoiner extends AbstractJoiner {
 
+    private static void verifyInvariant(boolean check, String msg) {
+        if (!check) throw new AssertionError(msg);
+    }
+
     private final TestNodeRegistry registry;
 
     MockJoiner(Node node, TestNodeRegistry registry) {
@@ -47,7 +51,7 @@ class MockJoiner extends AbstractJoiner {
             while (node.isRunning() && !node.joined() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
                 try {
                     Address joinAddress = getJoinAddress();
-                    assert joinAddress != null;
+                    verifyInvariant(joinAddress != null, "joinAddress should not be null");
 
                     if (node.getThisAddress().equals(joinAddress)) {
                         logger.fine("This node is found as master, no need to join.");
@@ -74,7 +78,7 @@ class MockJoiner extends AbstractJoiner {
         if (!joined) {
             node.shutdown(true);
         }
-        assert joined : node.getThisAddress() + " should have been joined to " + node.getMasterAddress();
+        verifyInvariant(joined, node.getThisAddress() + " should have been joined to " + node.getMasterAddress());
     }
 
     private Address getJoinAddress() {
@@ -107,7 +111,7 @@ class MockJoiner extends AbstractJoiner {
                 continue;
             }
 
-            assert address.equals(foundNode.getThisAddress());
+            verifyInvariant(address.equals(foundNode.getThisAddress()), "The address should be equal to the one in the found node");
 
             if (foundNode.getThisAddress().equals(node.getThisAddress())) {
                 continue;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -23,13 +23,9 @@ import com.hazelcast.internal.cluster.impl.ClusterJoinManager;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
-import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 class MockJoiner extends AbstractJoiner {
 
@@ -51,7 +47,7 @@ class MockJoiner extends AbstractJoiner {
             while (node.isRunning() && !node.joined() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
                 try {
                     Address joinAddress = getJoinAddress();
-                    assertNotNull(joinAddress);
+                    assert joinAddress != null;
 
                     if (node.getThisAddress().equals(joinAddress)) {
                         logger.fine("This node is found as master, no need to join.");
@@ -78,7 +74,7 @@ class MockJoiner extends AbstractJoiner {
         if (!joined) {
             node.shutdown(true);
         }
-        assertTrue(node.getThisAddress() + " should have been joined to " + node.getMasterAddress(), joined);
+        assert joined : node.getThisAddress() + " should have been joined to " + node.getMasterAddress();
     }
 
     private Address getJoinAddress() {
@@ -111,7 +107,7 @@ class MockJoiner extends AbstractJoiner {
                 continue;
             }
 
-            Assert.assertEquals(address, foundNode.getThisAddress());
+            assert address.equals(foundNode.getThisAddress());
 
             if (foundNode.getThisAddress().equals(node.getThisAddress())) {
                 continue;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -27,11 +27,9 @@ import com.hazelcast.util.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 
-class MockJoiner extends AbstractJoiner {
+import static com.hazelcast.test.HazelcastTestSupport.verifyInvariant;
 
-    private static void verifyInvariant(boolean check, String msg) {
-        if (!check) throw new AssertionError(msg);
-    }
+class MockJoiner extends AbstractJoiner {
 
     private final TestNodeRegistry registry;
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -23,6 +23,7 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeContext;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastTestSupport;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,11 +33,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-public final class TestNodeRegistry {
-
-    private static void verifyInvariant(boolean check, String msg) {
-        if (!check) throw new AssertionError(msg);
-    }
+public final class TestNodeRegistry extends HazelcastTestSupport {
 
     private final ConcurrentMap<Address, Node> nodes = new ConcurrentHashMap<Address, Node>(10);
     private final Collection<Address> joinAddresses;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -23,7 +23,6 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeContext;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.nio.Address;
-import com.hazelcast.test.HazelcastTestSupport;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -33,7 +32,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-public final class TestNodeRegistry extends HazelcastTestSupport {
+import static com.hazelcast.test.HazelcastTestSupport.verifyInvariant;
+
+public final class TestNodeRegistry {
 
     private final ConcurrentMap<Address, Node> nodes = new ConcurrentHashMap<Address, Node>(10);
     private final Collection<Address> joinAddresses;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -32,8 +32,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static org.junit.Assert.assertEquals;
-
 public final class TestNodeRegistry {
 
     private final ConcurrentMap<Address, Node> nodes = new ConcurrentHashMap<Address, Node>(10);
@@ -46,7 +44,8 @@ public final class TestNodeRegistry {
     public NodeContext createNodeContext(Address address) {
         Node node;
         if ((node = nodes.get(address)) != null) {
-            assertEquals("This address is already in registry! " + address, NodeState.SHUT_DOWN, node.getState());
+            assert NodeState.SHUT_DOWN == node.getState() : "This address is already in registry! " + address;
+//            assertEquals("This address is already in registry! " + address, NodeState.SHUT_DOWN, node.getState());
             nodes.remove(address, node);
         }
         return new MockNodeContext(this, address);
@@ -110,7 +109,7 @@ public final class TestNodeRegistry {
         Address address = node.getThisAddress();
         Node currentNode = nodes.putIfAbsent(address, node);
         if (currentNode != null) {
-            assertEquals("This address is already in registry! " + address, currentNode, node);
+            assert currentNode.equals(node) : "This address is already in registry! " + address;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -45,7 +45,6 @@ public final class TestNodeRegistry {
         Node node;
         if ((node = nodes.get(address)) != null) {
             assert NodeState.SHUT_DOWN == node.getState() : "This address is already in registry! " + address;
-//            assertEquals("This address is already in registry! " + address, NodeState.SHUT_DOWN, node.getState());
             nodes.remove(address, node);
         }
         return new MockNodeContext(this, address);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -32,12 +32,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.test.HazelcastTestSupport.verifyInvariant;
-
 public final class TestNodeRegistry {
 
     private final ConcurrentMap<Address, Node> nodes = new ConcurrentHashMap<Address, Node>(10);
     private final Collection<Address> joinAddresses;
+
+    private static void verifyInvariant(boolean check, String msg) {
+        if (!check) throw new AssertionError(msg);
+    }
 
     public TestNodeRegistry(Collection<Address> addresses) {
         this.joinAddresses = addresses;

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -34,6 +34,10 @@ import java.util.concurrent.ConcurrentMap;
 
 public final class TestNodeRegistry {
 
+    private static void verifyInvariant(boolean check, String msg) {
+        if (!check) throw new AssertionError(msg);
+    }
+
     private final ConcurrentMap<Address, Node> nodes = new ConcurrentHashMap<Address, Node>(10);
     private final Collection<Address> joinAddresses;
 
@@ -44,7 +48,7 @@ public final class TestNodeRegistry {
     public NodeContext createNodeContext(Address address) {
         Node node;
         if ((node = nodes.get(address)) != null) {
-            assert NodeState.SHUT_DOWN == node.getState() : "This address is already in registry! " + address;
+            verifyInvariant(NodeState.SHUT_DOWN == node.getState(), "This address is already in registry! " + address);
             nodes.remove(address, node);
         }
         return new MockNodeContext(this, address);
@@ -108,7 +112,7 @@ public final class TestNodeRegistry {
         Address address = node.getThisAddress();
         Node currentNode = nodes.putIfAbsent(address, node);
         if (currentNode != null) {
-            assert currentNode.equals(node) : "This address is already in registry! " + address;
+            verifyInvariant(currentNode.equals(node), "This address is already in registry! " + address);
         }
     }
 


### PR DESCRIPTION
This PR is based on issue #8868. It removes the dependency on JUnit for the `MockJoiner` and `TestNodeRegistry` classes.