### PR TITLE
Fixed NearCacheTest.testMapContainsKey_withNearCache()

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
@@ -302,7 +302,7 @@ public class NearCacheTest extends NearCacheTestSupport {
         config.getMapConfig(mapName).setNearCacheConfig(newNearCacheConfig().setInvalidateOnChange(true));
         HazelcastInstance instance = createHazelcastInstanceFactory(clusterSize).newInstances(config)[0];
 
-        IMap<String, String> map = instance.getMap("mapName");
+        IMap<String, String> map = instance.getMap(mapName);
         map.put("key1", "value1");
         map.put("key2", "value2");
         map.put("key3", "value3");


### PR DESCRIPTION
Fixed wrong mapName being used in test, so no Near Cache was configured.

Found this due to missing code coverage in the `NearCachedMapProxyImpl`.