### PR TITLE
Added IMap Near Cache tests for null vs. NULL_OBJECT

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -28,6 +28,16 @@ import org.junit.runner.RunWith;
 public class ClientNearCacheTest extends ClientNearCacheTestSupport {
 
     @Test
+    public void whenEmptyMapThenPopulatedNearCacheShouldReturnNullNeverNULL_OBJECTWithBinaryInMemoryFormat() {
+        whenEmptyMapThenPopulatedNearCacheShouldReturnNullNeverNULL_OBJECT(InMemoryFormat.BINARY);
+    }
+
+    @Test
+    public void whenEmptyMapThenPopulatedNearCacheShouldReturnNullNeverNULL_OBJECTWithObjectInMemoryFormat() {
+        whenEmptyMapThenPopulatedNearCacheShouldReturnNullNeverNULL_OBJECT(InMemoryFormat.OBJECT);
+    }
+
+    @Test
     public void putAndGetFromCacheAndThenGetFromClientNearCacheWithBinaryInMemoryFormat() {
         putAndGetFromCacheAndThenGetFromClientNearCache(InMemoryFormat.BINARY);
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -149,6 +149,18 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
         return nearCacheTestContext;
     }
 
+    protected void whenEmptyMapThenPopulatedNearCacheShouldReturnNullNeverNULL_OBJECT(InMemoryFormat inMemoryFormat) {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+        NearCacheTestContext nearCacheTestContext = createNearCacheTest(DEFAULT_CACHE_NAME, nearCacheConfig);
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            // populate Near Cache
+            assertNull(nearCacheTestContext.cache.get(i));
+            // fetch value from Near Cache
+            assertNull(nearCacheTestContext.cache.get(i));
+        }
+    }
+
     protected void putAndGetFromCacheAndThenGetFromClientNearCache(InMemoryFormat inMemoryFormat) {
         NearCacheConfig nearCacheConfig = createNearCacheConfig(inMemoryFormat);
         NearCacheTestContext nearCacheTestContext = createNearCacheTestAndFillWithData(DEFAULT_CACHE_NAME, nearCacheConfig);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -86,6 +86,19 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
+    public void test_whenEmptyMap_thenPopulatedNearCacheShouldReturnNull_neverNULL_OBJECT() {
+        int size = 10;
+
+        IMap<Integer, Integer> map = getNearCachedMapFromClient(newNoInvalidationNearCacheConfig());
+        for (int i = 0; i < size; i++) {
+            // populate Near Cache
+            assertNull(map.get(i));
+            // fetch value from Near Cache
+            assertNull(map.get(i));
+        }
+    }
+
+    @Test
     public void testGetAllChecksNearCacheFirst() {
         IMap<Integer, Integer> map = getNearCachedMapFromClient(newNoInvalidationNearCacheConfig());
 
@@ -827,7 +840,7 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
 
         int expectedCacheMisses = 17;
         for (int i = 0; i < expectedCacheMisses; i++) {
-            map.get("NOT_THERE");
+            assertNull(map.get("NOT_THERE"));
         }
 
         NearCacheStats stats = getNearCacheStats(map);

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
@@ -129,6 +129,27 @@ public class NearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
+    public void test_whenEmptyMap_thenPopulatedNearCacheShouldReturnNull_neverNULL_OBJECT() {
+        int size = 10;
+        String mapName = randomMapName();
+
+        Config config = getConfig();
+        config.getMapConfig(mapName).setNearCacheConfig(newNearCacheConfig());
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(1);
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+
+        // populate map
+        IMap<Integer, Integer> map = instance.getMap(mapName);
+        for (int i = 0; i < size; i++) {
+            // populate Near Cache
+            assertNull(map.get(i));
+            // fetch value from Near Cache
+            assertNull(map.get(i));
+        }
+    }
+
+    @Test
     public void testNearCacheEviction() {
         String mapName = "testNearCacheEviction";
 


### PR DESCRIPTION
Added tests for Near Cache to check that a Near Cache implementation never returns the internal `NULL_OBJECT` when there is no record, but always `null`.

The `NULL_OBJECT` handling is spread out into six (!) different proxies and I couldn't find an explicit test for this. So I want to have those tests in place before I replace the `ClientHeapNearCache` and `NearCacheImpl` with `DefaultNearCache` (and maybe move all this logic into the Near Cache implementation itself in the end).