### PR TITLE
Increased code coverage of MC requests and operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/GetMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/GetMapConfigOperation.java
@@ -32,6 +32,7 @@ public class GetMapConfigOperation extends Operation {
     private String mapName;
     private MapConfig mapConfig;
 
+    @SuppressWarnings("unused")
     public GetMapConfigOperation() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -39,6 +39,7 @@ public class ScriptExecutorOperation extends Operation {
     private Map<String, Object> bindings;
     private Object result;
 
+    @SuppressWarnings("unused")
     public ScriptExecutorOperation() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ThreadDumpOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ThreadDumpOperation.java
@@ -31,6 +31,7 @@ public class ThreadDumpOperation extends Operation {
     private boolean dumpDeadlocks;
     private String result;
 
+    @SuppressWarnings("unused")
     public ThreadDumpOperation() {
         this(false);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateManagementCenterUrlOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateManagementCenterUrlOperation.java
@@ -33,6 +33,7 @@ public class UpdateManagementCenterUrlOperation extends Operation {
     private static final int SLEEP_MILLIS = 1000;
     private String newUrl;
 
+    @SuppressWarnings("unused")
     public UpdateManagementCenterUrlOperation() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateMapConfigOperation.java
@@ -50,6 +50,7 @@ public class UpdateMapConfigOperation extends Operation {
     private String mapName;
     private MapConfig mapConfig;
 
+    @SuppressWarnings("unused")
     public UpdateMapConfigOperation() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
@@ -51,8 +51,7 @@ public class ExecuteScriptRequest implements ConsoleRequest {
     public ExecuteScriptRequest() {
     }
 
-    public ExecuteScriptRequest(String script, String engine,
-                                boolean targetAllMembers, Map<String, Object> bindings) {
+    public ExecuteScriptRequest(String script, String engine, boolean targetAllMembers, Map<String, Object> bindings) {
         this.script = script;
         this.engine = engine;
         this.targets = new HashSet<String>(0);
@@ -60,8 +59,7 @@ public class ExecuteScriptRequest implements ConsoleRequest {
         this.bindings = bindings;
     }
 
-    public ExecuteScriptRequest(String script, String engine,
-                                Set<String> targets, Map<String, Object> bindings) {
+    public ExecuteScriptRequest(String script, String engine, Set<String> targets, Map<String, Object> bindings) {
         this.script = script;
         this.targets = targets;
         this.engine = engine;
@@ -74,41 +72,40 @@ public class ExecuteScriptRequest implements ConsoleRequest {
         return ConsoleRequestConstants.REQUEST_TYPE_EXECUTE_SCRIPT;
     }
 
-
     @Override
     public void writeResponse(ManagementCenterService mcs, JsonObject root) throws Exception {
-        final JsonObject jsonResult = new JsonObject();
+        JsonObject jsonResult = new JsonObject();
         ArrayList results;
         if (targetAllMembers) {
-            final Set<Member> members = mcs.getHazelcastInstance().getCluster().getMembers();
-            final ArrayList list = new ArrayList(members.size());
+            Set<Member> members = mcs.getHazelcastInstance().getCluster().getMembers();
+            ArrayList<Object> list = new ArrayList<Object>(members.size());
             for (Member member : members) {
                 list.add(mcs.callOnMember(member, new ScriptExecutorOperation(engine, script, bindings)));
             }
             results = list;
         } else {
-            final ArrayList list = new ArrayList(targets.size());
+            ArrayList<Object> list = new ArrayList<Object>(targets.size());
             for (String address : targets) {
-                final AddressUtil.AddressHolder addressHolder = AddressUtil.getAddressHolder(address);
-                final Address targetAddress = new Address(addressHolder.getAddress(), addressHolder.getPort());
+                AddressUtil.AddressHolder addressHolder = AddressUtil.getAddressHolder(address);
+                Address targetAddress = new Address(addressHolder.getAddress(), addressHolder.getPort());
                 list.add(mcs.callOnAddress(targetAddress, new ScriptExecutorOperation(engine, script, bindings)));
             }
             results = list;
         }
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (Object result : results) {
             if (result instanceof String) {
                 sb.append(result);
             } else if (result instanceof List) {
-                final List list = (List) result;
+                List list = (List) result;
                 for (Object o : list) {
                     sb.append(o).append("\n");
                 }
             } else if (result instanceof Map) {
-                final Map map = (Map) result;
+                Map map = (Map) result;
                 for (Object o : map.entrySet()) {
-                    final Map.Entry entry = (Map.Entry) o;
+                    Map.Entry entry = (Map.Entry) o;
                     sb.append(entry.getKey()).append("->").append(entry.getValue()).append("\n");
                 }
             } else if (result == null) {
@@ -127,7 +124,7 @@ public class ExecuteScriptRequest implements ConsoleRequest {
 
     @Override
     public JsonObject toJson() {
-        final JsonObject root = new JsonObject();
+        JsonObject root = new JsonObject();
         root.add("script", script);
         root.add("engine", engine);
         JsonArray jsonTargets = new JsonArray();

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ThreadDumpRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ThreadDumpRequest.java
@@ -53,7 +53,6 @@ public class ThreadDumpRequest implements ConsoleRequest {
             result.add("hasDump", false);
         }
         root.add("result", result);
-
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeClusterStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeClusterStateRequestTest.java
@@ -4,7 +4,6 @@ import com.eclipsesource.json.JsonObject;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.request.ChangeClusterStateRequest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -22,16 +21,14 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class ChangeClusterStateRequestTest extends HazelcastTestSupport {
 
-    private HazelcastInstance hz;
     private Cluster cluster;
     private ManagementCenterService managementCenterService;
 
     @Before
     public void setUp() {
-        hz = createHazelcastInstance();
-        Node node = getNode(hz);
-        managementCenterService = node.getManagementCenterService();
+        HazelcastInstance hz = createHazelcastInstance();
         cluster = hz.getCluster();
+        managementCenterService = getNode(hz).getManagementCenterService();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
@@ -2,7 +2,6 @@ package com.hazelcast.internal.management;
 
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.operation.ChangeWanStateOperation;
 import com.hazelcast.internal.management.request.ChangeWanStateRequest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -27,8 +26,7 @@ public class ChangeWanStateRequestTest extends HazelcastTestSupport {
     @Before
     public void setUp() {
         HazelcastInstance hz = createHazelcastInstance();
-        Node node = getNode(hz);
-        managementCenterService = node.getManagementCenterService();
+        managementCenterService = getNode(hz).getManagementCenterService();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
@@ -1,0 +1,108 @@
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.management.request.ExecuteScriptRequest;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ExecuteScriptRequestTest extends HazelcastTestSupport {
+
+    private Cluster cluster;
+    private ManagementCenterService managementCenterService;
+    private Map<String, Object> bindings = new HashMap<String, Object>();
+
+    @Before
+    public void setUp() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        cluster = instances[0].getCluster();
+        managementCenterService = getNode(instances[0]).getManagementCenterService();
+
+        bindings.put("key", "value");
+    }
+
+    @Test
+    public void testExecuteScriptRequest() throws Exception {
+        ExecuteScriptRequest request = new ExecuteScriptRequest("print('test');", "JavaScript", false, bindings);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        String response = (String) request.readResponse(result);
+        assertEquals("", response.trim());
+    }
+
+    @Test
+    public void testExecuteScriptRequest_whenTargetAllMembers() throws Exception {
+        ExecuteScriptRequest request = new ExecuteScriptRequest("print('test');", "JavaScript", true, null);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        String response = (String) request.readResponse(result);
+        assertEquals(format("error%nerror%n"), response);
+    }
+
+    @Test
+    public void testExecuteScriptRequest_whenTargetAllMembers_withTarget() throws Exception {
+        Address address = cluster.getLocalMember().getAddress();
+        Set<String> targets = Collections.singleton(address.getHost() + ":" + address.getPort());
+        ExecuteScriptRequest request = new ExecuteScriptRequest("print('test');", "JavaScript", targets, bindings);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        String response = (String) request.readResponse(result);
+        assertEquals("error", response.trim());
+    }
+
+    @Test
+    public void testExecuteScriptRequest_withIllegalScriptEngine() throws Exception {
+        ExecuteScriptRequest request = new ExecuteScriptRequest("script", "engine", true, bindings);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        String response = (String) request.readResponse(result);
+        assertTrue(response.contains("IllegalArgumentException"));
+    }
+
+    @Test
+    public void testExecuteScriptRequest_withScriptException() throws Exception {
+        ExecuteScriptRequest request = new ExecuteScriptRequest("print(;", "JavaScript", true, bindings);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        String response = (String) request.readResponse(result);
+        assertNotNull(response);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ForceStartNodeRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ForceStartNodeRequestTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.management;
 
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.request.ForceStartNodeRequest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -36,20 +35,18 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelTest.class})
 public class ForceStartNodeRequestTest extends HazelcastTestSupport {
 
-
-    private ForceStartNodeRequest request;
     private ManagementCenterService managementCenterService;
 
     @Before
     public void setUp() {
         HazelcastInstance hz = createHazelcastInstance();
-        Node node = getNode(hz);
-        managementCenterService = node.getManagementCenterService();
-        request = new ForceStartNodeRequest();
+        managementCenterService = getNode(hz).getManagementCenterService();
     }
 
     @Test
     public void testForceStart_fails_withNoEnterprise() throws Exception {
+        ForceStartNodeRequest request = new ForceStartNodeRequest();
+
         JsonObject jsonObject = new JsonObject();
         request.writeResponse(managementCenterService, jsonObject);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/GetClusterStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/GetClusterStateRequestTest.java
@@ -4,7 +4,6 @@ import com.eclipsesource.json.JsonObject;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.request.GetClusterStateRequest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -21,27 +20,25 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelTest.class})
 public class GetClusterStateRequestTest extends HazelcastTestSupport {
 
-    private HazelcastInstance hz;
     private Cluster cluster;
-    private GetClusterStateRequest getClusterStateRequest;
     private ManagementCenterService managementCenterService;
 
     @Before
     public void setUp() {
-        hz = createHazelcastInstance();
-        Node node = getNode(hz);
-        managementCenterService = node.getManagementCenterService();
+        HazelcastInstance hz = createHazelcastInstance();
         cluster = hz.getCluster();
-        getClusterStateRequest = new GetClusterStateRequest();
+        managementCenterService = getNode(hz).getManagementCenterService();
     }
 
     @Test
     public void testGetClusterState() throws Exception {
+        GetClusterStateRequest request = new GetClusterStateRequest();
+
         ClusterState clusterState = cluster.getClusterState();
         JsonObject jsonObject = new JsonObject();
-        getClusterStateRequest.writeResponse(managementCenterService, jsonObject);
+        request.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        assertEquals(clusterState.name(), getClusterStateRequest.readResponse(result));
+        assertEquals(clusterState.name(), request.readResponse(result));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/JettyServer.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/JettyServer.java
@@ -6,9 +6,9 @@ import org.eclipse.jetty.webapp.WebAppContext;
 
 public class JettyServer {
 
-    Server server;
+    private Server server;
 
-    public JettyServer(int port, String sourceDir, String serverXml) throws Exception {
+    JettyServer(int port, String sourceDir, String serverXml) throws Exception {
         buildJetty(port, sourceDir, serverXml);
     }
 
@@ -25,7 +25,15 @@ public class JettyServer {
         server.start();
     }
 
-    public void buildJetty(int port, String sourceDir, String webXmlFile) throws Exception {
+    public boolean isRunning() {
+        if (server == null) {
+            return false;
+        } else {
+            return server.isRunning();
+        }
+    }
+
+    private void buildJetty(int port, String sourceDir, String webXmlFile) throws Exception {
         server = new Server();
 
         SelectChannelConnector connector = new SelectChannelConnector();
@@ -41,13 +49,5 @@ public class JettyServer {
         server.setHandler(context);
 
         server.start();
-    }
-
-    public boolean isRunning() {
-        if (server == null) {
-            return false;
-        } else {
-            return server.isRunning();
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -35,8 +35,8 @@ import static org.junit.Assert.assertNotEquals;
 @Category(SlowTest.class)
 public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport {
 
-    private JettyServer jettyServer;
     private int portNum;
+    private JettyServer jettyServer;
 
     @Before
     public void setUp() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
@@ -21,13 +21,13 @@ import static org.junit.Assert.assertTrue;
 public class ManagementCenterServiceTest extends HazelcastTestSupport {
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         setLoggingLog4j();
         setLogLevel(Level.DEBUG);
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         resetLogLevel();
 
         Hazelcast.shutdownAll();
@@ -56,5 +56,4 @@ public class ManagementCenterServiceTest extends HazelcastTestSupport {
     public void testCleanupUrl_withNull() {
         assertNull(cleanupUrl(null));
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MancenterServlet.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MancenterServlet.java
@@ -44,5 +44,4 @@ public class MancenterServlet extends HttpServlet {
         memberState = new TimedMemberState();
         memberState.fromJson(json.get("timedMemberState").asObject());
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MapConfigRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MapConfigRequestTest.java
@@ -1,0 +1,62 @@
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.management.dto.MapConfigDTO;
+import com.hazelcast.internal.management.request.MapConfigRequest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapConfigRequestTest extends HazelcastTestSupport {
+
+    private ManagementCenterService managementCenterService;
+    private String mapName;
+    private MapConfigDTO dto;
+
+    @Before
+    public void setUp() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        managementCenterService = getNode(instances[0]).getManagementCenterService();
+        mapName = randomMapName();
+        dto = new MapConfigDTO(new MapConfig("MapConfigRequestTest"));
+    }
+
+    @Test
+    public void testGetMapConfig() {
+        MapConfigRequest request = new MapConfigRequest(mapName, dto, false);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        MapConfig mapConfig = (MapConfig) request.readResponse(result);
+        assertNotNull(mapConfig);
+        assertEquals("default", mapConfig.getName());
+    }
+
+    @Test
+    public void testUpdateMapConfig() {
+        MapConfigRequest request = new MapConfigRequest(mapName, dto, true);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertEquals("success", request.readResponse(result));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/PartitionServiceBeanDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/PartitionServiceBeanDTOTest.java
@@ -24,8 +24,11 @@ public class PartitionServiceBeanDTOTest extends HazelcastTestSupport {
         Hazelcast.shutdownAll();
     }
 
-    @Test //https://github.com/hazelcast/hazelcast/issues/8463
-    public void testJMXStatsWithPublicAdressHostName() {
+    /**
+     * https://github.com/hazelcast/hazelcast/issues/8463
+     */
+    @Test
+    public void testJMXStatsWithPublicAddressHostName() {
         Config config = new Config();
         config.getNetworkConfig().setPublicAddress("hazelcast.org");
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
@@ -34,5 +37,4 @@ public class PartitionServiceBeanDTOTest extends HazelcastTestSupport {
         PartitionServiceBeanDTO partitionServiceDTO = memberState.getMXBeans().getPartitionServiceBean();
         assertEquals(partitionServiceDTO.getPartitionCount(), partitionServiceDTO.getActivePartitionCount());
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ShutdownClusterRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ShutdownClusterRequestTest.java
@@ -1,11 +1,9 @@
 package com.hazelcast.internal.management;
 
 import com.eclipsesource.json.JsonObject;
-import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleService;
-import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.request.ShutdownClusterRequest;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -24,32 +22,28 @@ import static org.junit.Assert.assertFalse;
 @Category({QuickTest.class, ParallelTest.class})
 public class ShutdownClusterRequestTest extends HazelcastTestSupport {
 
-    private final String SUCCESS = "SUCCESS";
-
-    private HazelcastInstance hz;
     private LifecycleService lifecycleService;
     private Cluster cluster;
-    private ShutdownClusterRequest shutdownClusterRequest;
     private ManagementCenterService managementCenterService;
 
     @Before
     public void setUp() {
-        hz = createHazelcastInstance();
+        HazelcastInstance hz = createHazelcastInstance();
         lifecycleService = hz.getLifecycleService();
-        Node node = getNode(hz);
-        managementCenterService = node.getManagementCenterService();
         cluster = hz.getCluster();
-        shutdownClusterRequest = new ShutdownClusterRequest();
+        managementCenterService = getNode(hz).getManagementCenterService();
     }
 
     @Test
     public void testShutdownCluster() throws Exception {
-        ClusterState clusterState = cluster.getClusterState();
+        ShutdownClusterRequest request = new ShutdownClusterRequest();
+
+        cluster.getClusterState();
         JsonObject jsonObject = new JsonObject();
-        shutdownClusterRequest.writeResponse(managementCenterService, jsonObject);
+        request.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        assertEquals(SUCCESS, shutdownClusterRequest.readResponse(result));
+        assertEquals("SUCCESS", request.readResponse(result));
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -59,4 +53,3 @@ public class ShutdownClusterRequestTest extends HazelcastTestSupport {
         });
     }
 }
-

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ThreadDumpRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ThreadDumpRequestTest.java
@@ -1,0 +1,53 @@
+package com.hazelcast.internal.management;
+
+import com.eclipsesource.json.JsonObject;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.management.request.ThreadDumpRequest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ThreadDumpRequestTest extends HazelcastTestSupport {
+
+    private ManagementCenterService managementCenterService;
+
+    @Before
+    public void setUp() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        managementCenterService = getNode(instances[0]).getManagementCenterService();
+    }
+
+    @Test
+    public void testThreadDumpRequest() throws Exception {
+        ThreadDumpRequest request = new ThreadDumpRequest(false);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertNotNull(request.readResponse(result));
+    }
+
+    @Test
+    public void testThreadDumpRequest_withDeadlocks() throws Exception {
+        ThreadDumpRequest request = new ThreadDumpRequest(true);
+
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertNotNull(request.readResponse(result));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/UpdateManagementCenterUrlRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/UpdateManagementCenterUrlRequestTest.java
@@ -1,0 +1,36 @@
+package com.hazelcast.internal.management;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.ascii.rest.HttpCommand;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class UpdateManagementCenterUrlRequestTest extends HazelcastTestSupport {
+
+    private ManagementCenterService managementCenterService;
+
+    @Before
+    public void setUp() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        managementCenterService = getNode(instances[0]).getManagementCenterService();
+    }
+
+    @Test
+    public void testExecuteScriptRequest() throws Exception {
+        byte[] result = managementCenterService.clusterWideUpdateManagementCenterUrl("dev", "dev-pass", "invalid");
+        assertEquals(HttpCommand.RES_204, result);
+    }
+}


### PR DESCRIPTION
I think we might have some dead code in two MC specific operations. If I'm not totally wrong they are just executed locally, so their serialization code cannot be invoked -> no code coverage:
```
MapConfig cfg = (MapConfig) mcs.callOnThis(new GetMapConfigOperation(mapName));
String threadDump = (String) mcs.callOnThis(new ThreadDumpOperation(dumpDeadlocks));
```
I recommend to check this and delete the unused code to increase the code coverage over the official limits.