### PR TITLE
PartitionIteratingOperation & Backup more detail in diagnostics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/InvocationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/InvocationPlugin.java
@@ -27,6 +27,7 @@ import com.hazelcast.util.Clock;
 import com.hazelcast.util.ItemCounter;
 
 import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
+import static com.hazelcast.internal.diagnostics.OperationDescriptors.toOperationDesc;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -98,12 +99,13 @@ public class InvocationPlugin extends DiagnosticsPlugin {
         writer.startSection("Pending");
         for (Invocation invocation : invocationRegistry) {
             long durationMs = now - invocation.firstInvocationTimeMillis;
+            String operationDesc = toOperationDesc(invocation.op);
             if (durationMs >= thresholdMillis) {
                 writer.writeEntry(invocation.toString() + " duration=" + durationMs + " ms");
-                slowOccurrences.add(invocation.op.getClass().getName(), 1);
+                slowOccurrences.add(operationDesc, 1);
             }
 
-            occurrences.add(invocation.op.getClass().getName(), 1);
+            occurrences.add(operationDesc, 1);
         }
         writer.endSection();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationDescriptors.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationDescriptors.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Converts an operation class into something readable. In most cases the class name is sufficient, but there are certain
+ * operations like {@link Backup} and {@link PartitionIteratingOperation} where one needs to see inside the content
+ * of an operation.
+ */
+public final class OperationDescriptors {
+
+    // the key is the name of the class as string, to prevent any class references being retained
+    private static final ConcurrentMap<String, String> DESCRIPTORS = new ConcurrentHashMap<String, String>();
+
+    private OperationDescriptors() {
+    }
+
+    public static String toOperationDesc(Operation op) {
+        Class<? extends Operation> operationClass = op.getClass();
+        if (PartitionIteratingOperation.class.isAssignableFrom(operationClass)) {
+            PartitionIteratingOperation partitionIteratingOperation = (PartitionIteratingOperation) op;
+            OperationFactory operationFactory = partitionIteratingOperation.getOperationFactory();
+            String desc = DESCRIPTORS.get(operationFactory.getClass().getName());
+            if (desc == null) {
+                desc = PartitionIteratingOperation.class.getSimpleName() + "(" + operationFactory.getClass().getName() + ")";
+                DESCRIPTORS.put(operationFactory.getClass().getName(), desc);
+            }
+            return desc;
+        } else if (Backup.class.isAssignableFrom(operationClass)) {
+            Backup backup = (Backup) op;
+            Operation backupOperation = backup.getBackupOp();
+            String desc = DESCRIPTORS.get(backupOperation.getClass().getName());
+            if (desc == null) {
+                desc = Backup.class.getSimpleName() + "(" + backup.getBackupOp().getClass().getName() + ")";
+                DESCRIPTORS.put(backupOperation.getClass().getName(), desc);
+            }
+            return desc;
+        } else {
+            return operationClass.getName();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
@@ -23,8 +23,8 @@ import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketWriter;
 import com.hazelcast.nio.tcp.spinning.SpinningSocketWriter;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -227,9 +227,8 @@ public class OverloadedConnectionsPlugin extends DiagnosticsPlugin {
                 Object result = serializationService.toObject(packet);
                 if (result == null) {
                     return "null";
-                } else if (result instanceof Backup) {
-                    Backup backup = (Backup) result;
-                    return Backup.class.getName() + "#" + backup.getBackupOp().getClass().getName();
+                } else if (result instanceof Operation) {
+                    return OperationDescriptors.toOperationDesc((Operation) result);
                 } else {
                     return result.getClass().getName();
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/PendingInvocationsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/PendingInvocationsPlugin.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.properties.HazelcastProperty;
 import com.hazelcast.util.ItemCounter;
 
 import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
+import static com.hazelcast.internal.diagnostics.OperationDescriptors.toOperationDesc;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -54,7 +55,7 @@ public final class PendingInvocationsPlugin extends DiagnosticsPlugin {
             = new HazelcastProperty(PREFIX + ".pending.invocations.threshold", 1);
 
     private final InvocationRegistry invocationRegistry;
-    private final ItemCounter<Class> occurrenceMap = new ItemCounter<Class>();
+    private final ItemCounter<String> occurrenceMap = new ItemCounter<String>();
     private final long periodMillis;
     private final int threshold;
 
@@ -90,7 +91,7 @@ public final class PendingInvocationsPlugin extends DiagnosticsPlugin {
 
     private void scan() {
         for (Invocation invocation : invocationRegistry) {
-            occurrenceMap.add(invocation.op.getClass(), 1);
+            occurrenceMap.add(toOperationDesc(invocation.op), 1);
         }
     }
 
@@ -103,13 +104,13 @@ public final class PendingInvocationsPlugin extends DiagnosticsPlugin {
 
     private void renderInvocations(DiagnosticsLogWriter writer) {
         writer.startSection("invocations");
-        for (Class op : occurrenceMap.keySet()) {
+        for (String op : occurrenceMap.keySet()) {
             long count = occurrenceMap.get(op);
             if (count < threshold) {
                 continue;
             }
 
-            writer.writeKeyValueEntry(op.getName(), count);
+            writer.writeKeyValueEntry(op, count);
         }
         writer.endSection();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -52,6 +52,10 @@ public final class PartitionIteratingOperation extends Operation implements Iden
         this.partitions = toIntArray(partitions);
     }
 
+    public OperationFactory getOperationFactory() {
+        return operationFactory;
+    }
+
     @Override
     public void run() throws Exception {
         try {

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OperationDescriptorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OperationDescriptorsTest.java
@@ -1,0 +1,69 @@
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationFactory;
+import com.hazelcast.spi.impl.operationservice.impl.DummyOperation;
+import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.LinkedList;
+
+import static com.hazelcast.internal.diagnostics.OperationDescriptors.toOperationDesc;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * idea: in the future we could check the operation 'names'. E.g. it would be helpful to figure out of a Get operation from
+ * employees map would be slow. Currently you would see just 'Get operation'
+ */
+public class OperationDescriptorsTest {
+
+    @Test
+    public void testNormalOperation() {
+        assertEquals(DummyOperation.class.getName(), toOperationDesc(new DummyOperation()));
+    }
+
+    @Test
+    public void testBackupOperation() throws UnknownHostException {
+        Backup backup = new Backup(new DummyBackupOperation(), new Address("127.0.0.1", 5701), new long[]{}, false);
+        String result = toOperationDesc(backup);
+        assertEquals(format("Backup(%s)", DummyBackupOperation.class.getName()), result);
+    }
+
+    @Test
+    public void testPartitionIteratingOperation() throws UnknownHostException {
+        PartitionIteratingOperation op = new PartitionIteratingOperation(new DummyOperationFactory(), new LinkedList<Integer>());
+        String result = toOperationDesc(op);
+        assertEquals(format("PartitionIteratingOperation(%s)", DummyOperationFactory.class.getName()), result);
+    }
+
+    static class DummyOperationFactory implements OperationFactory{
+        @Override
+        public Operation createOperation() {
+            return new DummyOperation();
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+
+        }
+    }
+
+    static class DummyBackupOperation extends Operation implements BackupOperation {
+        @Override
+        public void run() throws Exception {
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
@@ -86,7 +86,7 @@ public class OverloadedConnectionsPluginTest extends AbstractDiagnosticsPluginTe
     public void toKey() {
         assertToKey(DummyOperation.class.getName(), new DummyOperation());
         assertToKey(Integer.class.getName(), new Integer(10));
-        assertToKey(Backup.class.getName() + "#" + DummyOperation.class.getName(),
+        assertToKey("Backup(" + DummyOperation.class.getName() + ")",
                 new Backup(new DummyOperation(), getAddress(local), new long[0], true));
     }
 


### PR DESCRIPTION
If a PartitionIteratingOperation or a Backup is found in the invocations or
in the pending connections, instead of just mentioning the outer classname,
the diagnostics tries to look inside so one can see e.g.
PartitionIteratingOperation(MapSizeFactory) as name.

This gives better insight of the type of operations being encountered.

fix #8855