### PR TITLE
Fixes isNotNull messages

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/maxsize/impl/CompositeMaxSizeChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/maxsize/impl/CompositeMaxSizeChecker.java
@@ -52,8 +52,8 @@ public abstract class CompositeMaxSizeChecker implements MaxSizeChecker {
 
     public static CompositeMaxSizeChecker newCompositeMaxSizeChecker(CompositionOperator compositionOperator,
                                                                      MaxSizeChecker... maxSizeCheckers) {
-        Preconditions.isNotNull(compositionOperator, "Composition operator cannot be null!");
-        Preconditions.isNotNull(maxSizeCheckers, "MaxSizeChecker's cannot be null!");
+        Preconditions.isNotNull(compositionOperator, "composition");
+        Preconditions.isNotNull(maxSizeCheckers, "maxSizeCheckers");
         if (maxSizeCheckers.length == 0) {
             throw new IllegalArgumentException("MaxSizeChecker's cannot be empty!");
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -379,7 +379,7 @@ public class CacheConfig<K, V>
      * @return The current cache config instance.
      */
     public CacheConfig setEvictionConfig(EvictionConfig evictionConfig) {
-        isNotNull(evictionConfig, "Eviction config cannot be null !");
+        isNotNull(evictionConfig, "evictionConfig");
 
         // TODO Remove this check in the future since "CacheEvictionConfig" is deprecated
         if (evictionConfig instanceof CacheEvictionConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -485,7 +485,7 @@ public class CacheSimpleConfig {
      * @return the updated CacheSimpleConfig.
      */
     public CacheSimpleConfig setEvictionConfig(EvictionConfig evictionConfig) {
-        this.evictionConfig = isNotNull(evictionConfig, "Eviction config cannot be null !");
+        this.evictionConfig = isNotNull(evictionConfig, "evictionConfig");
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/GroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/GroupConfig.java
@@ -83,7 +83,7 @@ public final class GroupConfig {
      * @throws IllegalArgumentException if name is null.
      */
     public GroupConfig setName(final String name) {
-        this.name = isNotNull(name, "group name");
+        this.name = isNotNull(name, "name");
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NativeMemoryConfig.java
@@ -62,7 +62,7 @@ public class NativeMemoryConfig {
     }
 
     public NativeMemoryConfig setSize(final MemorySize size) {
-        this.size = isNotNull(size, "Memory size");
+        this.size = isNotNull(size, "size");
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -318,7 +318,7 @@ public class NearCacheConfig
      * @return This Near Cache config instance.
      */
     public NearCacheConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
-        this.inMemoryFormat = isNotNull(inMemoryFormat, "In-Memory format cannot be null !");
+        this.inMemoryFormat = isNotNull(inMemoryFormat, "inMemoryFormat");
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitionGroupConfig.java
@@ -206,7 +206,7 @@ public class PartitionGroupConfig {
      * @see #addMemberGroupConfig(MemberGroupConfig)
      */
     public PartitionGroupConfig addMemberGroupConfig(MemberGroupConfig memberGroupConfig) {
-        memberGroupConfigs.add(isNotNull(memberGroupConfig, "MemberGroupConfig"));
+        memberGroupConfigs.add(isNotNull(memberGroupConfig, "memberGroupConfig"));
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -212,8 +212,8 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
 
     @Override
     public V put(K key, V value) {
-        isNotNull(key, "key must not be null!");
-        isNotNull(value, "value must not be null!");
+        isNotNull(key, "key");
+        isNotNull(value, "value");
         Data dataKey = nodeEngine.toData(key);
         Data dataValue = nodeEngine.toData(value);
         int partitionId = nodeEngine.getPartitionService().getPartitionId(dataKey);
@@ -226,8 +226,8 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
 
     @Override
     public V put(K key, V value, long ttl, TimeUnit timeUnit) {
-        isNotNull(key, "key must not be null!");
-        isNotNull(value, "value must not be null!");
+        isNotNull(key, "key");
+        isNotNull(value, "value");
         isNotNull(timeUnit, "timeUnit");
         if (ttl < 0) {
             throw new IllegalArgumentException("ttl must be a positive integer");
@@ -272,8 +272,8 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
 
             // first we fill entrySetPerPartition
             for (Entry entry : entries.entrySet()) {
-                isNotNull(entry.getKey(), "key must not be null!");
-                isNotNull(entry.getValue(), "value must not be null!");
+                isNotNull(entry.getKey(), "key");
+                isNotNull(entry.getValue(), "value");
 
                 int partitionId = partitionService.getPartitionId(entry.getKey());
                 ReplicatedMapEntries mapEntries = entrySetPerPartition[partitionId];


### PR DESCRIPTION
Only the argument name to check should be passed, the method makes the full
message itself. If a full message is passed as argument, the final message
will be scrambled.