### PR TITLE
Cleanup of DefaultNearCache classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/NearCacheContext.java
@@ -24,25 +24,20 @@ import com.hazelcast.spi.serialization.SerializationService;
  */
 public class NearCacheContext {
 
-    private NearCacheManager nearCacheManager;
     private final SerializationService serializationService;
     private final NearCacheExecutor nearCacheExecutor;
     private final ClassLoader classLoader;
 
-    public NearCacheContext(SerializationService serializationService,
-                            NearCacheExecutor nearCacheExecutor,
-                            ClassLoader classLoader) {
-        this(null, serializationService, nearCacheExecutor, classLoader);
-    }
+    private NearCacheManager nearCacheManager;
 
     public NearCacheContext(NearCacheManager nearCacheManager,
                             SerializationService serializationService,
                             NearCacheExecutor nearCacheExecutor,
                             ClassLoader classLoader) {
-        this.nearCacheManager = nearCacheManager;
         this.serializationService = serializationService;
         this.nearCacheExecutor = nearCacheExecutor;
         this.classLoader = classLoader;
+        this.nearCacheManager = nearCacheManager;
     }
 
     public NearCacheManager getNearCacheManager() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/DefaultNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/DefaultNearCacheManager.java
@@ -28,9 +28,7 @@ import java.util.concurrent.ConcurrentMap;
 
 public class DefaultNearCacheManager implements NearCacheManager {
 
-    private final ConcurrentMap<String, NearCache> nearCacheMap =
-            new ConcurrentHashMap<String, NearCache>();
-
+    private final ConcurrentMap<String, NearCache> nearCacheMap = new ConcurrentHashMap<String, NearCache>();
     private final Object mutex = new Object();
 
     @Override


### PR DESCRIPTION
* Removed `DefaultNearCache::init()`, which just prevented clean `final` fields and was not needed for the EE extension, since we already initialize new fields in the overloaded EE constructors, so we don't have to duplicate this in `init()`
* Small cleanup of `DefaultNearCache$ExpirationTask` creation
* Moved superfluous constructor of `NearCacheContext`, which was just used in EE (and did nothing but set a parameter to `null`)

Requires an EE change.