### PR TITLE
[DO-NOT-MERGE] Back-pressure for replicated map

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/AbstractReplicatedMapOperation.java
@@ -17,15 +17,21 @@
 package com.hazelcast.replicatedmap.impl.operation;
 
 import com.hazelcast.cluster.memberselector.MemberSelectors;
+import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
+import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.impl.SimpleExecutionCallback;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.INVOCATION_TRY_COUNT;
 
@@ -38,13 +44,54 @@ public abstract class AbstractReplicatedMapOperation extends Operation {
     protected long ttl;
     protected transient VersionResponsePair response;
 
+    private transient boolean postponeReply;
+
+    private enum CallbackResponseMode {
+        /**
+         * Callback does not have to send a response -> the operation itself will return the response
+         *
+         */
+        DO_NOT_SEND_RESPONSE,
+
+        /**
+         * Callback will send the response, but the response will not set expectedAck. This is useful
+         * in cases where we are updating a local portion of the replicated map
+         *
+         */
+        SEND_PLAIN_RESPONSE
+    }
 
     protected void sendReplicationOperation(final boolean isRemove) {
         final OperationService operationService = getNodeEngine().getOperationService();
         Collection<Address> members = getMemberAddresses();
-        for (Address address : members) {
-            invoke(isRemove, operationService, address, name, key, value, ttl, response);
+        if (members.size() == 0) {
+            return;
         }
+
+        ReplicatedMapService service = getService();
+        CallbackResponseMode callbackResponseMode = resolveCallbackResponseMode(service);
+
+        ExecutionCallback callback = new ReplicatedMapCallback(this, members.size(), callbackResponseMode);
+        for (Address address : members) {
+            ReplicateUpdateOperation operation = new ReplicateUpdateOperation(name, key, value, ttl, response,
+                    isRemove, getCallerAddress());
+            invoke(operation, operationService, address, callback);
+            service.replicateUpdateOperationStarted();
+        }
+    }
+
+    private OperationServiceImpl getOperationServiceImpl() {
+        return (OperationServiceImpl) getNodeEngine().getOperationService();
+    }
+
+    private CallbackResponseMode resolveCallbackResponseMode(ReplicatedMapService service) {
+        boolean backpressureNeeded = service.isBackpressureNeeded();
+        if (backpressureNeeded) {
+            postponeReply = true;
+            getOperationServiceImpl().onStartAsyncOperation(this);
+            return CallbackResponseMode.SEND_PLAIN_RESPONSE;
+        }
+        return CallbackResponseMode.DO_NOT_SEND_RESPONSE;
     }
 
     protected Collection<Address> getMemberAddresses() {
@@ -61,16 +108,16 @@ public abstract class AbstractReplicatedMapOperation extends Operation {
         return addresses;
     }
 
-    private void invoke(boolean isRemove, OperationService operationService, Address address, String name, Data key,
-                        Data value, long ttl, VersionResponsePair response) {
-        ReplicateUpdateOperation updateOperation = new ReplicateUpdateOperation(name, key, value, ttl, response,
-                isRemove, getCallerAddress());
+    private void invoke(ReplicateUpdateOperation updateOperation, OperationService operationService,
+                        Address address, ExecutionCallback callback) {
         updateOperation.setPartitionId(getPartitionId());
         updateOperation.setValidateTarget(false);
-        operationService
+        InvocationBuilder invocation = operationService
                 .createInvocationBuilder(getServiceName(), updateOperation, address)
                 .setTryCount(INVOCATION_TRY_COUNT)
-                .invoke();
+                .setExecutionCallback(callback);
+        invocation.invoke();
+
     }
 
     protected void sendUpdateCallerOperation(boolean isRemove) {
@@ -87,6 +134,11 @@ public abstract class AbstractReplicatedMapOperation extends Operation {
     }
 
     @Override
+    public boolean returnsResponse() {
+        return !postponeReply;
+    }
+
+    @Override
     public Object getResponse() {
         if (getNodeEngine().getThisAddress().equals(getCallerAddress())) {
             return response;
@@ -100,5 +152,40 @@ public abstract class AbstractReplicatedMapOperation extends Operation {
         super.toString(sb);
 
         sb.append(", name=").append(name);
+    }
+
+    private final class ReplicatedMapCallback extends SimpleExecutionCallback<Object> {
+        private final AbstractReplicatedMapOperation op;
+        private final AtomicInteger count;
+        private final CallbackResponseMode callbackResponseMode;
+        private final ReplicatedMapService service;
+
+        private ReplicatedMapCallback(AbstractReplicatedMapOperation op, int count, CallbackResponseMode callbackResponseMode) {
+            this.op = op;
+            this.count = new AtomicInteger(count);
+            this.callbackResponseMode = callbackResponseMode;
+            this.service = getService();
+        }
+
+        @Override
+        public void notify(Object ignored) {
+            service.replicateUpdateOperationCompleted();
+            if (count.decrementAndGet() == 0) {
+                lastResponseReceived();
+            }
+        }
+
+        private void lastResponseReceived() {
+            switch (callbackResponseMode) {
+                case SEND_PLAIN_RESPONSE:
+                    op.sendResponse(getResponse());
+                    getOperationServiceImpl().onCompletionAsyncOperation(AbstractReplicatedMapOperation.this);
+                    break;
+                case DO_NOT_SEND_RESPONSE:
+                    break;
+                default:
+                    getLogger().warning("Unexpected response mode " + callbackResponseMode);
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
@@ -66,11 +66,11 @@ public class PutOperation extends AbstractReplicatedMapOperation implements Part
         if (!isLocal) {
             sendUpdateCallerOperation(false);
         }
+        sendReplicationOperation(false);
     }
 
     @Override
     public void afterRun() throws Exception {
-        sendReplicationOperation(false);
         ReplicatedMapEventPublishingService eventPublishingService = service.getEventPublishingService();
         eventPublishingService.fireEntryListenerEvent(key, oldValue, value, name, getCallerAddress());
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
@@ -59,11 +59,11 @@ public class RemoveOperation extends AbstractReplicatedMapOperation implements P
         if (!getCallerAddress().equals(thisAddress)) {
             sendUpdateCallerOperation(true);
         }
+        sendReplicationOperation(true);
     }
 
     @Override
     public void afterRun() throws Exception {
-        sendReplicationOperation(true);
         ReplicatedMapEventPublishingService eventPublishingService = service.getEventPublishingService();
         eventPublishingService.fireEntryListenerEvent(key, oldValue, null, name, getCallerAddress());
     }


### PR DESCRIPTION
When a number of in-flight ReplicateUpdateOperation exceeds
a limit then Put and Remove operations post-pone sending theirs
result until they receive responses from ReplicateUpdateOperation
they created.