### PR TITLE
Initial work on removing ClientDelegatingFuture

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -96,7 +96,7 @@ abstract class AbstractClientCacheProxy<K, V>
         }
         final Data expiryPolicyData = toData(expiryPolicy);
         ClientMessage request = CacheGetCodec.encodeRequest(nameWithPrefix, keyData, expiryPolicyData);
-        ClientInvocationFuture future;
+        ClientInvocationFuture<ClientMessage> future;
         try {
             final int partitionId = clientContext.getPartitionService().getPartitionId(key);
             final HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
@@ -315,7 +315,7 @@ abstract class AbstractClientCacheProxy<K, V>
             List<Map.Entry<Data, Data>>[] entriesPerPartition =
                     groupDataToPartitions(map, partitionService, partitionCount);
 
-            // Then we invoke the operations and sync on completion of these operations
+            // Then we invokeDecoded the operations and sync on completion of these operations
             putToAllPartitionsAndWaitForCompletion(entriesPerPartition, expiryPolicy, start);
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
@@ -220,10 +220,10 @@ abstract class AbstractClientCacheProxyBase<K, V>
     protected ClientMessage invoke(ClientMessage clientMessage, Data keyData) {
         try {
             final int partitionId = clientContext.getPartitionService().getPartitionId(keyData);
-            final Future future = new ClientInvocation((HazelcastClientInstanceImpl) clientContext.getHazelcastInstance(),
+            final Future<ClientMessage> future
+                    = new ClientInvocation((HazelcastClientInstanceImpl) clientContext.getHazelcastInstance(),
                     clientMessage, partitionId).invoke();
-            return (ClientMessage) future.get();
-
+            return future.get();
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -79,7 +79,7 @@ import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
 
 /**
  * Abstract {@link com.hazelcast.cache.ICache} implementation which provides shared internal implementations
- * of cache operations like put, replace, remove and invoke. These internal implementations are delegated
+ * of cache operations like put, replace, remove and invokeDecoded. These internal implementations are delegated
  * by actual cache methods.
  * <p/>
  * <p>Note: this partial implementation is used by client.</p>
@@ -236,7 +236,7 @@ abstract class AbstractClientInternalCacheProxy<K, V>
         try {
             HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
             final ClientInvocation clientInvocation = new ClientInvocation(client, req, partitionId);
-            ClientInvocationFuture f = clientInvocation.invoke();
+            ClientInvocationFuture<ClientMessage> f = clientInvocation.invoke();
             if (completionOperation) {
                 waitCompletionLatch(completionId, f);
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -285,7 +285,7 @@ public class ClientCacheProxy<K, V>
     @Override
     public <T> Map<K, EntryProcessorResult<T>> invokeAll(Set<? extends K> keys, EntryProcessor<K, V, T> entryProcessor,
                                                          Object... arguments) {
-        // TODO Implement a multiple (batch) invoke operation and its factory
+        // TODO Implement a multiple (batch) invokeDecoded operation and its factory
         ensureOpen();
         validateNotNull(keys);
         if (entryProcessor == null) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -76,7 +76,7 @@ public class ClientClusterWideIterator<K, V>
                     .encodeRequest(cacheProxy.getPrefixedName(), partitionIndex, lastTableIndex, fetchSize);
             try {
                 ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionIndex);
-                ClientInvocationFuture f = clientInvocation.invoke();
+                ClientInvocationFuture<ClientMessage> f = clientInvocation.invoke();
                 CacheIterateEntriesCodec.ResponseParameters responseParameters = CacheIterateEntriesCodec.
                         decodeResponse(f.get());
                 setLastTableIndex(responseParameters.entries, responseParameters.tableIndex);
@@ -89,7 +89,7 @@ public class ClientClusterWideIterator<K, V>
                     .encodeRequest(cacheProxy.getPrefixedName(), partitionIndex, lastTableIndex, fetchSize);
             try {
                 ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionIndex);
-                ClientInvocationFuture f = clientInvocation.invoke();
+                ClientInvocationFuture<ClientMessage> f = clientInvocation.invoke();
                 CacheIterateCodec.ResponseParameters responseParameters = CacheIterateCodec.decodeResponse(f.get());
                 setLastTableIndex(responseParameters.keys, responseParameters.tableIndex);
                 return responseParameters.keys;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
@@ -22,9 +22,8 @@ import com.hazelcast.client.impl.protocol.codec.MapFetchEntriesCodec;
 import com.hazelcast.client.impl.protocol.codec.MapFetchKeysCodec;
 import com.hazelcast.client.proxy.ClientMapProxy;
 import com.hazelcast.client.spi.ClientContext;
-import com.hazelcast.client.spi.impl.ClientInvocation;
-import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.map.impl.iterator.AbstractMapPartitionIterator;
+import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -55,9 +54,8 @@ public class ClientMapPartitionIterator<K, V> extends AbstractMapPartitionIterat
     private List fetchWithoutPrefetchValues(HazelcastClientInstanceImpl client) {
         ClientMessage request = MapFetchKeysCodec.encodeRequest(mapProxy.getName(), partitionId,
                 lastTableIndex, fetchSize);
-        ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionId);
         try {
-            ClientInvocationFuture f = clientInvocation.invoke();
+            InternalCompletableFuture<ClientMessage> f = client.getInvocationService().invokeOnPartition(partitionId, request);
             MapFetchKeysCodec.ResponseParameters responseParameters = MapFetchKeysCodec.decodeResponse(f.get());
             setLastTableIndex(responseParameters.keys, responseParameters.tableIndex);
             return responseParameters.keys;
@@ -69,9 +67,8 @@ public class ClientMapPartitionIterator<K, V> extends AbstractMapPartitionIterat
     private List fetchWithPrefetchValues(HazelcastClientInstanceImpl client) {
         ClientMessage request = MapFetchEntriesCodec.encodeRequest(mapProxy.getName(), partitionId, lastTableIndex,
                 fetchSize);
-        ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionId);
         try {
-            ClientInvocationFuture f = clientInvocation.invoke();
+            InternalCompletableFuture<ClientMessage> f = client.getInvocationService().invokeOnPartition(partitionId, request);
             MapFetchEntriesCodec.ResponseParameters responseParameters = MapFetchEntriesCodec.decodeResponse(f.get());
             setLastTableIndex(responseParameters.entries, responseParameters.tableIndex);
             return responseParameters.entries;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
@@ -91,7 +91,6 @@ public class ClientConditionProxy extends PartitionSpecificClientProxy implement
         return ConditionAwaitCodec.decodeResponse(response).response;
     }
 
-
     @Override
     public boolean awaitUntil(Date deadline) throws InterruptedException {
         long until = deadline.getTime();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -536,7 +536,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         return response;
     }
 
-    private Object retrieveResultFromMessage(ClientInvocationFuture f) {
+    private Object retrieveResultFromMessage(ClientInvocationFuture<ClientMessage> f) {
         Object response;
         try {
             SerializationService serializationService = getClient().getSerializationService();
@@ -631,7 +631,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         }
     }
 
-    private ClientInvocationFuture invokeOnPartitionOwner(ClientMessage request, int partitionId) {
+    private ClientInvocationFuture<ClientMessage> invokeOnPartitionOwner(ClientMessage request, int partitionId) {
         try {
             ClientInvocation clientInvocation = new ClientInvocation(getClient(), request, partitionId);
             return clientInvocation.invoke();
@@ -640,7 +640,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         }
     }
 
-    private ClientInvocationFuture invokeOnTarget(ClientMessage request, Address target) {
+    private ClientInvocationFuture<ClientMessage> invokeOnTarget(ClientMessage request, Address target) {
         try {
             ClientInvocation invocation = new ClientInvocation(getClient(), request, target);
             return invocation.invoke();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -347,12 +347,10 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
 
         @Override
         public void beforeListenerRegister() {
-
         }
 
         @Override
         public void onListenerRegister() {
-
         }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -106,7 +106,7 @@ public class ClientMapReduceProxy
             ClientConnection sendConnection = trackableJob.clientInvocation.getSendConnectionOrWait();
             Address runningMember = sendConnection.getEndPoint();
             final ClientInvocation clientInvocation = new ClientInvocation(getClient(), request, runningMember);
-            ClientInvocationFuture future = clientInvocation.invoke();
+            ClientInvocationFuture<ClientMessage> future = clientInvocation.invoke();
             return future.get();
         }
         return null;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
@@ -17,19 +17,23 @@
 package com.hazelcast.client.spi;
 
 import com.hazelcast.client.connection.nio.ClientConnection;
+import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.InternalCompletableFuture;
 
 import java.io.IOException;
 
 /**
- * @author mdogan 5/16/13
+ * Invocation Service for clients.
  */
 public interface ClientInvocationService {
 
-    void start();
+    InternalCompletableFuture<ClientMessage> invokeOnPartition(int partitionId, ClientMessage request);
+
+    <E> InternalCompletableFuture<E> invokeOnPartition(int partitionId, ClientMessage request, ClientMessageDecoder decoder);
 
     void invokeOnConnection(ClientInvocation invocation, ClientConnection connection) throws IOException;
 
@@ -40,6 +44,8 @@ public interface ClientInvocationService {
     void invokeOnTarget(ClientInvocation invocation, Address target) throws IOException;
 
     boolean isRedoOperation();
+
+    void start();
 
     void shutdown();
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.impl.JCacheDetector;
 import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnection;
+import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientExceptionFactory;
 import com.hazelcast.client.impl.protocol.ClientMessage;
@@ -34,6 +35,7 @@ import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.util.collection.MPSCQueue;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.io.IOException;
@@ -80,6 +82,19 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
         invocationLogger = client.getLoggingService().getLogger(ClientInvocationService.class);
 
         client.getMetricsRegistry().scanAndRegister(this, "invocations");
+    }
+
+    @Override
+    public InternalCompletableFuture<ClientMessage> invokeOnPartition(int partitionId, ClientMessage request) {
+        ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionId);
+        return clientInvocation.invoke();
+    }
+
+    @Override
+    public <E> InternalCompletableFuture<E> invokeOnPartition(
+            int partitionId, ClientMessage request, ClientMessageDecoder decoder) {
+        ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionId, decoder);
+        return clientInvocation.invokeDecoded();
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -51,7 +51,7 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
     public void invokeOnRandomTarget(ClientInvocation invocation) throws IOException {
         final Address randomAddress = getRandomAddress();
         if (randomAddress == null) {
-            throw new IOException("Not address found to invoke ");
+            throw new IOException("Not address found to invokeDecoded ");
         }
         final Connection connection = getConnection(randomAddress);
         send(invocation, (ClientConnection) connection);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
@@ -77,7 +77,7 @@ public class ClientNonSmartListenerService extends ClientListenerServiceImpl imp
         ClientInvocation invocation = new ClientInvocation(client, request);
         invocation.setEventHandler(handler);
 
-        ClientInvocationFuture future = invocation.invoke();
+        ClientInvocationFuture<ClientMessage> future = invocation.invoke();
         String registrationId = registrationKey.getCodec().decodeAddResponse(future.get());
         handler.onListenerRegister();
         Address address = future.getInvocation().getSendConnection().getRemoteEndpoint();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientAddressCancellableDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientAddressCancellableDelegatingFuture.java
@@ -84,7 +84,7 @@ public class ClientAddressCancellableDelegatingFuture<V> extends ClientCancellab
         ClientMessage request = ExecutorServiceCancelOnAddressCodec.encodeRequest(uuid, target, mayInterruptIfRunning);
         clientInvocation = new ClientInvocation(client, request, target);
         try {
-            ClientInvocationFuture f = clientInvocation.invoke();
+            ClientInvocationFuture<ClientMessage> f = clientInvocation.invoke();
             return ExecutorServiceCancelOnAddressCodec.decodeResponse(f.get()).response;
         } catch (Exception e) {
             throw rethrow(e);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeoutException;
  */
 public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
 
-    private final ClientInvocationFuture future;
+    private final ClientInvocationFuture<ClientMessage> future;
     private final SerializationService serializationService;
     private final ClientMessageDecoder clientMessageDecoder;
     private final V defaultValue;
@@ -51,7 +51,7 @@ public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
     private volatile Object response = mutex;
     private volatile boolean done;
 
-    public ClientDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
+    public ClientDelegatingFuture(ClientInvocationFuture<ClientMessage> clientInvocationFuture,
                                   SerializationService serializationService,
                                   ClientMessageDecoder clientMessageDecoder, V defaultValue) {
         this.future = clientInvocationFuture;
@@ -60,8 +60,9 @@ public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
         this.defaultValue = defaultValue;
     }
 
-    public ClientDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
-                                  SerializationService serializationService, ClientMessageDecoder clientMessageDecoder) {
+    public ClientDelegatingFuture(ClientInvocationFuture<ClientMessage> clientInvocationFuture,
+                                  SerializationService serializationService,
+                                  ClientMessageDecoder clientMessageDecoder) {
         this.future = clientInvocationFuture;
         this.serializationService = serializationService;
         this.clientMessageDecoder = clientMessageDecoder;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/atomicreference/ClientAtomicReferenceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/atomicreference/ClientAtomicReferenceTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,6 +51,8 @@ public class ClientAtomicReferenceTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
+        setLoggingLog4j();
+        setLogLevel(Level.DEBUG);
         HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         String name = randomString();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheInvalidationTest.java
@@ -86,7 +86,7 @@ public class ClientNearCacheInvalidationTest extends HazelcastTestSupport {
     // we start MEMBER_COUNT members in the test and validate count of events against this number
     static final int MEMBER_COUNT = 2;
 
-    // when true, invoke operations which are supposed to deliver invalidation events from a Cache instance on a member
+    // when true, invokeDecoded operations which are supposed to deliver invalidation events from a Cache instance on a member
     // otherwise use the client-side proxy.
     @Parameter
     public boolean invokeCacheOperationsFromMember;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceCancelTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceCancelTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 @Ignore
 /*
- * This test is failing because of order problem between actual invoke and cancel.
+ * This test is failing because of order problem between actual invokeDecoded and cancel.
  * For random and partition, the reason of broken order is also unknown to me (@sancar )
  * For submit to member, it is because we do not have order guarantee in the first place.
  * and when there is partition movement, we can not is partition id since tasks will not move with partitions

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -407,7 +407,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 return;
             }
             try {
-                method.invoke(this, new Object[]{child});
+                method.invokeDecoded(this, new Object[]{child});
             } catch (Exception e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
This class is heavily used on the client and requires quite some work. This is the first of a series of PR that eventually completely removed the ClientDelegatingFuture and lets the ClientInvocationFuture take care of the work.
