### PR TITLE
Fix expected memory costs in tests

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
@@ -92,7 +92,6 @@ public class HeapData implements Data {
 
     @Override
     public int getHeapCost() {
-        // reference (assuming compressed oops)
         return REFERENCE_COST_IN_BYTES + (payload != null ? ARRAY_HEADER_SIZE_IN_BYTES + payload.length : 0);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.util.JVMUtil.REFERENCE_COST_IN_BYTES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -41,6 +42,8 @@ import static org.mockito.Mockito.mock;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class LazyEntryViewFromRecordTest {
+
+    private static final int ENTRY_VIEW_COST_IN_BYTES = 97 + 3 * REFERENCE_COST_IN_BYTES;
 
     private final String key = "key";
     private final String value = "value";
@@ -80,7 +83,7 @@ public class LazyEntryViewFromRecordTest {
 
     @Test
     public void test_getCost() throws Exception {
-        assertEquals(109, view.getCost());
+        assertEquals(ENTRY_VIEW_COST_IN_BYTES, view.getCost());
     }
 
     @Test


### PR DESCRIPTION
The expected memory costs in test code were previously calculated assuming compressed oops is enabled (or a 32-bit JVM). These have now been updated to take into account the JVM reference cost in bytes as estimated by `JVMUtil`.

Fixes #8908 and #8909 