### PR TITLE
[BACKPORT] Fix expected memory costs in tests

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
@@ -92,7 +92,6 @@ public class HeapData implements Data {
 
     @Override
     public int getHeapCost() {
-        // reference (assuming compressed oops)
         return REFERENCE_COST_IN_BYTES + (payload != null ? ARRAY_HEADER_SIZE_IN_BYTES + payload.length : 0);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/SizeEstimatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/SizeEstimatorTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.util.JVMUtil.REFERENCE_COST_IN_BYTES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -38,6 +39,11 @@ import static org.junit.Assert.assertTrue;
 public class SizeEstimatorTest extends HazelcastTestSupport {
 
     protected TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+    // the JVM-independent portion of the cost of Integer key + Long value record is 124 bytes
+    // (without taking into account 8 references to key, record and value objects)
+    private static final int JVM_INDEPENDENT_ENTRY_COST_IN_BYTES = 124;
+    // JVM-dependent total cost of entry
+    private static final int ENTRY_COST_IN_BYTES = JVM_INDEPENDENT_ENTRY_COST_IN_BYTES + 8 * REFERENCE_COST_IN_BYTES;
 
     @Test
     public void smoke() throws InterruptedException {
@@ -52,12 +58,11 @@ public class SizeEstimatorTest extends HazelcastTestSupport {
         SizeEstimatorTestMapBuilder<Integer, Long> testMapBuilder = new SizeEstimatorTestMapBuilder<Integer, Long>(factory);
         IMap<Integer, Long> map = testMapBuilder.withNodeCount(1).withBackupCount(0).build(getConfig());
         map.put(0, 10L);
-        assertEquals(expectedPerEntryHeapCost, testMapBuilder.totalHeapCost());
+        assertEquals(ENTRY_COST_IN_BYTES, testMapBuilder.totalHeapCost());
     }
 
     @Test
     public void testExactHeapCostAfterUpdateWithMultipleBackupNodes() throws InterruptedException {
-        long expectedPerEntryHeapCost = 156L;
         int putCount = 1;
         int nodeCount = 1;
         SizeEstimatorTestMapBuilder<Integer, Long> testMapBuilder = new SizeEstimatorTestMapBuilder<Integer, Long>(factory);
@@ -67,7 +72,7 @@ public class SizeEstimatorTest extends HazelcastTestSupport {
         }
         final long heapCost = testMapBuilder.totalHeapCost();
         assertEquals("Heap cost calculation is wrong!",
-                expectedPerEntryHeapCost * putCount * nodeCount, heapCost);
+                ENTRY_COST_IN_BYTES * putCount * nodeCount, heapCost);
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.util.JVMUtil.REFERENCE_COST_IN_BYTES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -41,6 +42,8 @@ import static org.mockito.Mockito.mock;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class LazyEntryViewFromRecordTest {
+
+    private static final int ENTRY_VIEW_COST_IN_BYTES = 97 + 3 * REFERENCE_COST_IN_BYTES;
 
     private final String key = "key";
     private final String value = "value";
@@ -80,7 +83,7 @@ public class LazyEntryViewFromRecordTest {
 
     @Test
     public void test_getCost() throws Exception {
-        assertEquals(109, view.getCost());
+        assertEquals(ENTRY_VIEW_COST_IN_BYTES, view.getCost());
     }
 
     @Test


### PR DESCRIPTION
Backport of #8927 , updates expected memory costs taking into account the reference cost in bytes in the current JVM.