### PR TITLE
Removed deprecated OperationService methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -387,7 +387,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
             Collection<Member> memberList = nodeEngine.getClusterService().getMembers();
             OperationService operationService = nodeEngine.getOperationService();
             ClientDisconnectionOperation op = createClientDisconnectionOperation(endpoint.getUuid());
-            operationService.runOperationOnCallingThread(op);
+            operationService.run(op);
 
             for (Member member : memberList) {
                 if (!member.localMember()) {
@@ -429,7 +429,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
                 if (deadMemberUuid.equals(memberUuid)) {
                     iterator.remove();
                     ClientDisconnectionOperation op = createClientDisconnectionOperation(clientUuid);
-                    nodeEngine.getOperationService().runOperationOnCallingThread(op);
+                    nodeEngine.getOperationService().run(op);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -111,7 +111,7 @@ public abstract class CollectionService implements ManagedService, RemoteService
                     .setPartitionId(partitionId)
                     .setService(this)
                     .setNodeEngine(nodeEngine);
-            operationService.executeOperation(operation);
+            operationService.execute(operation);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -312,7 +312,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
                     .setPartitionId(partitionId)
                     .setService(this)
                     .setNodeEngine(nodeEngine);
-            operationService.executeOperation(operation);
+            operationService.execute(operation);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
@@ -79,7 +79,7 @@ public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data
         operation.setValidateTarget(false);
         operation.setAsyncBackup(true);
 
-        operationService.executeOperation(operation);
+        operationService.execute(operation);
     }
 
     private class UnlockResponseHandler implements OperationResponseHandler {

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -198,7 +198,7 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
             Data key = lock.getKey();
             if (uuid.equals(lock.getOwner()) && !lock.isTransactional()) {
                 UnlockOperation op = createLockCleanupOperation(partitionId, lockStore.getNamespace(), key, uuid);
-                operationService.runOperationOnCallingThread(op);
+                operationService.run(op);
             }
             lockStore.cleanWaitersAndSignalsFor(key, uuid);
         }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
@@ -118,7 +118,7 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
                     .setService(this)
                     .setNodeEngine(nodeEngine)
                     .setServiceName(SERVICE_NAME);
-            operationService.executeOperation(op);
+            operationService.execute(op);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -217,7 +217,7 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
                 if (!member.localMember()) {
                     os.send(operation, member.getAddress());
                 } else {
-                    os.executeOperation(operation);
+                    os.execute(operation);
                 }
             }
         } catch (Throwable t) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -361,7 +361,7 @@ public abstract class AbstractJoiner implements Joiner {
         Operation mergeClustersOperation = new MergeClustersOperation(targetAddress);
         mergeClustersOperation.setNodeEngine(node.nodeEngine).setService(clusterService)
                 .setOperationResponseHandler(createEmptyResponseHandler());
-        operationService.runOperationOnCallingThread(mergeClustersOperation);
+        operationService.run(mergeClustersOperation);
     }
 
     private boolean prepareClusterState(ClusterServiceImpl clusterService) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
@@ -136,7 +136,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         OperationAccessor.setCallerAddress(postJoinOp, getCallerAddress());
         OperationAccessor.setConnection(postJoinOp, getConnection());
         postJoinOp.setOperationResponseHandler(createEmptyResponseHandler());
-        operationService.runOperationOnCallingThread(postJoinOp);
+        operationService.run(postJoinOp);
     }
 
     private void sendPostJoinOperations() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -201,7 +201,7 @@ public class MigrationManager {
 
                 op.setPartitionId(partitionId).setNodeEngine(nodeEngine).setValidateTarget(false)
                         .setService(partitionService);
-                nodeEngine.getOperationService().executeOperation(op);
+                nodeEngine.getOperationService().execute(op);
                 removeActiveMigration(partitionId);
             } else {
                 final Address partitionOwner = partitionStateManager.getPartitionImpl(partitionId).getOwnerOrNull();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -138,7 +138,7 @@ public class PromotionCommitOperation extends Operation implements MigrationCycl
             int currentReplicaIndex = promotion.getDestinationCurrentReplicaIndex();
             FinalizePromotionOperation op = new FinalizePromotionOperation(currentReplicaIndex, success);
             op.setPartitionId(promotion.getPartitionId()).setNodeEngine(nodeEngine).setService(partitionService);
-            operationService.executeOperation(op);
+            operationService.execute(op);
         }
     }
 
@@ -165,7 +165,7 @@ public class PromotionCommitOperation extends Operation implements MigrationCycl
                         .setService(nodeEngine.getPartitionService());
 
                 InternalOperationService operationService = nodeEngine.getOperationService();
-                operationService.runOperationOnCallingThread(op);
+                operationService.run(op);
             } finally {
                 completeTask();
             }
@@ -182,7 +182,7 @@ public class PromotionCommitOperation extends Operation implements MigrationCycl
             if (remainingTasks == 0) {
                 logger.fine("All before promotion tasks are completed, re-submitting PromotionCommitOperation.");
                 promotionCommitOperation.beforeStateCompleted = true;
-                nodeEngine.getOperationService().executeOperation(promotionCommitOperation);
+                nodeEngine.getOperationService().execute(promotionCommitOperation);
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
@@ -369,7 +369,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
                 .setCallerUuid(nodeEngine.getLocalMember().getUuid())
                 .setOperationResponseHandler(createEmptyResponseHandler());
 
-        operationService.executeOperation(operation);
+        operationService.execute(operation);
     }
 
     protected void removeFromStagingArea(DelayedEntry delayedEntry) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationService.java
@@ -24,8 +24,8 @@ import java.util.Map;
 /**
  * The OperationService is responsible for executing operations.
  * <p/>
- * A single operation can be executed locally using {@link #runOperationOnCallingThread(Operation)}
- * and {@link #executeOperation(Operation)}. Or it can executed remotely using one of the send methods.
+ * A single operation can be executed locally using {@link #run(Operation)}
+ * and {@link #execute(Operation)}. Or it can executed remotely using one of the send methods.
  * <p/>
  * It also is possible to execute multiple operation on multiple partitions using one of the invoke methods.
  */
@@ -35,24 +35,8 @@ public interface OperationService {
      * Runs an operation in the calling thread.
      *
      * @param op the operation to execute in the calling thread
-     * @deprecated since 3.7. Use {@link #run(Operation)}
-     */
-    void runOperationOnCallingThread(Operation op);
-
-    /**
-     * Runs an operation in the calling thread.
-     *
-     * @param op the operation to execute in the calling thread
      */
     void run(Operation op);
-
-    /**
-     * Executes an operation in the operation executor pool.
-     *
-     * @param op the operation to execute in the operation executor pool.
-     * @deprecated since 3.7. Use {@link #execute(Operation)}.
-     */
-    void executeOperation(Operation op);
 
     /**
      * Executes an operation in the operation executor pool.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunnerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunnerFactory.java
@@ -51,7 +51,7 @@ public interface OperationRunnerFactory {
      * into problems.
      *
      * @return the created ad hoc OperationRunner.
-     * @see com.hazelcast.spi.OperationService#runOperationOnCallingThread(com.hazelcast.spi.Operation)
+     * @see com.hazelcast.spi.OperationService#run(com.hazelcast.spi.Operation)
      */
     OperationRunner createAdHocRunner();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl.java
@@ -93,7 +93,7 @@ public class OperationParkerImpl implements OperationParker, LiveOperationsTrack
     }
 
     private void invalidate(final ParkedOperation waitingOp) throws Exception {
-        nodeEngine.getOperationService().executeOperation(waitingOp);
+        nodeEngine.getOperationService().execute(waitingOp);
     }
 
     // Runs in operation thread, we can assume that
@@ -136,7 +136,7 @@ public class OperationParkerImpl implements OperationParker, LiveOperationsTrack
                     if (waitingOp.shouldWait()) {
                         return;
                     }
-                    nodeEngine.getOperationService().runOperationOnCallingThread(op);
+                    nodeEngine.getOperationService().run(op);
                 }
                 waitingOp.setValid(false);
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -82,8 +82,8 @@ public interface InternalOperationService extends OperationService {
 
     /**
      * Returns true if the given operation is allowed to run on the calling thread, false otherwise.
-     * If this method returns true, then the operation can be executed using {@link #runOperationOnCallingThread(Operation)}
-     * method, otherwise {@link #executeOperation(Operation)} should be used.
+     * If this method returns true, then the operation can be executed using {@link #run(Operation)}
+     * method, otherwise {@link #execute(Operation)} should be used.
      *
      * @param op the operation to check.
      * @return true if the operation is allowed to run on the calling thread, false otherwise.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -271,18 +271,8 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     }
 
     @Override
-    public void runOperationOnCallingThread(Operation op) {
-        run(op);
-    }
-
-    @Override
     public void run(Operation op) {
         operationExecutor.run(op);
-    }
-
-    @Override
-    public void executeOperation(Operation op) {
-        execute(op);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/instance/NodeStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/NodeStateTest.java
@@ -143,7 +143,7 @@ public class NodeStateTest extends HazelcastTestSupport {
                     }
                 };
 
-                nodeEngine.getOperationService().runOperationOnCallingThread(op);
+                nodeEngine.getOperationService().run(op);
                 assertOpenEventually(latch);
             }
         };
@@ -183,7 +183,7 @@ public class NodeStateTest extends HazelcastTestSupport {
                     }
                 };
 
-                nodeEngine.getOperationService().runOperationOnCallingThread(op);
+                nodeEngine.getOperationService().run(op);
                 assertOpenEventually(latch);
             }
         };


### PR DESCRIPTION
runOnCallingThread and executeOperation were deprecated in 3.7

No enterprise change needed; they already make use of newer versions.