### PR TITLE
Removed InternalCompletableFuture.getSafely

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -165,11 +165,6 @@ public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
         }
     }
 
-    @Override
-    public V getSafely() {
-        return join();
-    }
-
     private V getResult() {
         if (defaultValue != null) {
             return defaultValue;

--- a/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
@@ -33,12 +33,7 @@ public interface InternalCompletableFuture<E> extends ICompletableFuture<E> {
      */
     E join();
 
-    /**
-     * @deprecated since 3.7. Use {@link #join()} instead.
-     */
-    E getSafely();
-
-    /**
+     /**
      * Completes this future.
      *
      * @param value the value to complete this future with.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -138,11 +138,6 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
     }
 
     @Override
-    public final V getSafely() {
-        return join();
-    }
-
-    @Override
     public final V get() throws InterruptedException, ExecutionException {
         Object response = registerWaiter(Thread.currentThread(), null);
         if (response != VOID) {

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
@@ -76,11 +76,6 @@ public final class CompletedFuture<V> implements InternalCompletableFuture<V> {
     }
 
     @Override
-    public V getSafely() {
-        return join();
-    }
-
-    @Override
     public boolean complete(Object value) {
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
@@ -159,11 +159,6 @@ public class DelegatingFuture<V> implements InternalCompletableFuture<V> {
     }
 
     @Override
-    public V getSafely() {
-        return resolve(future.join());
-    }
-
-    @Override
     public void andThen(final ExecutionCallback<V> callback) {
         future.andThen(new DelegatingExecutionCallback(callback));
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetSafely.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetSafely.java
@@ -27,7 +27,7 @@ public class AbstractInvocationFuture_GetSafely extends AbstractInvocationFuture
         Future joinFuture = spawn(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
-                return future.getSafely();
+                return future.join();
             }
         });
 
@@ -43,7 +43,7 @@ public class AbstractInvocationFuture_GetSafely extends AbstractInvocationFuture
         Future joinFuture = spawn(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
-                return future.getSafely();
+                return future.join();
             }
         });
 
@@ -64,7 +64,7 @@ public class AbstractInvocationFuture_GetSafely extends AbstractInvocationFuture
         Future joinFuture = spawn(new Callable<Object>() {
             @Override
             public Object call() throws Exception {
-                return future.getSafely();
+                return future.join();
             }
         });
 

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/DelegatingFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/DelegatingFutureTest.java
@@ -212,11 +212,6 @@ public class DelegatingFutureTest {
         }
 
         @Override
-        public V getSafely() {
-            return join();
-        }
-
-        @Override
         public boolean complete(Object value) {
             return false;
         }


### PR DESCRIPTION
replaced by join which was added in 3.7 as replacement for getSafely