### PR TITLE
Removed returnsResponse true implementations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueOperation.java
@@ -76,11 +76,6 @@ public abstract class QueueOperation extends Operation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public final Object getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
@@ -53,11 +53,6 @@ public class GetOperation extends Operation implements IdentifiedDataSerializabl
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return response;
     }


### PR DESCRIPTION
If they extend from Operation, then they get true by default. No point in overriding and
return true again.