### PR TITLE
[DONT MERGE] Operation Run status

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -85,7 +85,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.emptyResponseHandler;
 
 /**
  * Class that requests, listeners from client handled in node side.
@@ -403,7 +403,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         op.setNodeEngine(nodeEngine)
                 .setServiceName(SERVICE_NAME)
                 .setService(this)
-                .setOperationResponseHandler(createEmptyResponseHandler());
+                .setOperationResponseHandler(emptyResponseHandler());
         return op;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
@@ -60,11 +60,6 @@ public class ClientDisconnectionOperation extends Operation implements UrgentSys
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(clientUuid);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientReAuthOperation.java
@@ -52,11 +52,6 @@ public class ClientReAuthOperation extends Operation implements UrgentSystemOper
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     public Object getResponse() {
         return Boolean.TRUE;
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTransactionRollbackOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/operations/CollectionTransactionRollbackOperation.java
@@ -43,11 +43,6 @@ public class CollectionTransactionRollbackOperation extends CollectionOperation 
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     public int getId() {
         return CollectionDataSerializerHook.TX_ROLLBACK;
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -49,7 +49,7 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.emptyResponseHandler;
 
 public final class LockServiceImpl implements LockService, ManagedService, RemoteService, MembershipAwareService,
         MigrationAwareService, ClientAwareService {
@@ -210,7 +210,7 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
         op.setNodeEngine(nodeEngine);
         op.setServiceName(SERVICE_NAME);
         op.setService(LockServiceImpl.this);
-        op.setOperationResponseHandler(createEmptyResponseHandler());
+        op.setOperationResponseHandler(emptyResponseHandler());
         op.setPartitionId(partitionId);
         op.setValidateTarget(false);
         return op;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
@@ -43,7 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getPartitionKey;
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.emptyResponseHandler;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 
 public class SemaphoreService implements ManagedService, MigrationAwareService, MembershipAwareService, RemoteService,
@@ -114,7 +114,7 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
             Operation op = new SemaphoreDeadMemberOperation(name, caller)
                     .setPartitionId(partitionId)
                     .setValidateTarget(false)
-                    .setOperationResponseHandler(createEmptyResponseHandler())
+                    .setOperationResponseHandler(emptyResponseHandler())
                     .setService(this)
                     .setNodeEngine(nodeEngine)
                     .setServiceName(SERVICE_NAME);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDeadMemberOperation.java
@@ -53,11 +53,6 @@ public class SemaphoreDeadMemberOperation extends SemaphoreBackupAwareOperation 
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     public boolean shouldBackup() {
         final NodeEngine nodeEngine = getNodeEngine();
         IPartitionService partitionService = nodeEngine.getPartitionService();

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -25,14 +25,14 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationReturnStatus;
+import com.hazelcast.spi.OperationRunStatus;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
-import static com.hazelcast.spi.OperationReturnStatus.DOING_IT_MYSELF;
+import static com.hazelcast.spi.OperationRunStatus.DOING_IT_MYSELF;
 
 abstract class AbstractCallableTaskOperation extends Operation  {
 
@@ -90,7 +90,7 @@ abstract class AbstractCallableTaskOperation extends Operation  {
     }
 
     @Override
-    public OperationReturnStatus getReturnStatus() {
+    public OperationRunStatus getRunStatus() {
         return DOING_IT_MYSELF;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.emptyResponseHandler;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 
 public abstract class AbstractJoiner implements Joiner {
@@ -360,7 +360,7 @@ public abstract class AbstractJoiner implements Joiner {
 
         Operation mergeClustersOperation = new MergeClustersOperation(targetAddress);
         mergeClustersOperation.setNodeEngine(node.nodeEngine).setService(clusterService)
-                .setOperationResponseHandler(createEmptyResponseHandler());
+                .setOperationResponseHandler(emptyResponseHandler());
         operationService.run(mergeClustersOperation);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
@@ -36,7 +36,7 @@ import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import java.io.IOException;
 import java.util.Collection;
 
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.emptyResponseHandler;
 
 public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements JoinOperation {
 
@@ -135,7 +135,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         postJoinOp.setNodeEngine(nodeEngine);
         OperationAccessor.setCallerAddress(postJoinOp, getCallerAddress());
         OperationAccessor.setConnection(postJoinOp, getConnection());
-        postJoinOp.setOperationResponseHandler(createEmptyResponseHandler());
+        postJoinOp.setOperationResponseHandler(emptyResponseHandler());
         operationService.run(postJoinOp);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/CheckReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/CheckReplicaVersion.java
@@ -32,13 +32,15 @@ import java.io.IOException;
 public final class CheckReplicaVersion extends Operation implements PartitionAwareOperation, AllowedDuringPassiveState {
 
     private long version;
+    private boolean returnResponse;
     private boolean response;
 
     public CheckReplicaVersion() {
     }
 
-    public CheckReplicaVersion(long version) {
+    public CheckReplicaVersion(long version, boolean returnResponse) {
         this.version = version;
+        this.returnResponse = returnResponse;
     }
 
     @Override
@@ -68,6 +70,11 @@ public final class CheckReplicaVersion extends Operation implements PartitionAwa
     }
 
     @Override
+    public boolean returnsResponse() {
+        return returnResponse;
+    }
+
+    @Override
     public Object getResponse() {
         return response;
     }
@@ -90,11 +97,13 @@ public final class CheckReplicaVersion extends Operation implements PartitionAwa
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeLong(version);
+        out.writeBoolean(returnResponse);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         version = in.readLong();
+        returnResponse = in.readBoolean();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/CheckReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/CheckReplicaVersion.java
@@ -32,15 +32,13 @@ import java.io.IOException;
 public final class CheckReplicaVersion extends Operation implements PartitionAwareOperation, AllowedDuringPassiveState {
 
     private long version;
-    private boolean returnResponse;
     private boolean response;
 
     public CheckReplicaVersion() {
     }
 
-    public CheckReplicaVersion(long version, boolean returnResponse) {
+    public CheckReplicaVersion(long version) {
         this.version = version;
-        this.returnResponse = returnResponse;
     }
 
     @Override
@@ -70,11 +68,6 @@ public final class CheckReplicaVersion extends Operation implements PartitionAwa
     }
 
     @Override
-    public boolean returnsResponse() {
-        return returnResponse;
-    }
-
-    @Override
     public Object getResponse() {
         return response;
     }
@@ -97,13 +90,11 @@ public final class CheckReplicaVersion extends Operation implements PartitionAwa
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeLong(version);
-        out.writeBoolean(returnResponse);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         version = in.readLong();
-        returnResponse = in.readBoolean();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ReplicaSyncResponse.java
@@ -180,12 +180,6 @@ public class ReplicaSyncResponse extends Operation
         }
     }
 
-
-    @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
     @Override
     public boolean validatesTarget() {
         return false;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindStore.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.emptyResponseHandler;
 
 /**
  * Write behind map data store implementation.
@@ -367,7 +367,7 @@ public class WriteBehindStore extends AbstractMapDataStore<Data, Object> {
                 .setNodeEngine(nodeEngine)
                 .setPartitionId(partitionId)
                 .setCallerUuid(nodeEngine.getLocalMember().getUuid())
-                .setOperationResponseHandler(createEmptyResponseHandler());
+                .setOperationResponseHandler(emptyResponseHandler());
 
         operationService.execute(operation);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -79,11 +79,6 @@ public class ClearExpiredOperation extends Operation implements PartitionAwareOp
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         throw new UnsupportedOperationException();
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
@@ -53,11 +53,6 @@ public class GetOperation extends Operation implements IdentifiedDataSerializabl
     }
 
     @Override
-    public boolean returnsResponse() {
-        return true;
-    }
-
-    @Override
     public Object getResponse() {
         return response;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -169,7 +169,7 @@ public abstract class Operation implements DataSerializable {
         return this;
     }
 
-    void setNotNilResponse(boolean notNilResponse){
+    void setNotNilResponse(boolean notNilResponse) {
         setFlag(notNilResponse, BITMASK_NOT_NIL_RESPONSE);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -35,8 +35,8 @@ import java.util.logging.Level;
 
 import static com.hazelcast.spi.ExceptionAction.RETRY_INVOCATION;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
-import static com.hazelcast.spi.OperationReturnStatus.NIL_RESPONSE;
-import static com.hazelcast.spi.OperationReturnStatus.RESPONSE_READY;
+import static com.hazelcast.spi.OperationRunStatus.NIL_RESPONSE;
+import static com.hazelcast.spi.OperationRunStatus.RESPONSE_READY;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.StringUtil.timeToString;
 
@@ -102,7 +102,7 @@ public abstract class Operation implements DataSerializable {
         return true;
     }
 
-    public OperationReturnStatus getReturnStatus() {
+    public OperationRunStatus getRunStatus() {
         if (!isFlagSet(BITMASK_NOT_NIL_RESPONSE)) {
             return NIL_RESPONSE;
         }
@@ -424,7 +424,7 @@ public abstract class Operation implements DataSerializable {
     public void logError(Throwable e) {
         ILogger logger = getLogger();
         if (e instanceof RetryableException) {
-            Level level = getReturnStatus() == NIL_RESPONSE ? Level.WARNING : Level.FINEST;
+            Level level = getRunStatus() == NIL_RESPONSE ? Level.WARNING : Level.FINEST;
             if (logger.isLoggable(level)) {
                 logger.log(level, e.getClass().getName() + ": " + e.getMessage());
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
@@ -49,7 +49,7 @@ public final class OperationAccessor {
         op.setCallId(callId);
     }
 
-    public static void setNilResponse(Operation op, boolean nilResponse) {
+    public static void setNotNilResponse(Operation op, boolean nilResponse) {
         op.setNotNilResponse(nilResponse);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
@@ -49,6 +49,10 @@ public final class OperationAccessor {
         op.setCallId(callId);
     }
 
+    public static void setNilResponse(Operation op, boolean nilResponse) {
+        op.setNotNilResponse(nilResponse);
+    }
+
     /**
      * Sets the invocation time for the Operation.
      *

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationReturnStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationReturnStatus.java
@@ -1,5 +1,26 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.spi;
 
+/**
+ * todo:
+ * - automatic deregistration in case of DOING_IT_MYSELF
+ * -
+ */
 public enum OperationReturnStatus {
 
     /**
@@ -18,6 +39,9 @@ public enum OperationReturnStatus {
      */
     RESPONSE_READY,
 
+    /**
+     * In case of a blocking operation.
+     */
     BLOCKED,
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationReturnStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationReturnStatus.java
@@ -1,0 +1,39 @@
+package com.hazelcast.spi;
+
+public enum OperationReturnStatus {
+
+    /**
+     * A nil response indicates that the operation will never return a response. This will be the case for operations that
+     * have a 0 call id and therefor there is no invocation needing a response. These are typically internal operations.
+     *
+     * So once an operation has executed with a NIL_RESPONSE, the operation can be discarded and that is the end of it.
+     */
+    NIL_RESPONSE,
+
+    /**
+     * A response is ready to be send. For example when a simple Map get is executed and read value is ready to be returned.
+     *
+     * In this case the {@link Operation#getResponse()} is called to obtain the result of the {@link Operation#run()} and will
+     * send the response back to the caller.
+     */
+    RESPONSE_READY,
+
+    BLOCKED,
+
+    /**
+     * Not yet used.
+     *
+     * The MORE_RUNNING_NEEDED can be used to provide operation interleaving in case of 'batch' operations like EntryProcessor
+     * operations that runs on a whole partition. It could run for e.g. 10ms and then give up its thread and return
+     * MORE_RUNNING_NEEDED to indicate it has more work to do and wants to be rescheduled. Eventually when all data has been
+     * processed, it probably returns RESPONSE_READY.
+     */
+    MORE_RUNNING_NEEDED,
+
+    /**
+     * A response is not ready to be send, but at some point it will be. For example the Operation spawns a set of partition
+     * operations and when all these partition iterating operations have completed, a response will be send. This will happen
+     * at some point in the future.
+     */
+    DOING_IT_MYSELF
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationRunStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationRunStatus.java
@@ -17,11 +17,15 @@
 package com.hazelcast.spi;
 
 /**
+ * The status of an Operation after it completes the {@link Operation#run()}. Most operations have a respone that needs to
+ * be returned and will use {@link #RESPONSE_READY}; but there are more types of responses that easily fit into the
+ * Operation execution. Using this {@link OperationRunStatus} the {@link OperationService} knows how to deal with all the cases.
+ *
  * todo:
  * - automatic deregistration in case of DOING_IT_MYSELF
- * -
+ * - BLOCKED
  */
-public enum OperationReturnStatus {
+public enum OperationRunStatus {
 
     /**
      * A nil response indicates that the operation will never return a response. This will be the case for operations that

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
@@ -27,7 +27,7 @@ public final class OperationResponseHandlerFactory {
     private OperationResponseHandlerFactory() {
     }
 
-    public static OperationResponseHandler createEmptyResponseHandler() {
+    public static OperationResponseHandler emptyResponseHandler() {
         return EMPTY_RESPONSE_HANDLER;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/ParkedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/ParkedOperation.java
@@ -174,11 +174,6 @@ class ParkedOperation extends Operation implements Delayed, PartitionAwareOperat
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     public String getServiceName() {
         return op.getServiceName();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -36,6 +36,7 @@ import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.exception.ResponseAlreadySentException;
 import com.hazelcast.spi.exception.RetryableException;
@@ -166,6 +167,7 @@ public abstract class Invocation implements OperationResponseHandler {
                long callTimeoutMillis, boolean deserialize) {
         this.context = context;
         this.op = op;
+        OperationAccessor.setNilResponse(op, false);
         this.tryCount = tryCount;
         this.tryPauseMillis = tryPauseMillis;
         this.callTimeoutMillis = getCallTimeoutMillis(callTimeoutMillis);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -167,7 +167,7 @@ public abstract class Invocation implements OperationResponseHandler {
                long callTimeoutMillis, boolean deserialize) {
         this.context = context;
         this.op = op;
-        OperationAccessor.setNilResponse(op, false);
+        OperationAccessor.setNotNilResponse(op, true);
         this.tryCount = tryCount;
         this.tryPauseMillis = tryPauseMillis;
         this.callTimeoutMillis = getCallTimeoutMillis(callTimeoutMillis);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -23,11 +23,13 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationReturnStatus;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 
 import static com.hazelcast.internal.partition.InternalPartition.MAX_BACKUP_COUNT;
 import static com.hazelcast.spi.OperationAccessor.setCallId;
+import static com.hazelcast.spi.OperationReturnStatus.NIL_RESPONSE;
 import static java.lang.Math.min;
 
 /**
@@ -66,7 +68,7 @@ final class OperationBackupHandler {
         int asyncBackups = asyncBackups(requestedSyncBackups, requestedAsyncBackups, syncForced);
 
         // TODO: This could cause a problem with back pressure
-        if (!op.returnsResponse()) {
+        if (op.getReturnStatus() == NIL_RESPONSE) {
             asyncBackups += syncBackups;
             syncBackups = 0;
         }
@@ -235,7 +237,7 @@ final class OperationBackupHandler {
     }
 
     private Backup newBackup(BackupAwareOperation backupAwareOp, Object backupOp, long[] replicaVersions,
-            int replicaIndex, boolean respondBack) {
+                             int replicaIndex, boolean respondBack) {
         Operation op = (Operation) backupAwareOp;
         Backup backup;
         if (backupOp instanceof Operation) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -28,7 +28,7 @@ import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 
 import static com.hazelcast.internal.partition.InternalPartition.MAX_BACKUP_COUNT;
 import static com.hazelcast.spi.OperationAccessor.setCallId;
-import static com.hazelcast.spi.OperationReturnStatus.NIL_RESPONSE;
+import static com.hazelcast.spi.OperationRunStatus.NIL_RESPONSE;
 import static java.lang.Math.min;
 
 /**
@@ -80,7 +80,7 @@ final class OperationBackupHandler {
         int asyncBackups = asyncBackups(requestedSyncBackups, requestedAsyncBackups, syncForced);
 
         // TODO: This could cause a problem with back pressure
-        if (op.getReturnStatus() == NIL_RESPONSE) {
+        if (op.getRunStatus() == NIL_RESPONSE) {
             asyncBackups += syncBackups;
             syncBackups = 0;
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationReturnStatus;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 
@@ -47,6 +46,19 @@ final class OperationBackupHandler {
         this.node = operationService.node;
         this.nodeEngine = operationService.nodeEngine;
         this.backpressureRegulator = operationService.backpressureRegulator;
+    }
+
+    public int backup(Operation op) throws Exception {
+        if (!(op instanceof BackupAwareOperation)) {
+            return 0;
+        }
+
+        int backupAcks = 0;
+        BackupAwareOperation backupAwareOp = (BackupAwareOperation) op;
+        if (backupAwareOp.shouldBackup()) {
+            backupAcks = backup(backupAwareOp);
+        }
+        return backupAcks;
     }
 
     public int backup(BackupAwareOperation backupAwareOp) throws Exception {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -62,7 +62,7 @@ import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.nio.IOUtil.extractOperationCallId;
 import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
 import static com.hazelcast.spi.OperationAccessor.setConnection;
-import static com.hazelcast.spi.OperationReturnStatus.NIL_RESPONSE;
+import static com.hazelcast.spi.OperationRunStatus.NIL_RESPONSE;
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.emptyResponseHandler;
 import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
 import static com.hazelcast.spi.impl.operationutil.Operations.isMigrationOperation;
@@ -186,7 +186,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
 
             op.run();
 
-            switch (op.getReturnStatus()) {
+            switch (op.getRunStatus()) {
                 case NIL_RESPONSE:
                     backupHandler.backup(op);
                     break;
@@ -346,7 +346,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
             failedBackupsCounter.inc();
         }
 
-        if (operation.getReturnStatus() == NIL_RESPONSE) {
+        if (operation.getRunStatus() == NIL_RESPONSE) {
             return;
         }
 
@@ -415,7 +415,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
 
     private void setOperationResponseHandler(Operation op) {
         OperationResponseHandler handler = remoteResponseHandler;
-        if (op.getReturnStatus() == NIL_RESPONSE) {
+        if (op.getRunStatus() == NIL_RESPONSE) {
             //todo:
             if (op.returnsResponse()) {
                 throw new HazelcastException(

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -70,6 +70,7 @@ import static com.hazelcast.spi.InvocationBuilder.DEFAULT_DESERIALIZE_RESULT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_REPLICA_INDEX;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_COUNT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS;
+import static com.hazelcast.spi.OperationReturnStatus.NIL_RESPONSE;
 import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
@@ -339,10 +340,9 @@ public final class OperationServiceImpl implements InternalOperationService, Met
 
     @Override
     public boolean isCallTimedOut(Operation op) {
-        // Join operations should not be checked for timeout
-        // because caller is not member of this cluster
+        // Join operations should not be checked for timeout because caller is not member of this cluster
         // and can have a different clock.
-        if (!op.returnsResponse() || isJoinOperation(op)) {
+        if (op.getReturnStatus() == NIL_RESPONSE || isJoinOperation(op)) {
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -70,7 +70,7 @@ import static com.hazelcast.spi.InvocationBuilder.DEFAULT_DESERIALIZE_RESULT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_REPLICA_INDEX;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_COUNT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS;
-import static com.hazelcast.spi.OperationReturnStatus.NIL_RESPONSE;
+import static com.hazelcast.spi.OperationRunStatus.NIL_RESPONSE;
 import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
@@ -342,7 +342,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     public boolean isCallTimedOut(Operation op) {
         // Join operations should not be checked for timeout because caller is not member of this cluster
         // and can have a different clock.
-        if (op.getReturnStatus() == NIL_RESPONSE || isJoinOperation(op)) {
+        if (op.getRunStatus() == NIL_RESPONSE || isJoinOperation(op)) {
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
+import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.emptyResponseHandler;
 import static com.hazelcast.spi.partition.IPartition.MAX_BACKUP_COUNT;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 
@@ -122,7 +122,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
             backupOp.setCallerUuid(getCallerUuid());
             OperationAccessor.setCallerAddress(backupOp, getCallerAddress());
             OperationAccessor.setInvocationTime(backupOp, Clock.currentTimeMillis());
-            backupOp.setOperationResponseHandler(createEmptyResponseHandler());
+            backupOp.setOperationResponseHandler(emptyResponseHandler());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -25,7 +25,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationResponseHandler;
-import com.hazelcast.spi.OperationReturnStatus;
+import com.hazelcast.spi.OperationRunStatus;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
-import static com.hazelcast.spi.OperationReturnStatus.DOING_IT_MYSELF;
+import static com.hazelcast.spi.OperationRunStatus.DOING_IT_MYSELF;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
 
 /**
@@ -73,7 +73,7 @@ public final class PartitionIteratingOperation extends Operation implements Iden
     }
 
     @Override
-    public OperationReturnStatus getReturnStatus() {
+    public OperationRunStatus getRunStatus() {
         return DOING_IT_MYSELF;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationResponseHandler;
+import com.hazelcast.spi.OperationReturnStatus;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
@@ -37,6 +38,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
+import static com.hazelcast.spi.OperationReturnStatus.DOING_IT_MYSELF;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
 
 /**
@@ -71,15 +73,12 @@ public final class PartitionIteratingOperation extends Operation implements Iden
     }
 
     @Override
-    public boolean returnsResponse() {
-        // since this call is non blocking, we don't have a response. The response is send when the actual operations complete.
-        return false;
+    public OperationReturnStatus getReturnStatus() {
+        return DOING_IT_MYSELF;
     }
 
     @Override
     public void run() throws Exception {
-        getOperationServiceImpl().onStartAsyncOperation(this);
-
         PartitionAwareOperationFactory partitionAware = getPartitionAwareFactoryOrNull();
         if (partitionAware == null) {
             executeOperations();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -74,11 +74,6 @@ public class PostJoinProxyOperation extends Operation {
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         int len = proxies != null ? proxies.size() : 0;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/operations/ClearRemoteTransactionBackupOperation.java
@@ -50,11 +50,6 @@ public class ClearRemoteTransactionBackupOperation extends AbstractXAOperation i
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeData(xidData);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/InternalPartitionServiceStackOverflowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/InternalPartitionServiceStackOverflowTest.java
@@ -67,7 +67,7 @@ public class InternalPartitionServiceStackOverflowTest extends HazelcastTestSupp
             } else {
                 op = new SlowPartitionUnawareSystemOperation(latch);
             }
-            op.setOperationResponseHandler(OperationResponseHandlerFactory.createEmptyResponseHandler());
+            op.setOperationResponseHandler(OperationResponseHandlerFactory.emptyResponseHandler());
             opService.execute(op);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture_IsDoneTest.java
@@ -7,6 +7,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.apache.log4j.Level;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -71,6 +72,8 @@ public class InvocationFuture_IsDoneTest extends HazelcastTestSupport {
 
     @Test
     public void isDone_whenObjectResponse() {
+        setLoggingLog4j();
+        setLogLevel(Level.DEBUG);
         DummyOperation op = new DummyOperation("foobar");
 
         InternalCompletableFuture future = operationService.invokeOnTarget(null, op, getAddress(local));

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
@@ -192,7 +192,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
     private void assertBackup(final int syncBackups, final int asyncBackups, int expectedResult) throws Exception {
         final DummyBackupAwareOperation backupAwareOp = makeOperation(syncBackups, asyncBackups);
 
-        int result = backupHandler.backup(backupAwareOp);
+        int result = backupHandler.backup((BackupAwareOperation) backupAwareOp);
 
         assertEquals(expectedResult, result);
         assertTrueEventually(new AssertTask() {


### PR DESCRIPTION
Currently the response status of an operation indicates there or there is no response. This doesn't fit operations that have a response, but at a later point in time. It also don't fit interleaving of operations. 

So a OperationRunStatus is introduced a replacement for the boolean value.

Normally the method returnsResponse isn't needed at all. The operation could be tagged so that in the operation header a bit is set if an invocation is waiting on the other side (in theory also the call id could be used for this.. if >0, then there is an invocation).