### PR TITLE
Fixed deprecation of Near Cache eviction configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -43,6 +43,11 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
     public static final int DEFAULT_MAX_ENTRY_COUNT = 10000;
 
     /**
+     * Default maximum entry count for Map on-heap Near Caches.
+     */
+    public static final int DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP = Integer.MAX_VALUE;
+
+    /**
      * Default Max-Size Policy.
      */
     public static final MaxSizePolicy DEFAULT_MAX_SIZE_POLICY = MaxSizePolicy.ENTRY_COUNT;

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigAccessor.java
@@ -29,7 +29,7 @@ public final class EvictionConfigAccessor {
 
     public static EvictionConfig initDefaultMaxSize(EvictionConfig evictionConfig) {
         if (!evictionConfig.sizeConfigured) {
-            evictionConfig.setSize(NearCacheConfig.DEFAULT_MAX_SIZE);
+            evictionConfig.setSize(EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP);
         }
         return evictionConfig;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -51,9 +51,9 @@ public class NearCacheConfig implements DataSerializable, Serializable {
     /**
      * Default value of the maximum size.
      *
-     * @deprecated since 3.8, please use {@link EvictionConfig#DEFAULT_MAX_ENTRY_COUNT}
+     * @deprecated since 3.8, please use {@link EvictionConfig#DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP}
      */
-    public static final int DEFAULT_MAX_SIZE = Integer.MAX_VALUE;
+    public static final int DEFAULT_MAX_SIZE = EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP;
 
     /**
      * Default value for the eviction policy.
@@ -82,8 +82,8 @@ public class NearCacheConfig implements DataSerializable, Serializable {
     private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
     private int maxIdleSeconds = DEFAULT_MAX_IDLE_SECONDS;
 
-    private int maxSize = DEFAULT_MAX_SIZE;
-    private String evictionPolicy = DEFAULT_EVICTION_POLICY;
+    private int maxSize = EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP;
+    private String evictionPolicy = EvictionConfig.DEFAULT_EVICTION_POLICY.name();
 
     private InMemoryFormat inMemoryFormat = DEFAULT_MEMORY_FORMAT;
 


### PR DESCRIPTION
```
NearCacheConfig.DEFAULT_MAX_SIZE -> Integer.MAX_VALUE (deprecated)
EvictionConfig.DEFAULT_MAX_SIZE  -> 10000 (default for HD and JCache)
EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP -> Integer.MAX_VALUE (new)
```

`NearCacheConfig#DEFAULT_MAX_ENTRY_COUNT` was deprecated in 3.8, but is still used internally. We cannot use `EvictionConfig#DEFAULT_MAX_ENTRY_COUNT`, because we need different default values for different scenarios (`Integer.MAX_VALUE` for on-heap maps vs. `10000` for HD and JCaches). This PR fixes that.

 * Added new constant in `EvictionConfig` as replacement for outdated `NearCacheConfig#DEFAULT_MAX_SIZE`
 * Made usage of new constant in all places

If you have a better name than `DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP`, please feel free to give me feedback. That default value is just used for the client and member Near Cache on on-heap maps (not on off-heap map, on-heap JCache or off-heap JCache).