### PR TITLE
Stops background expiration task when cluster state is PASSIVE

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -22,6 +22,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.cluster.ClusterStateListener;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceBuilder;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
@@ -44,6 +45,7 @@ import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.servicemanager.ServiceManager;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
@@ -51,6 +53,7 @@ import com.hazelcast.wan.WanReplicationService;
 import com.hazelcast.wan.impl.WanReplicationServiceImpl;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static com.hazelcast.map.impl.MapServiceConstructor.getDefaultMapServiceConstructor;
@@ -218,6 +221,12 @@ public class DefaultNodeExtension implements NodeExtension {
 
     @Override
     public void onClusterStateChange(ClusterState newState, boolean persistentChange) {
+        NodeEngineImpl nodeEngine = node.getNodeEngine();
+        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        List<ClusterStateListener> listeners = serviceManager.getServices(ClusterStateListener.class);
+        for (ClusterStateListener listener : listeners) {
+            listener.onClusterStateChange(newState);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterStateListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterStateListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster;
+
+import com.hazelcast.cluster.ClusterState;
+
+/**
+ * Used by services which needs to act against new cluster state.
+ *
+ * @since 3.8
+ */
+public interface ClusterStateListener {
+
+    /**
+     * Called when cluster state is changed
+     *
+     * @param newState new cluster state
+     * @see ClusterState
+     */
+    void onClusterStateChange(ClusterState newState);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.internal.cluster.ClusterStateListener;
 import com.hazelcast.map.impl.event.MapEventPublishingService;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.spi.ClientAwareService;
@@ -69,7 +71,7 @@ import static com.hazelcast.core.EntryEventType.INVALIDATION;
 public class MapService implements ManagedService, MigrationAwareService,
         TransactionalService, RemoteService, EventPublishingService<Object, ListenerAdapter>,
         PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService, StatisticsAwareService,
-        PartitionAwareService, ClientAwareService, QuorumAwareService, NotifiableEventListener {
+        PartitionAwareService, ClientAwareService, QuorumAwareService, NotifiableEventListener, ClusterStateListener {
 
     public static final String SERVICE_NAME = "hz:impl:mapService";
 
@@ -213,5 +215,10 @@ public class MapService implements ManagedService, MigrationAwareService,
 
     public int getOwnerMigrationsInFlight() {
         return migrationAwareService.getOwnerMigrationsInFlight();
+    }
+
+    @Override
+    public void onClusterStateChange(ClusterState newState) {
+        mapServiceContext.onClusterStateChange(newState);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.core.PartitioningStrategy;
@@ -150,4 +151,6 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     void removePartitioningStrategyFromCache(String mapName);
 
     PartitionContainer[] getPartitionContainers();
+
+    void onClusterStateChange(ClusterState newState);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
@@ -615,5 +616,14 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public PartitionContainer[] getPartitionContainers() {
         return partitionContainers;
+    }
+
+    @Override
+    public void onClusterStateChange(ClusterState newState) {
+        if (newState == ClusterState.PASSIVE) {
+            expirationManager.stop();
+        } else {
+            expirationManager.start();
+        }
     }
 }


### PR DESCRIPTION
Also adds `ClusterStateListener` for internal usages
