### PR TITLE
[BACKPORT] Do not send query operations to Lite Members

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -61,6 +61,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.query.PagingPredicateAccessor.getNearestAnchorEntry;
 import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
 import static com.hazelcast.spi.properties.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
@@ -533,7 +534,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
     }
 
     protected List<Future<QueryResult>> queryOnMembers(String mapName, Predicate predicate, IterationType iterationType) {
-        Collection<Member> members = clusterService.getMembers();
+        Collection<Member> members = clusterService.getMembers(DATA_MEMBER_SELECTOR);
         List<Future<QueryResult>> futures = new ArrayList<Future<QueryResult>>(members.size());
         for (Member member : members) {
             Operation operation = new QueryOperation(mapName, predicate, iterationType);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutAllOperation.java
@@ -33,6 +33,8 @@ import com.hazelcast.spi.partition.IPartitionService;
 import java.io.IOException;
 import java.util.Collection;
 
+import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+
 /**
  * Puts a set of records to the replicated map.
  */
@@ -73,7 +75,7 @@ public class PutAllOperation extends AbstractOperation implements IdentifiedData
 
     private void publishReplicationMessage(Data key, Data value, VersionResponsePair response) {
         OperationService operationService = getNodeEngine().getOperationService();
-        Collection<Member> members = getNodeEngine().getClusterService().getMembers();
+        Collection<Member> members = getNodeEngine().getClusterService().getMembers(DATA_MEMBER_SELECTOR);
         for (Member member : members) {
             Address address = member.getAddress();
             if (address.equals(getNodeEngine().getThisAddress())) {


### PR DESCRIPTION
Backport of #8952, Fixes #8849

Also the same fix applied for Replicated Map