### PR TITLE
OperationServiceImpl.isCallTimedOut cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -339,10 +339,9 @@ public final class OperationServiceImpl implements InternalOperationService, Met
 
     @Override
     public boolean isCallTimedOut(Operation op) {
-        // Join operations should not be checked for timeout
-        // because caller is not member of this cluster
+        // Join operations should not be checked for timeout because caller is not member of this cluster
         // and can have a different clock.
-        if (!op.returnsResponse() || isJoinOperation(op)) {
+        if (isJoinOperation(op)) {
             return false;
         }
 


### PR DESCRIPTION
This method should not rely on 'returnsResponse' if something is timed out. It should solely rely
on the call timeout.

By default each Operation is created with a Long.MAX_VALUE call timeout so unless this is explicitly changed, an Operation will not timeout. And if configured otherwise it is better to obey the behavior to timeout and not to ignore the timeout because it doesn't return a response.