### PR TITLE
[BACKPORT] JCache backup operation do not propagate CacheNotExistsException

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractBackupCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractBackupCacheOperation.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.operation;
+
+import com.hazelcast.cache.CacheNotExistsException;
+import com.hazelcast.nio.serialization.Data;
+
+abstract class AbstractBackupCacheOperation extends AbstractCacheOperation {
+
+    AbstractBackupCacheOperation(String name, Data key) {
+        super(name, key);
+    }
+
+    AbstractBackupCacheOperation() {
+    }
+
+
+    protected abstract void runInternal() throws Exception;
+    protected abstract void afterRunInternal() throws Exception;
+
+    @Override
+    public final void beforeRun() throws Exception {
+        try {
+            super.beforeRun();
+        } catch (CacheNotExistsException e) {
+            cache = null;
+            getLogger().finest("Error while getting a cache", e);
+        }
+    }
+
+    @Override
+    public final void run() throws Exception {
+        if (cache != null) {
+            runInternal();
+        }
+    }
+
+    @Override
+    public final void afterRun() throws Exception {
+        if (cache != null) {
+            afterRunInternal();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AbstractCacheOperation.java
@@ -66,7 +66,7 @@ abstract class AbstractCacheOperation
     }
 
     @Override
-    public final void beforeRun()
+    public void beforeRun()
             throws Exception {
         cacheService = getService();
         cache = cacheService.getOrCreateRecordStore(name, getPartitionId());

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheBackupEntryProcessorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheBackupEntryProcessorOperation.java
@@ -39,7 +39,7 @@ import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLET
  * functionality to apply the backup using the given {@link javax.cache.processor.EntryProcessor}.</p>
  */
 public class CacheBackupEntryProcessorOperation
-        extends AbstractCacheOperation
+        extends AbstractBackupCacheOperation
         implements BackupOperation, IdentifiedDataSerializable {
 
     private EntryProcessor entryProcessor;
@@ -61,13 +61,13 @@ public class CacheBackupEntryProcessorOperation
     }
 
     @Override
-    public void run()
+    public void runInternal()
             throws Exception {
         cache.invoke(key, entryProcessor, arguments, IGNORE_COMPLETION);
     }
 
     @Override
-    public void afterRun() throws Exception {
+    public void afterRunInternal() throws Exception {
         if (cache.isWanReplicationEnabled()) {
             CacheRecord record = cache.getRecord(key);
             if (record != null) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl.operation;
 
+import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
@@ -44,7 +45,12 @@ public class CacheClearBackupOperation extends AbstractNamedOperation
     public void beforeRun()
             throws Exception {
         ICacheService service = getService();
-        cache = service.getOrCreateRecordStore(name, getPartitionId());
+        try {
+            cache = service.getOrCreateRecordStore(name, getPartitionId());
+        } catch (CacheNotExistsException e) {
+            getLogger().finest("Error while getting a cache", e);
+        }
+
     }
 
     @Override
@@ -54,7 +60,9 @@ public class CacheClearBackupOperation extends AbstractNamedOperation
 
     @Override
     public void run() throws Exception {
-        cache.clear();
+        if (cache != null) {
+            cache.clear();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl.operation;
 
+import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
@@ -56,11 +57,18 @@ public class CachePutAllBackupOperation
     public void beforeRun()
             throws Exception {
         ICacheService service = getService();
-        cache = service.getOrCreateRecordStore(name, getPartitionId());
+        try {
+            cache = service.getOrCreateRecordStore(name, getPartitionId());
+        } catch (CacheNotExistsException e) {
+            getLogger().finest("Error while getting a cache", e);
+        }
     }
 
     @Override
     public void run() throws Exception {
+        if (cache == null) {
+            return;
+        }
         if (cacheRecords != null) {
             for (Map.Entry<Data, CacheRecord> entry : cacheRecords.entrySet()) {
                 CacheRecord record = entry.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutBackupOperation.java
@@ -39,7 +39,7 @@ import java.io.IOException;
  * @see CacheGetAndReplaceOperation
  */
 public class CachePutBackupOperation
-        extends AbstractCacheOperation
+        extends AbstractBackupCacheOperation
         implements BackupOperation, MutatingOperation {
 
     private CacheRecord cacheRecord;
@@ -65,7 +65,7 @@ public class CachePutBackupOperation
     }
 
     @Override
-    public void run()
+    public void runInternal()
             throws Exception {
         ICacheService service = getService();
         ICacheRecordStore cache = service.getOrCreateRecordStore(name, getPartitionId());
@@ -74,7 +74,7 @@ public class CachePutBackupOperation
     }
 
     @Override
-    public void afterRun() throws Exception {
+    public void afterRunInternal() throws Exception {
         if (!wanOriginated && cache.isWanReplicationEnabled()) {
             CacheEntryView<Data, Data> entryView = CacheEntryViews.createDefaultEntryView(key,
                     getNodeEngine().getSerializationService().toData(cacheRecord.getValue()), cacheRecord);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveAllBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl.operation;
 
+import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
@@ -70,12 +71,19 @@ public class CacheRemoveAllBackupOperation
     public void beforeRun()
             throws Exception {
         ICacheService service = getService();
-        cache = service.getOrCreateRecordStore(name, getPartitionId());
+        try {
+            cache = service.getOrCreateRecordStore(name, getPartitionId());
+        } catch (CacheNotExistsException e) {
+            getLogger().finest("Error while getting a cache", e);
+        }
     }
 
     @Override
     public void run()
             throws Exception {
+        if (cache == null) {
+            return;
+        }
         if (keys != null) {
             for (Data key : keys) {
                 cache.removeRecord(key);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheRemoveBackupOperation.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * Backup operation used by remove operations.
  */
 public class CacheRemoveBackupOperation
-        extends AbstractCacheOperation
+        extends AbstractBackupCacheOperation
         implements BackupOperation, MutatingOperation {
 
     private boolean wanOriginated;
@@ -47,17 +47,13 @@ public class CacheRemoveBackupOperation
     }
 
     @Override
-    public void run()
+    public void runInternal()
             throws Exception {
-        if (cache != null) {
-            response = cache.removeRecord(key);
-        } else {
-            response = Boolean.FALSE;
-        }
+        cache.removeRecord(key);
     }
 
     @Override
-    public void afterRun() throws Exception {
+    public void afterRunInternal() throws Exception {
         if (!wanOriginated && cache.isWanReplicationEnabled()) {
             wanEventPublisher.publishWanReplicationRemoveBackup(name, key);
         }


### PR DESCRIPTION
Backport of #8916

Reasoning:
1. I am a partition owner. You are a backup replica. I execute PUT and send you BACKUP
2. before you process the BACKUP someone else will tell you to destroy the cache
3. when you start processing the BACKUP then the cache no longer exists -> exception

New cache creation is blocking a caller until the cache is created on all members
->
if backup operation does not find the cache then it's because it was already destroyed.
not because it wasn't created yet.
->
Skipping the backup when a cache is not found will not lose any item.

(cherry picked from commit 99bd335)