### PR TITLE
Fixes #8943 :: start.sh fails to start Hazelcast when path contains spaces

### DIFF
--- a/hazelcast/src/main/resources/start.sh
+++ b/hazelcast/src/main/resources/start.sh
@@ -40,7 +40,7 @@ if [ "x$MAX_HEAP_SIZE" != "x" ]; then
 	JAVA_OPTS="$JAVA_OPTS -Xmx${MAX_HEAP_SIZE}"
 fi
 
-export CLASSPATH=$HAZELCAST_HOME/lib/hazelcast-all-${project.version}.jar
+export CLASSPATH="$HAZELCAST_HOME/lib/hazelcast-all-${project.version}.jar"
 
 echo "########################################"
 echo "# RUN_JAVA=$RUN_JAVA"


### PR DESCRIPTION
This PR fixes #8943 in starting Hazelcast with start.sh when the installation path contains spaces.