### PR TITLE
Removed copy paste code OperationServiceImpl.invokeOnPartitions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -72,6 +72,7 @@ import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_COUNT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_TRY_PAUSE_MILLIS;
 import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
+import static com.hazelcast.util.CollectionUtil.toIntegerList;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.Collections.newSetFromMap;
@@ -373,7 +374,6 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     @Override
     public Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory,
                                                    Collection<Integer> partitions) throws Exception {
-
         Map<Address, List<Integer>> memberPartitions = new HashMap<Address, List<Integer>>(3);
         InternalPartitionService partitionService = nodeEngine.getPartitionService();
         for (int partition : partitions) {
@@ -392,20 +392,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     @Override
     public Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory, int[] partitions)
             throws Exception {
-        // todo: copy paste logic from the above code.
-        Map<Address, List<Integer>> memberPartitions = new HashMap<Address, List<Integer>>(3);
-        InternalPartitionService partitionService = nodeEngine.getPartitionService();
-        for (int partition : partitions) {
-            Address owner = partitionService.getPartitionOwnerOrWait(partition);
-
-            if (!memberPartitions.containsKey(owner)) {
-                memberPartitions.put(owner, new ArrayList<Integer>());
-            }
-
-            memberPartitions.get(owner).add(partition);
-        }
-        InvokeOnPartitions invokeOnPartitions = new InvokeOnPartitions(this, serviceName, operationFactory, memberPartitions);
-        return invokeOnPartitions.invoke();
+        return invokeOnPartitions(serviceName, operationFactory, toIntegerList(partitions));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
- * Various collection utility methods, mainly targeted to use internally.
+ * Various collection utility methods.
  */
 public final class CollectionUtil {
 
@@ -82,7 +82,6 @@ public final class CollectionUtil {
      * @param collection the given collection
      * @param position   position of the wanted item
      * @return the item on position or {@code null} if the given collection is too small
-     *
      * @throws NullPointerException if collection is {@code null}
      */
     public static <T> T getItemAtPositionOrNull(Collection<T> collection, int position) {
@@ -106,7 +105,6 @@ public final class CollectionUtil {
      * @param collection           the given collection
      * @param serializationService will be used for converting object to {@link Data}
      * @return collection of data
-     *
      * @throws NullPointerException if collection is {@code null} or contains a {@code null} item
      */
     public static <C> Collection<Data> objectToDataCollection(Collection<C> collection,
@@ -124,7 +122,6 @@ public final class CollectionUtil {
      *
      * @param collection the given collection
      * @return a primitive int[] array
-     *
      * @throws NullPointerException if collection is {@code null}
      */
     public static int[] toIntArray(Collection<Integer> collection) {
@@ -141,7 +138,6 @@ public final class CollectionUtil {
      *
      * @param collection the given collection
      * @return a primitive long[] array
-     *
      * @throws NullPointerException if collection is {@code null}
      */
     public static long[] toLongArray(Collection<Long> collection) {
@@ -151,5 +147,22 @@ public final class CollectionUtil {
             collectionArray[index++] = item;
         }
         return collectionArray;
+    }
+
+    /**
+     * Converts an int array to an Integer {@link List}.
+     *
+     * The returned collection can be modified after it is created; it isn't protected by an immutable wrapper.
+     *
+     * @param array the array
+     * @return the list.
+     * throws {@link NullPointerException} if array is null.
+     */
+    public static List<Integer> toIntegerList(int[] array) {
+        List<Integer> result = new ArrayList<Integer>(array.length);
+        for (int partitionId : array) {
+            result.add(partitionId);
+        }
+        return result;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/CollectionUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/CollectionUtilTest.java
@@ -41,7 +41,9 @@ import static com.hazelcast.util.CollectionUtil.isEmpty;
 import static com.hazelcast.util.CollectionUtil.isNotEmpty;
 import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
+import static com.hazelcast.util.CollectionUtil.toIntegerList;
 import static com.hazelcast.util.CollectionUtil.toLongArray;
+import static java.util.Arrays.asList;
 import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -233,5 +235,22 @@ public class CollectionUtilTest extends HazelcastTestSupport {
     @Test(expected = NullPointerException.class)
     public void testToLongArray_whenNull_thenThrowNPE() {
         toLongArray(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testToIntegerList_whenNull(){
+        toIntegerList(null);
+    }
+
+    @Test
+    public void testToIntegerList_whenEmpty(){
+        List<Integer> result = toIntegerList(new int[0]);
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testToIntegerList_whenNotEmpty(){
+        List<Integer> result = toIntegerList(new int[]{1,2,3,4});
+        assertEquals(asList(1,2,3,4), result);
     }
 }


### PR DESCRIPTION
The method was copied to deal with int array and collection<Integer>. Code has
been cleaned up so that the int array converts to collection and then forwards
to the main method.