### PR TITLE
backupFailureCount moved to OperationService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunnerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunnerFactory.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.spi.impl.operationexecutor;
 
-import com.hazelcast.internal.util.counters.Counter;
-
 /**
  * A Factory for creating {@link OperationRunner} instances.
  */
@@ -30,7 +28,7 @@ public interface OperationRunnerFactory {
      * @param partitionId the id of the partition.
      * @return the created OperationRunner.
      */
-    OperationRunner createPartitionRunner(int partitionId, Counter failedBackupsCounter);
+    OperationRunner createPartitionRunner(int partitionId);
 
     /**
      * Creates an OperationRunner to execute generic Operations.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerFactoryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerFactoryImpl.java
@@ -16,10 +16,11 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.internal.util.counters.Counter;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunnerFactory;
+
+import static com.hazelcast.spi.Operation.GENERIC_PARTITION_ID;
+import static com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.AD_HOC_PARTITION_ID;
 
 class OperationRunnerFactoryImpl implements OperationRunnerFactory {
     private OperationServiceImpl operationService;
@@ -30,16 +31,16 @@ class OperationRunnerFactoryImpl implements OperationRunnerFactory {
 
     @Override
     public OperationRunner createAdHocRunner() {
-        return new OperationRunnerImpl(operationService, OperationRunnerImpl.AD_HOC_PARTITION_ID, null);
+        return new OperationRunnerImpl(operationService, AD_HOC_PARTITION_ID, null);
     }
 
     @Override
-    public OperationRunner createPartitionRunner(int partitionId, Counter failedBackupsCounter) {
-        return new OperationRunnerImpl(operationService, partitionId, failedBackupsCounter);
+    public OperationRunner createPartitionRunner(int partitionId) {
+        return new OperationRunnerImpl(operationService, partitionId, operationService.failedBackupsCount);
     }
 
     @Override
     public OperationRunner createGenericRunner() {
-        return new OperationRunnerImpl(operationService, Operation.GENERIC_PARTITION_ID, null);
+        return new OperationRunnerImpl(operationService, GENERIC_PARTITION_ID, null);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -62,6 +63,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_RESPONSE;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
@@ -111,13 +113,16 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     final AtomicLong completedOperationsCount = new AtomicLong();
 
     @Probe(name = "operationTimeoutCount", level = MANDATORY)
-    final MwCounter operationTimeoutCount = MwCounter.newMwCounter();
+    final MwCounter operationTimeoutCount = newMwCounter();
 
     @Probe(name = "callTimeoutCount", level = MANDATORY)
-    final MwCounter callTimeoutCount = MwCounter.newMwCounter();
+    final MwCounter callTimeoutCount = newMwCounter();
 
     @Probe(name = "retryCount", level = MANDATORY)
-    final MwCounter retryCount = MwCounter.newMwCounter();
+    final MwCounter retryCount = newMwCounter();
+
+    @Probe(name = "failedBackups", level = MANDATORY)
+    final Counter failedBackupsCount = newMwCounter();
 
     final NodeEngineImpl nodeEngine;
     final Node node;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -177,7 +177,7 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
         DummyOperationRunner adhocHandler;
 
         @Override
-        public OperationRunner createPartitionRunner(int partitionId, Counter failedBackupsCounter) {
+        public OperationRunner createPartitionRunner(int partitionId) {
             DummyOperationRunner operationHandler = new DummyOperationRunner(partitionId);
             partitionOperationHandlers.add(operationHandler);
             return operationHandler;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
@@ -33,7 +33,7 @@ public class OperationThreadTest extends OperationExecutorImpl_AbstractTest {
         handlerFactory = mock(OperationRunnerFactory.class);
         OperationRunner handler = mock(OperationRunner.class);
         when(handlerFactory.createGenericRunner()).thenReturn(handler);
-        when(handlerFactory.createPartitionRunner(anyInt(), (Counter)any())).thenReturn(handler);
+        when(handlerFactory.createPartitionRunner(anyInt())).thenReturn(handler);
 
         initExecutor();
 
@@ -113,7 +113,7 @@ public class OperationThreadTest extends OperationExecutorImpl_AbstractTest {
         handlerFactory = mock(OperationRunnerFactory.class);
         OperationRunner handler = mock(OperationRunner.class);
         when(handlerFactory.createGenericRunner()).thenReturn(handler);
-        when(handlerFactory.createPartitionRunner(anyInt(), (Counter)any())).thenReturn(handler);
+        when(handlerFactory.createPartitionRunner(anyInt())).thenReturn(handler);
 
         initExecutor();
 


### PR DESCRIPTION
detecting of the backup failure is a concern of the OperationRunnerImpl and therefor at
the same level as the OperationServiceImpl. The OperationExecutor is one level below this.

So the counter should be taken care of by the OperationRunnerImpl and the OperationExecutor
doesn't need to deal with a concern of the layer above.

The counter also has been made mandatory, so we always see it.