### PR TITLE
OperationRunnerImpl sendBackup moved

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -47,7 +47,29 @@ final class OperationBackupHandler {
         this.backpressureRegulator = operationService.backpressureRegulator;
     }
 
-    public int backup(BackupAwareOperation backupAwareOp) throws Exception {
+    /**
+     * Sends the appropriate backups. This call will not wait till the backups have ACK'ed.
+     *
+     * If this call is made with a none BackupAwareOperation, then 0 is returned.
+     *
+     * @param op the Operation to backup.
+     * @return the number of ACKS required to complete the invocation.
+     * @throws Exception if there is any exception sending the backups.
+     */
+    int sendBackups(Operation op) throws Exception {
+        if (!(op instanceof BackupAwareOperation)) {
+            return 0;
+        }
+
+        int backupAcks = 0;
+        BackupAwareOperation backupAwareOp = (BackupAwareOperation) op;
+        if (backupAwareOp.shouldBackup()) {
+            backupAcks = sendBackups0(backupAwareOp);
+        }
+        return backupAcks;
+    }
+
+    int sendBackups0(BackupAwareOperation backupAwareOp) throws Exception {
         int requestedSyncBackups = requestedSyncBackups(backupAwareOp);
         int requestedAsyncBackups = requestedAsyncBackups(backupAwareOp);
         int requestedTotalBackups = requestedTotalBackups(backupAwareOp);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -128,7 +128,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     final NodeEngineImpl nodeEngine;
     final Node node;
     final ILogger logger;
-    final OperationBackupHandler operationBackupHandler;
+    final OperationBackupHandler backupHandler;
     final BackpressureRegulator backpressureRegulator;
     volatile Invocation.Context invocationContext;
 
@@ -167,7 +167,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
                 nodeEngine, thisAddress, node.getHazelcastThreadGroup(), node.getProperties(), invocationRegistry,
                 node.getLogger(InvocationMonitor.class), serializationService, nodeEngine.getServiceManager());
 
-        this.operationBackupHandler = new OperationBackupHandler(this);
+        this.backupHandler = new OperationBackupHandler(this);
 
         this.responseHandler = new ResponseHandler(
                 node.getLogger(ResponseHandler.class), node.getSerializationService(), invocationRegistry, nodeEngine);
@@ -379,6 +379,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     @Override
     public Map<Integer, Object> invokeOnPartitions(String serviceName, OperationFactory operationFactory,
                                                    Collection<Integer> partitions) throws Exception {
+
         Map<Address, List<Integer>> memberPartitions = new HashMap<Address, List<Integer>>(3);
         InternalPartitionService partitionService = nodeEngine.getPartitionService();
         for (int partition : partitions) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandlerTest.java
@@ -53,7 +53,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         local = cluster[0];
 
         operationService = (OperationServiceImpl) getOperationService(local);
-        backupHandler = operationService.operationBackupHandler;
+        backupHandler = operationService.backupHandler;
     }
 
     // ============================ syncBackups =================================
@@ -126,7 +126,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         setup(BACKPRESSURE_ENABLED);
 
         BackupAwareOperation op = makeOperation(-1, 0);
-        backupHandler.backup(op);
+        backupHandler.sendBackups0(op);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -134,7 +134,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         setup(BACKPRESSURE_ENABLED);
 
         BackupAwareOperation op = makeOperation(MAX_BACKUP_COUNT + 1, 0);
-        backupHandler.backup(op);
+        backupHandler.sendBackups0(op);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -142,7 +142,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         setup(BACKPRESSURE_ENABLED);
 
         BackupAwareOperation op = makeOperation(0, -1);
-        backupHandler.backup(op);
+        backupHandler.sendBackups0(op);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -150,7 +150,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         setup(BACKPRESSURE_ENABLED);
 
         BackupAwareOperation op = makeOperation(0, MAX_BACKUP_COUNT + 1);
-        backupHandler.backup(op);
+        backupHandler.sendBackups0(op);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -158,7 +158,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
         setup(BACKPRESSURE_ENABLED);
 
         BackupAwareOperation op = makeOperation(1, MAX_BACKUP_COUNT);
-        backupHandler.backup(op);
+        backupHandler.sendBackups0(op);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class OperationBackupHandlerTest extends HazelcastTestSupport {
     private void assertBackup(final int syncBackups, final int asyncBackups, int expectedResult) throws Exception {
         final DummyBackupAwareOperation backupAwareOp = makeOperation(syncBackups, asyncBackups);
 
-        int result = backupHandler.backup(backupAwareOp);
+        int result = backupHandler.sendBackups0(backupAwareOp);
 
         assertEquals(expectedResult, result);
         assertTrueEventually(new AssertTask() {


### PR DESCRIPTION
this method has been moved to the OperationBackupHandler since it is a more of a concern
for the latter than the former. Else the logic is spread over multiple classes.