### PR TITLE
OperationRunnerImpl.handleOperationError remove returnsResponse check

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -24,11 +24,9 @@ import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
@@ -73,17 +71,8 @@ abstract class AbstractCallableTaskOperation extends Operation implements Identi
         }
     }
 
-    /**
-     * since this operation handles responses in an async way, we need to handle serialization exceptions too
-     * @return
-     */
     private Callable getCallable() {
-        try {
-            return getNodeEngine().toObject(callableData);
-        } catch (HazelcastSerializationException e) {
-            sendResponse(e);
-            throw ExceptionUtil.rethrow(e);
-        }
+        return getNodeEngine().toObject(callableData);
     }
 
     private ManagedContext getManagedContext() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -265,6 +265,7 @@ final class OperationBackupHandler {
         // if getServiceName() method is overridden to return the same name
         // then this will have no effect.
         backupOp.setServiceName(op.getServiceName());
+        setCallId(backupOp, op.getCallId());
         return backupOp;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -43,6 +43,10 @@ import java.util.Arrays;
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
 import static com.hazelcast.spi.partition.IPartition.MAX_BACKUP_COUNT;
 
+/**
+ * The Backup is a container around the operation that takes care of the actual backup. Backups
+ * are sent from the primary and don't have a call'id set.
+ */
 public final class Backup extends Operation implements BackupOperation, IdentifiedDataSerializable {
 
     private Address originalCaller;
@@ -148,12 +152,12 @@ public final class Backup extends Operation implements BackupOperation, Identifi
 
     @Override
     public void afterRun() throws Exception {
-        if (!valid || !sync || getCallId() == 0 || originalCaller == null) {
+        if (!valid || !sync || backupOp.getCallId() == 0 || originalCaller == null) {
             return;
         }
 
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        long callId = getCallId();
+        long callId = backupOp.getCallId();
         OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
 
         if (nodeEngine.getThisAddress().equals(originalCaller)) {

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorSerializationErrorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorSerializationErrorTest.java
@@ -1,0 +1,76 @@
+package com.hazelcast.executor;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.test.ExpectedRuntimeException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Checks if the Executor deals correctly with deserialization issues of the task.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ExecutorSerializationErrorTest extends HazelcastTestSupport {
+
+    private HazelcastInstance local;
+    private HazelcastInstance remote;
+    private IExecutorService executor;
+
+    @Before
+    public void setup() {
+        HazelcastInstance[] cluster = createHazelcastInstanceFactory(2).newInstances();
+        warmUpPartitions(cluster);
+        local = cluster[0];
+        remote = cluster[1];
+        executor = local.getExecutorService("foo");
+    }
+
+    @Test
+    public void test() throws Exception {
+        Future f = executor.submitToMember(new BrokenCallable(), remote.getCluster().getLocalMember());
+
+        assertCompletesEventually(f);
+
+        try {
+            f.get();
+            fail();
+        } catch (ExecutionException e) {
+            assertInstanceOf(HazelcastSerializationException.class, e.getCause());
+            assertInstanceOf(ExpectedRuntimeException.class, e.getCause().getCause());
+        }
+    }
+
+    private static class BrokenCallable implements DataSerializable, Callable {
+        @Override
+        public Object call() throws Exception {
+            return null;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            throw new ExpectedRuntimeException();
+        }
+    }
+}


### PR DESCRIPTION
If there is a response handler set, just send it.

The problem is that a method might decide as part of its run that it does or does not have a response (yet). So it could start out with an initial value 'returnsResponse=false', but if there is an exception, we need to send back an error response no matter of the 'returnsResponse' status because the real response is likely never to be send since the run failed. 

This is partly a cleanup but also it resolves an issue with exceptions not being returned.

There is another important change. In case of a Backup, the callId is set on the backup. This causes the wrong response handler to be set on the Backup; this ResponseHandler is a remote responde handler that returns to the primary; and not the caller. This is potentially dangerous because the response could be matched with an arbitrary invocation on the primary; instead of on the caller. 

Instead of setting the call id on Backup, it is set on the contained BackupOperation. This causes the Backup to be initiated with an Empty ResponseHandler once it gets deserialized.
