### PR TITLE
Removed OperationResponseHandler.isLocal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockEvictionProcessor.java
@@ -94,10 +94,5 @@ public final class LockEvictionProcessor implements ScheduledEntryProcessor<Data
                 }
             }
         }
-
-        @Override
-        public boolean isLocal() {
-            return true;
-        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PostJoinOperation.java
@@ -70,11 +70,6 @@ public class PostJoinOperation extends Operation implements UrgentSystemOperatio
                             }
                         }
                     }
-
-                    @Override
-                    public boolean isLocal() {
-                        return true;
-                    }
                 });
 
                 OperationAccessor.setCallerAddress(op, getCallerAddress());

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -49,11 +49,6 @@ public final class MigrationOperation extends BaseMigrationOperation {
         public void sendResponse(Operation op, Object obj) {
             throw new HazelcastException("Migration operations can not send response!");
         }
-
-        @Override
-        public boolean isLocal() {
-            return true;
-        }
     };
 
     private long[] replicaVersions;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/BasicRecordStoreLoader.java
@@ -221,11 +221,6 @@ class BasicRecordStoreLoader implements RecordStoreLoader {
                     loaded.set(true);
                 }
             }
-
-            @Override
-            public boolean isLocal() {
-                return true;
-            }
         });
         operation.setPartitionId(partitionId);
         OperationAccessor.setCallerAddress(operation, nodeEngine.getThisAddress());

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
@@ -25,7 +25,6 @@ import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.DefaultObjectNamespace;
-import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.WaitNotifyKey;
 
 import java.util.Collection;
@@ -46,8 +45,7 @@ public class GetAllOperation extends MultiMapKeyBasedOperation implements Blocki
         Collection coll = null;
         if (multiMapValue != null) {
             multiMapValue.incrementHit();
-            OperationResponseHandler responseHandler = getOperationResponseHandler();
-            coll = multiMapValue.getCollection(responseHandler.isLocal());
+            coll = multiMapValue.getCollection(executedLocally());
         }
         response = new MultiMapResponse(coll, getValueCollectionType(container));
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
@@ -40,7 +40,7 @@ public class RemoveAllOperation extends MultiMapBackupAwareOperation {
     @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        coll = remove(getOperationResponseHandler().isLocal());
+        coll = remove(executedLocally());
         response = new MultiMapResponse(coll, getValueCollectionType(container));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
@@ -59,9 +59,9 @@ public class TxnLockAndGetOperation extends MultiMapKeyBasedOperation implements
             throw new TransactionException("Transaction couldn't obtain lock!");
         }
         MultiMapValue multiMapValue = getMultiMapValueOrNull();
-        final boolean isLocal = getOperationResponseHandler().isLocal();
+        boolean isLocal = executedLocally();
         Collection<MultiMapRecord> collection = multiMapValue == null ? null : multiMapValue.getCollection(isLocal);
-        final MultiMapResponse multiMapResponse = new MultiMapResponse(collection, getValueCollectionType(container));
+        MultiMapResponse multiMapResponse = new MultiMapResponse(collection, getValueCollectionType(container));
         multiMapResponse.setNextRecordId(container.nextId());
         response = multiMapResponse;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -80,6 +80,10 @@ public abstract class Operation implements DataSerializable {
         setFlag(true, BITMASK_CALL_TIMEOUT_64_BIT);
     }
 
+    public boolean executedLocally() {
+        return nodeEngine.getThisAddress().equals(callerAddress);
+    }
+
     public boolean isUrgent() {
         return this instanceof UrgentSystemOperation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationResponseHandler.java
@@ -34,11 +34,4 @@ public interface OperationResponseHandler<O extends Operation> {
      * @param response the response of the operation that got executed.
      */
     void sendResponse(O op, Object response);
-
-    /**
-     * Checks if this OperationResponseHandler is for a local invocation.
-     *
-     * @return true if local, false otherwise.
-     */
-    boolean isLocal();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/OperationResponseHandlerFactory.java
@@ -37,11 +37,6 @@ public final class OperationResponseHandlerFactory {
         @Override
         public void sendResponse(Operation op, Object obj) {
         }
-
-        @Override
-        public boolean isLocal() {
-            return false;
-        }
     }
 
     public static OperationResponseHandler createErrorLoggingResponseHandler(ILogger logger) {
@@ -61,11 +56,6 @@ public final class OperationResponseHandlerFactory {
                 Throwable t = (Throwable) obj;
                 logger.severe(t);
             }
-        }
-
-        @Override
-        public boolean isLocal() {
-            return true;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -363,11 +363,6 @@ public abstract class Invocation implements OperationResponseHandler {
         }
     }
 
-    @Override
-    public boolean isLocal() {
-        return true;
-    }
-
     void notifyError(Object error) {
         assert error != null;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -343,12 +343,11 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
     }
 
     private void sendResponseAfterOperationError(Operation operation, Throwable e) {
-        OperationResponseHandler responseHandler = operation.getOperationResponseHandler();
         try {
             if (node.getState() != NodeState.SHUT_DOWN) {
-                responseHandler.sendResponse(operation, e);
-            } else if (responseHandler.isLocal()) {
-                responseHandler.sendResponse(operation, new HazelcastInstanceNotActiveException());
+                operation.sendResponse(e);
+            } else if (operation.executedLocally()) {
+                operation.sendResponse(new HazelcastInstanceNotActiveException());
             }
         } catch (Throwable t) {
             logger.warning("While sending op error... op: " + operation + ", error: " + e, t);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RemoteInvocationResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/RemoteInvocationResponseHandler.java
@@ -53,9 +53,4 @@ final class RemoteInvocationResponseHandler implements OperationResponseHandler 
                     + ". " + operation);
         }
     }
-
-    @Override
-    public boolean isLocal() {
-        return false;
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -232,11 +232,6 @@ public final class PartitionIteratingOperation extends Operation implements Iden
 
             PartitionIteratingOperation.this.sendResponse(new PartitionResponse(partitions, results));
         }
-
-        @Override
-        public boolean isLocal() {
-            return true;
-        }
     }
 
     @Override


### PR DESCRIPTION
The OperationResponseHandler.isLocal call is removed. A response handler should handle the response, it should not provide information about where to respond to.

This question can be answered by the Operation; so an additional method has been introduced to check if the operation is running locally or not.