### PR TITLE
Backport #8866 - Allow nested Spring transactions to be rolled back cleanly

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
@@ -21,6 +21,12 @@ public class OtherServiceBeanWithTransactionalContext {
         transactionalContext.getMap("dummyObjectMap").put(object.getId(), object);
     }
 
+    @Transactional
+    public void putWithException(DummyObject object) {
+        put(object);
+        throw new RuntimeException("oops, let's rollback in " + this.getClass().getSimpleName() + "!");
+    }
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void putInNewTransaction(DummyObject object) {
         put(object);

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
@@ -31,7 +31,21 @@ public class ServiceBeanWithTransactionalContext {
         otherService.put(object);
     }
 
+    public void putUsingOtherBean_sameTransaction_withException(DummyObject object) {
+        otherService.putWithException(object);
+    }
+
     public void putUsingOtherBean_newTransaction(DummyObject object) {
         otherService.putInNewTransaction(object);
+    }
+
+    public void putUsingSameBean_thenOtherBeanThrowingException_sameTransaction(DummyObject object, DummyObject otherObject) {
+        put(object);
+        otherService.putWithException(otherObject);
+    }
+
+    public void putUsingOtherBean_thenSameBeanThrowingException_sameTransaction(DummyObject object, DummyObject otherObject) {
+        otherService.put(otherObject);
+        putWithException(object);
     }
 }


### PR DESCRIPTION
* HazelcastTransactionObject now implements Spring's
SmartTransactionObject, exposing the boolean field isRollbackOnly

* Make HazelcastTransactionManager override doSetRollbackOnly so that if
a transaction is participating in another one, and there is a rollback,
we force the participant to be rollback-only

* Add tests that verify that in the middle of persisting objects through several beans, even when one exception is thrown after some of the objects have been persisted, the
transaction gets fully rolled back, leaving behind an empty map.

Credit to @jrosiek for input