### PR TITLE
Removed IOBalancer TcpIpConnection coupling.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/AbstractHandler.java
@@ -30,7 +30,7 @@ import java.nio.channels.SelectionKey;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 
-public abstract class AbstractHandler implements MigratableHandler {
+public abstract class AbstractHandler implements SelectionHandler, MigratableHandler {
 
     protected final ILogger logger;
     protected final SocketChannelWrapper socketChannel;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/MigratableHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/MigratableHandler.java
@@ -17,10 +17,10 @@
 package com.hazelcast.nio.tcp.nonblocking;
 
 /**
- * A {@link SelectionHandler} that supports migration between {@link NonBlockingIOThread} instances.
+ * A nio event handler that supports migration between {@link NonBlockingIOThread} instances.
  * This API is called by the {@link com.hazelcast.nio.tcp.nonblocking.iobalancer.IOBalancer}.
  */
-public interface MigratableHandler extends SelectionHandler {
+public interface MigratableHandler {
 
     /**
      * Requests the MigratableHandler to move to the new NonBlockingIOThread. This call will not wait for the

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
@@ -168,12 +168,17 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
 
     @Override
     public void onConnectionAdded(TcpIpConnection connection) {
-        ioBalancer.connectionAdded(connection);
+        NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
+        NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
+
+        ioBalancer.connectionAdded(socketReader, socketWriter);
     }
 
     @Override
     public void onConnectionRemoved(TcpIpConnection connection) {
-        ioBalancer.connectionRemoved(connection);
+        NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
+        NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
+        ioBalancer.connectionRemoved(socketReader, socketWriter);
     }
 
     private void startIOBalancer() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/iobalancer/IOBalancer.java
@@ -22,7 +22,6 @@ import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.nio.tcp.nonblocking.MigratableHandler;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingIOThread;
 import com.hazelcast.nio.tcp.nonblocking.NonBlockingSocketReader;
@@ -103,18 +102,14 @@ public class IOBalancer {
         return outLoadTracker;
     }
 
-    public void connectionAdded(TcpIpConnection connection) {
-        NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
-        NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
-        inLoadTracker.notifyHandlerAdded(socketReader);
-        outLoadTracker.notifyHandlerAdded(socketWriter);
+    public void connectionAdded(MigratableHandler readHandler, MigratableHandler writeHandler) {
+        inLoadTracker.notifyHandlerAdded(readHandler);
+        outLoadTracker.notifyHandlerAdded(writeHandler);
     }
 
-    public void connectionRemoved(TcpIpConnection connection) {
-        NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
-        NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
-        inLoadTracker.notifyHandlerRemoved(socketReader);
-        outLoadTracker.notifyHandlerRemoved(socketWriter);
+    public void connectionRemoved(MigratableHandler readHandler, MigratableHandler writeHandler) {
+        inLoadTracker.notifyHandlerRemoved(readHandler);
+        outLoadTracker.notifyHandlerRemoved(writeHandler);
     }
 
     public void start() {


### PR DESCRIPTION
This is required for the SSL performance improvement for client task. Client will get
the same threading model as serverside including balancer. For this the threading model
and iobalancer need to become TcpIpConnection (serverside) agnostic.