### PR TITLE
MetricsRegistry weakreference support

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -63,7 +63,6 @@ public class DefaultNodeContext implements NodeContext {
         if (spinning) {
             return new SpinningIOThreadingModel(
                     node.loggingService,
-                    node.nodeEngine.getMetricsRegistry(),
                     node.getHazelcastThreadGroup());
         } else {
             return new NonBlockingIOThreadingModel(

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -108,6 +108,18 @@ public interface MetricsRegistry {
     <S> void scanAndRegister(S source, String namePrefix);
 
     /**
+     * Same as {@link #scanAndRegister(Object, String)} however the source object is wrapped in a
+     * {@link java.lang.ref.WeakReference} so it doesn't need to be {@link #deregister(Object)} manually. This call is useful
+     * when objects dynamically are added and removed like connections.
+     *
+     * @param source     the object to scan.
+     * @param namePrefix the name prefix.
+     * @throws NullPointerException     if namePrefix or source is null.
+     * @throws IllegalArgumentException if the source contains Gauge annotation on a field/method of unsupported type.
+     */
+    <S> void scanAndWeakRegister(S source, String namePrefix);
+
+    /**
      * Registers a probe.
      *
      * If a probe for the given name exists, it will be overwritten.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
@@ -37,8 +37,8 @@ class DoubleGaugeImpl extends AbstractGauge implements DoubleGauge {
         Object source = null;
 
         if (probeInstance != null) {
-            function = probeInstance.function;
-            source = probeInstance.source;
+            function = probeInstance.getFunction();
+            source = probeInstance.getSource();
         }
 
         if (function == null || source == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -55,9 +55,9 @@ abstract class FieldProbe implements ProbeFunction {
         field.setAccessible(true);
     }
 
-    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
+    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix, boolean weakReference) {
         String name = getName(namePrefix);
-        metricsRegistry.registerInternal(source, name, probe.level(), this);
+        metricsRegistry.register0(source, name, probe.level(), this, weakReference);
     }
 
     private String getName(String namePrefix) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
@@ -37,8 +37,8 @@ class LongGaugeImpl extends AbstractGauge implements LongGauge {
         Object source = null;
 
         if (probeInstance != null) {
-            function = probeInstance.function;
-            source = probeInstance.source;
+            function = probeInstance.getFunction();
+            source = probeInstance.getSource();
         }
 
         if (function == null || source == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -57,9 +57,9 @@ abstract class MethodProbe implements ProbeFunction {
         method.setAccessible(true);
     }
 
-    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
+    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix, boolean weakReference) {
         String name = getName(namePrefix);
-        metricsRegistry.registerInternal(source, name, probe.level(), this);
+        metricsRegistry.register0(source, name, probe.level(), this, weakReference);
     }
 
     private String getName(String namePrefix) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeInstance.java
@@ -18,14 +18,16 @@ package com.hazelcast.internal.metrics.impl;
 
 import com.hazelcast.internal.metrics.ProbeFunction;
 
+import java.lang.ref.WeakReference;
+
 /**
  * A Probe Instance is an actual instance of a probe.
  *
  * A probe instance contains:
  * <ol>
- *     <li>A source object, e.g. an OperationService instance</li>
- *     <li>A ProbeFunction: e.g. an {@link com.hazelcast.internal.metrics.LongProbeFunction} that retrieves the number of
- *     executed operations.</li>
+ * <li>A source object, e.g. an OperationService instance</li>
+ * <li>A ProbeFunction: e.g. an {@link com.hazelcast.internal.metrics.LongProbeFunction} that retrieves the number of
+ * executed operations.</li>
  * </ol>
  *
  * @param <S>
@@ -33,12 +35,35 @@ import com.hazelcast.internal.metrics.ProbeFunction;
 class ProbeInstance<S> {
 
     final String name;
-    volatile ProbeFunction function;
-    volatile S source;
+    private volatile ProbeFunction function;
+    private volatile Object source;
 
-    ProbeInstance(String name, S source, ProbeFunction function) {
+    ProbeInstance(String name, Object source, ProbeFunction function) {
         this.name = name;
         this.function = function;
         this.source = source;
+    }
+
+    public void setSource(Object source) {
+        this.source = source;
+    }
+
+    public ProbeFunction getFunction() {
+        return function;
+    }
+
+    public S getSource() {
+        Object source = this.source;
+        return (S) (source instanceof WeakReference ? ((WeakReference) source).get() : source);
+    }
+
+    public void destroy() {
+        function = null;
+        source = null;
+    }
+
+    public void overwrite(Object source, ProbeFunction function) {
+        this.source = source;
+        this.function = function;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
@@ -47,13 +47,13 @@ final class SourceMetadata {
         }
     }
 
-    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
+    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix, boolean weakReference) {
         for (FieldProbe field : fields) {
-            field.register(metricsRegistry, source, namePrefix);
+            field.register(metricsRegistry, source, namePrefix, weakReference);
         }
 
         for (MethodProbe method : methods) {
-            method.register(metricsRegistry, source, namePrefix);
+            method.register(metricsRegistry, source, namePrefix, weakReference);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.internal.metrics.MetricsProvider;
+import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -43,7 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @see IOThreadingModel
  */
 @SuppressWarnings("checkstyle:methodcount")
-public final class TcpIpConnection implements Connection {
+public final class TcpIpConnection implements Connection, MetricsProvider {
 
     private final SocketChannelWrapper socketChannel;
 
@@ -79,6 +81,11 @@ public final class TcpIpConnection implements Connection {
         this.socketChannel = socketChannel;
         this.socketWriter = ioThreadingModel.newSocketWriter(this);
         this.socketReader = ioThreadingModel.newSocketReader(this);
+    }
+
+    @Override
+    public void provideMetrics(MetricsRegistry metricsRegistry) {
+        metricsRegistry.collectMetrics(socketWriter, socketWriter);
     }
 
     public SocketReader getSocketReader() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -369,6 +369,8 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
                     + channel.socket().getLocalSocketAddress() + " and " + channel.socket().getRemoteSocketAddress());
             openedCount.inc();
 
+            metricsRegistry.collectMetrics(connection);
+
             return connection;
         } finally {
             acceptedSockets.remove(channel);
@@ -491,7 +493,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
                 serverSocketChannel,
                 this);
         acceptorThread.start();
-        metricsRegistry.scanAndRegister(acceptorThread, "tcp." + acceptorThread.getName());
+        metricsRegistry.scanAndWeakRegister(acceptorThread, "tcp." + acceptorThread.getName());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
@@ -170,7 +170,6 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
     public void onConnectionAdded(TcpIpConnection connection) {
         NonBlockingSocketReader socketReader = (NonBlockingSocketReader) connection.getSocketReader();
         NonBlockingSocketWriter socketWriter = (NonBlockingSocketWriter) connection.getSocketWriter();
-
         ioBalancer.connectionAdded(socketReader, socketWriter);
     }
 
@@ -217,7 +216,7 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
         if (outputThread == null) {
             throw new IllegalStateException("IO thread is closed!");
         }
-        return new NonBlockingSocketWriter(connection, outputThread, metricsRegistry);
+        return new NonBlockingSocketWriter(connection, outputThread);
     }
 
     @Override
@@ -227,6 +226,6 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
         if (inputThread == null) {
             throw new IllegalStateException("IO thread is closed!");
         }
-        return new NonBlockingSocketReader(connection, inputThread, metricsRegistry);
+        return new NonBlockingSocketReader(connection, inputThread);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningIOThreadingModel.java
@@ -17,7 +17,6 @@
 package com.hazelcast.nio.tcp.spinning;
 
 import com.hazelcast.instance.HazelcastThreadGroup;
-import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.IOThreadingModel;
@@ -43,17 +42,14 @@ import com.hazelcast.nio.tcp.TcpIpConnection;
 public class SpinningIOThreadingModel implements IOThreadingModel {
 
     private final ILogger logger;
-    private final MetricsRegistry metricsRegistry;
     private final LoggingService loggingService;
     private final SpinningInputThread inputThread;
     private final SpinningOutputThread outThread;
 
     public SpinningIOThreadingModel(
             LoggingService loggingService,
-            MetricsRegistry metricsRegistry,
             HazelcastThreadGroup hazelcastThreadGroup) {
         this.logger = loggingService.getLogger(SpinningIOThreadingModel.class);
-        this.metricsRegistry = metricsRegistry;
         this.loggingService = loggingService;
         this.inputThread = new SpinningInputThread(hazelcastThreadGroup);
         this.outThread = new SpinningOutputThread(hazelcastThreadGroup);
@@ -67,13 +63,13 @@ public class SpinningIOThreadingModel implements IOThreadingModel {
     @Override
     public SocketWriter newSocketWriter(TcpIpConnection connection) {
         ILogger logger = loggingService.getLogger(SpinningSocketWriter.class);
-        return new SpinningSocketWriter(connection, metricsRegistry, logger);
+        return new SpinningSocketWriter(connection, logger);
     }
 
     @Override
     public SocketReader newSocketReader(TcpIpConnection connection) {
         ILogger logger = loggingService.getLogger(SpinningSocketReader.class);
-        return new SpinningSocketReader(connection, metricsRegistry, logger);
+        return new SpinningSocketReader(connection, logger);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RenderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/RenderTest.java
@@ -33,8 +33,8 @@ public class RenderTest {
 
         for (String name : metricsRegistry.getNames()) {
             ProbeInstance probeInstance = metricsRegistry.getProbeInstance(name);
-            if (probeInstance != null && probeInstance.source != null) {
-                metricsRegistry.deregister(probeInstance.source);
+            if (probeInstance != null && probeInstance.getSource() != null) {
+                metricsRegistry.deregister(probeInstance.getSource());
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ScanAndWeakRegisterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ScanAndWeakRegisterTest.java
@@ -1,0 +1,49 @@
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.LongGauge;
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static org.junit.Assert.assertEquals;
+
+public class ScanAndWeakRegisterTest extends HazelcastTestSupport {
+
+    private MetricsRegistryImpl metricsRegistry;
+
+    @Before
+    public void setup() {
+        metricsRegistry = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), INFO);
+    }
+
+    @Test
+    public void testGcEventually() {
+        metricsRegistry.scanAndWeakRegister(new DummyObject(), "dummy");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                System.gc();
+                LongGauge gauge = metricsRegistry.newLongGauge("dummy.value");
+                assertEquals(0, gauge.read());
+            }
+        });
+    }
+
+    @Test
+    public void test() {
+        DummyObject source = new DummyObject();
+        metricsRegistry.scanAndWeakRegister(source, "dummy");
+        LongGauge gauge = metricsRegistry.newLongGauge("dummy.value");
+        assertEquals(100, gauge.read());
+    }
+
+    static class DummyObject {
+        @Probe
+        int value = 100;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_IOThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/spinning/Spinning_IOThreadingModelFactory.java
@@ -10,7 +10,6 @@ public class Spinning_IOThreadingModelFactory implements IOThreadingModelFactory
     public SpinningIOThreadingModel create(MockIOService ioService, MetricsRegistry metricsRegistry) {
         return new SpinningIOThreadingModel(
                 ioService.loggingService,
-                metricsRegistry,
                 ioService.hazelcastThreadGroup);
     }
 }


### PR DESCRIPTION
Instead of needing to deregister, lets the gc take care of it. This is done by wrapping
the source in a WeakReference.

The connection logic has been cleaned up:
- no more metrics registry in the constructor
- no more deregister; but rely on weakreference instead