### PR TITLE
Discardable metrics provider

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/DiscardableMetricsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/DiscardableMetricsProvider.java
@@ -17,9 +17,10 @@
 package com.hazelcast.internal.metrics;
 
 /**
- * To be implemented by an object that can provide metrics (so has a bunch of probes).
+ * A {@link MetricsProvider} that has the ability to discard to provided metrics. This is useful for dynamic metrics; so
+ * metrics that get added and removed during the lifecycle of the MetricsRegistry like a connection.
  */
-public interface MetricsProvider {
+public interface DiscardableMetricsProvider extends MetricsProvider {
 
-    void provideMetrics(MetricsRegistry registry);
+    void discardMetrics(MetricsRegistry registry);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -138,8 +138,7 @@ public interface MetricsRegistry {
      *
      * If the object was never registered, the call is ignored.
      *
-     * @param source the object to deregister
-     * @throws NullPointerException if source is null.
+     * @param source the object to deregister. If called with null, then ignored.
      */
     <S> void deregister(S source);
 
@@ -171,4 +170,12 @@ public interface MetricsRegistry {
      * @param objects the array of objects to initialize.
      */
     void collectMetrics(Object... objects);
+
+    /**
+     * For each object that implements {@link DiscardableMetricsProvider} the
+     * {@link DiscardableMetricsProvider#discardMetrics(MetricsRegistry)} is called.
+     *
+     * @param objects the array of objects to check.
+     */
+    void discardMetrics(Object... objects);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.metrics.impl;
 
+import com.hazelcast.internal.metrics.DiscardableMetricsProvider;
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
@@ -205,7 +206,9 @@ public class MetricsRegistryImpl implements MetricsRegistry {
 
     @Override
     public <S> void deregister(S source) {
-        checkNotNull(source, "source can't be null");
+        if (source == null) {
+            return;
+        }
 
         boolean changed = false;
         for (Map.Entry<String, ProbeInstance> entry : probeInstances.entrySet()) {
@@ -252,6 +255,15 @@ public class MetricsRegistryImpl implements MetricsRegistry {
         for (Object object : objects) {
             if (object instanceof MetricsProvider) {
                 ((MetricsProvider) object).provideMetrics(this);
+            }
+        }
+    }
+
+    @Override
+    public void discardMetrics(Object... objects) {
+        for (Object object : objects) {
+            if (object instanceof DiscardableMetricsProvider) {
+                ((DiscardableMetricsProvider) object).discardMetrics(this);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.internal.metrics.MetricsProvider;
+import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.DiscardableMetricsProvider;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -43,7 +46,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @see IOThreadingModel
  */
 @SuppressWarnings("checkstyle:methodcount")
-public final class TcpIpConnection implements Connection {
+public final class TcpIpConnection implements Connection, MetricsProvider, DiscardableMetricsProvider {
 
     private final SocketChannelWrapper socketChannel;
 
@@ -79,6 +82,16 @@ public final class TcpIpConnection implements Connection {
         this.socketChannel = socketChannel;
         this.socketWriter = ioThreadingModel.newSocketWriter(this);
         this.socketReader = ioThreadingModel.newSocketReader(this);
+    }
+
+    @Override
+    public void discardMetrics(MetricsRegistry registry) {
+        registry.discardMetrics(socketReader, socketWriter);
+    }
+
+    @Override
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.collectMetrics(socketReader, socketWriter);
     }
 
     public SocketReader getSocketReader() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -369,6 +369,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
                     + channel.socket().getLocalSocketAddress() + " and " + channel.socket().getRemoteSocketAddress());
             openedCount.inc();
 
+            metricsRegistry.collectMetrics(connection);
             return connection;
         } finally {
             acceptedSockets.remove(channel);
@@ -425,6 +426,8 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
             if (connection instanceof TcpIpConnection) {
                 ioThreadingModel.onConnectionRemoved((TcpIpConnection) connection);
             }
+
+            metricsRegistry.discardMetrics(connection);
         }
 
         Address endPoint = connection.getEndPoint();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
@@ -217,7 +217,7 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
         if (outputThread == null) {
             throw new IllegalStateException("IO thread is closed!");
         }
-        return new NonBlockingSocketWriter(connection, outputThread, metricsRegistry);
+        return new NonBlockingSocketWriter(connection, outputThread);
     }
 
     @Override
@@ -227,6 +227,6 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
         if (inputThread == null) {
             throw new IllegalStateException("IO thread is closed!");
         }
-        return new NonBlockingSocketReader(connection, inputThread, metricsRegistry);
+        return new NonBlockingSocketReader(connection, inputThread);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio.tcp.nonblocking;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.DiscardableMetricsProvider;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.util.counters.SwCounter;
@@ -50,7 +51,7 @@ import static java.lang.System.currentTimeMillis;
  * {@link #handle()} is called to read out the data from the socket into a bytebuffer and hand it over to the
  * {@link ReadHandler} to get processed.
  */
-public final class NonBlockingSocketReader extends AbstractHandler implements SocketReader {
+public final class NonBlockingSocketReader extends AbstractHandler implements SocketReader, DiscardableMetricsProvider {
 
     @Probe(name = "eventCount")
     private final SwCounter eventCount = newSwCounter();
@@ -60,20 +61,24 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
     private final SwCounter normalFramesRead = newSwCounter();
     @Probe(name = "priorityFramesRead")
     private final SwCounter priorityFramesRead = newSwCounter();
-    private final MetricsRegistry metricRegistry;
 
     private ReadHandler readHandler;
     private ByteBuffer inputBuffer;
     private volatile long lastReadTime;
 
-    public NonBlockingSocketReader(
-            TcpIpConnection connection,
-            NonBlockingIOThread ioThread,
-            MetricsRegistry metricsRegistry) {
+    public NonBlockingSocketReader(TcpIpConnection connection, NonBlockingIOThread ioThread) {
         super(connection, ioThread, SelectionKey.OP_READ);
         this.ioThread = ioThread;
-        this.metricRegistry = metricsRegistry;
-        metricRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].in");
+    }
+
+    @Override
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].in");
+    }
+
+    @Override
+    public void discardMetrics(MetricsRegistry registry) {
+        registry.deregister(this);
     }
 
     @Probe(name = "idleTimeMs")
@@ -221,7 +226,6 @@ public final class NonBlockingSocketReader extends AbstractHandler implements So
     public void close() {
         //todo:
         // ioThread race, shutdown can end up on the old selector
-        metricRegistry.deregister(this);
         ioThread.addTaskAndWakeup(new Runnable() {
             @Override
             public void run() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio.tcp.nonblocking;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.DiscardableMetricsProvider;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.nio.IOUtil;
@@ -52,7 +53,7 @@ import static java.lang.System.currentTimeMillis;
 /**
  * The writing side of the {@link TcpIpConnection}.
  */
-public final class NonBlockingSocketWriter extends AbstractHandler implements Runnable, SocketWriter {
+public final class NonBlockingSocketWriter extends AbstractHandler implements Runnable, SocketWriter, DiscardableMetricsProvider {
 
     private static final long TIMEOUT = 3;
 
@@ -72,7 +73,6 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
     private final SwCounter normalFramesWritten = newSwCounter();
     @Probe(name = "priorityFramesWritten")
     private final SwCounter priorityFramesWritten = newSwCounter();
-    private final MetricsRegistry metricsRegistry;
 
     private volatile OutboundFrame currentFrame;
     private WriteHandler writeHandler;
@@ -83,12 +83,18 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
     // This prevents running into an NonBlockingIOThread that is migrating.
     private NonBlockingIOThread newOwner;
 
-    NonBlockingSocketWriter(TcpIpConnection connection, NonBlockingIOThread ioThread, MetricsRegistry metricsRegistry) {
+    NonBlockingSocketWriter(TcpIpConnection connection, NonBlockingIOThread ioThread) {
         super(connection, ioThread, SelectionKey.OP_WRITE);
+    }
 
-        // sensors
-        this.metricsRegistry = metricsRegistry;
-        metricsRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].out");
+    @Override
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].out");
+    }
+
+    @Override
+    public void discardMetrics(MetricsRegistry registry) {
+        registry.deregister(this);
     }
 
     @Override
@@ -408,7 +414,6 @@ public final class NonBlockingSocketWriter extends AbstractHandler implements Ru
 
     @Override
     public void close() {
-        metricsRegistry.deregister(this);
         writeQueue.clear();
         urgentWriteQueue.clear();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningIOThreadingModel.java
@@ -67,13 +67,13 @@ public class SpinningIOThreadingModel implements IOThreadingModel {
     @Override
     public SocketWriter newSocketWriter(TcpIpConnection connection) {
         ILogger logger = loggingService.getLogger(SpinningSocketWriter.class);
-        return new SpinningSocketWriter(connection, metricsRegistry, logger);
+        return new SpinningSocketWriter(connection, logger);
     }
 
     @Override
     public SocketReader newSocketReader(TcpIpConnection connection) {
         ILogger logger = loggingService.getLogger(SpinningSocketReader.class);
-        return new SpinningSocketReader(connection, metricsRegistry, logger);
+        return new SpinningSocketReader(connection, logger);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
@@ -17,6 +17,7 @@
 package com.hazelcast.nio.tcp.spinning;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.DiscardableMetricsProvider;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.util.counters.SwCounter;
@@ -45,7 +46,7 @@ import static com.hazelcast.util.StringUtil.bytesToString;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
 
-public class SpinningSocketReader extends AbstractHandler implements SocketReader {
+public class SpinningSocketReader extends AbstractHandler implements SocketReader, DiscardableMetricsProvider {
 
     @Probe(name = "bytesRead")
     private final SwCounter bytesRead = newSwCounter();
@@ -53,18 +54,25 @@ public class SpinningSocketReader extends AbstractHandler implements SocketReade
     private final SwCounter normalFramesRead = newSwCounter();
     @Probe(name = "priorityFramesRead")
     private final SwCounter priorityFramesRead = newSwCounter();
-    private final MetricsRegistry metricRegistry;
     private final SocketChannelWrapper socketChannel;
     private volatile long lastReadTime;
     private ReadHandler readHandler;
     private ByteBuffer inputBuffer;
     private ByteBuffer protocolBuffer = ByteBuffer.allocate(3);
 
-    public SpinningSocketReader(TcpIpConnection connection, MetricsRegistry metricsRegistry, ILogger logger) {
+    public SpinningSocketReader(TcpIpConnection connection,  ILogger logger) {
         super(connection, logger);
-        this.metricRegistry = metricsRegistry;
         this.socketChannel = connection.getSocketChannelWrapper();
-        metricRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].in");
+    }
+
+    @Override
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].in");
+    }
+
+    @Override
+    public void discardMetrics(MetricsRegistry registry) {
+        registry.deregister(this);
     }
 
     @Override
@@ -94,7 +102,7 @@ public class SpinningSocketReader extends AbstractHandler implements SocketReade
 
     @Override
     public void close() {
-        metricRegistry.deregister(this);
+        //no-op
     }
 
     public void read() throws Exception {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio.tcp.spinning;
 
+import com.hazelcast.internal.metrics.DiscardableMetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.counters.SwCounter;
@@ -47,7 +48,7 @@ import static com.hazelcast.nio.Protocols.CLUSTER;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 import static java.lang.System.currentTimeMillis;
 
-public class SpinningSocketWriter extends AbstractHandler implements SocketWriter {
+public class SpinningSocketWriter extends AbstractHandler implements SocketWriter, DiscardableMetricsProvider {
 
     private static final long TIMEOUT = 3;
 
@@ -68,20 +69,26 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
     private final SwCounter normalFramesWritten = newSwCounter();
     @Probe(name = "priorityFramesWritten")
     private final SwCounter priorityFramesWritten = newSwCounter();
-    private final MetricsRegistry metricsRegistry;
     private volatile long lastWriteTime;
     private WriteHandler writeHandler;
     private volatile OutboundFrame currentFrame;
 
-    public SpinningSocketWriter(TcpIpConnection connection, MetricsRegistry metricsRegistry, ILogger logger) {
+    public SpinningSocketWriter(TcpIpConnection connection,  ILogger logger) {
         super(connection, logger);
-        this.metricsRegistry = metricsRegistry;
         this.logger = logger;
         this.socketChannel = connection.getSocketChannelWrapper();
         this.writeQueue = new ConcurrentLinkedQueue<OutboundFrame>();
         this.urgentWriteQueue = new ConcurrentLinkedQueue<OutboundFrame>();
-        // sensors
-        metricsRegistry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].out");
+    }
+
+    @Override
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "tcp.connection[" + connection.getMetricsId() + "].out");
+    }
+
+    @Override
+    public void discardMetrics(MetricsRegistry registry) {
+        registry.deregister(this);
     }
 
     @Override
@@ -212,7 +219,6 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
 
     @Override
     public void close() {
-        metricsRegistry.deregister(this);
         writeQueue.clear();
         urgentWriteQueue.clear();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -130,8 +130,8 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "event");
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "event");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -202,14 +202,14 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "operation");
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "operation");
 
-        metricsRegistry.collectMetrics((Object[]) genericThreads);
-        metricsRegistry.collectMetrics((Object[]) partitionThreads);
-        metricsRegistry.collectMetrics(adHocOperationRunner);
-        metricsRegistry.collectMetrics((Object[]) genericOperationRunners);
-        metricsRegistry.collectMetrics((Object[]) partitionOperationRunners);
+        registry.collectMetrics((Object[]) genericThreads);
+        registry.collectMetrics((Object[]) partitionThreads);
+        registry.collectMetrics(adHocOperationRunner);
+        registry.collectMetrics((Object[]) genericOperationRunners);
+        registry.collectMetrics((Object[]) partitionOperationRunners);
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP")

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -144,8 +144,8 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "operation.thread[" + getName() + "]");
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "operation.thread[" + getName() + "]");
     }
 
     public final void shutdown() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncResponseHandler.java
@@ -88,8 +88,8 @@ public class AsyncResponseHandler implements PacketHandler, MetricsProvider {
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "operation");
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "operation");
     }
 
     public void start() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -126,8 +126,8 @@ class InvocationMonitor implements PacketHandler, MetricsProvider {
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "operation.invocations");
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "operation.invocations");
     }
 
     private ScheduledExecutorService newScheduler(final HazelcastThreadGroup threadGroup) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -67,8 +67,8 @@ public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "operation");
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "operation");
     }
 
     @Probe(name = "invocations.usedPercentage")

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -119,9 +119,9 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
+    public void provideMetrics(MetricsRegistry registry) {
         if (partitionId >= 0) {
-            metricsRegistry.scanAndRegister(this, "operation.partition[" + partitionId + "]");
+            registry.scanAndRegister(this, "operation.partition[" + partitionId + "]");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -451,9 +451,9 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "operation");
-        metricsRegistry.collectMetrics(invocationRegistry, invocationMonitor, responseHandler, asyncResponseHandler,
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "operation");
+        registry.collectMetrics(invocationRegistry, invocationMonitor, responseHandler, asyncResponseHandler,
                 operationExecutor);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/ResponseHandler.java
@@ -70,8 +70,8 @@ public final class ResponseHandler implements PacketHandler, MetricsProvider {
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "operation.invocations");
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "operation.invocations");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -105,8 +105,8 @@ public class ProxyServiceImpl
     }
 
     @Override
-    public void provideMetrics(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scanAndRegister(this, "proxy");
+    public void provideMetrics(MetricsRegistry registry) {
+        registry.scanAndRegister(this, "proxy");
     }
 
     public void init() {


### PR DESCRIPTION
Added the DiscardableMetricsProvider as an easy mechanism to discard Metrics. 

Also cleanup the TcpIpConnection/ClientConnection and read/write handlers to make use of it.