### PR TITLE
MapReduceForMultiMapMessageTask should use MultiMapKeyValueSource

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMultiMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMultiMapReduceTest.java
@@ -1,0 +1,681 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.mapreduce;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.mapreduce.Collator;
+import com.hazelcast.mapreduce.Context;
+import com.hazelcast.mapreduce.Job;
+import com.hazelcast.mapreduce.JobTracker;
+import com.hazelcast.mapreduce.KeyPredicate;
+import com.hazelcast.mapreduce.KeyValueSource;
+import com.hazelcast.mapreduce.Mapper;
+import com.hazelcast.mapreduce.Reducer;
+import com.hazelcast.mapreduce.ReducerFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(SlowTest.class)
+public class ClientMultiMapReduceTest
+        extends AbstractClientMapReduceJobTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testExceptionDistribution() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i/2, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new ExceptionThrowingMapper()).submit();
+
+        try {
+            Map<String, List<Integer>> result = future.get();
+            fail();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(e.getCause() instanceof NullPointerException);
+            throw e;
+        }
+    }
+
+    @Test(timeout = 60000, expected = CancellationException.class)
+    public void testInProcessCancellation() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i/2, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TimeConsumingMapper()).submit();
+
+        future.cancel(true);
+
+        try {
+            Map<String, List<Integer>> result = future.get();
+            fail();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testMapper() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TestMapper()).submit();
+
+        Map<String, List<Integer>> result = future.get();
+
+        assertEquals(100, result.size());
+        for (List<Integer> value : result.values()) {
+            assertEquals(1, value.size());
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testMapperReducer() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Map<String, Integer>> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
+                .submit();
+
+        Map<String, Integer> result = future.get();
+
+        // Precalculate results
+        int[] expectedResults = new int[4];
+        for (int i = 0; i < 100; i++) {
+            int index = i % 4;
+            expectedResults[index] += i;
+        }
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedResults[i], (int) result.get(String.valueOf(i)));
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testMapperCollator() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i/2, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).submit(new GroupingTestCollator());
+
+        int result = future.get();
+
+        // Precalculate result
+        int expectedResult = 0;
+        for (int i = 0; i < 100; i++) {
+            expectedResult += i;
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testKeyedMapperCollator() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 10000; i++) {
+            m1.put(i, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Integer> future = job.onKeys(50).mapper(new TestMapper()).submit(new GroupingTestCollator());
+
+        int result = future.get();
+
+        assertEquals(50, result);
+    }
+
+    @Test(timeout = 120000)
+    public void testKeyPredicateMapperCollator() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 10000; i++) {
+            m1.put(i, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Integer> future = job.keyPredicate(new TestKeyPredicate()).mapper(new TestMapper())
+                .submit(new GroupingTestCollator());
+
+        int result = future.get();
+
+        assertEquals(50, result);
+    }
+
+    @Test(timeout = 120000)
+    public void testMapperReducerCollator() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i/2, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
+                .submit(new TestCollator());
+
+        int result = future.get();
+
+        // Precalculate result
+        int expectedResult = 0;
+        for (int i = 0; i < 100; i++) {
+            expectedResult += i;
+        }
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testAsyncMapper() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i, i);
+        }
+
+        final Map<String, List<Integer>> listenerResults = new HashMap<String, List<Integer>>();
+        final Semaphore semaphore = new Semaphore(1);
+        semaphore.acquire();
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Map<String, List<Integer>>> future = job.mapper(new TestMapper()).submit();
+
+        future.andThen(new ExecutionCallback<Map<String, List<Integer>>>() {
+            @Override
+            public void onResponse(Map<String, List<Integer>> response) {
+                listenerResults.putAll(response);
+                semaphore.release();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                semaphore.release();
+            }
+        });
+
+        semaphore.acquire();
+
+        assertEquals(100, listenerResults.size());
+        for (List<Integer> value : listenerResults.values()) {
+            assertEquals(1, value.size());
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testKeyedAsyncMapper() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i, i);
+        }
+
+        final Map<String, List<Integer>> listenerResults = new HashMap<String, List<Integer>>();
+        final Semaphore semaphore = new Semaphore(1);
+        semaphore.acquire();
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Map<String, List<Integer>>> future = job.onKeys(50).mapper(new TestMapper()).submit();
+
+        future.andThen(new ExecutionCallback<Map<String, List<Integer>>>() {
+            @Override
+            public void onResponse(Map<String, List<Integer>> response) {
+                listenerResults.putAll(response);
+                semaphore.release();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                semaphore.release();
+            }
+        });
+
+        semaphore.acquire();
+
+        assertEquals(1, listenerResults.size());
+        for (List<Integer> value : listenerResults.values()) {
+            assertEquals(1, value.size());
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testAsyncMapperReducer() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i, i);
+        }
+
+        final Map<String, Integer> listenerResults = new HashMap<String, Integer>();
+        final Semaphore semaphore = new Semaphore(1);
+        semaphore.acquire();
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Map<String, Integer>> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
+                .submit();
+
+        future.andThen(new ExecutionCallback<Map<String, Integer>>() {
+            @Override
+            public void onResponse(Map<String, Integer> response) {
+                listenerResults.putAll(response);
+                semaphore.release();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                semaphore.release();
+            }
+        });
+
+        // Precalculate results
+        int[] expectedResults = new int[4];
+        for (int i = 0; i < 100; i++) {
+            int index = i % 4;
+            expectedResults[index] += i;
+        }
+
+        semaphore.acquire();
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedResults[i], (int) listenerResults.get(String.valueOf(i)));
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testAsyncMapperCollator() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i/2, i);
+        }
+
+        final int[] result = new int[1];
+        final Semaphore semaphore = new Semaphore(1);
+        semaphore.acquire();
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper())//
+                .submit(new GroupingTestCollator());
+
+        future.andThen(new ExecutionCallback<Integer>() {
+            @Override
+            public void onResponse(Integer response) {
+                result[0] = response.intValue();
+                semaphore.release();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                semaphore.release();
+            }
+        });
+
+        // Precalculate result
+        int expectedResult = 0;
+        for (int i = 0; i < 100; i++) {
+            expectedResult += i;
+        }
+
+        semaphore.acquire();
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedResult, result[0]);
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testAsyncMapperReducerCollator() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i/2, i);
+        }
+
+        final int[] result = new int[1];
+        final Semaphore semaphore = new Semaphore(1);
+        semaphore.acquire();
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).reducer(new TestReducerFactory())
+                .submit(new TestCollator());
+
+        future.andThen(new ExecutionCallback<Integer>() {
+            @Override
+            public void onResponse(Integer response) {
+                result[0] = response.intValue();
+                semaphore.release();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                semaphore.release();
+            }
+        });
+
+        // Precalculate result
+        int expectedResult = 0;
+        for (int i = 0; i < 100; i++) {
+            expectedResult += i;
+        }
+
+        semaphore.acquire();
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedResult, result[0]);
+        }
+    }
+
+    static KeyValueSource<Integer, Integer> integerKvSource(MultiMap<Integer, Integer> m) {
+        return KeyValueSource.fromMultiMap(m);
+    }
+
+    public static class ExceptionThrowingMapper
+            implements Mapper<Integer, Integer, String, Integer> {
+
+        @Override
+        public void map(Integer key, Integer value, Context<String, Integer> context) {
+            throw new NullPointerException("BUMM!");
+        }
+    }
+
+    public static class TimeConsumingMapper
+            implements Mapper<Integer, Integer, String, Integer> {
+
+        @Override
+        public void map(Integer key, Integer value, Context<String, Integer> collector) {
+            try {
+                Thread.sleep(1000);
+            } catch (Exception ignore) {
+            }
+            collector.emit(String.valueOf(key), value);
+        }
+    }
+
+    public static class TestKeyPredicate
+            implements KeyPredicate<Integer> {
+
+        @Override
+        public boolean evaluate(Integer key) {
+            return key == 50;
+        }
+    }
+
+    public static class TestMapper
+            implements Mapper<Integer, Integer, String, Integer> {
+
+        @Override
+        public void map(Integer key, Integer value, Context<String, Integer> collector) {
+            collector.emit(String.valueOf(key), value);
+        }
+    }
+
+    public static class GroupingTestMapper
+            implements Mapper<Integer, Integer, String, Integer> {
+
+        @Override
+        public void map(Integer key, Integer value, Context<String, Integer> collector) {
+            collector.emit(String.valueOf(key % 4), value);
+        }
+    }
+
+    public static class TestReducer
+            extends Reducer<Integer, Integer> {
+
+        private int sum = 0;
+
+        @Override
+        public void reduce(Integer value) {
+            sum += value;
+        }
+
+        @Override
+        public Integer finalizeReduce() {
+            return sum;
+        }
+    }
+
+    public static class TestReducerFactory
+            implements ReducerFactory<String, Integer, Integer> {
+
+        public TestReducerFactory() {
+        }
+
+        @Override
+        public Reducer<Integer, Integer> newReducer(String key) {
+            return new TestReducer();
+        }
+    }
+
+    public static class GroupingTestCollator
+            implements Collator<Map.Entry<String, List<Integer>>, Integer> {
+
+        @Override
+        public Integer collate(Iterable<Map.Entry<String, List<Integer>>> values) {
+            int sum = 0;
+            for (Map.Entry<String, List<Integer>> entry : values) {
+                for (Integer value : entry.getValue()) {
+                    sum += value;
+                }
+            }
+            return sum;
+        }
+    }
+
+    public static class TestCollator
+            implements Collator<Map.Entry<String, Integer>, Integer> {
+
+        @Override
+        public Integer collate(Iterable<Map.Entry<String, Integer>> values) {
+            int sum = 0;
+            for (Map.Entry<String, Integer> entry : values) {
+                sum += entry.getValue();
+            }
+            return sum;
+        }
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMultiMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMultiMapReduceTest.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.mapreduce;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.mapreduce.Collator;
+import com.hazelcast.mapreduce.Combiner;
+import com.hazelcast.mapreduce.CombinerFactory;
+import com.hazelcast.mapreduce.Context;
+import com.hazelcast.mapreduce.Job;
+import com.hazelcast.mapreduce.JobTracker;
+import com.hazelcast.mapreduce.Mapper;
+import com.hazelcast.mapreduce.Reducer;
+import com.hazelcast.mapreduce.ReducerFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+
+import static com.hazelcast.client.mapreduce.ClientMultiMapReduceTest.integerKvSource;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(NightlyTest.class)
+@SuppressWarnings("unused")
+public class DistributedMapperClientMultiMapReduceTest
+        extends AbstractClientMapReduceJobTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test(timeout = 120000)
+    public void testMapperReducer() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Map<String, Integer>> future = job.mapper(new GroupingTestMapper()).combiner(new TestCombinerFactory())
+                .reducer(new TestReducerFactory()).submit();
+
+        Map<String, Integer> result = future.get();
+
+        // Precalculate results
+        int[] expectedResults = new int[4];
+        for (int i = 0; i < 100; i++) {
+            int index = i % 4;
+            expectedResults[index] += i;
+        }
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedResults[i], (int) result.get(String.valueOf(i)));
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testMapperReducerCollator() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i/2, i);
+        }
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).combiner(new TestCombinerFactory())
+                .reducer(new TestReducerFactory()).submit(new TestCollator());
+
+        int result = future.get();
+
+        // Precalculate result
+        int expectedResult = 0;
+        for (int i = 0; i < 100; i++) {
+            expectedResult += i;
+        }
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedResult, result);
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testAsyncMapperReducer() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i, i);
+        }
+
+        final Map<String, Integer> listenerResults = new HashMap<String, Integer>();
+        final Semaphore semaphore = new Semaphore(1);
+        semaphore.acquire();
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Map<String, Integer>> future = job.mapper(new GroupingTestMapper()).combiner(new TestCombinerFactory())
+                .reducer(new TestReducerFactory()).submit();
+
+        future.andThen(new ExecutionCallback<Map<String, Integer>>() {
+            @Override
+            public void onResponse(Map<String, Integer> response) {
+                try {
+                    listenerResults.putAll(response);
+                } finally {
+                    semaphore.release();
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                semaphore.release();
+            }
+        });
+
+        // Precalculate results
+        int[] expectedResults = new int[4];
+        for (int i = 0; i < 100; i++) {
+            int index = i % 4;
+            expectedResults[index] += i;
+        }
+
+        semaphore.acquire();
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedResults[i], (int) listenerResults.get(String.valueOf(i)));
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void testAsyncMapperReducerCollator() throws Exception {
+        Config config = buildConfig();
+
+        HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
+        MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
+        for (int i = 0; i < 100; i++) {
+            m1.put(i/2, i);
+        }
+
+        final int[] result = new int[1];
+        final Semaphore semaphore = new Semaphore(1);
+        semaphore.acquire();
+
+        JobTracker tracker = client.getJobTracker("default");
+        Job<Integer, Integer> job = tracker.newJob(integerKvSource(m1));
+        ICompletableFuture<Integer> future = job.mapper(new GroupingTestMapper()).combiner(new TestCombinerFactory())
+                .reducer(new TestReducerFactory()).submit(new TestCollator());
+
+        future.andThen(new ExecutionCallback<Integer>() {
+            @Override
+            public void onResponse(Integer response) {
+                try {
+                    result[0] = response.intValue();
+                } finally {
+                    semaphore.release();
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                semaphore.release();
+            }
+        });
+
+        // Precalculate result
+        int expectedResult = 0;
+        for (int i = 0; i < 100; i++) {
+            expectedResult += i;
+        }
+
+        semaphore.acquire();
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedResult, result[0]);
+        }
+    }
+
+    public static class TestCombiner
+            extends Combiner<Integer, Integer> {
+
+        private transient int sum;
+
+        @Override
+        public void combine(Integer value) {
+            sum += value;
+        }
+
+        @Override
+        public Integer finalizeChunk() {
+            int v = sum;
+            sum = 0;
+            return v;
+        }
+    }
+
+    public static class TestCombinerFactory
+            implements CombinerFactory<String, Integer, Integer> {
+
+        public TestCombinerFactory() {
+        }
+
+        @Override
+        public Combiner<Integer, Integer> newCombiner(String key) {
+            return new TestCombiner();
+        }
+    }
+
+    public static class GroupingTestMapper
+            implements Mapper<Integer, Integer, String, Integer> {
+
+        @Override
+        public void map(Integer key, Integer value, Context<String, Integer> collector) {
+            collector.emit(String.valueOf(key % 4), value);
+        }
+    }
+
+    public static class TestReducer
+            extends Reducer<Integer, Integer> {
+
+        private int sum;
+
+        @Override
+        public void reduce(Integer value) {
+            sum += value;
+        }
+
+        @Override
+        public Integer finalizeReduce() {
+            return sum;
+        }
+    }
+
+    public static class TestReducerFactory
+            implements ReducerFactory<String, Integer, Integer> {
+
+        @Override
+        public Reducer<Integer, Integer> newReducer(String key) {
+            return new TestReducer();
+        }
+    }
+
+    public static class TestCollator
+            implements Collator<Map.Entry<String, Integer>, Integer> {
+
+        @Override
+        public Integer collate(Iterable<Map.Entry<String, Integer>> values) {
+            int sum = 0;
+            for (Map.Entry<String, Integer> entry : values) {
+                sum += entry.getValue();
+            }
+            return sum;
+        }
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AvgAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AvgAggregationMultiMapTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.mapreduce.aggregation;
+
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.mapreduce.aggregation.Aggregation;
+import com.hazelcast.mapreduce.aggregation.Aggregations;
+import com.hazelcast.mapreduce.aggregation.Supplier;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+@Ignore //https://github.com/hazelcast/hazelcast/issues/5916
+public class AvgAggregationMultiMapTest
+        extends AbstractAggregationTest {
+
+    @Test(timeout = 60000)
+    public void testBigDecimalAvg()
+            throws Exception {
+
+        BigDecimal[] values = buildPlainValues(new ValueProvider<BigDecimal>() {
+            @Override
+            public BigDecimal provideRandom(Random random) {
+                return BigDecimal.valueOf(10000.0D + random(1000, 2000));
+            }
+        }, BigDecimal.class);
+
+        BigDecimal expectation = BigDecimal.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            expectation = expectation.add(values[i]);
+        }
+        expectation = expectation.divide(BigDecimal.valueOf(values.length));
+
+        Aggregation<String, BigDecimal, BigDecimal> aggregation = Aggregations.bigDecimalAvg();
+        BigDecimal result = testAvg(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testBigIntegerAvg()
+            throws Exception {
+
+        BigInteger[] values = buildPlainValues(new ValueProvider<BigInteger>() {
+            @Override
+            public BigInteger provideRandom(Random random) {
+                return BigInteger.valueOf(10000L + random(1000, 2000));
+            }
+        }, BigInteger.class);
+
+        BigInteger expectation = BigInteger.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            expectation = expectation.add(values[i]);
+        }
+        expectation = expectation.divide(BigInteger.valueOf(values.length));
+
+        Aggregation<String, BigInteger, BigInteger> aggregation = Aggregations.bigIntegerAvg();
+        BigInteger result = testAvg(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testDoubleAvg()
+            throws Exception {
+
+        Double[] values = buildPlainValues(new ValueProvider<Double>() {
+            @Override
+            public Double provideRandom(Random random) {
+                return 10000.0D + random(1000, 2000);
+            }
+        }, Double.class);
+
+        double expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i];
+        }
+        expectation = expectation / values.length;
+
+        Aggregation<String, Double, Double> aggregation = Aggregations.doubleAvg();
+        double result = testAvg(values, aggregation);
+        assertEquals(expectation, result, 0.0);
+    }
+
+    @Test(timeout = 60000)
+    public void testIntegerAvg()
+            throws Exception {
+
+        Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
+            @Override
+            public Integer provideRandom(Random random) {
+                return random(1000, 2000);
+            }
+        }, Integer.class);
+
+        int expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i];
+        }
+        expectation = (int) ((double) expectation / values.length);
+
+        Aggregation<String, Integer, Integer> aggregation = Aggregations.integerAvg();
+        int result = testAvg(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testLongAvg()
+            throws Exception {
+
+        Long[] values = buildPlainValues(new ValueProvider<Long>() {
+            @Override
+            public Long provideRandom(Random random) {
+                return 10000L + random(1000, 2000);
+            }
+        }, Long.class);
+
+        long expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i];
+        }
+        expectation = (long) ((double) expectation / values.length);
+
+        Aggregation<String, Long, Long> aggregation = Aggregations.longAvg();
+        long result = testAvg(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testBigDecimalAvgWithExtractor()
+            throws Exception {
+
+        Value<BigDecimal>[] values = buildValues(new ValueProvider<BigDecimal>() {
+            @Override
+            public BigDecimal provideRandom(Random random) {
+                return BigDecimal.valueOf(10000.0D + random(1000, 2000));
+            }
+        });
+
+        BigDecimal expectation = BigDecimal.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            expectation = expectation.add(values[i].value);
+        }
+        expectation = expectation.divide(BigDecimal.valueOf(values.length));
+
+        Aggregation<String, BigDecimal, BigDecimal> aggregation = Aggregations.bigDecimalAvg();
+        BigDecimal result = testAvgWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testBigIntegerAvgWithExtractor()
+            throws Exception {
+
+        Value<BigInteger>[] values = buildValues(new ValueProvider<BigInteger>() {
+            @Override
+            public BigInteger provideRandom(Random random) {
+                return BigInteger.valueOf(10000L + random(1000, 2000));
+            }
+        });
+
+        BigInteger expectation = BigInteger.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            expectation = expectation.add(values[i].value);
+        }
+        expectation = expectation.divide(BigInteger.valueOf(values.length));
+
+        Aggregation<String, BigInteger, BigInteger> aggregation = Aggregations.bigIntegerAvg();
+        BigInteger result = testAvgWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testDoubleAvgWithExtractor()
+            throws Exception {
+
+        Value<Double>[] values = buildValues(new ValueProvider<Double>() {
+            @Override
+            public Double provideRandom(Random random) {
+                return 10000.0D + random(1000, 2000);
+            }
+        });
+
+        double expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i].value;
+        }
+        expectation = expectation / values.length;
+
+        Aggregation<String, Double, Double> aggregation = Aggregations.doubleAvg();
+        double result = testAvgWithExtractor(values, aggregation);
+        assertEquals(expectation, result, 0.0);
+    }
+
+    @Test(timeout = 60000)
+    public void testIntegerAvgWithExtractor()
+            throws Exception {
+
+        Value<Integer>[] values = buildValues(new ValueProvider<Integer>() {
+            @Override
+            public Integer provideRandom(Random random) {
+                return random(1000, 2000);
+            }
+        });
+
+        int expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i].value;
+        }
+        expectation = (int) ((double) expectation / values.length);
+
+        Aggregation<String, Integer, Integer> aggregation = Aggregations.integerAvg();
+        int result = testAvgWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testLongAvgWithExtractor()
+            throws Exception {
+
+        Value<Long>[] values = buildValues(new ValueProvider<Long>() {
+            @Override
+            public Long provideRandom(Random random) {
+                return 10000L + random(1000, 2000);
+            }
+        });
+
+        long expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i].value;
+        }
+        expectation = (long) ((double) expectation / values.length);
+
+        Aggregation<String, Long, Long> aggregation = Aggregations.longAvg();
+        long result = testAvgWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    private <T, R> R testAvg(T[] values, Aggregation<String, T, R> aggregation)
+            throws Exception {
+
+        String mapName = randomMapName();
+        MultiMap<String, T> map = client.getMultiMap(mapName);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, T, T> supplier = Supplier.all();
+        return map.aggregate(supplier, aggregation);
+    }
+
+    private <T, R> R testAvgWithExtractor(Value<T>[] values, Aggregation<String, T, R> aggregation)
+            throws Exception {
+
+        String mapName = randomMapName();
+        MultiMap<String, Value<T>> map = client.getMultiMap(mapName);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, Value<T>, T> supplier = Supplier.all(new ValuePropertyExtractor<T>());
+        return map.aggregate(supplier, aggregation);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/BaseAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/BaseAggregationMultiMapTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.mapreduce.aggregation;
+
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.mapreduce.aggregation.Aggregation;
+import com.hazelcast.mapreduce.aggregation.Aggregations;
+import com.hazelcast.mapreduce.aggregation.Supplier;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+@Ignore //https://github.com/hazelcast/hazelcast/issues/5916
+public class BaseAggregationMultiMapTest
+        extends AbstractAggregationTest {
+
+    @Test
+    public void testCountAggregation()
+            throws Exception {
+
+        String mapName = randomMapName();
+        MultiMap<String, Integer> map = client.getMultiMap(mapName);
+
+        Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
+            @Override
+            public Integer provideRandom(Random random) {
+                return random(1000, 2000);
+            }
+        }, Integer.class);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, Integer, Object> supplier = Supplier.all();
+        Aggregation<String, Object, Long> aggregation = Aggregations.count();
+        long count = map.aggregate(supplier, aggregation);
+        assertEquals(values.length, count);
+    }
+
+    @Test
+    public void testDistinctValuesAggregation()
+            throws Exception {
+
+        final String[] probes = {"Dog", "Food", "Champion", "Hazelcast", "Security", "Integer", "Random", "System"};
+        Set<String> expectation = new HashSet<String>(Arrays.asList(probes));
+
+        String mapName = randomMapName();
+        MultiMap<String, String> map = client.getMultiMap(mapName);
+
+        String[] values = buildPlainValues(new ValueProvider<String>() {
+            @Override
+            public String provideRandom(Random random) {
+                int index = random.nextInt(probes.length);
+                return probes[index];
+            }
+        }, String.class);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, String, String> supplier = Supplier.all();
+        Aggregation<String, String, Set<String>> aggregation = Aggregations.distinctValues();
+        Set<String> distinctValues = map.aggregate(supplier, aggregation);
+        assertEquals(expectation, distinctValues);
+
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MaxAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MaxAggregationMultiMapTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.mapreduce.aggregation;
+
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.mapreduce.aggregation.Aggregation;
+import com.hazelcast.mapreduce.aggregation.Aggregations;
+import com.hazelcast.mapreduce.aggregation.Supplier;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+@Ignore //https://github.com/hazelcast/hazelcast/issues/5916
+public class MaxAggregationMultiMapTest
+        extends AbstractAggregationTest {
+
+    @Test(timeout = 60000)
+    public void testBigDecimalMax()
+            throws Exception {
+
+        BigDecimal[] values = buildPlainValues(new ValueProvider<BigDecimal>() {
+            @Override
+            public BigDecimal provideRandom(Random random) {
+                return BigDecimal.valueOf(10000.0D + random(1000, 2000));
+            }
+        }, BigDecimal.class);
+
+        BigDecimal expectation = BigDecimal.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            BigDecimal value = values[i];
+            expectation = i == 0 ? value : expectation.max(value);
+        }
+
+        Aggregation<String, BigDecimal, BigDecimal> aggregation = Aggregations.bigDecimalMax();
+        BigDecimal result = testMax(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testBigIntegerMax()
+            throws Exception {
+
+        BigInteger[] values = buildPlainValues(new ValueProvider<BigInteger>() {
+            @Override
+            public BigInteger provideRandom(Random random) {
+                return BigInteger.valueOf(10000L + random(1000, 2000));
+            }
+        }, BigInteger.class);
+
+        BigInteger expectation = BigInteger.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            BigInteger value = values[i];
+            expectation = i == 0 ? value : expectation.max(value);
+        }
+
+        Aggregation<String, BigInteger, BigInteger> aggregation = Aggregations.bigIntegerMax();
+        BigInteger result = testMax(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testDoubleMax()
+            throws Exception {
+
+        Double[] values = buildPlainValues(new ValueProvider<Double>() {
+            @Override
+            public Double provideRandom(Random random) {
+                return 10000.0D + random(1000, 2000);
+            }
+        }, Double.class);
+
+        double expectation = -Double.MAX_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            double value = values[i];
+            if (value > expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Double, Double> aggregation = Aggregations.doubleMax();
+        double result = testMax(values, aggregation);
+        assertEquals(expectation, result, 0.0);
+    }
+
+    @Test(timeout = 60000)
+    public void testIntegerMax()
+            throws Exception {
+
+        Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
+            @Override
+            public Integer provideRandom(Random random) {
+                return random(1000, 2000);
+            }
+        }, Integer.class);
+
+        int expectation = Integer.MIN_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            int value = values[i];
+            if (value > expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Integer, Integer> aggregation = Aggregations.integerMax();
+        int result = testMax(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testLongMax()
+            throws Exception {
+
+        Long[] values = buildPlainValues(new ValueProvider<Long>() {
+            @Override
+            public Long provideRandom(Random random) {
+                return 10000L + random(1000, 2000);
+            }
+        }, Long.class);
+
+        long expectation = Long.MIN_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            long value = values[i];
+            if (value > expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Long, Long> aggregation = Aggregations.longMax();
+        long result = testMax(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testBigDecimalMaxWithExtractor()
+            throws Exception {
+
+        Value<BigDecimal>[] values = buildValues(new ValueProvider<BigDecimal>() {
+            @Override
+            public BigDecimal provideRandom(Random random) {
+                return BigDecimal.valueOf(10000.0D + random(1000, 2000));
+            }
+        });
+
+        BigDecimal expectation = BigDecimal.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            Value<BigDecimal> value = values[i];
+            expectation = i == 0 ? value.value : expectation.max(value.value);
+        }
+
+        Aggregation<String, BigDecimal, BigDecimal> aggregation = Aggregations.bigDecimalMax();
+        BigDecimal result = testMaxWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testBigIntegerMaxWithExtractor()
+            throws Exception {
+
+        Value<BigInteger>[] values = buildValues(new ValueProvider<BigInteger>() {
+            @Override
+            public BigInteger provideRandom(Random random) {
+                return BigInteger.valueOf(10000L + random(1000, 2000));
+            }
+        });
+
+        BigInteger expectation = BigInteger.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            Value<BigInteger> value = values[i];
+            expectation = i == 0 ? value.value : expectation.max(value.value);
+        }
+
+        Aggregation<String, BigInteger, BigInteger> aggregation = Aggregations.bigIntegerMax();
+        BigInteger result = testMaxWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testDoubleMaxWithExtractor()
+            throws Exception {
+
+        Value<Double>[] values = buildValues(new ValueProvider<Double>() {
+            @Override
+            public Double provideRandom(Random random) {
+                return 10000.0D + random(1000, 2000);
+            }
+        });
+
+        double expectation = -Double.MAX_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            double value = values[i].value;
+            if (value > expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Double, Double> aggregation = Aggregations.doubleMax();
+        double result = testMaxWithExtractor(values, aggregation);
+        assertEquals(expectation, result, 0.0);
+    }
+
+    @Test(timeout = 60000)
+    public void testIntegerMaxWithExtractor()
+            throws Exception {
+
+        Value<Integer>[] values = buildValues(new ValueProvider<Integer>() {
+            @Override
+            public Integer provideRandom(Random random) {
+                return random(1000, 2000);
+            }
+        });
+
+        int expectation = Integer.MIN_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            int value = values[i].value;
+            if (value > expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Integer, Integer> aggregation = Aggregations.integerMax();
+        int result = testMaxWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testLongMaxWithExtractor()
+            throws Exception {
+
+        Value<Long>[] values = buildValues(new ValueProvider<Long>() {
+            @Override
+            public Long provideRandom(Random random) {
+                return 10000L + random(1000, 2000);
+            }
+        });
+
+        long expectation = Long.MIN_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            long value = values[i].value;
+            if (value > expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Long, Long> aggregation = Aggregations.longMax();
+        long result = testMaxWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    private <T, R> R testMax(T[] values, Aggregation<String, T, R> aggregation)
+            throws Exception {
+
+        String mapName = randomMapName();
+        MultiMap<String, T> map = client.getMultiMap(mapName);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, T, T> supplier = Supplier.all();
+        return map.aggregate(supplier, aggregation);
+    }
+
+    private <T, R> R testMaxWithExtractor(Value<T>[] values, Aggregation<String, T, R> aggregation)
+            throws Exception {
+
+        String mapName = randomMapName();
+        MultiMap<String, Value<T>> map = client.getMultiMap(mapName);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, Value<T>, T> supplier = Supplier.all(new ValuePropertyExtractor<T>());
+        return map.aggregate(supplier, aggregation);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MinAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MinAggregationMultiMapTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.mapreduce.aggregation;
+
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.mapreduce.aggregation.Aggregation;
+import com.hazelcast.mapreduce.aggregation.Aggregations;
+import com.hazelcast.mapreduce.aggregation.Supplier;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+@Ignore //https://github.com/hazelcast/hazelcast/issues/5916
+public class MinAggregationMultiMapTest
+        extends AbstractAggregationTest {
+
+    @Test(timeout = 60000)
+    public void testBigDecimalMin()
+            throws Exception {
+
+        BigDecimal[] values = buildPlainValues(new ValueProvider<BigDecimal>() {
+            @Override
+            public BigDecimal provideRandom(Random random) {
+                return BigDecimal.valueOf(10000.0D + random(1000, 2000));
+            }
+        }, BigDecimal.class);
+
+        BigDecimal expectation = BigDecimal.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            BigDecimal value = values[i];
+            expectation = i == 0 ? value : expectation.min(value);
+        }
+
+        Aggregation<String, BigDecimal, BigDecimal> aggregation = Aggregations.bigDecimalMin();
+        BigDecimal result = testMin(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testBigIntegerMin()
+            throws Exception {
+
+        BigInteger[] values = buildPlainValues(new ValueProvider<BigInteger>() {
+            @Override
+            public BigInteger provideRandom(Random random) {
+                return BigInteger.valueOf(10000L + random(1000, 2000));
+            }
+        }, BigInteger.class);
+
+        BigInteger expectation = BigInteger.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            BigInteger value = values[i];
+            expectation = i == 0 ? value : expectation.min(value);
+        }
+
+        Aggregation<String, BigInteger, BigInteger> aggregation = Aggregations.bigIntegerMin();
+        BigInteger result = testMin(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testDoubleMin()
+            throws Exception {
+
+        Double[] values = buildPlainValues(new ValueProvider<Double>() {
+            @Override
+            public Double provideRandom(Random random) {
+                return 10000.0D + random(1000, 2000);
+            }
+        }, Double.class);
+
+        double expectation = Double.MAX_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            double value = values[i];
+            if (value < expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Double, Double> aggregation = Aggregations.doubleMin();
+        double result = testMin(values, aggregation);
+        assertEquals(expectation, result, 0.0);
+    }
+
+    @Test(timeout = 60000)
+    public void testIntegerMin()
+            throws Exception {
+
+        Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
+            @Override
+            public Integer provideRandom(Random random) {
+                return random(1000, 2000);
+            }
+        }, Integer.class);
+
+        int expectation = Integer.MAX_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            int value = values[i];
+            if (value < expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Integer, Integer> aggregation = Aggregations.integerMin();
+        int result = testMin(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testLongMin()
+            throws Exception {
+
+        Long[] values = buildPlainValues(new ValueProvider<Long>() {
+            @Override
+            public Long provideRandom(Random random) {
+                return 10000L + random(1000, 2000);
+            }
+        }, Long.class);
+
+        long expectation = Long.MAX_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            long value = values[i];
+            if (value < expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Long, Long> aggregation = Aggregations.longMin();
+        long result = testMin(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testBigDecimalMinWithExtractor()
+            throws Exception {
+
+        Value<BigDecimal>[] values = buildValues(new ValueProvider<BigDecimal>() {
+            @Override
+            public BigDecimal provideRandom(Random random) {
+                return BigDecimal.valueOf(10000.0D + random(1000, 2000));
+            }
+        });
+
+        BigDecimal expectation = BigDecimal.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            Value<BigDecimal> value = values[i];
+            expectation = i == 0 ? value.value : expectation.min(value.value);
+        }
+
+        Aggregation<String, BigDecimal, BigDecimal> aggregation = Aggregations.bigDecimalMin();
+        BigDecimal result = testMinWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testBigIntegerMinWithExtractor()
+            throws Exception {
+
+        Value<BigInteger>[] values = buildValues(new ValueProvider<BigInteger>() {
+            @Override
+            public BigInteger provideRandom(Random random) {
+                return BigInteger.valueOf(10000L + random(1000, 2000));
+            }
+        });
+
+        BigInteger expectation = BigInteger.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            Value<BigInteger> value = values[i];
+            expectation = i == 0 ? value.value : expectation.min(value.value);
+        }
+
+        Aggregation<String, BigInteger, BigInteger> aggregation = Aggregations.bigIntegerMin();
+        BigInteger result = testMinWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testDoubleMinWithExtractor()
+            throws Exception {
+
+        Value<Double>[] values = buildValues(new ValueProvider<Double>() {
+            @Override
+            public Double provideRandom(Random random) {
+                return 10000.0D + random(1000, 2000);
+            }
+        });
+
+        double expectation = Double.MAX_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            double value = values[i].value;
+            if (value < expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Double, Double> aggregation = Aggregations.doubleMin();
+        double result = testMinWithExtractor(values, aggregation);
+        assertEquals(expectation, result, 0.0);
+    }
+
+    @Test(timeout = 60000)
+    public void testIntegerMinWithExtractor()
+            throws Exception {
+
+        Value<Integer>[] values = buildValues(new ValueProvider<Integer>() {
+            @Override
+            public Integer provideRandom(Random random) {
+                return random(1000, 2000);
+            }
+        });
+
+        int expectation = Integer.MAX_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            int value = values[i].value;
+            if (value < expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Integer, Integer> aggregation = Aggregations.integerMin();
+        int result = testMinWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test(timeout = 60000)
+    public void testLongMinWithExtractor()
+            throws Exception {
+
+        Value<Long>[] values = buildValues(new ValueProvider<Long>() {
+            @Override
+            public Long provideRandom(Random random) {
+                return 10000L + random(1000, 2000);
+            }
+        });
+
+        long expectation = Long.MAX_VALUE;
+        for (int i = 0; i < values.length; i++) {
+            long value = values[i].value;
+            if (value < expectation) {
+                expectation = value;
+            }
+        }
+
+        Aggregation<String, Long, Long> aggregation = Aggregations.longMin();
+        long result = testMinWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    private <T, R> R testMin(T[] values, Aggregation<String, T, R> aggregation)
+            throws Exception {
+
+        String mapName = randomMapName();
+        MultiMap<String, T> map = client.getMultiMap(mapName);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, T, T> supplier = Supplier.all();
+        return map.aggregate(supplier, aggregation);
+    }
+
+    private <T, R> R testMinWithExtractor(Value<T>[] values, Aggregation<String, T, R> aggregation)
+            throws Exception {
+
+        String mapName = randomMapName();
+        MultiMap<String, Value<T>> map = client.getMultiMap(mapName);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, Value<T>, T> supplier = Supplier.all(new ValuePropertyExtractor<T>());
+        return map.aggregate(supplier, aggregation);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MultiMapAggregationLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MultiMapAggregationLiteMemberTest.java
@@ -1,0 +1,91 @@
+package com.hazelcast.client.mapreduce.aggregation;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.mapreduce.aggregation.Aggregation;
+import com.hazelcast.mapreduce.aggregation.Aggregations;
+import com.hazelcast.mapreduce.aggregation.Supplier;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MultiMapAggregationLiteMemberTest extends HazelcastTestSupport {
+
+    private TestHazelcastFactory factory;
+
+    private HazelcastInstance client;
+
+    @Before
+    public void before() {
+        factory = new TestHazelcastFactory();
+        final HazelcastInstance lite = factory.newHazelcastInstance(new Config().setLiteMember(true));
+        final HazelcastInstance instance1 = factory.newHazelcastInstance();
+        final HazelcastInstance instance2 = factory.newHazelcastInstance();
+
+        assertClusterSizeEventually(3, lite);
+        assertClusterSizeEventually(3, instance1);
+        assertClusterSizeEventually(3, instance2);
+
+        client = factory.newHazelcastClient();
+    }
+
+    @After
+    public void after() {
+        factory.terminateAll();
+    }
+
+    @Test(timeout = 60000)
+    public void testMaxAggregation() {
+        testMaxAggregation(client);
+    }
+
+
+    public static void testMaxAggregation(final HazelcastInstance instance) {
+        final int size = 2000;
+        List<Integer> numbers = new ArrayList<Integer>(size);
+        for (int i = 0; i < size; i++) {
+            numbers.add(i);
+        }
+
+        Collections.shuffle(numbers);
+        numbers = numbers.subList(0, 1000);
+        final Integer expected = Collections.max(numbers);
+
+        final MultiMap<Integer, Integer> map = instance.getMultiMap(randomMapName());
+        for (Integer number : numbers) {
+            map.put(number / 2, number);
+        }
+
+        final Aggregation<Integer, Integer, Integer> maxAggregation = Aggregations.integerMax();
+        final Integer max = map.aggregate(new ValueSupplier(), maxAggregation);
+
+        assertEquals(expected, max);
+    }
+
+    public static class ValueSupplier extends Supplier<Integer, Integer, Integer> implements Serializable {
+
+        @Override
+        public Integer apply(Map.Entry<Integer, Integer> entry) {
+            return entry.getValue();
+        }
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/SumAggregationMultiMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/SumAggregationMultiMapTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.mapreduce.aggregation;
+
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.mapreduce.aggregation.Aggregation;
+import com.hazelcast.mapreduce.aggregation.Aggregations;
+import com.hazelcast.mapreduce.aggregation.Supplier;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+@Ignore //https://github.com/hazelcast/hazelcast/issues/5096
+public class SumAggregationMultiMapTest
+        extends AbstractAggregationTest {
+
+    @Test
+    public void testBigDecimalSum()
+            throws Exception {
+
+        BigDecimal[] values = buildPlainValues(new ValueProvider<BigDecimal>() {
+            @Override
+            public BigDecimal provideRandom(Random random) {
+                return BigDecimal.valueOf(10000.0D + random(1000, 2000));
+            }
+        }, BigDecimal.class);
+
+        BigDecimal expectation = BigDecimal.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            expectation = expectation.add(values[i]);
+        }
+
+        Aggregation<String, BigDecimal, BigDecimal> aggregation = Aggregations.bigDecimalSum();
+        BigDecimal result = testSum(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test
+    public void testBigIntegerSum()
+            throws Exception {
+
+        BigInteger[] values = buildPlainValues(new ValueProvider<BigInteger>() {
+            @Override
+            public BigInteger provideRandom(Random random) {
+                return BigInteger.valueOf(10000L + random(1000, 2000));
+            }
+        }, BigInteger.class);
+
+        BigInteger expectation = BigInteger.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            expectation = expectation.add(values[i]);
+        }
+
+        Aggregation<String, BigInteger, BigInteger> aggregation = Aggregations.bigIntegerSum();
+        BigInteger result = testSum(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test
+    public void testDoubleSum()
+            throws Exception {
+
+        Double[] values = buildPlainValues(new ValueProvider<Double>() {
+            @Override
+            public Double provideRandom(Random random) {
+                return 10000.0D + random(1000, 2000);
+            }
+        }, Double.class);
+
+        double expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i];
+        }
+
+        Aggregation<String, Double, Double> aggregation = Aggregations.doubleSum();
+        double result = testSum(values, aggregation);
+        assertEquals(expectation, result, 0.0);
+    }
+
+    @Test
+    public void testIntegerSum()
+            throws Exception {
+
+        Integer[] values = buildPlainValues(new ValueProvider<Integer>() {
+            @Override
+            public Integer provideRandom(Random random) {
+                return random(1000, 2000);
+            }
+        }, Integer.class);
+
+        int expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i];
+        }
+
+        Aggregation<String, Integer, Integer> aggregation = Aggregations.integerSum();
+        int result = testSum(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test
+    public void testLongSum()
+            throws Exception {
+
+        Long[] values = buildPlainValues(new ValueProvider<Long>() {
+            @Override
+            public Long provideRandom(Random random) {
+                return 10000L + random(1000, 2000);
+            }
+        }, Long.class);
+
+        long expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i];
+        }
+
+        Aggregation<String, Long, Long> aggregation = Aggregations.longSum();
+        long result = testSum(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test
+    public void testBigDecimalSumWithExtractor()
+            throws Exception {
+
+        Value<BigDecimal>[] values = buildValues(new ValueProvider<BigDecimal>() {
+            @Override
+            public BigDecimal provideRandom(Random random) {
+                return BigDecimal.valueOf(10000.0D + random(1000, 2000));
+            }
+        });
+
+        BigDecimal expectation = BigDecimal.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            expectation = expectation.add(values[i].value);
+        }
+
+        Aggregation<String, BigDecimal, BigDecimal> aggregation = Aggregations.bigDecimalSum();
+        BigDecimal result = testSumWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test
+    public void testBigIntegerSumWithExtractor()
+            throws Exception {
+
+        Value<BigInteger>[] values = buildValues(new ValueProvider<BigInteger>() {
+            @Override
+            public BigInteger provideRandom(Random random) {
+                return BigInteger.valueOf(10000L + random(1000, 2000));
+            }
+        });
+
+        BigInteger expectation = BigInteger.ZERO;
+        for (int i = 0; i < values.length; i++) {
+            expectation = expectation.add(values[i].value);
+        }
+
+        Aggregation<String, BigInteger, BigInteger> aggregation = Aggregations.bigIntegerSum();
+        BigInteger result = testSumWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test
+    public void testDoubleSumWithExtractor()
+            throws Exception {
+
+        Value<Double>[] values = buildValues(new ValueProvider<Double>() {
+            @Override
+            public Double provideRandom(Random random) {
+                return 10000.0D + random(1000, 2000);
+            }
+        });
+
+        double expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i].value;
+        }
+
+        Aggregation<String, Double, Double> aggregation = Aggregations.doubleSum();
+        double result = testSumWithExtractor(values, aggregation);
+        assertEquals(expectation, result, 0.0);
+    }
+
+    @Test
+    public void testIntegerSumWithExtractor()
+            throws Exception {
+
+        Value<Integer>[] values = buildValues(new ValueProvider<Integer>() {
+            @Override
+            public Integer provideRandom(Random random) {
+                return random(1000, 2000);
+            }
+        });
+
+        int expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i].value;
+        }
+
+        Aggregation<String, Integer, Integer> aggregation = Aggregations.integerSum();
+        int result = testSumWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    @Test
+    public void testLongSumWithExtractor()
+            throws Exception {
+
+        Value<Long>[] values = buildValues(new ValueProvider<Long>() {
+            @Override
+            public Long provideRandom(Random random) {
+                return 10000L + random(1000, 2000);
+            }
+        });
+
+        long expectation = 0;
+        for (int i = 0; i < values.length; i++) {
+            expectation += values[i].value;
+        }
+
+        Aggregation<String, Long, Long> aggregation = Aggregations.longSum();
+        long result = testSumWithExtractor(values, aggregation);
+        assertEquals(expectation, result);
+    }
+
+    private <T, R> R testSum(T[] values, Aggregation<String, T, R> aggregation)
+            throws Exception {
+
+        String mapName = randomMapName();
+        MultiMap<String, T> map = client.getMultiMap(mapName);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, T, T> supplier = Supplier.all();
+        return map.aggregate(supplier, aggregation);
+    }
+
+    private <T, R> R testSumWithExtractor(Value<T>[] values, Aggregation<String, T, R> aggregation)
+            throws Exception {
+
+        String mapName = randomMapName();
+        MultiMap<String, Value<T>> map = client.getMultiMap(mapName);
+
+        for (int i = 0; i < values.length; i++) {
+            map.put("key-" + (i/2), values[i]);
+        }
+
+        Supplier<String, Value<T>, T> supplier = Supplier.all(new ValuePropertyExtractor<T>());
+        return map.aggregate(supplier, aggregation);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMultiMapMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/mapreduce/MapReduceForMultiMapMessageTask.java
@@ -24,7 +24,7 @@ import com.hazelcast.mapreduce.KeyPredicate;
 import com.hazelcast.mapreduce.KeyValueSource;
 import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.ReducerFactory;
-import com.hazelcast.mapreduce.impl.MapKeyValueSource;
+import com.hazelcast.mapreduce.impl.MultiMapKeyValueSource;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 
@@ -56,7 +56,7 @@ public class MapReduceForMultiMapMessageTask
 
     @Override
     protected KeyValueSource getKeyValueSource() {
-        return new MapKeyValueSource(parameters.multiMapName);
+        return new MultiMapKeyValueSource(parameters.multiMapName);
     }
 
     @Override


### PR DESCRIPTION
based on #8959 for the master branch, fixes #8876 