### PR TITLE
Added clear near-cache invalidation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAllPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapAllPartitionsMessageTask.java
@@ -45,6 +45,6 @@ abstract class AbstractMapAllPartitionsMessageTask<P> extends AbstractAllPartiti
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         NearCacheProvider nearCacheProvider = mapServiceContext.getNearCacheProvider();
         NearCacheInvalidator nearCacheInvalidator = nearCacheProvider.getNearCacheInvalidator();
-        nearCacheInvalidator.invalidate(null, mapName, getEndpoint().getUuid());
+        nearCacheInvalidator.clear(mapName, getEndpoint().getUuid());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
@@ -49,8 +49,7 @@ public class NearCacheProvider {
     protected final NearCacheManager nearCacheManager;
     protected final MapServiceContext mapServiceContext;
     protected final NodeEngine nodeEngine;
-
-    private final NearCacheInvalidator nearCacheInvalidator;
+    protected final NearCacheInvalidator nearCacheInvalidator;
 
     public NearCacheProvider(MapServiceContext mapServiceContext) {
         this(mapServiceContext, new DefaultNearCacheManager());
@@ -60,13 +59,7 @@ public class NearCacheProvider {
         this.nearCacheManager = nearCacheManager;
         this.mapServiceContext = mapServiceContext;
         this.nodeEngine = mapServiceContext.getNodeEngine();
-        this.nearCacheInvalidator = createNearCacheInvalidator(mapServiceContext);
-    }
-
-    private NearCacheInvalidator createNearCacheInvalidator(MapServiceContext mapServiceContext) {
-        return isBatchingEnabled()
-                ? new BatchInvalidator(mapServiceContext, this)
-                : new NonStopInvalidator(mapServiceContext, this);
+        this.nearCacheInvalidator = isBatchingEnabled() ? new BatchInvalidator(nodeEngine) : new NonStopInvalidator(nodeEngine);
     }
 
     private boolean isBatchingEnabled() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/BatchNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/BatchNearCacheInvalidation.java
@@ -28,16 +28,12 @@ import static java.util.Collections.emptyList;
 
 public class BatchNearCacheInvalidation extends Invalidation {
 
-    private List<SingleNearCacheInvalidation> invalidations;
+    private List<Invalidation> invalidations = emptyList();
 
     public BatchNearCacheInvalidation() {
     }
 
-    public BatchNearCacheInvalidation(int size, String mapName) {
-        this(new ArrayList<SingleNearCacheInvalidation>(size), mapName);
-    }
-
-    public BatchNearCacheInvalidation(List<SingleNearCacheInvalidation> invalidations, String mapName) {
+    public BatchNearCacheInvalidation(List<Invalidation> invalidations, String mapName) {
         super(mapName);
 
         this.invalidations = checkNotNull(invalidations, "invalidations cannot be null");
@@ -48,11 +44,11 @@ public class BatchNearCacheInvalidation extends Invalidation {
         invalidationHandler.handle(this);
     }
 
-    public void add(SingleNearCacheInvalidation invalidation) {
+    public void add(Invalidation invalidation) {
         invalidations.add(invalidation);
     }
 
-    public List<SingleNearCacheInvalidation> getInvalidations() {
+    public List<Invalidation> getInvalidations() {
         return invalidations;
     }
 
@@ -61,8 +57,8 @@ public class BatchNearCacheInvalidation extends Invalidation {
         super.writeData(out);
 
         out.writeInt(invalidations.size());
-        for (SingleNearCacheInvalidation singleNearCacheInvalidation : invalidations) {
-            singleNearCacheInvalidation.writeData(out);
+        for (Invalidation invalidation : invalidations) {
+            out.writeObject(invalidation);
         }
     }
 
@@ -72,23 +68,19 @@ public class BatchNearCacheInvalidation extends Invalidation {
 
         int size = in.readInt();
         if (size != 0) {
-            List<SingleNearCacheInvalidation> invalidations = new ArrayList<SingleNearCacheInvalidation>(size);
+            List<Invalidation> invalidations = new ArrayList<Invalidation>(size);
             for (int i = 0; i < size; i++) {
-                SingleNearCacheInvalidation invalidation = new SingleNearCacheInvalidation();
-                invalidation.readData(in);
-
+                Invalidation invalidation = in.readObject();
                 invalidations.add(invalidation);
             }
             this.invalidations = invalidations;
-        } else {
-            this.invalidations = emptyList();
         }
     }
 
     @Override
     public String toString() {
         StringBuilder str = new StringBuilder();
-        for (SingleNearCacheInvalidation invalidation : invalidations) {
+        for (Invalidation invalidation : invalidations) {
             str.append(invalidation.toString());
         }
         return str.toString();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/ClearNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/ClearNearCacheInvalidation.java
@@ -18,32 +18,25 @@ package com.hazelcast.map.impl.nearcache.invalidation;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
- * Represents a single key invalidation.
+ * Represents a clear invalidation event.
  */
-public class SingleNearCacheInvalidation extends Invalidation {
+public class ClearNearCacheInvalidation extends Invalidation {
 
-    private Data key;
     private String sourceUuid;
 
-    public SingleNearCacheInvalidation() {
+    public ClearNearCacheInvalidation() {
     }
 
-    public SingleNearCacheInvalidation(Data key, String mapName, String sourceUuid) {
+    public ClearNearCacheInvalidation(String mapName, String sourceUuid) {
         super(mapName);
 
-        this.key = checkNotNull(key, "key cannot be null");
         this.sourceUuid = checkNotNull(sourceUuid, "sourceUuid cannot be null");
-    }
-
-    public Data getKey() {
-        return key;
     }
 
     @Override
@@ -61,7 +54,6 @@ public class SingleNearCacheInvalidation extends Invalidation {
         super.writeData(out);
 
         out.writeUTF(sourceUuid);
-        out.writeData(key);
     }
 
     @Override
@@ -69,15 +61,13 @@ public class SingleNearCacheInvalidation extends Invalidation {
         super.readData(in);
 
         sourceUuid = in.readUTF();
-        key = in.readData();
     }
 
     @Override
     public String toString() {
-        return "SingleNearCacheInvalidation{"
+        return "ClearNearCacheInvalidation{"
                 + "mapName='" + mapName + '\''
                 + ", sourceUuid='" + sourceUuid + '\''
-                + ", key='" + key + '\''
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/Invalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/Invalidation.java
@@ -71,5 +71,4 @@ public abstract class Invalidation implements IMapEvent, DataSerializable {
     public void readData(ObjectDataInput in) throws IOException {
         mapName = in.readUTF();
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationHandler.java
@@ -22,6 +22,13 @@ package com.hazelcast.map.impl.nearcache.invalidation;
 public interface InvalidationHandler {
 
     /**
+     * Handles a single key invalidation
+     *
+     * @param invalidation invalidation event
+     */
+    void handle(SingleNearCacheInvalidation invalidation);
+
+    /**
      * Handles batch invalidations
      *
      * @param invalidation invalidation event
@@ -29,9 +36,9 @@ public interface InvalidationHandler {
     void handle(BatchNearCacheInvalidation invalidation);
 
     /**
-     * Handles a single invalidation
+     * Handles clear near-cache invalidation
      *
      * @param invalidation invalidation event
      */
-    void handle(SingleNearCacheInvalidation invalidation);
+    void handle(ClearNearCacheInvalidation invalidation);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/NearCacheInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/NearCacheInvalidator.java
@@ -27,13 +27,21 @@ import com.hazelcast.spi.ManagedService;
 public interface NearCacheInvalidator {
 
     /**
-     * Invalidates supplied key from this maps near-caches.
+     * Invalidates supplied key from near-caches of supplied map name.
      *
-     * @param key        key of the entry to be removed from near-cache.
-     * @param mapName    name of the map.
+     * @param key        key of the entry to be removed from near-cache
+     * @param mapName    name of the map to be invalidated
      * @param sourceUuid caller uuid
      */
     void invalidate(Data key, String mapName, String sourceUuid);
+
+    /**
+     * Invalidates all keys from near-caches of supplied map name.
+     *
+     * @param mapName    name of the map to be cleared
+     * @param sourceUuid caller  uuid
+     */
+    void clear(String mapName, String sourceUuid);
 
     /**
      * Removes supplied maps invalidation queue and flushes its content.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -910,7 +910,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     protected void sendNearCacheClearEvent() {
         NearCacheProvider nearCacheProvider = mapServiceContext.getNearCacheProvider();
         NearCacheInvalidator nearCacheInvalidator = nearCacheProvider.getNearCacheInvalidator();
-        nearCacheInvalidator.invalidate(null, name, localMemberUuid);
+        nearCacheInvalidator.clear(name, localMemberUuid);
     }
 
     public String addMapInterceptorInternal(MapInterceptor interceptor) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/BatchNearCacheInvalidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/BatchNearCacheInvalidationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache.invalidation;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BatchNearCacheInvalidationTest extends HazelcastTestSupport {
+
+    HazelcastInstance node = createHazelcastInstance();
+    InternalSerializationService ss = getSerializationService(node);
+
+    @Test
+    public void equals_itself_after_deserialization() throws Exception {
+        Data key = ss.toData("key");
+        String mapName = "mapName";
+        String sourceUuid = "sourceUuid";
+
+        List<Invalidation> invalidations = new ArrayList<Invalidation>();
+        invalidations.add(new SingleNearCacheInvalidation(key, mapName, sourceUuid));
+        invalidations.add(new ClearNearCacheInvalidation(mapName, sourceUuid));
+
+        BatchNearCacheInvalidation batch = new BatchNearCacheInvalidation(invalidations, mapName);
+
+
+        Data data = ss.toData(batch);
+        Object object = ss.toObject(data);
+
+        assertInstanceOf(BatchNearCacheInvalidation.class, object);
+
+        List<Invalidation> actualInvalidations = ((BatchNearCacheInvalidation) object).getInvalidations();
+        assertDeserializedEqualsExpected(key, mapName, sourceUuid, actualInvalidations);
+    }
+
+    private void assertDeserializedEqualsExpected(Data key, String mapName, String sourceUuid, List<Invalidation> invalidations) {
+        for (Invalidation invalidation : invalidations) {
+
+            if (invalidation instanceof SingleNearCacheInvalidation) {
+                assertEquals(key, ((SingleNearCacheInvalidation) invalidation).getKey());
+            }
+
+            assertEquals(mapName, invalidation.getName());
+            assertEquals(sourceUuid, invalidation.getSourceUuid());
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/NonStopInvalidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/NonStopInvalidatorTest.java
@@ -1,7 +1,5 @@
 package com.hazelcast.map.impl.nearcache.invalidation;
 
-import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.map.impl.nearcache.NearCacheProvider;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -14,7 +12,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -28,13 +25,7 @@ public class NonStopInvalidatorTest {
         key = mock(Data.class);
 
         NodeEngine nodeEngine = mock(NodeEngine.class);
-
-        MapServiceContext context = mock(MapServiceContext.class);
-        when(context.getNodeEngine()).thenReturn(nodeEngine);
-
-        NearCacheProvider nearCacheProvider = mock(NearCacheProvider.class);
-
-        invalidator = new NonStopInvalidator(context, nearCacheProvider);
+        invalidator = new NonStopInvalidator(nodeEngine);
     }
 
     @RequireAssertEnabled
@@ -47,5 +38,17 @@ public class NonStopInvalidatorTest {
     @Test(expected = AssertionError.class)
     public void testInvalidate_withInvalidSourceUuid() {
         invalidator.invalidate(key, "anyMapName", null);
+    }
+
+    @RequireAssertEnabled
+    @Test(expected = AssertionError.class)
+    public void testClear_withInvalidMapName() {
+        invalidator.clear(null, "anySourceUuid");
+    }
+
+    @RequireAssertEnabled
+    @Test(expected = AssertionError.class)
+    public void testClear_withInvalidSourceUuid() {
+        invalidator.clear("anyMapName", null);
     }
 }


### PR DESCRIPTION
Added `ClearNearCacheInvalidation` and removed special case for `SingleNearCacheInvalidation` with null key. Before this PR we were accepting a null key-ed invalidation as a clearing invalidation., this was the special case for `SingleNearCacheInvalidation`. Now every invalidation has its own type.