### PR TITLE
InternalLockNamespace toString() impl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
@@ -95,4 +95,9 @@ public final class InternalLockNamespace implements ObjectNamespace {
         //warning: this intentionally does not use name field see class-level JavaDoc above
         return getServiceName().hashCode();
     }
+
+    @Override
+    public String toString() {
+        return "InternalLockNamespace{service='" + LockService.SERVICE_NAME + '\'' + ", objectName=" + name + '}';
+    }
 }


### PR DESCRIPTION
It helps with troubleshooting as lock names are now
visible in slow invocation detector and diagnostic log