### PR TITLE
fixed aws address translator public ip issue

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -227,7 +227,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 if (connection != null) {
                     return connection;
                 }
-                AuthenticationFuture firstCallback = triggerConnect(address, asOwner);
+                AuthenticationFuture firstCallback = triggerConnect(addressTranslator.translate(address), asOwner);
                 connection = firstCallback.get(connectionTimeout);
                 if (!asOwner) {
                     return connection;


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/8944
Scenario: 
hazelcast member inside aws
hazelcast client outside aws
When client tries to initial connection, it should translate address ( from private to public ). Otherwise it couldn't connect. ( because it tries private)

Also in AwsAddressTranslator, if address is already translated, we shouldn't retranslate it. I added small enhancement/fix.

I couldn't add tests, since it aws related issue. I have manually tested many times. 