### PR TITLE
Added IO utils for Near Cache preloader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/BufferingInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/BufferingInputStream.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.lang.System.arraycopy;
+
+/**
+ * {@link InputStream} implementation with a configurable buffer.
+ */
+public class BufferingInputStream extends InputStream {
+
+    private static final int BYTE_MASK = 0xff;
+
+    private final InputStream in;
+    private final byte[] buf;
+
+    private int position;
+    private int limit;
+
+    public BufferingInputStream(InputStream in, int bufferSize) {
+        this.in = in;
+        this.buf = new byte[bufferSize];
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (!ensureDataInBuffer()) {
+            return -1;
+        }
+        return buf[position++] & BYTE_MASK;
+    }
+
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public int read(byte[] destBuf, int off, int len) throws IOException {
+        if (!ensureDataInBuffer()) {
+            return -1;
+        }
+        int transferredCount = Math.min(limit - position, len);
+        arraycopy(buf, position, destBuf, off, transferredCount);
+        position += transferredCount;
+        return transferredCount;
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    private boolean ensureDataInBuffer() throws IOException {
+        if (position != limit) {
+            return true;
+        }
+        position = 0;
+        final int newLimit = in.read(buf);
+        if (newLimit == -1) {
+            limit = 0;
+            return false;
+        } else {
+            limit = newLimit;
+            return true;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/BufferingInputStreamTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/BufferingInputStreamTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+
+import static com.hazelcast.nio.IOUtil.closeResource;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BufferingInputStreamTest {
+
+    private final byte[] mockInput = {1, 2, 3, 4};
+
+    private BufferingInputStream in;
+
+    @Before
+    public void setUp() {
+        in = new BufferingInputStream(new ByteArrayInputStream(mockInput), 1 << 16);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        closeResource(in);
+    }
+
+    @Test
+    public void readByteByByte() throws Exception {
+        for (byte b : mockInput) {
+            assertEquals(b, (byte) in.read());
+        }
+        assertEquals(-1, in.read());
+    }
+
+    @Test
+    public void readBufByBuf() throws Exception {
+        // given
+        byte[] buf = new byte[mockInput.length / 2];
+        int streamPos = 0;
+
+        // when - then
+        for (int count; (count = in.read(buf)) != -1;) {
+            for (int i = 0; i < count; i++) {
+                assertEquals(mockInput[streamPos++], buf[i]);
+            }
+        }
+        assertEquals(mockInput.length, streamPos);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -47,11 +47,27 @@ import java.nio.ByteBuffer;
 
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createObjectDataInputStream;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createObjectDataOutputStream;
+import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.nio.IOUtil.compress;
+import static com.hazelcast.nio.IOUtil.decompress;
+import static com.hazelcast.nio.IOUtil.delete;
+import static com.hazelcast.nio.IOUtil.deleteQuietly;
 import static com.hazelcast.nio.IOUtil.extractOperationCallId;
+import static com.hazelcast.nio.IOUtil.getFileFromResources;
+import static com.hazelcast.nio.IOUtil.newInputStream;
+import static com.hazelcast.nio.IOUtil.newOutputStream;
+import static com.hazelcast.nio.IOUtil.readByteArray;
+import static com.hazelcast.nio.IOUtil.readFully;
+import static com.hazelcast.nio.IOUtil.readFullyOrNothing;
+import static com.hazelcast.nio.IOUtil.readObject;
+import static com.hazelcast.nio.IOUtil.toFileName;
+import static com.hazelcast.nio.IOUtil.writeByteArray;
+import static com.hazelcast.nio.IOUtil.writeObject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -59,9 +75,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- * @author Tomasz Nurkiewicz
- */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class IOUtilTest extends HazelcastTestSupport {
@@ -135,15 +148,15 @@ public class IOUtilTest extends HazelcastTestSupport {
         assertNull(output);
     }
 
-    private static byte[] writeAndReadByteArray(byte[] bytes) throws IOException {
+    private static byte[] writeAndReadByteArray(byte[] bytes) throws Exception {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         ObjectDataOutput out = createObjectDataOutputStream(bout, serializationService);
-        IOUtil.writeByteArray(out, bytes);
+        writeByteArray(out, bytes);
         byte[] data = bout.toByteArray();
 
         ByteArrayInputStream bin = new ByteArrayInputStream(data);
         ObjectDataInput in = createObjectDataInputStream(bin, serializationService);
-        return IOUtil.readByteArray(in);
+        return readByteArray(in);
     }
 
     @Test
@@ -166,21 +179,82 @@ public class IOUtilTest extends HazelcastTestSupport {
         assertEquals(expected, actual);
     }
 
-    private static Object writeAndReadObject(Object input) throws IOException {
+    private static Object writeAndReadObject(Object input) throws Exception {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         ObjectDataOutput out = createObjectDataOutputStream(bout, serializationService);
-        IOUtil.writeObject(out, input);
+        writeObject(out, input);
         byte[] data = bout.toByteArray();
 
         ByteArrayInputStream bin = new ByteArrayInputStream(data);
         ObjectDataInput in = createObjectDataInputStream(bin, serializationService);
-        return IOUtil.readObject(in);
+        return readObject(in);
+    }
+
+    private final byte[] streamInput = {1, 2, 3, 4};
+
+    @Test
+    public void testReadFullyOrNothing() throws Exception {
+        InputStream in = new ByteArrayInputStream(streamInput);
+        byte[] buffer = new byte[4];
+
+        boolean result = readFullyOrNothing(in, buffer);
+
+        assertTrue(result);
+        for (int i = 0; i < buffer.length; i++) {
+            assertEquals(buffer[i], streamInput[i]);
+        }
+    }
+
+    @Test
+    public void testReadFullyOrNothing_whenThereIsNoData_thenReturnFalse() throws Exception {
+        InputStream in = new ByteArrayInputStream(new byte[0]);
+        byte[] buffer = new byte[4];
+
+        boolean result = readFullyOrNothing(in, buffer);
+
+        assertFalse(result);
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadFullyOrNothing_whenThereIsNotEnoughData_thenThrowException() throws Exception {
+        InputStream in = new ByteArrayInputStream(streamInput);
+        byte[] buffer = new byte[8];
+
+        readFullyOrNothing(in, buffer);
+    }
+
+    @Test
+    public void testReadFully() throws Exception {
+        InputStream in = new ByteArrayInputStream(streamInput);
+        byte[] buffer = new byte[4];
+
+        readFully(in, buffer);
+
+        for (int i = 0; i < buffer.length; i++) {
+            assertEquals(buffer[i], streamInput[i]);
+        }
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadFully_whenThereIsNoData_thenThrowException() throws Exception {
+        InputStream in = new ByteArrayInputStream(new byte[0]);
+        byte[] buffer = new byte[4];
+
+        readFully(in, buffer);
+    }
+
+    @Test(expected = EOFException.class)
+    public void testReadFully_whenThereIsNotEnoughData_thenThrowException() throws Exception {
+        InputStream in = new ByteArrayInputStream(streamInput);
+        byte[] buffer = new byte[8];
+
+        readFully(in, buffer);
     }
 
     @Test
     public void testNewOutputStream_shouldWriteWholeByteBuffer() throws Exception {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[SIZE]);
-        OutputStream outputStream = IOUtil.newOutputStream(buffer);
+        OutputStream outputStream = newOutputStream(buffer);
         assertEquals(SIZE, buffer.remaining());
 
         outputStream.write(new byte[SIZE]);
@@ -191,7 +265,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test
     public void testNewOutputStream_shouldWriteSingleByte() throws Exception {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[SIZE]);
-        OutputStream outputStream = IOUtil.newOutputStream(buffer);
+        OutputStream outputStream = newOutputStream(buffer);
         assertEquals(SIZE, buffer.remaining());
 
         outputStream.write(23);
@@ -202,7 +276,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test
     public void testNewOutputStream_shouldWriteInChunks() throws Exception {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[SIZE]);
-        OutputStream outputStream = IOUtil.newOutputStream(buffer);
+        OutputStream outputStream = newOutputStream(buffer);
         assertEquals(SIZE, buffer.remaining());
 
         outputStream.write(new byte[1], 0, 1);
@@ -214,7 +288,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test(expected = BufferOverflowException.class)
     public void testNewOutputStream_shouldThrowWhenTryingToWriteToEmptyByteBuffer() throws Exception {
         ByteBuffer empty = ByteBuffer.wrap(EMPTY_BYTE_ARRAY);
-        OutputStream outputStream = IOUtil.newOutputStream(empty);
+        OutputStream outputStream = newOutputStream(empty);
 
         outputStream.write(23);
     }
@@ -222,7 +296,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test
     public void testNewInputStream_shouldReturnMinusOneWhenEmptyByteBufferProvidedAndReadingOneByte() throws Exception {
         ByteBuffer empty = ByteBuffer.wrap(EMPTY_BYTE_ARRAY);
-        InputStream inputStream = IOUtil.newInputStream(empty);
+        InputStream inputStream = newInputStream(empty);
 
         int read = inputStream.read();
 
@@ -232,7 +306,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test
     public void testNewInputStream_shouldReadWholeByteBuffer() throws Exception {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[SIZE]);
-        InputStream inputStream = IOUtil.newInputStream(buffer);
+        InputStream inputStream = newInputStream(buffer);
 
         int read = inputStream.read(new byte[SIZE]);
 
@@ -242,7 +316,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test
     public void testNewInputStream_shouldAllowReadingByteBufferInChunks() throws Exception {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[SIZE]);
-        InputStream inputStream = IOUtil.newInputStream(buffer);
+        InputStream inputStream = newInputStream(buffer);
 
         int firstRead = inputStream.read(new byte[1]);
         int secondRead = inputStream.read(new byte[SIZE - 1]);
@@ -254,7 +328,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test
     public void testNewInputStream_shouldReturnMinusOneWhenNothingRemainingInByteBuffer() throws Exception {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[SIZE]);
-        InputStream inputStream = IOUtil.newInputStream(buffer);
+        InputStream inputStream = newInputStream(buffer);
 
         int firstRead = inputStream.read(new byte[SIZE]);
         int secondRead = inputStream.read();
@@ -266,7 +340,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test
     public void testNewInputStream_shouldReturnMinusOneWhenEmptyByteBufferProvidedAndReadingSeveralBytes() throws Exception {
         ByteBuffer empty = ByteBuffer.wrap(EMPTY_BYTE_ARRAY);
-        InputStream inputStream = IOUtil.newInputStream(empty);
+        InputStream inputStream = newInputStream(empty);
 
         int read = inputStream.read(NON_EMPTY_BYTE_ARRAY);
 
@@ -276,7 +350,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test(expected = EOFException.class)
     public void testNewInputStream_shouldThrowWhenTryingToReadFullyFromEmptyByteBuffer() throws Exception {
         ByteBuffer empty = ByteBuffer.wrap(EMPTY_BYTE_ARRAY);
-        DataInputStream inputStream = new DataInputStream(IOUtil.newInputStream(empty));
+        DataInputStream inputStream = new DataInputStream(newInputStream(empty));
 
         inputStream.readFully(NON_EMPTY_BYTE_ARRAY);
     }
@@ -284,7 +358,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     @Test(expected = EOFException.class)
     public void testNewInputStream_shouldThrowWhenByteBufferExhaustedAndTryingToReadFully() throws Exception {
         ByteBuffer buffer = ByteBuffer.wrap(new byte[SIZE]);
-        DataInputStream inputStream = new DataInputStream(IOUtil.newInputStream(buffer));
+        DataInputStream inputStream = new DataInputStream(newInputStream(buffer));
         inputStream.readFully(new byte[SIZE]);
 
         inputStream.readFully(NON_EMPTY_BYTE_ARRAY);
@@ -296,8 +370,8 @@ public class IOUtilTest extends HazelcastTestSupport {
                 + " and I will give you a complete account of the system, and expound the actual teachings of the great explorer"
                 + " of the truth, the master-builder of human happiness.";
 
-        byte[] compressed = IOUtil.compress(expected.getBytes());
-        byte[] decompressed = IOUtil.decompress(compressed);
+        byte[] compressed = compress(expected.getBytes());
+        byte[] decompressed = decompress(compressed);
 
         assertEquals(expected, new String(decompressed));
     }
@@ -306,8 +380,8 @@ public class IOUtilTest extends HazelcastTestSupport {
     public void testCompressAndDecompress_withEmptyString() throws Exception {
         String expected = "";
 
-        byte[] compressed = IOUtil.compress(expected.getBytes());
-        byte[] decompressed = IOUtil.decompress(compressed);
+        byte[] compressed = compress(expected.getBytes());
+        byte[] decompressed = decompress(compressed);
 
         assertEquals(expected, new String(decompressed));
     }
@@ -316,7 +390,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     public void testCloseResource() throws Exception {
         Closeable closeable = mock(Closeable.class);
 
-        IOUtil.closeResource(closeable);
+        closeResource(closeable);
 
         verify(closeable).close();
         verifyNoMoreInteractions(closeable);
@@ -327,7 +401,7 @@ public class IOUtilTest extends HazelcastTestSupport {
         Closeable closeable = mock(Closeable.class);
         doThrow(new IOException("expected")).when(closeable).close();
 
-        IOUtil.closeResource(closeable);
+        closeResource(closeable);
 
         verify(closeable).close();
         verifyNoMoreInteractions(closeable);
@@ -335,26 +409,14 @@ public class IOUtilTest extends HazelcastTestSupport {
 
     @Test
     public void testCloseResource_withNull() {
-        IOUtil.closeResource(null);
-    }
-
-    private static class IoUtilTestOperation extends AbstractTestOperation {
-
-        public IoUtilTestOperation(int partitionId) {
-            super(partitionId);
-        }
-
-        @Override
-        protected Object doRun() {
-            return null;
-        }
+        closeResource(null);
     }
 
     @Test
     public void testDelete_shouldDoNothingWithNonExistentFile() {
         File file = new File("notFound");
 
-        IOUtil.delete(file);
+        delete(file);
     }
 
     @Test
@@ -366,7 +428,7 @@ public class IOUtilTest extends HazelcastTestSupport {
         File childFile1 = createFile(childDir, "childFile1");
         File childFile2 = createFile(childDir, "childFile2");
 
-        IOUtil.delete(parentDir);
+        delete(parentDir);
 
         assertFalse(parentDir.exists());
         assertFalse(file1.exists());
@@ -380,18 +442,36 @@ public class IOUtilTest extends HazelcastTestSupport {
     public void testDelete_shouldDeleteSingleFile() throws Exception {
         File file = createFile("singleFile");
 
-        IOUtil.delete(file);
+        delete(file);
 
         assertFalse(file.exists());
     }
 
     @Test(expected = HazelcastException.class)
-    public void testDelete_shouldThrowIfFileCouldNotBeDeleted() throws Exception {
+    public void testDelete_shouldThrowIfFileCouldNotBeDeleted() {
         File file = mock(File.class);
         when(file.exists()).thenReturn(true);
         when(file.delete()).thenReturn(false);
 
-        IOUtil.delete(file);
+        delete(file);
+    }
+
+    @Test
+    public void testDeleteQuietly_shouldDeleteSingleFile() throws Exception {
+        File file = createFile("singleFile");
+
+        deleteQuietly(file);
+
+        assertFalse(file.exists());
+    }
+
+    @Test
+    public void testDeleteQuietly_shouldDoNothingIfFileCouldNotBeDeleted() {
+        File file = mock(File.class);
+        when(file.exists()).thenReturn(true);
+        when(file.delete()).thenReturn(false);
+
+        deleteQuietly(file);
     }
 
     private static File createDirectory(String dirName) throws IOException {
@@ -438,7 +518,7 @@ public class IOUtilTest extends HazelcastTestSupport {
     public void testToFileName_shouldNotChangeValidFileName() {
         String expected = "valid-fileName_23.txt";
 
-        String actual = IOUtil.toFileName(expected);
+        String actual = toFileName(expected);
 
         assertEquals(expected, actual);
     }
@@ -447,14 +527,38 @@ public class IOUtilTest extends HazelcastTestSupport {
     public void testToFileName_shouldChangeInvalidFileName() {
         String expected = "a_b_c_d_e_f_g_h_j_k_l_m.txt";
 
-        String actual = IOUtil.toFileName("a:b?c*d\"e|f<g>h'j,k\\l/m.txt");
+        String actual = toFileName("a:b?c*d\"e|f<g>h'j,k\\l/m.txt");
 
         assertEquals(expected, actual);
     }
 
+    @Test
+    public void testGetFileFromResources_shouldReturnExistingFile() {
+        File file = getFileFromResources("logging.properties");
+
+        assertTrue(file.exists());
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void testGetFileFromResources_shouldThrowExceptionIfFileDoesNotExist() {
+        getFileFromResources("doesNotExist");
+    }
+
+    private static class IoUtilTestOperation extends AbstractTestOperation {
+
+        IoUtilTestOperation(int partitionId) {
+            super(partitionId);
+        }
+
+        @Override
+        protected Object doRun() {
+            return null;
+        }
+    }
+
     private static class IdentifiedIoUtilTestOperation extends IoUtilTestOperation implements IdentifiedDataSerializable {
 
-        public IdentifiedIoUtilTestOperation(int partitionId) {
+        IdentifiedIoUtilTestOperation(int partitionId) {
             super(partitionId);
         }
 


### PR DESCRIPTION
* Added `BufferingInputStream` from HotRestart to `utils` package
* Added `readFully()` and `readFullyOrNothing()` from HotRestart to `IOUtil`
* Added `deleteQuietly()` to `IOUtil` to delete a file without exceptions (for `finally` blocks)
* Added `getFileFromResources()` to `IOUtil` (for tests)

This is mostly HotRestart code I'm going to re-use in the Near Cache preloader. Once this is merged, I can remove the code duplication in EE.