### PR TITLE
Fixes char array growing issue in Diagnostics

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/internal/diagnostics/SystemLogPluginConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/internal/diagnostics/SystemLogPluginConnectionTest.java
@@ -41,8 +41,6 @@ public class SystemLogPluginConnectionTest extends AbstractDiagnosticsPluginTest
 
     @Before
     public void setUp() {
-        setLoggingLog4j();
-
         Config config = new Config();
         config.setProperty(LOG_PARTITIONS.getName(), "true");
 
@@ -63,7 +61,6 @@ public class SystemLogPluginConnectionTest extends AbstractDiagnosticsPluginTest
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                clean();
                 plugin.run(logWriter);
                 assertContains("ConnectionAdded");
             }
@@ -73,7 +70,6 @@ public class SystemLogPluginConnectionTest extends AbstractDiagnosticsPluginTest
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                clean();
                 plugin.run(logWriter);
                 assertContains("ConnectionRemoved");
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriter.java
@@ -32,7 +32,8 @@ class MultiLineDiagnosticsLogWriter extends DiagnosticsLogWriter {
             LINE_SEPARATOR + "                          ",
             LINE_SEPARATOR + "                                  ",
             LINE_SEPARATOR + "                                          ",
-            LINE_SEPARATOR + "                                                  ", };
+            LINE_SEPARATOR + "                                                  ",
+    };
 
     private final StringBuffer tmpSb = new StringBuffer();
 
@@ -40,50 +41,50 @@ class MultiLineDiagnosticsLogWriter extends DiagnosticsLogWriter {
     public void startSection(String name) {
         if (sectionLevel == -1) {
             appendDateTime();
-            sb.append(' ');
+            write(' ');
         }
 
         if (sectionLevel >= 0) {
-            sb.append(INDENTS[sectionLevel]);
+            write(INDENTS[sectionLevel]);
         }
 
-        sb.append(name);
-        sb.append('[');
+        write(name);
+        write('[');
         sectionLevel++;
     }
 
     @Override
     public void endSection() {
-        sb.append(']');
+        write(']');
         sectionLevel--;
 
         if (sectionLevel == -1) {
-            sb.append(LINE_SEPARATOR);
+            write(LINE_SEPARATOR);
         }
     }
 
     @Override
     public void writeEntry(String s) {
-        sb.append(INDENTS[sectionLevel]);
-        sb.append(s);
+        write(INDENTS[sectionLevel]);
+        write(s);
     }
 
     @Override
     public void writeKeyValueEntry(String key, String value) {
         writeKeyValueHead(key);
-        sb.append(value);
+        write(value);
     }
 
     // we can't rely on NumberFormat since it generates a ton of garbage
     @SuppressWarnings("checkstyle:magicnumber")
     void writeLong(long value) {
         if (value == Long.MIN_VALUE) {
-            sb.append(STR_LONG_MIN_VALUE);
+            write(STR_LONG_MIN_VALUE);
             return;
         }
 
         if (value < 0) {
-            sb.append('-');
+            write('-');
             value = -value;
         }
 
@@ -103,14 +104,14 @@ class MultiLineDiagnosticsLogWriter extends DiagnosticsLogWriter {
 
         for (int k = tmpSb.length() - 1; k >= 0; k--) {
             char c = tmpSb.charAt(k);
-            sb.append(c);
+            write(c);
         }
     }
 
     @Override
     public void writeKeyValueEntry(String key, double value) {
         writeKeyValueHead(key);
-        sb.append(value);
+        write(value);
     }
 
     @Override
@@ -122,12 +123,12 @@ class MultiLineDiagnosticsLogWriter extends DiagnosticsLogWriter {
     @Override
     public void writeKeyValueEntry(String key, boolean value) {
         writeKeyValueHead(key);
-        sb.append(value);
+        write(value);
     }
 
     private void writeKeyValueHead(String key) {
-        sb.append(INDENTS[sectionLevel]);
-        sb.append(key);
-        sb.append('=');
+        write(INDENTS[sectionLevel]);
+        write(key);
+        write('=');
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SingleLineDiagnosticsLogWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SingleLineDiagnosticsLogWriter.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.diagnostics;
 
+import java.io.PrintWriter;
+
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 
 /**
@@ -29,66 +31,66 @@ class SingleLineDiagnosticsLogWriter extends DiagnosticsLogWriter {
     public void startSection(String name) {
         if (sectionLevel == -1) {
             appendDateTime();
-            sb.append(' ');
+            write(' ');
         }
 
         appendComma();
-        sb.append(name).append('[');
+        write(name).write('[');
         firstEntry = true;
         sectionLevel++;
     }
 
     @Override
     public void endSection() {
-        sb.append(']');
+        write(']');
         sectionLevel--;
 
         if (sectionLevel == -1) {
-            sb.append(LINE_SEPARATOR);
+            write(LINE_SEPARATOR);
         }
     }
 
     @Override
     public void writeEntry(String s) {
         appendComma();
-        sb.append(s);
+        write(s);
     }
 
     private void appendComma() {
         if (firstEntry) {
             firstEntry = false;
         } else {
-            sb.append(',');
+            write(',');
         }
     }
 
     @Override
     public void writeKeyValueEntry(String key, String value) {
         appendComma();
-        sb.append(key).append('=').append(value);
+        write(key).write('=').write(value);
     }
 
     @Override
     public void writeKeyValueEntry(String key, double value) {
         appendComma();
-        sb.append(key).append('=').append(value);
+        write(key).write('=').write(value);
     }
 
     @Override
     public void writeKeyValueEntry(String key, long value) {
         appendComma();
-        sb.append(key).append('=').append(value);
+        write(key).write('=').write(value);
     }
 
     @Override
     public void writeKeyValueEntry(String key, boolean value) {
         appendComma();
-        sb.append(key).append('=').append(value);
+        write(key).write('=').write(value);
     }
 
     @Override
-    protected void clean() {
+    protected void init(PrintWriter writer) {
         firstEntry = true;
-        super.clean();
+        super.init(writer);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/AbstractDiagnosticsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/AbstractDiagnosticsPluginTest.java
@@ -1,20 +1,28 @@
 package com.hazelcast.internal.diagnostics;
 
 import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+
+import java.io.CharArrayWriter;
+import java.io.PrintWriter;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class AbstractDiagnosticsPluginTest extends HazelcastTestSupport {
 
-    protected DiagnosticsLogWriter logWriter = new MultiLineDiagnosticsLogWriter();
+    protected DiagnosticsLogWriter logWriter;
+    private CharArrayWriter out;
 
-    protected void clean() {
-        logWriter.clean();
+    @Before
+    public void setupLogWriter(){
+        logWriter = new MultiLineDiagnosticsLogWriter();
+        out = new CharArrayWriter();
+        logWriter.init(new PrintWriter(out));
     }
 
     protected String getContent() {
-        return logWriter.sb.toString();
+        return out.toString();
     }
 
     protected void assertContains(String expected) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/ConfigPropertiesPluginTest.java
@@ -22,8 +22,8 @@ public class ConfigPropertiesPluginTest extends AbstractDiagnosticsPluginTest {
 
     @Before
     public void setup() {
-        Config config = new Config();
-        config.setProperty("property1", "value1");
+        Config config = new Config()
+                .setProperty("property1", "value1");
         HazelcastInstance hz = createHazelcastInstance(config);
         plugin = new ConfigPropertiesPlugin(getNodeEngineImpl(hz));
         plugin.onStart();

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DiagnosticsLogTest.java
@@ -40,11 +40,11 @@ public class DiagnosticsLogTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        Config config = new Config();
-        config.setProperty(Diagnostics.ENABLED.getName(), "true");
-        config.setProperty(Diagnostics.MAX_ROLLED_FILE_SIZE_MB.getName(), "0.2");
-        config.setProperty(Diagnostics.MAX_ROLLED_FILE_COUNT.getName(), "3");
-        config.setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
+        Config config = new Config()
+                .setProperty(Diagnostics.ENABLED.getName(), "true")
+                .setProperty(Diagnostics.MAX_ROLLED_FILE_SIZE_MB.getName(), "0.2")
+                .setProperty(Diagnostics.MAX_ROLLED_FILE_COUNT.getName(), "3")
+                .setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
 
         HazelcastInstance hz = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/HealthMonitorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/HealthMonitorTest.java
@@ -15,6 +15,10 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
+import static com.hazelcast.spi.properties.GroupProperty.HEALTH_MONITORING_DELAY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.HEALTH_MONITORING_LEVEL;
+import static com.hazelcast.spi.properties.GroupProperty.HEALTH_MONITORING_THRESHOLD_CPU_PERCENTAGE;
+import static com.hazelcast.spi.properties.GroupProperty.HEALTH_MONITORING_THRESHOLD_MEMORY_PERCENTAGE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -29,10 +33,10 @@ public class HealthMonitorTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         Config config = new Config();
-        config.setProperty(GroupProperty.HEALTH_MONITORING_LEVEL.getName(), HealthMonitorLevel.NOISY.toString());
-        config.setProperty(GroupProperty.HEALTH_MONITORING_DELAY_SECONDS.getName(), "1");
-        config.setProperty(GroupProperty.HEALTH_MONITORING_THRESHOLD_MEMORY_PERCENTAGE.getName(), "70");
-        config.setProperty(GroupProperty.HEALTH_MONITORING_THRESHOLD_CPU_PERCENTAGE.getName(), "70");
+        config.setProperty(HEALTH_MONITORING_LEVEL.getName(), HealthMonitorLevel.NOISY.toString())
+                .setProperty(HEALTH_MONITORING_DELAY_SECONDS.getName(), "1")
+                .setProperty(HEALTH_MONITORING_THRESHOLD_MEMORY_PERCENTAGE.getName(), "70")
+                .setProperty(HEALTH_MONITORING_THRESHOLD_CPU_PERCENTAGE.getName(), "70");
 
         HazelcastInstance hz = createHazelcastInstance(config);
         healthMonitor = new HealthMonitor(getNode(hz));

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/InvocationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/InvocationPluginTest.java
@@ -26,9 +26,9 @@ public class InvocationPluginTest extends AbstractDiagnosticsPluginTest {
 
     @Before
     public void setup() {
-        Config config = new Config();
-        config.setProperty(InvocationPlugin.SAMPLE_PERIOD_SECONDS.getName(), "1");
-        config.setProperty(InvocationPlugin.SLOW_THRESHOLD_SECONDS.getName(), "5");
+        Config config = new Config()
+                .setProperty(InvocationPlugin.SAMPLE_PERIOD_SECONDS.getName(), "1")
+                .setProperty(InvocationPlugin.SLOW_THRESHOLD_SECONDS.getName(), "5");
 
         hz = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPluginTest.java
@@ -9,8 +9,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -28,7 +28,7 @@ public class MemberHazelcastInstanceInfoPluginTest extends AbstractDiagnosticsPl
 
     @Test
     public void testGetPeriodMillis() {
-        assertEquals(TimeUnit.SECONDS.toMillis(60), plugin.getPeriodMillis());
+        assertEquals(SECONDS.toMillis(60), plugin.getPeriodMillis());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MetricsPluginTest.java
@@ -27,9 +27,9 @@ public class MetricsPluginTest extends AbstractDiagnosticsPluginTest {
 
     @Before
     public void setup() {
-        Config config = new Config();
-        config.setProperty(Diagnostics.ENABLED.getName(), "true");
-        config.setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
+        Config config = new Config()
+                .setProperty(Diagnostics.ENABLED.getName(), "true")
+                .setProperty(MetricsPlugin.PERIOD_SECONDS.getName(), "1");
         HazelcastInstance hz = createHazelcastInstance(config);
         NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(hz);
         metricsRegistry = nodeEngineImpl.getMetricsRegistry();
@@ -52,7 +52,6 @@ public class MetricsPluginTest extends AbstractDiagnosticsPluginTest {
             }
         });
 
-        logWriter.clean();
         plugin.run(logWriter);
         assertContains("broken=java.lang.RuntimeException:error");
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriterTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.CharArrayWriter;
+import java.io.PrintWriter;
 import java.util.Locale;
 
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
@@ -17,11 +19,13 @@ import static org.junit.Assert.assertEquals;
 @Category(QuickTest.class)
 public class MultiLineDiagnosticsLogWriterTest extends HazelcastTestSupport {
 
-    private MultiLineDiagnosticsLogWriter writer;
+    protected DiagnosticsLogWriter writer;
+    private CharArrayWriter out = new CharArrayWriter();
 
     @Before
-    public void setup() {
+    public void setupLogWriter() {
         writer = new MultiLineDiagnosticsLogWriter();
+        writer.init(new PrintWriter(out));
     }
 
     @Test
@@ -37,7 +41,7 @@ public class MultiLineDiagnosticsLogWriterTest extends HazelcastTestSupport {
         writer.writeEntry("foobar");
         writer.endSection();
 
-        String actual = writer.sb.toString();
+        String actual = out.toString();
 
         // we need to get rid of the time/date prefix
         actual = actual.substring(actual.indexOf("SomeSection"));
@@ -117,11 +121,14 @@ public class MultiLineDiagnosticsLogWriterTest extends HazelcastTestSupport {
     }
 
     private void assertLongValue(long value) {
-        writer.clean();
+        CharArrayWriter out = new CharArrayWriter();
+        MultiLineDiagnosticsLogWriter writer = new MultiLineDiagnosticsLogWriter();
+        writer.init(new PrintWriter(out));
+
         writer.writeLong(value);
 
         String expected = String.format(Locale.US, "%,d", value);
 
-        assertEquals(expected, writer.sb.toString());
+        assertEquals(expected, out.toString());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
@@ -38,10 +38,10 @@ public class OverloadedConnectionsPluginTest extends AbstractDiagnosticsPluginTe
     public void setup() throws InterruptedException {
         Hazelcast.shutdownAll();
 
-        Config config = new Config();
-        config.setProperty(OverloadedConnectionsPlugin.PERIOD_SECONDS.getName(), "1");
-        config.setProperty(OverloadedConnectionsPlugin.SAMPLES.getName(), "10");
-        config.setProperty(OverloadedConnectionsPlugin.THRESHOLD.getName(), "10");
+        Config config = new Config()
+                .setProperty(OverloadedConnectionsPlugin.PERIOD_SECONDS.getName(), "1")
+                .setProperty(OverloadedConnectionsPlugin.SAMPLES.getName(), "10")
+                .setProperty(OverloadedConnectionsPlugin.THRESHOLD.getName(), "10");
 
         local = Hazelcast.newHazelcastInstance(config);
         serializationService = getSerializationService(local);

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/PendingInvocationsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/PendingInvocationsPluginTest.java
@@ -27,9 +27,9 @@ public class PendingInvocationsPluginTest extends AbstractDiagnosticsPluginTest 
 
     @Before
     public void setup() {
-        Config config = new Config();
-        config.setProperty(PendingInvocationsPlugin.PERIOD_SECONDS.getName(), "1");
-        config.setProperty(PendingInvocationsPlugin.THRESHOLD.getName(), "1");
+        Config config = new Config()
+                .setProperty(PendingInvocationsPlugin.PERIOD_SECONDS.getName(), "1")
+                .setProperty(PendingInvocationsPlugin.THRESHOLD.getName(), "1");
 
         hz = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SingleLineDiagnosticsLogWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SingleLineDiagnosticsLogWriterTest.java
@@ -9,6 +9,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.CharArrayWriter;
+import java.io.PrintWriter;
+
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -16,12 +19,13 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class SingleLineDiagnosticsLogWriterTest extends HazelcastTestSupport {
-
+    private CharArrayWriter out = new CharArrayWriter();
     private SingleLineDiagnosticsLogWriter writer;
 
     @Before
     public void setup() {
         writer = new SingleLineDiagnosticsLogWriter();
+        writer.init(new PrintWriter(out));
     }
 
     @Test
@@ -29,7 +33,7 @@ public class SingleLineDiagnosticsLogWriterTest extends HazelcastTestSupport {
         writer.startSection("SomeSection");
 
         writer.writeKeyValueEntry("boolean", true);
-        writer.writeKeyValueEntry("long", 10l);
+        writer.writeKeyValueEntry("long", 10L);
 
         writer.startSection("SubSection");
         writer.writeKeyValueEntry("integer", 10);
@@ -41,7 +45,7 @@ public class SingleLineDiagnosticsLogWriterTest extends HazelcastTestSupport {
 
         writer.endSection();
 
-        assertTrue(writer.sb.toString().contains("SomeSection[boolean=true,long=10,SubSection[integer=10],string=foo,double=11.0,foobar]"));
+         assertTrue(out.toString().contains("SomeSection[boolean=true,long=10,SubSection[integer=10],string=foo,double=11.0,foobar]"));
     }
 
     @Test
@@ -49,7 +53,7 @@ public class SingleLineDiagnosticsLogWriterTest extends HazelcastTestSupport {
         DummyDiagnosticsPlugin plugin = new DummyDiagnosticsPlugin();
         plugin.run(writer);
 
-        String content = writer.sb.toString();
+        String content = out.toString();
         String[] split = content.split(" ");
         assertEquals(3, split.length);
         assertEquals("somesection[]" + LINE_SEPARATOR, split[2]);

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SlowOperationPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SlowOperationPluginTest.java
@@ -29,12 +29,11 @@ public class SlowOperationPluginTest extends AbstractDiagnosticsPluginTest {
 
     @Before
     public void setup() {
-        Config config = new Config();
-        config.setProperty(SLOW_OPERATION_DETECTOR_ENABLED.getName(), "true");
-        config.setProperty(SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS.getName(), "1000");
-        config.setProperty(SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS.getName(), "1000");
-        config.setProperty(SlowOperationPlugin.PERIOD_SECONDS.getName(), "1");
-
+        Config config = new Config()
+                .setProperty(SLOW_OPERATION_DETECTOR_ENABLED.getName(), "true")
+                .setProperty(SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS.getName(), "1000")
+                .setProperty(SLOW_INVOCATION_DETECTOR_THRESHOLD_MILLIS.getName(), "1000")
+                .setProperty(SlowOperationPlugin.PERIOD_SECONDS.getName(), "1");
 
         hz = createHazelcastInstance(config);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
@@ -61,7 +61,6 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                logWriter.clean();
                 plugin.run(logWriter);
 
                 assertContains("Lifecycle[\n" +
@@ -76,7 +75,6 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                logWriter.clean();
                 plugin.run(logWriter);
                 assertContains("MemberAdded[");
             }
@@ -86,7 +84,6 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                logWriter.clean();
                 plugin.run(logWriter);
                 assertContains("MemberRemoved[");
             }
@@ -105,7 +102,6 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                logWriter.clean();
                 plugin.run(logWriter);
                 assertContains("MigrationStarted");
                 assertContains("MigrationCompleted");


### PR DESCRIPTION
If a plugin has a lot of data to write, there are 2 buffers that are going to grow and
keep that size ever after; a stringbuffer and char array in the diagnostics sytem. This
is unacceptable since it can lead to unwanted memory usage.

This fix addresses the issue by immediately writing to a PrintWriter instead of
first to a strinbuffer then to an array and then to file.