### PR TITLE
Ring buffer store and RingbufferContainer refactoring

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddAllMessageTask.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 /**
  * Client Protocol Task for handling messages with type id:
- * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_OFFER}
+ * {@link com.hazelcast.client.impl.protocol.codec.RingbufferMessageType#RINGBUFFER_ADDALL}
  */
 public class RingbufferAddAllMessageTask
         extends AbstractPartitionMessageTask<RingbufferAddAllCodec.RequestParameters> {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferAddMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 
 /**
  * Client Protocol Task for handling messages with type id:
- * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_OFFER}
+ * {@link com.hazelcast.client.impl.protocol.codec.RingbufferMessageType#RINGBUFFER_ADD}
  */
 public class RingbufferAddMessageTask
         extends AbstractPartitionMessageTask<RingbufferAddCodec.RequestParameters> {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadManyMessageTask.java
@@ -36,7 +36,7 @@ import java.util.List;
 
 /**
  * Client Protocol Task for handling messages with type id:
- * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_OFFER}
+ * {@link com.hazelcast.client.impl.protocol.codec.RingbufferMessageType#RINGBUFFER_READMANY}
  */
 public class RingbufferReadManyMessageTask
         extends AbstractPartitionMessageTask<RingbufferReadManyCodec.RequestParameters> {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadOneMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/ringbuffer/RingbufferReadOneMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 
 /**
  * Client Protocol Task for handling messages with type id:
- * {@link com.hazelcast.client.impl.protocol.codec.QueueMessageType#QUEUE_OFFER}
+ * {@link com.hazelcast.client.impl.protocol.codec.RingbufferMessageType#RINGBUFFER_READONE}
  */
 public class RingbufferReadOneMessageTask
         extends AbstractPartitionMessageTask<RingbufferReadOneCodec.RequestParameters> {

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
@@ -62,6 +62,7 @@ public class RingbufferConfig {
     private int asyncBackupCount = DEFAULT_ASYNC_BACKUP_COUNT;
     private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
     private InMemoryFormat inMemoryFormat = DEFAULT_IN_MEMORY_FORMAT;
+    private RingbufferStoreConfig ringbufferStoreConfig;
 
     /**
      * Creates a RingbufferConfig with the provided name.
@@ -219,9 +220,9 @@ public class RingbufferConfig {
 
     /**
      * Sets the time to live in seconds.
-     *
+     * <p>
      * Time to live is the time the ringbuffer is going to retain items before deleting them.
-     *
+     * <p>
      * Time to live can be disabled by setting timeToLiveSeconds to 0. It means that items won't get removed because they
      * retire. They will only overwrite. This means that when timeToLiveSeconds is disabled, that after tail did a full
      * loop in the ring that the size will always be equal to the capacity.
@@ -246,23 +247,23 @@ public class RingbufferConfig {
 
     /**
      * Sets the InMemoryFormat.
-     *
+     * <p>
      * Setting the InMemoryFormat controls format of storing an item in the ringbuffer:
      * <ol>
-     *     <li>{@link InMemoryFormat#OBJECT}: the item is stored in deserialized format (so a regular object)</li>
-     *     <li>{@link InMemoryFormat#BINARY}: the item is stored in serialized format (so a is binary blob) </li>
+     * <li>{@link InMemoryFormat#OBJECT}: the item is stored in deserialized format (so a regular object)</li>
+     * <li>{@link InMemoryFormat#BINARY}: the item is stored in serialized format (so a is binary blob) </li>
      * </ol>
-     *
+     * <p>
      * The default is binary. The object InMemoryFormat is useful when:
      * <ol>
-     *     <li>of the object stored in object format has a smaller footprint than in binary format</li>
-     *     <li>if there are readers using a filter. Since for every filter invocation, the object needs to be available in
-     *     object format.</li>
+     * <li>of the object stored in object format has a smaller footprint than in binary format</li>
+     * <li>if there are readers using a filter. Since for every filter invocation, the object needs to be available in
+     * object format.</li>
      * </ol>
      *
      * @param inMemoryFormat the new in memory format.
      * @return the updated Config.
-     * @throws NullPointerException if inMemoryFormat is null.
+     * @throws NullPointerException     if inMemoryFormat is null.
      * @throws IllegalArgumentException if {@link InMemoryFormat#NATIVE} in memory format is selected.
      */
     public RingbufferConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
@@ -285,13 +286,43 @@ public class RingbufferConfig {
     }
 
     /**
+     * Get the RingbufferStore (load and store ring buffer items from/to a database) configuration.
+     *
+     * @return The ring buffer configuration.
+     */
+    public RingbufferStoreConfig getRingbufferStoreConfig() {
+        return ringbufferStoreConfig;
+    }
+
+    /**
+     * Set the RingbufferStore (load and store ring buffer items from/to a database) configuration.
+     *
+     * @param ringbufferStoreConfig Set the RingbufferStore configuration to this configuration.
+     * @return The RingbufferStore configuration.
+     */
+    public RingbufferConfig setRingbufferStoreConfig(RingbufferStoreConfig ringbufferStoreConfig) {
+        this.ringbufferStoreConfig = ringbufferStoreConfig;
+        return this;
+    }
+
+    /**
      * A readonly version of the {@link RingbufferConfig}.
      */
     @Beta
-    static class RingbufferConfigReadonly extends RingbufferConfig {
+    private static class RingbufferConfigReadonly extends RingbufferConfig {
 
-        public RingbufferConfigReadonly(RingbufferConfig config) {
+        RingbufferConfigReadonly(RingbufferConfig config) {
             super(config);
+        }
+
+        @Override
+        public RingbufferStoreConfig getRingbufferStoreConfig() {
+            final RingbufferStoreConfig storeConfig = super.getRingbufferStoreConfig();
+            if (storeConfig != null) {
+                return storeConfig.getAsReadOnly();
+            } else {
+                return null;
+            }
         }
 
         @Override
@@ -316,6 +347,11 @@ public class RingbufferConfig {
 
         @Override
         public RingbufferConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public RingbufferConfig setRingbufferStoreConfig(RingbufferStoreConfig ringbufferStoreConfig) {
             throw new UnsupportedOperationException("This config is read-only");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.core.RingbufferStore;
+import com.hazelcast.core.RingbufferStoreFactory;
+
+import java.util.Properties;
+
+import static com.hazelcast.util.Preconditions.isNotNull;
+
+/**
+ * Configuration for the {@link RingbufferStore}.
+ */
+public class RingbufferStoreConfig {
+
+    private boolean enabled = true;
+    private String className;
+    private String factoryClassName;
+    private Properties properties = new Properties();
+    private RingbufferStore storeImplementation;
+    private RingbufferStoreFactory factoryImplementation;
+    private RingbufferStoreConfigReadOnly readOnly;
+
+    public RingbufferStoreConfig() {
+    }
+
+    public RingbufferStoreConfig(RingbufferStoreConfig config) {
+        enabled = config.isEnabled();
+        className = config.getClassName();
+        storeImplementation = config.getStoreImplementation();
+        factoryClassName = config.getFactoryClassName();
+        factoryImplementation = config.getFactoryImplementation();
+        properties.putAll(config.getProperties());
+    }
+
+    public RingbufferStore getStoreImplementation() {
+        return storeImplementation;
+    }
+
+    public RingbufferStoreConfig setStoreImplementation(RingbufferStore storeImplementation) {
+        this.storeImplementation = storeImplementation;
+        return this;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public RingbufferStoreConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public RingbufferStoreConfig setClassName(String className) {
+        this.className = className;
+        return this;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public RingbufferStoreConfig setProperties(Properties properties) {
+        this.properties = isNotNull(properties, "properties");
+        return this;
+    }
+
+    public String getProperty(String name) {
+        return properties.getProperty(name);
+    }
+
+    public RingbufferStoreConfig setProperty(String name, String value) {
+        properties.put(name, value);
+        return this;
+    }
+
+    public String getFactoryClassName() {
+        return factoryClassName;
+    }
+
+    public RingbufferStoreConfig setFactoryClassName(String factoryClassName) {
+        this.factoryClassName = factoryClassName;
+        return this;
+    }
+
+    public RingbufferStoreFactory getFactoryImplementation() {
+        return factoryImplementation;
+    }
+
+    public RingbufferStoreConfig setFactoryImplementation(RingbufferStoreFactory factoryImplementation) {
+        this.factoryImplementation = factoryImplementation;
+        return this;
+    }
+
+    public RingbufferStoreConfigReadOnly getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new RingbufferStoreConfigReadOnly(this);
+        }
+        return readOnly;
+    }
+
+    public String toString() {
+        return "RingbufferStoreConfig{"
+                + "enabled=" + enabled
+                + ", className='" + className + '\''
+                + ", properties=" + properties
+                + '}';
+    }
+
+    /**
+     * A readonly version of the {@link RingbufferStoreConfig}.
+     */
+    private static class RingbufferStoreConfigReadOnly extends RingbufferStoreConfig {
+
+        public RingbufferStoreConfigReadOnly(RingbufferStoreConfig config) {
+            super(config);
+        }
+
+        @Override
+        public RingbufferStoreConfig setStoreImplementation(RingbufferStore storeImplementation) {
+            throw new UnsupportedOperationException("This config is read-only.");
+        }
+
+        @Override
+        public RingbufferStoreConfig setEnabled(boolean enabled) {
+            throw new UnsupportedOperationException("This config is read-only.");
+        }
+
+        @Override
+        public RingbufferStoreConfig setClassName(String className) {
+            throw new UnsupportedOperationException("This config is read-only.");
+        }
+
+        @Override
+        public RingbufferStoreConfig setProperties(Properties properties) {
+            throw new UnsupportedOperationException("This config is read-only.");
+        }
+
+        @Override
+        public RingbufferStoreConfig setProperty(String name, String value) {
+            throw new UnsupportedOperationException("This config is read-only.");
+        }
+
+        @Override
+        public RingbufferStoreConfig setFactoryClassName(String factoryClassName) {
+            throw new UnsupportedOperationException("This config is read-only.");
+        }
+
+        @Override
+        public RingbufferStoreConfig setFactoryImplementation(RingbufferStoreFactory factoryImplementation) {
+            throw new UnsupportedOperationException("This config is read-only.");
+        }
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/core/QueueStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/QueueStore.java
@@ -62,7 +62,7 @@ public interface QueueStore<T> {
      * Implementation can use any means of loading the given key;
      * such as an O/R mapping tool, simple SQL, reading a file, etc.
      *
-     * @param key
+     * @param key the key of the requested value
      * @return value of the key
      */
     T load(Long key);

--- a/hazelcast/src/main/java/com/hazelcast/core/RingbufferStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/RingbufferStore.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.core;
+
+/**
+ * Ringbuffer store makes a ring buffer backed by a central data store; such as database, disk, etc.
+ *
+ * @param <T> ring buffer item type
+ */
+public interface RingbufferStore<T> {
+
+    /**
+     * Stores one item with it's corresponding sequence.
+     *
+     * @param sequence the sequence ID of the data
+     * @param data     the value of the data to store
+     */
+    void store(long sequence, T data);
+
+    /**
+     * Stores multiple entries. Implementation of this method can optimize the store operation.
+     *
+     * @param firstItemSequence the sequence of the first item
+     * @param items             the items that are being stored
+     */
+    void storeAll(long firstItemSequence, T[] items);
+
+    /**
+     * Loads the value of a given sequence. Null value means that the item was not found.
+     *
+     * @param sequence the sequence of the requested item
+     * @return requested item, null if not found
+     */
+    T load(long sequence);
+
+    /**
+     * Return the largest sequence seen by the data store. Can return -1 if the data store doesn't have or can't access any data.
+     *
+     * @return the largest sequence of the data in the data store
+     */
+    long getLargestSequence();
+}

--- a/hazelcast/src/main/java/com/hazelcast/core/RingbufferStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/RingbufferStoreFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.core;
+
+import java.util.Properties;
+
+public interface RingbufferStoreFactory<T> {
+
+    RingbufferStore<T> newRingbufferStore(String name, Properties properties);
+}

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
@@ -18,14 +18,15 @@ package com.hazelcast.ringbuffer;
 
 /**
  * An {@link RuntimeException} that is thrown when accessing an item in the {@link Ringbuffer} using a sequence that is smaller
- * than the current head sequence. This means that the and old item is read, but it isn't available anymore in the ringbuffer.
+ * than the current head sequence and that the ringbuffer store is disabled. This means that the item isn't available in the
+ * ringbuffer and it cannot be loaded from the store either, thus being completely unavailable.
  */
 public class StaleSequenceException extends RuntimeException {
 
     private final long headSeq;
 
     /**
-     * Creates a SequenceOutOfBoundsException with the given message.
+     * Creates a StaleSequenceException with the given message.
      *
      * @param message the message
      * @param headSeq the last known head sequence.

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.ringbuffer.StaleSequenceException;
+
+
+/**
+ * The RingbufferContainer is responsible for storing the actual content of a ringbuffer.
+ * <p/>
+ * Currently the Ringbuffer is not a partitioned data-structure. So all data of a ringbuffer is stored in a single partition
+ * and replicated to the replica's. No thread-safety is needed since a partition can only be accessed by a single thread at
+ * any given moment.
+ * <p/>
+ * The ringItems is the ring that contains the actual items.
+ */
+public class ArrayRingbuffer implements Ringbuffer {
+    // contains the actual items
+    Object[] ringItems;
+    private long tailSequence = -1;
+    private long headSequence = tailSequence + 1;
+    private int capacity;
+
+    public ArrayRingbuffer(int capacity) {
+        this.capacity = capacity;
+        this.ringItems = new Object[capacity];
+    }
+
+    @Override
+    public long tailSequence() {
+        return tailSequence;
+    }
+
+    @Override
+    public void setTailSequence(long sequence) {
+        this.tailSequence = sequence;
+    }
+
+    @Override
+    public long headSequence() {
+        return headSequence;
+    }
+
+    @Override
+    public void setHeadSequence(long sequence) {
+        this.headSequence = sequence;
+    }
+
+    @Override
+    public long getCapacity() {
+        return capacity;
+    }
+
+    @Override
+    public long size() {
+        return tailSequence - headSequence + 1;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public long add(Object item) {
+        tailSequence++;
+
+        if (tailSequence - capacity == headSequence) {
+            headSequence++;
+        }
+
+        int index = toIndex(tailSequence);
+
+        ringItems[index] = item;
+
+        return tailSequence;
+    }
+
+
+    @Override
+    public Object read(long sequence) {
+        checkReadSequence(sequence);
+        return ringItems[toIndex(sequence)];
+    }
+
+    @Override
+    public void checkBlockableReadSequence(long readSequence) {
+        if (readSequence > tailSequence + 1) {
+            throw new IllegalArgumentException("sequence:" + readSequence
+                    + " is too large. The current tailSequence is:" + tailSequence);
+        }
+
+        if (readSequence < headSequence) {
+            throw new StaleSequenceException("sequence:" + readSequence
+                    + " is too small. The current headSequence is:" + headSequence
+                    + " tailSequence is:" + tailSequence, headSequence);
+        }
+    }
+
+
+    @Override
+    public void checkReadSequence(long sequence) {
+        if (sequence > tailSequence) {
+            throw new IllegalArgumentException("sequence:" + sequence
+                    + " is too large. The current tailSequence is:" + tailSequence);
+        }
+
+        if (sequence < headSequence) {
+            throw new StaleSequenceException("sequence:" + sequence
+                    + " is too small. The current headSequence is:" + headSequence
+                    + " tailSequence is:" + tailSequence, headSequence);
+        }
+    }
+
+    private int toIndex(long sequence) {
+        return (int) (sequence % ringItems.length);
+    }
+
+    @Override
+    public void set(long seq, Object data) {
+        ringItems[toIndex(seq)] = data;
+    }
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.ringbuffer.StaleSequenceException;
+
+/**
+ * The Ringbuffer is responsible for storing the actual content of a ringbuffer.
+ *
+ * @param <T> the type of the data stored in the ring buffer
+ */
+public interface Ringbuffer<T> {
+    /**
+     * Returns the capacity of this Ringbuffer.
+     *
+     * @return the capacity.
+     */
+    long getCapacity();
+
+    /**
+     * Returns number of items in the ringbuffer (meaning the number of items between the {@link #headSequence()} and
+     * {@link #tailSequence()}).
+     *
+     * @return the size.
+     */
+    long size();
+
+    /**
+     * Returns the sequence of the tail. The tail is the side of the ringbuffer where the items are added to.
+     * <p>
+     * The initial value of the tail is -1.
+     *
+     * @return the sequence of the tail.
+     */
+    long tailSequence();
+
+    /**
+     * Sets the tail sequence. The tail sequence cannot be less than {@link #headSequence()} - 1.
+     *
+     * @param tailSequence the new tail sequence
+     * @throws IllegalArgumentException if the target sequence is less than {@link #headSequence()} - 1
+     */
+    void setTailSequence(long tailSequence);
+
+    /**
+     * Returns the sequence of the head. The head is the side of the ringbuffer where the oldest items in the
+     * ringbuffer are found.
+     * <p>
+     * If the RingBuffer is empty, the head will be one more than the {@link #tailSequence()}.
+     * <p>
+     * The initial value of the head is 0 (1 more than tail).
+     *
+     * @return the sequence of the head.
+     */
+    long headSequence();
+
+    /**
+     * Sets the head sequence. The head sequence cannot be larger than {@link #tailSequence()} + 1
+     *
+     * @param sequence The new head sequence.
+     * @throws IllegalArgumentException if the target sequence is greater than {@link #tailSequence()} + 1
+     */
+    void setHeadSequence(long sequence);
+
+    /**
+     * Is the ring buffer empty.
+     *
+     * @return is the ring buffer empty
+     */
+    boolean isEmpty();
+
+    /**
+     * Adds an item to the tail of the Ringbuffer. If there is no space in the Ringbuffer, the add will overwrite the oldest
+     * item in the ringbuffer. The method allows null values.
+     * <p>
+     * The returned value is the sequence of the added item. Using this sequence you can read the added item.
+     * <p>
+     * <h3>Using the sequence as id</h3>
+     * This sequence will always be unique for this Ringbuffer instance so it can be used as a unique id generator if you are
+     * publishing items on this Ringbuffer. However you need to take care of correctly determining an initial id when any node
+     * uses the ringbuffer for the first time. The most reliable way to do that is to write a dummy item into the ringbuffer and
+     * use the returned sequence as initial id. On the reading side, this dummy item should be discard. Please keep in mind that
+     * this id is not the sequence of the item you are about to publish but from a previously published item. So it can't be used
+     * to find that item.
+     *
+     * @param item the item to add.
+     * @return the sequence of the added item.
+     */
+    long add(T item);
+
+    /**
+     * Reads one item from the Ringbuffer.
+     * <p>
+     * This method is not destructive unlike e.g. a queue.take. So the same item can be read by multiple readers or it can be
+     * read multiple times by the same reader.
+     *
+     * @param sequence the sequence of the item to read.
+     * @return the read item
+     * @throws StaleSequenceException if the sequence is smaller then {@link #headSequence()}
+     *                                or larger than {@link #tailSequence()}. Because a Ringbuffer won't store all event
+     *                                indefinitely, it can be that the data for the given sequence doesn't exist anymore
+     *                                and the {@link StaleSequenceException} is thrown. It is up to the caller to deal with
+     *                                this particular situation, e.g. throw an Exception or restart from the last known head.
+     *                                That is why the StaleSequenceException contains the last known head.
+     */
+    T read(long sequence);
+
+    /**
+     * Check if the sequence can be read from the ring buffer or if the sequence is of the next item to be added into the
+     * ringbuffer. This method also allows the sequence to be one greater than the {@link #tailSequence()}, giving the
+     * oportunity to block until the item is added into the ring buffer.
+     *
+     * @param readSequence the sequence wanting to be read
+     * @throws StaleSequenceException if the requested sequence is greater than the {@link #tailSequence()} + 1 or smaller
+     *                                than the {@link #headSequence()}
+     */
+    void checkBlockableReadSequence(long readSequence);
+
+    /**
+     * Check if the sequence can be read from the ring buffer.
+     *
+     * @param sequence the sequence wanting to be read
+     * @throws StaleSequenceException if the requested sequence is greater than the {@link #tailSequence()} or smaller than the
+     *                                {@link #headSequence()}
+     */
+    void checkReadSequence(long sequence);
+
+    /**
+     * Sets the item at the given sequence. The method allows null data.
+     *
+     * @param seq  The target sequence.
+     * @param data The data to be set
+     */
+    void set(long seq, T data);
+}

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -18,12 +18,12 @@ package com.hazelcast.ringbuffer.impl;
 
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.ringbuffer.StaleSequenceException;
-import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
@@ -31,74 +31,101 @@ import java.io.IOException;
 import static com.hazelcast.config.InMemoryFormat.BINARY;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.config.InMemoryFormat.values;
-import static com.hazelcast.util.Clock.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 
 /**
- * The RingbufferContainer is responsible for storing the actual content of a ringbuffer.
- * <p/>
- * Currently the Ringbuffer is not a partitioned data-structure. So all data of a ringbuffer is stored in a single partition
- * and replicated to the replica's. No thread-safety is needed since a partition can only be accessed by a single thread at
- * any given moment.
- * <p/>
- * The ringItems is the ring that contains the actual items.
- * The ringExpiration contains the expiration time of an item.
- * The if a time to live is set, the ringExpiration is created. Otherwise it is null to safe space.
- * The expiration time of an item can be found at the same index as the item itself. So these 2 arrays are always in step with
- * each other.
- * The reason why 2 array are created instead of just wrapping the item in a new object containing the expiration is that
- * we don't want to generate more waste than needed.
+ * The RingbufferContainer is responsible for creating the actual ring buffer, handling optional ring buffer storage,
+ * keeping the wait/notify key for blocking operations, ring buffer item expiration and other things not related to the
+ * actual ring buffer data structure.
+ * <p>
+ * The ringExpiration contains the expiration time of an item. If a time to live is set, the ringExpiration array is created,
+ * therwise it is null to save space.
  */
 public class RingbufferContainer implements DataSerializable {
-
     private static final long TTL_DISABLED = 0;
 
-    // contains the actual items
-    Object[] ringItems;
-    // contains the expiration time in ms when the item should be expired.
-    long[] ringExpirationMs;
-
-    InMemoryFormat inMemoryFormat;
-    long ttlMs;
-    RingbufferConfig config;
     String name;
-    long tailSequence = -1;
-    long headSequence = tailSequence + 1;
-    int capacity;
 
     // a cached version of the wait notify key needed to wait for a change if the ringbuffer is empty
     private final RingbufferWaitNotifyKey emptyRingWaitNotifyKey;
+    private RingbufferExpirationPolicy expirationPolicy;
+    private InMemoryFormat inMemoryFormat;
+    private RingbufferConfig config;
+    private RingbufferStoreWrapper store;
     private SerializationService serializationService;
 
+    private Ringbuffer ringbuffer;
+
+    /**
+     * Constructs the ring buffer container with only the name and the key for blocking operations. This does not fully
+     * prepare the container for usage. The caller must invoke the
+     * {@link #init(String, RingbufferConfig, SerializationService, ClassLoader)} method to complete the initialization before
+     * usage.
+     *
+     * @param name the name of the ring buffer container
+     */
     public RingbufferContainer(String name) {
         this.name = name;
         this.emptyRingWaitNotifyKey = new RingbufferWaitNotifyKey(name, "empty");
     }
 
-    public RingbufferContainer(RingbufferConfig config, SerializationService serializationService) {
-        this(config.getName(), config, serializationService);
+    public RingbufferContainer(String name, RingbufferConfig config,
+                               SerializationService serializationService,
+                               ClassLoader configClassLoader) {
+        this(name);
+
+        this.inMemoryFormat = config.getInMemoryFormat();
+        this.ringbuffer = new ArrayRingbuffer(config.getCapacity());
+
+        final long ttlMs = SECONDS.toMillis(config.getTimeToLiveSeconds());
+        if (ttlMs != TTL_DISABLED) {
+            this.expirationPolicy = new RingbufferExpirationPolicy(ringbuffer.getCapacity(), ttlMs);
+        }
+        init(name, config, serializationService, configClassLoader);
     }
 
-    public RingbufferContainer(String name, RingbufferConfig config, SerializationService serializationService) {
-        this(name);
-        this.serializationService = serializationService;
+    /**
+     * Initializes the ring buffer with references to other services, the ring buffer store and the config. This is because
+     * on a replication operation the container is only partially constructed. The init method finishes the configuration
+     * of the ring buffer container for further usage.
+     *
+     * @param name                 the name of the ring buffer
+     * @param config               the configuration of the ring buffer
+     * @param serializationService the serialization service
+     * @param configClassLoader    the class loader for which the ring buffer store classes will be loaded
+     */
+    public void init(String name, RingbufferConfig config,
+                     SerializationService serializationService,
+                     ClassLoader configClassLoader) {
         this.config = config;
-        this.capacity = config.getCapacity();
-        this.inMemoryFormat = config.getInMemoryFormat();
-        this.ringItems = new Object[capacity];
-        this.ttlMs = SECONDS.toMillis(config.getTimeToLiveSeconds());
+        this.serializationService = serializationService;
+        initRingbufferStore(name, config, serializationService, configClassLoader);
+    }
 
-        if (isTTLEnabled()) {
-            ringExpirationMs = new long[capacity];
+    private void initRingbufferStore(String name, RingbufferConfig config,
+                                     SerializationService serializationService, ClassLoader configClassLoader) {
+        this.store = RingbufferStoreWrapper.create(name,
+                config.getRingbufferStoreConfig(),
+                config.getInMemoryFormat(),
+                serializationService,
+                configClassLoader);
+        if (store.isEnabled()) {
+            try {
+                final long storeSequence = store.getLargestSequence();
+                ringbuffer.setTailSequence(storeSequence);
+                ringbuffer.setHeadSequence(storeSequence + 1);
+            } catch (Exception e) {
+                throw new HazelcastException(e);
+            }
         }
     }
 
-    public void init(NodeEngine nodeEngine) {
-        this.config = nodeEngine.getConfig().getRingbufferConfig(name);
-        this.serializationService = nodeEngine.getSerializationService();
-    }
-
+    /**
+     * Gets the wait/notify key for the blocking operations of reading from the ring buffer.
+     *
+     * @return the wait/notify key
+     */
     public RingbufferWaitNotifyKey getRingEmptyWaitNotifyKey() {
         return emptyRingWaitNotifyKey;
     }
@@ -108,120 +135,130 @@ public class RingbufferContainer implements DataSerializable {
     }
 
     public long tailSequence() {
-        return tailSequence;
+        return ringbuffer.tailSequence();
     }
 
     public long headSequence() {
-        return headSequence;
+        return ringbuffer.headSequence();
     }
 
     // just for testing
     public void setHeadSequence(long sequence) {
-        headSequence = sequence;
+        ringbuffer.setHeadSequence(sequence);
     }
 
-    public int getCapacity() {
-        return capacity;
+    public long getCapacity() {
+        return ringbuffer.getCapacity();
     }
 
     public long size() {
-        return tailSequence - headSequence + 1;
+        return ringbuffer.size();
     }
 
     public boolean isEmpty() {
-        return size() == 0;
+        return ringbuffer.isEmpty();
     }
 
+    /**
+     * Returns if the sequence is one after the sequence of the newest item in the ring buffer. In this case, the caller
+     * needs to wait for the item to be available. This method will throw an exception if the requested instance is larger than
+     * the sequence of the next item to be added (e.g. the second or third next item to added). If the ring buffer store is
+     * configured and enabled, this method will allow sequence values older than the head sequence.
+     *
+     * @param sequence the requested sequence
+     * @return should the caller wait for
+     * @throws StaleSequenceException if the requested sequence is
+     *                                1. greater than the tail sequence + 1 or
+     *                                2. smaller than the head sequence and the data store is not enabled
+     */
     public boolean shouldWait(long sequence) {
         checkBlockableReadSequence(sequence);
-
-        return sequence == tailSequence + 1;
+        return sequence == ringbuffer.tailSequence() + 1;
     }
 
+    /**
+     * Returns the remaining capacity of the ring buffer. If TTL is enabled, then the returned capacity is equal to the
+     * total capacity of the ringbuffer minus the number of used slots in the ringbuffer which have not yet been marked as
+     * expired and cleaned up. Keep in mind that some slots could have expired items that have not yet been cleaned up and
+     * that the returned value could be stale as soon as it is returned.
+     * <p>
+     * If TTL is disabled, the remaining capacity is equal to the total ringbuffer capacity.
+     *
+     * @return the remaining capacity of the ring buffer
+     */
     public long remainingCapacity() {
-        if (isTTLEnabled()) {
-            return capacity - size();
+        if (expirationPolicy != null) {
+            return ringbuffer.getCapacity() - size();
         }
 
-        return capacity;
+        return ringbuffer.getCapacity();
     }
 
-    private boolean isTTLEnabled() {
-        return ttlMs != TTL_DISABLED;
-    }
 
-    int toIndex(long sequence) {
-        return (int) (sequence % ringItems.length);
-    }
-
-    void checkReadSequence(long sequence) {
-        if (sequence > tailSequence) {
-            throw new IllegalArgumentException("sequence:" + sequence
-                    + " is too large. The current tailSequence is:" + tailSequence);
-        }
-
-        if (sequence < headSequence) {
-            throw new StaleSequenceException("sequence:" + sequence
-                    + " is too small. The current headSequence is:" + headSequence
-                    + " tailSequence is:" + tailSequence, headSequence);
-        }
-    }
-
-    public void checkBlockableReadSequence(long readSequence) {
-        if (readSequence > tailSequence + 1) {
-            throw new IllegalArgumentException("sequence:" + readSequence
-                    + " is too large. The current tailSequence is:" + tailSequence);
-        }
-
-        if (readSequence < headSequence) {
-            throw new StaleSequenceException("sequence:" + readSequence
-                    + " is too small. The current headSequence is:" + headSequence
-                    + " tailSequence is:" + tailSequence, headSequence);
-        }
-    }
-
+    /**
+     * Adds one item to the ring buffer. Also attempts to store the item in the data store if one is configured.
+     *
+     * @param item items to be stored in the ring buffer and data store
+     * @return the sequence id of the item stored in the ring buffer
+     * @throws HazelcastException                                              if there was any exception thrown by the data store
+     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException if the ring buffer is configured to keep items
+     *                                                                         in object format and the item could not be
+     *                                                                         deserialized
+     */
     public long add(Data item) {
-        return addInternal(item);
+        final long sequence = addInternal(item);
+        if (store.isEnabled()) {
+            try {
+                store.store(sequence, item);
+            } catch (Exception e) {
+                throw new HazelcastException(e);
+            }
+        }
+        return sequence;
     }
 
-    private long addInternal(Data dataItem) {
-        tailSequence++;
-
-        if (tailSequence - capacity == headSequence) {
-            headSequence++;
-        }
-
-        int index = toIndex(tailSequence);
-
-        Object item = dataItem;
-        if (inMemoryFormat == OBJECT) {
-            item = serializationService.toObject(dataItem);
-        }
-
-        // first we write the dataItem in the ring.
-        ringItems[index] = item;
-
-        // and then we optionally write the expiration.
-        if (isTTLEnabled()) {
-            ringExpirationMs[index] = currentTimeMillis() + ttlMs;
-        }
-
-        return tailSequence;
-    }
-
+    /**
+     * Adds all items to the ring buffer. Also attempts to store the items in the data store if one is configured.
+     *
+     * @param items items to be stored in the ring buffer and data store
+     * @return the sequence id of the last item stored in the ring buffer
+     * @throws HazelcastException                                              if there was any exception thrown by the data store
+     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException if the ring buffer is configured to keep items
+     *                                                                         in object format and the item could not be
+     *                                                                         deserialized
+     */
     public long addAll(Data[] items) {
-        long result = -1;
-        for (Data item : items) {
-            result = addInternal(item);
+        long firstSequence = -1;
+        long lastSequence = -1;
+
+        for (int i = 0; i < items.length; i++) {
+            lastSequence = addInternal(items[i]);
+            if (i == 0) {
+                firstSequence = lastSequence;
+            }
         }
-        return result;
+        if (store.isEnabled() && items.length != 0) {
+            try {
+                store.storeAll(firstSequence, items);
+            } catch (Exception e) {
+                throw new HazelcastException(e);
+            }
+        }
+        return lastSequence;
     }
 
+    /**
+     * Reads one item from the ring buffer.
+     *
+     * @param sequence The sequence of the item to be read
+     * @return The item read
+     * @throws StaleSequenceException if the sequence is :
+     *                                1. larger than the tailSequence or
+     *                                2. smaller than the headSequence and the data store is disabled
+     */
     public Data read(long sequence) {
         checkReadSequence(sequence);
-
-        int index = toIndex(sequence);
-        Object item = ringItems[index];
+        Object item = readOrLoadItem(sequence);
         return serializationService.toData(item);
     }
 
@@ -229,76 +266,129 @@ public class RingbufferContainer implements DataSerializable {
      * @param beginSequence the sequence of the first item to read.
      * @param result        the List where the result are stored in.
      * @return returns the sequenceId of the next item to read. This is needed if not all required items are found.
+     * @throws StaleSequenceException if the sequence is :
+     *                                1. larger than the tailSequence or
+     *                                2. smaller than the headSequence and the data store is disabled
      */
     public long readMany(long beginSequence, ReadResultSetImpl result) {
         checkReadSequence(beginSequence);
 
         long seq = beginSequence;
-        while (seq <= tailSequence) {
-            int index = toIndex(seq);
-            Object item = ringItems[index];
-
-            result.addItem(item);
-
+        while (seq <= ringbuffer.tailSequence()) {
+            result.addItem(readOrLoadItem(seq));
             seq++;
-
             if (result.isMaxSizeReached()) {
                 // we have found all items we are looking for. We are done.
                 break;
             }
         }
-
         return seq;
     }
 
-    /**
-     * Cleans up the ringbuffer by deleting all expired items.
-     */
+    @SuppressWarnings("unchecked")
     public void cleanup() {
-        if (!isTTLEnabled() || headSequence > tailSequence) {
-            return;
+        if (expirationPolicy != null) {
+            expirationPolicy.cleanup(ringbuffer);
+        }
+    }
+
+    /**
+     * Check if the sequence is of an item that can be read immediately or is the sequence of the next item to be added
+     * into the ringbuffer. Since this method allows the sequence to be one larger than the {@code {@link #tailSequence()}},
+     * the caller can use this method to determine if he is checking the sequence ID before performing a possibly blocking
+     * read.  Also, the requested sequence can be smaller than the head sequence if the data store is enabled.
+     *
+     * @param readSequence the sequence wanting to be read
+     * @throws StaleSequenceException if the requested sequence is
+     *                                1. greater than the tail sequence + 1 or
+     *                                2. smaller than the head sequence and the data store is not enabled
+     */
+    public void checkBlockableReadSequence(long readSequence) {
+        final long tailSequence = ringbuffer.tailSequence();
+
+        if (readSequence > tailSequence + 1) {
+            throw new IllegalArgumentException("sequence:" + readSequence
+                    + " is too large. The current tailSequence is:" + tailSequence);
         }
 
-        long now = currentTimeMillis();
-        while (headSequence <= tailSequence) {
-            int index = toIndex(headSequence);
-
-            if (ringExpirationMs[index] > now) {
-                return;
-            }
-
-            // we null the slot and allow the gc to take care of the object.
-            // if we don't clean it, we'll have a potential memory leak.
-            ringItems[index] = null;
-
-            // we don't need to 0 the ringExpirationMs slot since it contains a long value.
-
-            // and we move the head to the next item.
-            // if nothing remains in the ringbuffer, then the head will be 1 larger than the tail.
-            headSequence++;
+        final long headSequence = ringbuffer.headSequence();
+        if (readSequence < headSequence && !store.isEnabled()) {
+            throw new StaleSequenceException("sequence:" + readSequence
+                    + " is too small and data store is disabled. "
+                    + "The current headSequence is:" + headSequence
+                    + " tailSequence is:" + tailSequence, headSequence);
         }
+    }
+
+
+    /**
+     * Check if the sequence can be read from the ring buffer.
+     *
+     * @param sequence the sequence wanting to be read
+     * @throws StaleSequenceException if the requested sequence is
+     *                                1. greater than the tail sequence or
+     *                                2. smaller than the head sequence and the data store is not enabled
+     */
+    private void checkReadSequence(long sequence) {
+        final long tailSequence = ringbuffer.tailSequence();
+        if (sequence > tailSequence) {
+            throw new IllegalArgumentException("sequence:" + sequence
+                    + " is too large. The current tailSequence is:" + tailSequence);
+        }
+
+        final long headSequence = ringbuffer.headSequence();
+        if (sequence < headSequence && !store.isEnabled()) {
+            throw new StaleSequenceException("sequence:" + sequence
+                    + " is too small and data store is disabled."
+                    + " The current headSequence is:" + headSequence
+                    + " tailSequence is:" + tailSequence, headSequence);
+        }
+    }
+
+    private Object readOrLoadItem(long sequence) {
+        Object item;
+        if (sequence < ringbuffer.headSequence() && store.isEnabled()) {
+            item = store.load(sequence);
+        } else {
+            item = ringbuffer.read(sequence);
+        }
+        return item;
+    }
+
+    @SuppressWarnings("unchecked")
+    private long addInternal(Data dataItem) {
+        Object item = dataItem;
+        if (inMemoryFormat == OBJECT) {
+            item = serializationService.toObject(dataItem);
+        }
+
+        // first we write the dataItem in the ring.
+        final long tailSequence = ringbuffer.add(item);
+
+        // and then we optionally write the expiration.
+        if (expirationPolicy != null) {
+            expirationPolicy.setExpirationAt(tailSequence);
+        }
+        return tailSequence;
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeLong(tailSequence);
-        out.writeLong(headSequence);
-        out.writeInt(capacity);
-        out.writeLong(ttlMs);
+        boolean ttlEnabled = expirationPolicy != null;
+        out.writeLong(ringbuffer.tailSequence());
+        out.writeLong(ringbuffer.headSequence());
+        out.writeInt((int) ringbuffer.getCapacity());
+        out.writeLong(ttlEnabled ? expirationPolicy.getTtlMs() : 0);
         out.writeInt(inMemoryFormat.ordinal());
-
-        boolean ttlEnabled = isTTLEnabled();
 
         long now = System.currentTimeMillis();
 
         // we only write the actual content of the ringbuffer. So we don't write empty slots.
-        for (long seq = headSequence; seq <= tailSequence; seq++) {
-            int index = toIndex(seq);
-
+        for (long seq = ringbuffer.headSequence(); seq <= ringbuffer.tailSequence(); seq++) {
             if (inMemoryFormat == BINARY) {
-                out.writeData((Data) ringItems[index]);
+                out.writeData((Data) ringbuffer.read(seq));
             } else {
-                out.writeObject(ringItems[index]);
+                out.writeObject(ringbuffer.read(seq));
             }
 
             // we write the time difference compared to now. Because the clock on the receiving side
@@ -307,42 +397,51 @@ public class RingbufferContainer implements DataSerializable {
             // migrated to a machine with a time 1 hour earlier, the ttl would effectively become
             // 1 hours and 10 seconds.
             if (ttlEnabled) {
-                long deltaMs = ringExpirationMs[index] - now;
+                long deltaMs = expirationPolicy.getExpirationAt(seq) - now;
                 out.writeLong(deltaMs);
             }
         }
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public void readData(ObjectDataInput in) throws IOException {
-        tailSequence = in.readLong();
-        headSequence = in.readLong();
-        capacity = in.readInt();
-        ttlMs = in.readLong();
+        final long tailSequence = in.readLong();
+        final long headSequence = in.readLong();
+        final int capacity = in.readInt();
+        final long ttlMs = in.readLong();
         inMemoryFormat = values()[in.readInt()];
 
-        ringItems = new Object[capacity];
+        ringbuffer = new ArrayRingbuffer(capacity);
+        ringbuffer.setTailSequence(tailSequence);
+        ringbuffer.setHeadSequence(headSequence);
 
-        boolean ttlEnabled = isTTLEnabled();
+        boolean ttlEnabled = ttlMs != TTL_DISABLED;
         if (ttlEnabled) {
-            ringExpirationMs = new long[capacity];
+            this.expirationPolicy = new RingbufferExpirationPolicy(capacity, ttlMs);
         }
 
         long now = System.currentTimeMillis();
         for (long seq = headSequence; seq <= tailSequence; seq++) {
-            int index = toIndex(seq);
-
             if (inMemoryFormat == BINARY) {
-                ringItems[index] = in.readData();
+                ringbuffer.set(seq, in.readData());
             } else {
-                ringItems[index] = in.readObject();
+                ringbuffer.set(seq, in.readObject());
             }
 
             if (ttlEnabled) {
                 long delta = in.readLong();
-                ringExpirationMs[index] = delta + now;
+                expirationPolicy.setExpirationAt(seq, delta + now);
             }
         }
+    }
+
+    Ringbuffer getRingbuffer() {
+        return ringbuffer;
+    }
+
+    RingbufferExpirationPolicy getExpirationPolicy() {
+        return expirationPolicy;
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferExpirationPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferExpirationPolicy.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.ringbuffer.impl;
+
+import static com.hazelcast.util.Clock.currentTimeMillis;
+
+/**
+ * The expiration policy for the ring buffer items. Currently keeps the expiration times in an array of longs.
+ */
+final class RingbufferExpirationPolicy {
+    // contains the expiration time in ms when the item should be expired.
+    long[] ringExpirationMs;
+    private final long ttlMs;
+
+    RingbufferExpirationPolicy(long capacity, long ttlMs) {
+        this.ringExpirationMs = new long[(int) capacity];
+        this.ttlMs = ttlMs;
+    }
+
+    /**
+     * Cleans up the ringbuffer by deleting all expired items.
+     */
+    @SuppressWarnings("unchecked")
+    void cleanup(Ringbuffer ringbuffer) {
+        if (ringbuffer.headSequence() > ringbuffer.tailSequence()) {
+            return;
+        }
+
+        long now = currentTimeMillis();
+        while (ringbuffer.headSequence() <= ringbuffer.tailSequence()) {
+            final long headSequence = ringbuffer.headSequence();
+
+            if (ringExpirationMs[toIndex(headSequence)] > now) {
+                return;
+            }
+
+            // we null the slot and allow the gc to take care of the object.
+            // if we don't clean it, we'll have a potential memory leak.
+            ringbuffer.set(headSequence, null);
+
+            // we don't need to 0 the ringExpirationMs slot since it contains a long value.
+
+            // and we move the head to the next item.
+            // if nothing remains in the ringbuffer, then the head will be 1 larger than the tail.
+            ringbuffer.setHeadSequence(ringbuffer.headSequence() + 1);
+        }
+    }
+
+    int toIndex(long sequence) {
+        return (int) (sequence % ringExpirationMs.length);
+    }
+
+    /**
+     * Set the expiration value at the target sequence to the current time plus the TTL.
+     *
+     * @param sequence the sequence for which the expiration is set
+     */
+    void setExpirationAt(long sequence) {
+        setExpirationAt(sequence, currentTimeMillis() + ttlMs);
+    }
+
+    /**
+     * Get the expiration value for the sequence.
+     *
+     * @param seq the sequence for which the expiration is needed
+     * @return the time in milliseconds
+     */
+    long getExpirationAt(long seq) {
+        return ringExpirationMs[toIndex(seq)];
+    }
+
+    /**
+     * Set the expiration value at the target sequence.
+     *
+     * @param seq   the sequence for which the expiration is set
+     * @param value the value (time) at which the item is expired
+     */
+    void setExpirationAt(long seq, long value) {
+        ringExpirationMs[toIndex(seq)] = value;
+    }
+
+    /**
+     * Get the TTL in milliseconds.
+     *
+     * @return the TTL
+     */
+    long getTtlMs() {
+        return ttlMs;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferStoreWrapper.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.RingbufferStoreConfig;
+import com.hazelcast.core.RingbufferStore;
+import com.hazelcast.core.RingbufferStoreFactory;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.nio.ClassLoaderUtil;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.EmptyStatement;
+
+import java.util.Arrays;
+
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Wrapper for the ring buffer store. In charge of creation of a ring buffer store from
+ * configuration and enforcing rules defined by the ring buffer configuration (e.g.
+ * store format) before forwarding the calls to the underlying ring buffer store.
+ */
+public final class RingbufferStoreWrapper implements RingbufferStore<Data> {
+    private boolean enabled;
+
+    /**
+     * Is the data being stored in serialized (BINARY/NATIVE) or deserialized (OBJECT) format.
+     */
+    private InMemoryFormat inMemoryFormat;
+    private RingbufferStore store;
+    private SerializationService serializationService;
+
+
+    private RingbufferStoreWrapper() {
+    }
+
+    /**
+     * Factory method that creates a {@link RingbufferStoreWrapper}. It attempts to create the ring buffer store from several
+     * sources :
+     * <ul>
+     * <li>checks if the config contains the store implementation</li>
+     * <li>tries to create the store from the ring buffer store class</li>
+     * <li>tries to create one from the ring buffer store factory</li>
+     * <li>tries to instantiate the factory from the factory class and create the store from the factory</li>
+     * </ul>
+     *
+     * @param name                 ring buffer name
+     * @param storeConfig          store config of ring buffer
+     * @param inMemoryFormat       the format of the stored items (BINARY, OBJECT or NATIVE). NATIVE format translates into
+     *                             binary values on the store method calls.
+     * @param serializationService serialization service.
+     * @return returns a new instance of {@link RingbufferStoreWrapper}
+     */
+    public static RingbufferStoreWrapper create(String name,
+                                                RingbufferStoreConfig storeConfig,
+                                                InMemoryFormat inMemoryFormat, SerializationService serializationService,
+                                                ClassLoader classLoader) {
+        checkNotNull(name, "name should not be null");
+        checkNotNull(serializationService, "serializationService should not be null");
+
+        final RingbufferStoreWrapper storeWrapper = new RingbufferStoreWrapper();
+        storeWrapper.serializationService = serializationService;
+        if (storeConfig == null || !storeConfig.isEnabled()) {
+            return storeWrapper;
+        }
+        // create ring buffer store.
+        final RingbufferStore ringbufferStore = createRingbufferStore(name, storeConfig, classLoader);
+        if (ringbufferStore != null) {
+            storeWrapper.enabled = storeConfig.isEnabled();
+            storeWrapper.inMemoryFormat = inMemoryFormat;
+            storeWrapper.store = ringbufferStore;
+        }
+        return storeWrapper;
+    }
+
+    private static RingbufferStore createRingbufferStore(String name,
+                                                         RingbufferStoreConfig storeConfig,
+                                                         ClassLoader classLoader) {
+        // 1. Try to create store from `store impl.` class.
+        RingbufferStore store = getRingbufferStore(storeConfig, classLoader);
+        // 2. Try to create store from `store factory impl.` class.
+        if (store == null) {
+            store = getRingbufferStoreFactory(name, storeConfig, classLoader);
+        }
+        return store;
+    }
+
+    private static RingbufferStore getRingbufferStore(RingbufferStoreConfig storeConfig, ClassLoader classLoader) {
+        if (storeConfig == null) {
+            return null;
+        }
+        return getOrInstantiate(storeConfig.getStoreImplementation(), classLoader, storeConfig.getClassName());
+    }
+
+    private static RingbufferStore getRingbufferStoreFactory(String name,
+                                                             RingbufferStoreConfig storeConfig, ClassLoader classLoader) {
+        if (storeConfig == null) {
+            return null;
+        }
+        final RingbufferStoreFactory implementation = storeConfig.getFactoryImplementation();
+        final String className = storeConfig.getFactoryClassName();
+
+        final RingbufferStoreFactory factory = getOrInstantiate(implementation, classLoader, className);
+        return factory == null ? null : factory.newRingbufferStore(name, storeConfig.getProperties());
+    }
+
+    private static <T> T getOrInstantiate(T instance, ClassLoader classLoader, String className) {
+        if (instance != null) {
+            return instance;
+        }
+        try {
+            return ClassLoaderUtil.newInstance(classLoader, className);
+        } catch (Exception ignored) {
+            EmptyStatement.ignore(ignored);
+        }
+        return null;
+    }
+
+    /**
+     * Is the ring buffer store enabled.
+     *
+     * @return if the store is enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void store(long sequence, Data value) {
+        final Object actualValue;
+        if (isBinaryFormat()) {
+            // WARNING: we can't pass original byte array to the user
+            actualValue = Arrays.copyOf(value.toByteArray(), value.totalSize());
+        } else {
+            // here we deserialize the object again (the first time is in the actual ring buffer).
+            // if we are certain that the user cannot abuse the object, we can provide him with a reference to the
+            // stored value
+            actualValue = serializationService.toObject(value);
+        }
+        store.store(sequence, actualValue);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void storeAll(long firstItemSequence, Data[] items) {
+        final Object[] storedItems = new Object[items.length];
+        for (int i = 0; i < items.length; i++) {
+            final Data value = items[i];
+            if (isBinaryFormat()) {
+                // more defensive copying in the case of binary format
+                storedItems[i] = Arrays.copyOf(value.toByteArray(), value.totalSize());
+            } else {
+                // in the case of object format we have again deserialization. We could possibly pass the user the reference
+                // to the item in the RB store if it is safe
+                storedItems[i] = serializationService.toObject(value);
+            }
+
+        }
+        store.storeAll(firstItemSequence, storedItems);
+    }
+
+    private boolean isBinaryFormat() {
+        return inMemoryFormat.equals(BINARY) || inMemoryFormat.equals(NATIVE);
+    }
+
+    @Override
+    public Data load(long sequence) {
+        final Object val = store.load(sequence);
+        if (val == null) {
+            return null;
+        }
+
+        if (isBinaryFormat()) {
+            byte[] dataBuffer = (byte[]) val;
+            return new HeapData(Arrays.copyOf(dataBuffer, dataBuffer.length));
+        }
+        return serializationService.toData(val);
+    }
+
+    @Override
+    public long getLargestSequence() {
+        return store.getLargestSequence();
+    }
+}

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -1171,6 +1171,12 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
+    <xs:complexType name="ringbuffer-store">
+        <xs:all>
+            <xs:element ref="factory-or-class-name" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="true" type="xs:boolean"/>
+    </xs:complexType>
     <xs:complexType name="ringbuffer">
         <xs:all>
             <xs:element name="capacity" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
@@ -1218,6 +1224,14 @@
                         BINARY (default): keys and values are stored as binary data.
                         OBJECT: values are stored in their object forms.
                         NATIVE: keys and values are stored in native memory. Only available on Hazelcast Enterprise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ringbuffer-store" type="ringbuffer-store" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Includes the ring buffer store factory class name. The store format is the same as the
+                        in-memory-format for the ringbuffer.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.config.RingbufferStoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.RingbufferStore;
+import com.hazelcast.core.RingbufferStoreFactory;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.ConcurrencyUtil;
+import com.hazelcast.util.ConstructorFunction;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static com.hazelcast.config.RingbufferConfig.DEFAULT_CAPACITY;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class RingbufferStoreTest extends HazelcastTestSupport {
+
+    private static Config getConfig(String ringbufferName,
+                                    int capacity,
+                                    InMemoryFormat inMemoryFormat,
+                                    RingbufferStoreConfig ringbufferStoreConfig) {
+        final Config config = new Config();
+        final RingbufferConfig rbConfig = config
+                .getRingbufferConfig(ringbufferName)
+                .setInMemoryFormat(inMemoryFormat)
+                .setCapacity(capacity);
+        rbConfig.setRingbufferStoreConfig(ringbufferStoreConfig);
+        return config;
+    }
+
+    @Test
+    public void testRingbufferStore() throws Exception {
+        final int numItems = 2000;
+
+        final TestRingbufferStore<Integer> rbStore = new TestRingbufferStore<Integer>(2000, 0, 2000);
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setEnabled(true)
+                .setStoreImplementation(rbStore);
+        final Config config = getConfig("testRingbufferStore", DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+
+        final HazelcastInstance instance = factory.newHazelcastInstance(config);
+        final Ringbuffer<Object> ringbuffer = instance.getRingbuffer("testRingbufferStore");
+        for (int i = 0; i < numItems; i++) {
+            ringbuffer.add(i);
+        }
+        instance.shutdown();
+
+        final HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        final Ringbuffer<Object> ringbuffer2 = instance2.getRingbuffer("testRingbufferStore");
+
+        // the actual ring buffer is empty but we can still load items from it
+        assertEquals(0, ringbuffer2.size());
+        assertEquals(numItems, rbStore.store.size());
+
+        for (int i = 0; i < numItems; i++) {
+            assertEquals(i, ringbuffer2.readOne(i));
+        }
+
+        rbStore.assertAwait(3);
+    }
+
+    @Test
+    public void testRingbufferStoreMoreThanCapacity() throws Exception {
+        final int capacity = 1000;
+
+        final TestRingbufferStore<Integer> rbStore = new TestRingbufferStore<Integer>(capacity * 2, 0, 0);
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setEnabled(true)
+                .setStoreImplementation(rbStore);
+        final Config config = getConfig("testRingbufferStore", capacity, OBJECT, rbStoreConfig);
+
+        final HazelcastInstance instance = createHazelcastInstance(config);
+        final Ringbuffer<Object> ringbuffer = instance.getRingbuffer("testRingbufferStore");
+
+        for (int i = 0; i < capacity * 2; i++) {
+            ringbuffer.add(i);
+        }
+
+        assertEquals(capacity, ringbuffer.size());
+        assertEquals(capacity * 2, rbStore.store.size());
+
+        for (int i = 0; i < capacity * 2; i++) {
+            assertEquals(i, ringbuffer.readOne(i));
+        }
+
+        rbStore.assertAwait(3);
+    }
+
+    @Test
+    public void testStoreId_whenNodeDown() {
+        final IdCheckerRingbufferStore rbStore = new IdCheckerRingbufferStore();
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setEnabled(true)
+                .setStoreImplementation(rbStore);
+        final Config config = getConfig("default", DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
+
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        final HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        final String name = generateKeyOwnedBy(instance1);
+        final Ringbuffer<Object> ringbuffer = instance2.getRingbuffer(name);
+        ringbuffer.add(randomString());
+        ringbuffer.add(randomString());
+        ringbuffer.add(randomString());
+
+        instance1.shutdown();
+
+        ringbuffer.add(randomString());
+    }
+
+    @Test
+    public void testRingbufferStoreFactory() {
+        final String ringbufferName = randomString();
+        final SimpleRingbufferStoreFactory rbStoreFactory = new SimpleRingbufferStoreFactory();
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setEnabled(true)
+                .setFactoryImplementation(rbStoreFactory);
+        final Config config = getConfig(ringbufferName, DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
+        final HazelcastInstance instance = createHazelcastInstance(config);
+
+        final Ringbuffer<Object> ringbuffer = instance.getRingbuffer(ringbufferName);
+        ringbuffer.add(1);
+
+        assertEquals(1, rbStoreFactory.stores.size());
+
+        final TestRingbufferStore ringbufferStore = (TestRingbufferStore) rbStoreFactory.stores.get(ringbufferName);
+        int size = ringbufferStore.store.size();
+        assertEquals("Ring buffer store size should be 1 but found " + size, 1, size);
+    }
+
+    @Test
+    public void testRingbufferStoreFactoryIsNotInitialized_whenDisabledInRingbufferStoreConfig() {
+        final String ringbufferName = randomString();
+        final SimpleRingbufferStoreFactory rbStoreFactory = new SimpleRingbufferStoreFactory();
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setEnabled(false)
+                .setFactoryImplementation(rbStoreFactory);
+        final Config config = getConfig(ringbufferName, DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
+        final HazelcastInstance instance = createHazelcastInstance(config);
+
+        final Ringbuffer<Object> ringbuffer = instance.getRingbuffer(ringbufferName);
+        ringbuffer.add(1);
+
+        assertEquals("Expected that the ring buffer store would not be initialized" +
+                " since we disabled it in the ring buffer store config but found initialized ", 0, rbStoreFactory.stores.size());
+    }
+
+    @Test
+    public void testRingbufferStore_withBinaryModeOn() throws InterruptedException {
+        final String ringbufferName = randomString();
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setStoreImplementation(new TestRingbufferStore<Data>())
+                .setEnabled(true);
+        final Config config = getConfig(ringbufferName, DEFAULT_CAPACITY, BINARY, rbStoreConfig);
+
+        final HazelcastInstance node = createHazelcastInstance(config);
+        final Ringbuffer<Object> ringbuffer = node.getRingbuffer(ringbufferName);
+        ringbuffer.add(1);
+        ringbuffer.add(2);
+        final long lastSequence = ringbuffer.add(3);
+
+        assertEquals(3, ringbuffer.readOne(lastSequence));
+    }
+
+    static class SimpleRingbufferStoreFactory implements RingbufferStoreFactory<Integer> {
+
+        private final ConcurrentMap<String, RingbufferStore> stores = new ConcurrentHashMap<String, RingbufferStore>();
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public RingbufferStore<Integer> newRingbufferStore(String name, Properties properties) {
+            return ConcurrencyUtil.getOrPutIfAbsent(stores, name, new ConstructorFunction<String, RingbufferStore>() {
+                @Override
+                public RingbufferStore<Integer> createNew(String arg) {
+                    return new TestRingbufferStore<Integer>();
+                }
+            });
+        }
+    }
+
+    static class IdCheckerRingbufferStore implements RingbufferStore {
+        Long lastKey;
+
+        @Override
+        public void store(final long sequence, final Object value) {
+            if (lastKey != null && lastKey >= sequence) {
+                throw new RuntimeException("key[" + sequence + "] is already stored");
+            }
+            lastKey = sequence;
+        }
+
+        @Override
+        public void storeAll(long firstItemSequence, Object[] items) {
+
+        }
+
+        @Override
+        public Object load(final long sequence) {
+            return null;
+        }
+
+        @Override
+        public long getLargestSequence() {
+            return lastKey;
+        }
+    }
+
+    static class TestRingbufferStore<T> implements RingbufferStore<T> {
+
+        final Map<Long, T> store = new LinkedHashMap<Long, T>();
+        final AtomicInteger callCount = new AtomicInteger();
+        final AtomicInteger destroyCount = new AtomicInteger();
+
+        final CountDownLatch latchStore;
+        final CountDownLatch latchStoreAll;
+        final CountDownLatch latchLoad;
+
+        public TestRingbufferStore() {
+            this(0, 0, 0);
+        }
+
+        TestRingbufferStore(int expectedStore, int expectedStoreAll, int expectedLoad) {
+            latchStore = new CountDownLatch(expectedStore);
+            latchStoreAll = new CountDownLatch(expectedStoreAll);
+            latchLoad = new CountDownLatch(expectedLoad);
+        }
+
+        public void destroy() {
+            destroyCount.incrementAndGet();
+        }
+
+        void assertAwait(int seconds) throws Exception {
+            assertTrue("Store remaining: " + latchStore.getCount(), latchStore.await(seconds, SECONDS));
+            assertTrue("Store-all remaining: " + latchStoreAll.getCount(), latchStoreAll.await(seconds, SECONDS));
+            assertTrue("Load remaining: " + latchLoad.getCount(), latchLoad.await(seconds, SECONDS));
+        }
+
+        Map getStore() {
+            return store;
+        }
+
+        @Override
+        public void store(long sequence, T data) {
+            store.put(sequence, data);
+            callCount.incrementAndGet();
+            latchStore.countDown();
+        }
+
+        @Override
+        public void storeAll(long firstItemSequence, T[] items) {
+            for (int i = 0; i < items.length; i++) {
+                store.put(firstItemSequence + i, items[i]);
+            }
+            callCount.incrementAndGet();
+            latchStoreAll.countDown();
+        }
+
+        @Override
+        public T load(long sequence) {
+            callCount.incrementAndGet();
+            latchLoad.countDown();
+            return store.get(sequence);
+        }
+
+        @Override
+        public long getLargestSequence() {
+            final Set<Long> coll = store.keySet();
+            return coll.isEmpty() ? -1 : Collections.max(coll);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferTTLTest.java
@@ -23,6 +23,7 @@ public class RingbufferTTLTest extends HazelcastTestSupport {
     private HazelcastInstance hz;
     private Ringbuffer ringbuffer;
     private RingbufferContainer ringbufferContainer;
+    private ArrayRingbuffer arrayRingbuffer;
 
     public void setup(RingbufferConfig ringbufferConfig) {
         Config config = new Config();
@@ -32,6 +33,7 @@ public class RingbufferTTLTest extends HazelcastTestSupport {
 
         RingbufferService ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
         ringbufferContainer = ringbufferService.getContainer(ringbufferConfig.getName());
+        arrayRingbuffer = (ArrayRingbuffer) ringbufferContainer.getRingbuffer();
     }
 
     // when ttl is set, then eventually all the items needs to get expired.
@@ -63,7 +65,7 @@ public class RingbufferTTLTest extends HazelcastTestSupport {
 
         // and we verify that the slots are nulled so we don't have a memory leak on our hands.
         for (int k = 0; k < ringbuffer.capacity(); k++) {
-            assertNull(ringbufferContainer.ringItems[k]);
+            assertNull(arrayRingbuffer.ringItems[k]);
         }
     }
 


### PR DESCRIPTION
This is a recreated PR because the original PR couldn't be reopened after a forced git push. The original PR : https://github.com/hazelcast/hazelcast/pull/8995

This PR is consisted of two parts - adding a storing mechanism for the ring buffer and refactoring the RingbufferContainer class.

The ring buffer storing mechanism now allows reading sequences older than the head sequence thus reading items which are no longer in the ring buffer. Also, upon initialization the ring buffer will ask the store for the newest sequence ID and start from there. This allows the client to replay older messages in a reliable topic via the ReliableMessageListener even though the underlying ring buffer has overwritten the items.

The refactoring was made because the RingbufferContainer class contained logic for the actual ring buffer structure, the TTL expiration logic, the ring buffer store logic and the key for the wait/notify blocking ops. Some parts are now factored out of this class and can be reused (e.g. the ArrayRingbuffer) in other parts of the code.

Also, added some extra Javadoc :)