### PR TITLE
Upgrade JMH to 1.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.3</powermock.version>
-        <jmh.version>1.12</jmh.version>
+        <jmh.version>1.14.1</jmh.version>
 
         <findbugs.version>1.3.2</findbugs.version>
 


### PR DESCRIPTION
It'd be usually good to use the latest library version. :)

ref.
JMH 1.13:   http://mail.openjdk.java.net/pipermail/jmh-dev/2016-July/002269.html
JMH 1.14:   http://mail.openjdk.java.net/pipermail/jmh-dev/2016-September/002326.html
JMH 1.14.1: http://mail.openjdk.java.net/pipermail/jmh-dev/2016-September/002351.html
