### PR TITLE
Don't fail when registering a duplicate PortableFactory.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableHookLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortableHookLoader.java
@@ -80,13 +80,7 @@ final class PortableHookLoader {
     private void register(int factoryId, PortableFactory factory) {
         final PortableFactory current = factories.get(factoryId);
         if (current != null) {
-            if (current.equals(factory)) {
-                Logger.getLogger(getClass()).warning("PortableFactory[" + factoryId + "] is already registered! Skipping "
-                        + factory);
-            } else {
-                throw new IllegalArgumentException("PortableFactory[" + factoryId
-                        + "] is already registered! " + current + " -> " + factory);
-            }
+            Logger.getLogger(getClass()).warning("PortableFactory[" + factoryId + "] is already registered! Skipping " + factory);
         } else {
             factories.put(factoryId, factory);
         }


### PR DESCRIPTION
Resolves #2395.