### PR TITLE
IO handler cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThread.java
@@ -135,6 +135,10 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
         return selector;
     }
 
+    public NonBlockingIOThreadOutOfMemoryHandler getOomeHandler() {
+        return oomeHandler;
+    }
+
     /**
      * Returns the total number of selection-key events that have been processed by this thread.
      *

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingIOThreadingModel.java
@@ -216,7 +216,8 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
         if (outputThread == null) {
             throw new IllegalStateException("IO thread is closed!");
         }
-        return new NonBlockingSocketWriter(connection, outputThread);
+        return new NonBlockingSocketWriter(
+                connection, outputThread, loggingService.getLogger(NonBlockingSocketWriter.class), ioBalancer);
     }
 
     @Override
@@ -226,6 +227,7 @@ public class NonBlockingIOThreadingModel implements IOThreadingModel {
         if (inputThread == null) {
             throw new IllegalStateException("IO thread is closed!");
         }
-        return new NonBlockingSocketReader(connection, inputThread);
+        return new NonBlockingSocketReader(
+                connection, inputThread, loggingService.getLogger(NonBlockingSocketReader.class), ioBalancer);
     }
 }


### PR DESCRIPTION
The AbstractHandler is less serverside dependent. This way the same AbstractHandler can be used on client and server. No real logic changes; just matter of changing the way the dependencies get injected.