### PR TITLE
Client io system makes use of ReadHandler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageReadHandler.java
@@ -17,6 +17,8 @@
 package com.hazelcast.client.impl.protocol.util;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.internal.util.counters.SwCounter;
+import com.hazelcast.nio.tcp.ReadHandler;
 import com.hazelcast.util.collection.Long2ObjectHashMap;
 
 import java.nio.ByteBuffer;
@@ -28,23 +30,26 @@ import static com.hazelcast.client.impl.protocol.ClientMessage.END_FLAG;
 /**
  * Builds {@link ClientMessage}s from byte chunks. Fragmented messages are merged into single messages before processed.
  */
-public class ClientMessageBuilder {
+public class ClientMessageReadHandler implements ReadHandler {
 
     private final Long2ObjectHashMap<BufferBuilder> builderBySessionIdMap = new Long2ObjectHashMap<BufferBuilder>();
 
     private final MessageHandler delegate;
+    private final SwCounter messageCounter;
     private ClientMessage message = ClientMessage.create();
 
-    public ClientMessageBuilder(MessageHandler delegate) {
-        this.delegate = delegate;
+    public ClientMessageReadHandler(SwCounter messageCounter, MessageHandler messageHandler) {
+        this.messageCounter = messageCounter;
+        this.delegate = messageHandler;
     }
 
-    public int onData(final ByteBuffer buffer) {
+    @Override
+    public void onRead(ByteBuffer src) throws Exception {
         int messagesCreated = 0;
-        while (buffer.hasRemaining()) {
-            final boolean complete = message.readFrom(buffer);
+        while (src.hasRemaining()) {
+            final boolean complete = message.readFrom(src);
             if (!complete) {
-                return messagesCreated;
+                messageCounter.inc(messagesCreated);
             }
 
             //MESSAGE IS COMPLETE HERE
@@ -83,8 +88,6 @@ public class ClientMessageBuilder {
             message = ClientMessage.create();
             messagesCreated++;
         }
-
-        return messagesCreated;
     }
 
     private void handleMessage(ClientMessage message) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientReadHandler.java
@@ -17,7 +17,8 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.util.ClientMessageBuilder;
+import com.hazelcast.client.impl.protocol.util.ClientMessageReadHandler;
+import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.IOService;
 
@@ -25,7 +26,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * A {@link ReadHandler} for the new-client. It passes the ByteBuffer to the ClientMessageBuilder. For each
+ * A {@link ReadHandler} for the new-client. It passes the ByteBuffer to the ClientMessageReadHandler. For each
  * constructed ClientMessage, the {@link #handleMessage(ClientMessage)} is called; which passes the message
  * to the {@link IOService#handleClientMessage(ClientMessage, Connection)}.
  *
@@ -35,21 +36,21 @@ import java.nio.ByteBuffer;
  *
  * @see ClientWriteHandler
  */
-public class ClientReadHandler implements ReadHandler, ClientMessageBuilder.MessageHandler {
+public class ClientReadHandler implements ReadHandler, ClientMessageReadHandler.MessageHandler {
 
-    private final ClientMessageBuilder builder;
+    private final ClientMessageReadHandler readHandler;
     private final Connection connection;
     private final IOService ioService;
 
-    public ClientReadHandler(Connection connection, IOService ioService) throws IOException {
+    public ClientReadHandler(SwCounter messageCounter, Connection connection, IOService ioService) throws IOException {
         this.connection = connection;
         this.ioService = ioService;
-        this.builder = new ClientMessageBuilder(this);
+        this.readHandler = new ClientMessageReadHandler(messageCounter, this);
     }
 
     @Override
     public void onRead(ByteBuffer src) throws Exception {
-        builder.onData(src);
+        readHandler.onRead(src);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketReader.java
@@ -18,7 +18,6 @@ package com.hazelcast.nio.tcp.nonblocking;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
-import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.IOService;
@@ -93,12 +92,12 @@ public final class NonBlockingSocketReader
     }
 
     @Override
-    public Counter getNormalFramesReadCounter() {
+    public SwCounter getNormalFramesReadCounter() {
         return normalFramesRead;
     }
 
     @Override
-    public Counter getPriorityFramesReadCounter() {
+    public SwCounter getPriorityFramesReadCounter() {
         return priorityFramesRead;
     }
 
@@ -197,7 +196,7 @@ public final class NonBlockingSocketReader
             } else if (CLIENT_BINARY_NEW.equals(protocol)) {
                 configureBuffers(ioService.getSocketClientReceiveBufferSize() * KILO_BYTE);
                 socketWriter.setProtocol(CLIENT_BINARY_NEW);
-                readHandler = new ClientReadHandler(connection, ioService);
+                readHandler = new ClientReadHandler(getNormalFramesReadCounter(), connection, ioService);
             } else {
                 configureBuffers(ioService.getSocketReceiveBufferSize() * KILO_BYTE);
                 socketWriter.setProtocol(Protocols.TEXT);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketReader.java
@@ -168,7 +168,7 @@ public class SpinningSocketReader extends AbstractHandler implements SocketReade
         } else if (CLIENT_BINARY_NEW.equals(protocol)) {
             configureBuffers(ioService.getSocketClientReceiveBufferSize() * KILO_BYTE);
             socketWriter.setProtocol(CLIENT_BINARY_NEW);
-            readHandler = new ClientReadHandler(connection, ioService);
+            readHandler = new ClientReadHandler(normalFramesRead, connection, ioService);
         } else {
             configureBuffers(ioService.getSocketReceiveBufferSize() * KILO_BYTE);
             socketWriter.setProtocol(Protocols.TEXT);

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientReadHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientReadHandlerTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -26,12 +27,14 @@ public class ClientReadHandlerTest {
     private ClientReadHandler readHandler;
     private IOService ioService;
     private Connection connection;
+    private SwCounter counter;
 
     @Before
     public void setup() throws IOException {
         ioService = mock(IOService.class);
         connection = mock(Connection.class);
-        readHandler = new ClientReadHandler(connection, ioService);
+        counter = SwCounter.newSwCounter();
+        readHandler = new ClientReadHandler(counter, connection, ioService);
     }
 
     @Test


### PR DESCRIPTION
This is one other step to allign the client with the server. The idea is that we have
one non blocking socket reader/writer which can be used for both client and server.

The main change in this pr is that the ClientMessageBuilder is now renamed to
ClientMessageReadHandler and implements the ReadHandler interface from the server.