### PR TITLE
Fixes problem in the IORebalancing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/nonblocking/NonBlockingSocketWriter.java
@@ -68,8 +68,6 @@ public final class NonBlockingSocketWriter
     @SuppressWarnings("checkstyle:visibilitymodifier")
     @Probe(name = "priorityWriteQueueSize")
     public final Queue<OutboundFrame> urgentWriteQueue = new ConcurrentLinkedQueue<OutboundFrame>();
-    @Probe(name = "eventCount")
-    private final SwCounter eventCount = newSwCounter();
     private final AtomicBoolean scheduled = new AtomicBoolean(false);
     private final TcpIpConnectionManager connectionManager;
     private final IOService ioService;


### PR DESCRIPTION
The error was simple; the eventCount field was copied into the AbstractHandler
but it was not removed from the NonBlockingSocketWriter (subclass). So we have one eventCount
hiding another. The one in the AbstractHandler was used for migratation load
detection, but the one on NonBlockingSocketWriter gets updated by the io system.