### PR TITLE
Fixed setting of default max size in EvictionConfig

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.util.Preconditions.checkFalse;
 
 /**
@@ -138,7 +139,7 @@ public class ClientConfig {
         return this;
     }
 
-     /**
+    /**
      * Gets {@link java.util.Properties} object
      *
      * @return {@link java.util.Properties} object
@@ -288,7 +289,13 @@ public class ClientConfig {
         NearCacheConfig nearCacheConfig = lookupByPattern(nearCacheConfigMap, name);
         if (nearCacheConfig == null) {
             nearCacheConfig = nearCacheConfigMap.get("default");
+            if (nearCacheConfig != null) {
+                // if there is a default config we have to clone it,
+                // otherwise you will modify the same instances via different Near Cache names
+                nearCacheConfig = new NearCacheConfig(nearCacheConfig);
+            }
         }
+        initDefaultMaxSizeForOnHeapMaps(nearCacheConfig);
         return nearCacheConfig;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -42,7 +42,6 @@ import com.hazelcast.client.impl.protocol.codec.ReplicatedMapValuesCodec;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
-import com.hazelcast.config.EvictionConfigAccessor;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
@@ -407,8 +406,6 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
             if (nearCacheConfig == null) {
                 return;
             }
-            EvictionConfigAccessor.initDefaultMaxSize(nearCacheConfig.getEvictionConfig());
-
             NearCacheContext nearCacheContext = new NearCacheContext(
                     getContext().getSerializationService(),
                     new ClientNearCacheExecutor(getContext().getExecutionService()));

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -29,7 +29,6 @@ import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.client.util.ClientDelegatingFuture;
-import com.hazelcast.config.EvictionConfigAccessor;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
@@ -88,7 +87,6 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         ClientContext context = getContext();
 
         NearCacheConfig nearCacheConfig = context.getClientConfig().getNearCacheConfig(name);
-        EvictionConfigAccessor.initDefaultMaxSize(nearCacheConfig.getEvictionConfig());
 
         NearCacheContext nearCacheContext = new NearCacheContext(
                 context.getSerializationService(),

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.text.MessageFormat.format;
@@ -244,6 +245,7 @@ public class Config {
         String baseName = getBaseName(name);
         MapConfig config = lookupByPattern(mapConfigs, baseName);
         if (config != null) {
+            initDefaultMaxSizeForOnHeapMaps(config.getNearCacheConfig());
             return config.getAsReadOnly();
         }
         return getMapConfig("default").getAsReadOnly();
@@ -259,6 +261,7 @@ public class Config {
         if (defConfig == null) {
             defConfig = new MapConfig();
             defConfig.setName("default");
+            initDefaultMaxSizeForOnHeapMaps(defConfig.getNearCacheConfig());
             addMapConfig(defConfig);
         }
         config = new MapConfig(defConfig);
@@ -290,7 +293,6 @@ public class Config {
         }
         return this;
     }
-
 
     public CacheSimpleConfig findCacheConfig(String name) {
         name = getBaseName(name);
@@ -665,7 +667,6 @@ public class Config {
         return this;
     }
 
-
     /**
      * @return the topicConfigs
      */
@@ -861,7 +862,6 @@ public class Config {
         return this;
     }
 
-
     public WanReplicationConfig getWanReplicationConfig(String name) {
         return wanReplicationConfigs.get(name);
     }
@@ -956,7 +956,6 @@ public class Config {
         }
         return getQuorumConfig("default");
     }
-
 
     public Config setQuorumConfigs(Map<String, QuorumConfig> quorumConfigs) {
         this.quorumConfigs.clear();
@@ -1157,9 +1156,10 @@ public class Config {
     // See {@link ConfigCheck} for more information.
 
     /**
-     * @param config
-     * @return true if config is compatible with this one,
-     * false if config belongs to another group
+     * Checks if a {@link Config} matches the group configuration.
+     *
+     * @param config the {@link Config} to check
+     * @return {@code true} if config is compatible with this one, {@code false} if config belongs to another group
      * @throws RuntimeException if map, queue, topic configs are incompatible
      */
     public boolean isCompatible(final Config config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -57,7 +57,6 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
      */
     public static final EvictionPolicy DEFAULT_EVICTION_POLICY = EvictionPolicy.LRU;
 
-    protected boolean sizeConfigured;
     protected int size = DEFAULT_MAX_ENTRY_COUNT;
     protected MaxSizePolicy maxSizePolicy = DEFAULT_MAX_SIZE_POLICY;
     protected EvictionPolicy evictionPolicy = DEFAULT_EVICTION_POLICY;
@@ -65,6 +64,11 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
     protected EvictionPolicyComparator comparator;
 
     protected EvictionConfig readOnly;
+
+    /**
+     * Used by the {@link NearCacheConfigAccessor} to initialize the proper default value for on-heap maps.
+     */
+    boolean sizeConfigured;
 
     public EvictionConfig() {
     }
@@ -176,13 +180,6 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
     }
 
     public EvictionConfig setSize(int size) {
-        return setSizeInternal(size);
-    }
-
-    /**
-     * Package private method for {@link EvictionConfigAccessor}.
-     */
-    EvictionConfig setSizeInternal(int size) {
         this.sizeConfigured = true;
         this.size = checkPositive(size, "Size must be positive number!");
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigAccessor.java
@@ -19,18 +19,23 @@ package com.hazelcast.config;
 import com.hazelcast.spi.annotation.PrivateApi;
 
 /**
- * Accessor for the {@link EvictionConfig} to initialize the old default max size, if no size was configured by the user.
+ * Accessor for the {@link EvictionConfig} of a {@link NearCacheConfig} to initialize the old default max size,
+ * if no size was configured by the user.
  */
 @PrivateApi
-public final class EvictionConfigAccessor {
+public final class NearCacheConfigAccessor {
 
-    private EvictionConfigAccessor() {
+    private NearCacheConfigAccessor() {
     }
 
-    public static EvictionConfig initDefaultMaxSize(EvictionConfig evictionConfig) {
-        if (!evictionConfig.sizeConfigured) {
-            evictionConfig.setSizeInternal(EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP);
+    public static void initDefaultMaxSizeForOnHeapMaps(NearCacheConfig nearCacheConfig) {
+        if (nearCacheConfig == null) {
+            return;
         }
-        return evictionConfig;
+
+        EvictionConfig evictionConfig = nearCacheConfig.getEvictionConfig();
+        if (nearCacheConfig.getInMemoryFormat() != InMemoryFormat.NATIVE && !evictionConfig.sizeConfigured) {
+            evictionConfig.setSize(EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
@@ -81,9 +81,4 @@ public class NearCacheConfigReadOnly extends NearCacheConfig {
     public NearCacheConfig setEvictionConfig(EvictionConfig evictionConfig) {
         throw new UnsupportedOperationException("This config is read-only");
     }
-
-    @Override
-    public EvictionConfig getEvictionConfig() {
-        return super.getEvictionConfig().getAsReadOnly();
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
@@ -21,7 +21,6 @@ import com.hazelcast.cache.impl.nearcache.NearCacheContext;
 import com.hazelcast.cache.impl.nearcache.NearCacheExecutor;
 import com.hazelcast.cache.impl.nearcache.NearCacheManager;
 import com.hazelcast.cache.impl.nearcache.impl.DefaultNearCacheManager;
-import com.hazelcast.config.EvictionConfigAccessor;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapManagedService;
@@ -83,10 +82,7 @@ public class NearCacheProvider {
     }
 
     private NearCacheConfig getNearCacheConfig(String mapName) {
-        NearCacheConfig nearCacheConfig = nodeEngine.getConfig().getMapConfig(mapName).getNearCacheConfig();
-        EvictionConfigAccessor.initDefaultMaxSize(nearCacheConfig.getEvictionConfig());
-
-        return nearCacheConfig;
+        return nodeEngine.getConfig().getMapConfig(mapName).getNearCacheConfig();
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigAccessorTest.java
@@ -26,10 +26,15 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class EvictionConfigAccessorTest extends HazelcastTestSupport {
+public class NearCacheConfigAccessorTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor() {
-        assertUtilityConstructor(EvictionConfigAccessor.class);
+        assertUtilityConstructor(NearCacheConfigAccessor.class);
+    }
+
+    @Test
+    public void testInitDefaultMaxSizeForOnHeapMaps_whenNull_thenDoNothing() {
+        NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps(null);
     }
 }


### PR DESCRIPTION
Fixed the setting of the default max size in the `EvictionConfig` for on-heap `IMap`s by doing this once in the `Config` and `ClientConfig` class. We actually have to do this before we transform the configuration to a read-only version.