### PR TITLE
Unified Near Cache tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/BasicClientCacheNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/BasicClientCacheNearCacheTest.java
@@ -1,0 +1,141 @@
+package com.hazelcast.client.cache.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.client.cache.impl.HazelcastClientCacheManager;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.impl.adapter.ICacheDataStructureAdapter;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import javax.cache.spi.CachingProvider;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
+import static com.hazelcast.config.EvictionPolicy.LRU;
+import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+
+/**
+ * Basic Near Cache tests for {@link ICache} on Hazelcast clients.
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class BasicClientCacheNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public LocalUpdatePolicy localUpdatePolicy;
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Parameters(name = "format:{0} {1}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {InMemoryFormat.BINARY, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.BINARY, LocalUpdatePolicy.CACHE},
+                {InMemoryFormat.OBJECT, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.OBJECT, LocalUpdatePolicy.CACHE},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat)
+                .setLocalUpdatePolicy(localUpdatePolicy);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.shutdownAll();
+    }
+
+    @Override
+    protected <K, V> com.hazelcast.internal.nearcache.NearCacheTestContext<K, V, Data, String> createContext() {
+        ClientConfig clientConfig = getClientConfig()
+                .addNearCacheConfig(nearCacheConfig);
+
+        CacheConfig<K, V> cacheConfig = createCacheConfig(nearCacheConfig);
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(getConfig());
+        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
+
+        CachingProvider memberProvider = HazelcastServerCachingProvider.createCachingProvider(member);
+        HazelcastServerCacheManager memberCacheManager = (HazelcastServerCacheManager) memberProvider.getCacheManager();
+
+        NearCacheManager nearCacheManager = client.client.getNearCacheManager();
+        CachingProvider provider = HazelcastClientCachingProvider.createCachingProvider(client);
+        HazelcastClientCacheManager cacheManager = (HazelcastClientCacheManager) provider.getCacheManager();
+        String cacheNameWithPrefix = cacheManager.getCacheNameWithPrefix(DEFAULT_NEAR_CACHE_NAME);
+
+        ICache<K, V> clientCache = cacheManager.createCache(DEFAULT_NEAR_CACHE_NAME, cacheConfig);
+        ICache<K, V> memberCache = memberCacheManager.createCache(DEFAULT_NEAR_CACHE_NAME, cacheConfig);
+
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(cacheNameWithPrefix);
+
+        return new NearCacheTestContext<K, V, Data, String>(
+                client.getSerializationService(),
+                client,
+                member,
+                new ICacheDataStructureAdapter<K, V>(clientCache),
+                new ICacheDataStructureAdapter<K, V>(memberCache),
+                false,
+                nearCache,
+                nearCacheManager,
+                cacheManager,
+                memberCacheManager
+        );
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
+    }
+
+    private <K, V> CacheConfig<K, V> createCacheConfig(NearCacheConfig nearCacheConfig) {
+        CacheConfig<K, V> cacheConfig = new CacheConfig<K, V>()
+                .setName(DEFAULT_NEAR_CACHE_NAME)
+                .setInMemoryFormat(nearCacheConfig.getInMemoryFormat());
+
+        if (nearCacheConfig.getInMemoryFormat() == NATIVE) {
+            cacheConfig.getEvictionConfig()
+                    .setEvictionPolicy(LRU)
+                    .setMaximumSizePolicy(USED_NATIVE_MEMORY_PERCENTAGE)
+                    .setSize(90);
+        }
+
+        return cacheConfig;
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "The AbstractClientCacheProxy is missing `invalidateNearCache(keyData)` calls")
+    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.cache.nearcache;
 
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Ignore;
@@ -45,21 +44,6 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
                 {InMemoryFormat.BINARY},
                 {InMemoryFormat.OBJECT},
         });
-    }
-
-    @Test
-    public void whenEmptyMapThenPopulatedNearCacheShouldReturnNull_neverNULL_OBJECT() {
-        whenEmptyMapThenPopulatedNearCacheShouldReturnNullNeverNULL_OBJECT(inMemoryFormat);
-    }
-
-    @Test
-    public void whenCacheIsFullPutOnSameKeyShouldUpdateValue_withEvictionPolicyIsNONE_withLocalCachePolicyCACHE() {
-        whenCacheIsFullPutOnSameKeyShouldUpdateValue_withEvictionPolicyIsNONE(inMemoryFormat, LocalUpdatePolicy.CACHE);
-    }
-
-    @Test
-    public void whenCacheIsFullPutOnSameKeyShouldUpdateValue_withEvictionPolicyIsNONE_withLocalCachePolicyINVALIDATE() {
-        whenCacheIsFullPutOnSameKeyShouldUpdateValue_withEvictionPolicyIsNONE(inMemoryFormat, LocalUpdatePolicy.INVALIDATE);
     }
 
     @Test
@@ -119,11 +103,6 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     }
 
     @Test
-    public void testNearCacheEviction_() {
-        testNearCacheEviction(inMemoryFormat);
-    }
-
-    @Test
     public void testNearCacheTTLRecordsExpired_() {
         testNearCacheExpiration_withTTL(inMemoryFormat);
     }
@@ -131,15 +110,5 @@ public class ClientNearCacheTest extends ClientNearCacheTestSupport {
     @Test
     public void testNearCacheIdleRecordsExpired_() {
         testNearCacheExpiration_withMaxIdle(inMemoryFormat);
-    }
-
-    @Test
-    public void testNearCacheMemoryCostCalculation() {
-        testNearCacheMemoryCostCalculation(inMemoryFormat, 1);
-    }
-
-    @Test
-    public void testNearCacheMemoryCostCalculation_withConcurrentCacheMisses() {
-        testNearCacheMemoryCostCalculation(inMemoryFormat, 10);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/BasicClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/BasicClientMapNearCacheTest.java
@@ -1,0 +1,89 @@
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.impl.adapter.IMapDataStructureAdapter;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+
+/**
+ * Basic Near Cache tests for {@link IMap} on Hazelcast clients.
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class BasicClientMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {InMemoryFormat.BINARY},
+                {InMemoryFormat.OBJECT},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.shutdownAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
+        ClientConfig clientConfig = getClientConfig()
+                .addNearCacheConfig(nearCacheConfig);
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(getConfig());
+        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
+
+        IMap<K, V> memberMap = member.getMap(DEFAULT_NEAR_CACHE_NAME);
+        IMap<K, V> clientMap = client.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = client.client.getNearCacheManager();
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        return new NearCacheTestContext<K, V, Data, String>(
+                client.getSerializationService(),
+                client,
+                member,
+                new IMapDataStructureAdapter<K, V>(clientMap),
+                new IMapDataStructureAdapter<K, V>(memberMap),
+                false,
+                nearCache,
+                nearCacheManager);
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -86,19 +86,6 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
-    public void test_whenEmptyMap_thenPopulatedNearCacheShouldReturnNull_neverNULL_OBJECT() {
-        int size = 10;
-
-        IMap<Integer, Integer> map = getNearCachedMapFromClient(newNoInvalidationNearCacheConfig());
-        for (int i = 0; i < size; i++) {
-            // populate Near Cache
-            assertNull(map.get(i));
-            // fetch value from Near Cache
-            assertNull(map.get(i));
-        }
-    }
-
-    @Test
     public void testGetAllChecksNearCacheFirst() {
         IMap<Integer, Integer> map = getNearCachedMapFromClient(newNoInvalidationNearCacheConfig());
 
@@ -154,25 +141,6 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
         NearCacheStats stats = getNearCacheStats(map);
         assertEquals(size, stats.getOwnedEntryCount());
         assertEquals(size, stats.getHits());
-    }
-
-    @Test
-    public void testGetAsyncPopulatesNearCache() throws Exception {
-        NearCacheConfig nearCacheConfig = newNearCacheConfig().setInvalidateOnChange(false);
-        IMap<Integer, Integer> map = getNearCachedMapFromClient(nearCacheConfig);
-
-        int size = 1239;
-        populateMap(map, size);
-        // populate Near Cache
-        for (int i = 0; i < size; i++) {
-            Future future = map.getAsync(i);
-            future.get();
-        }
-        // generate Near Cache hits
-        populateNearCache(map, size);
-
-        long ownedEntryCount = getNearCacheStats(map).getOwnedEntryCount();
-        assertTrue("Near Cache must have some entries but current size is = " + ownedEntryCount, ownedEntryCount > 0);
     }
 
     @Test
@@ -580,36 +548,6 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
-    public void testAfterPutAllNearCacheIsInvalidated() {
-        int mapSize = 1000;
-        String mapName = randomMapName();
-        hazelcastFactory.newHazelcastInstance(newConfig());
-        HazelcastInstance client = getClient(hazelcastFactory,
-                newInvalidationOnChangeEnabledNearCacheConfig(mapName));
-
-        final IMap<Integer, Integer> clientMap = client.getMap(mapName);
-
-        HashMap<Integer, Integer> hashMap = new HashMap<Integer, Integer>();
-        for (int i = 0; i < mapSize; i++) {
-            clientMap.put(i, i);
-            hashMap.put(i, i);
-        }
-
-        for (int i = 0; i < mapSize; i++) {
-            clientMap.get(i);
-        }
-
-        clientMap.putAll(hashMap);
-
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertThatOwnedEntryCountEquals(clientMap, 0);
-            }
-        });
-    }
-
-
-    @Test
     public void testMemberPutAll_invalidates_clientNearCache() {
         int mapSize = 1000;
         String mapName = randomMapName();
@@ -866,15 +804,6 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
-    public void testNearCacheEviction() {
-        NearCacheConfig nearCacheConfig = newNearCacheConfigWithEntryCountEviction(EvictionPolicy.LRU, MAX_CACHE_SIZE)
-                .setCacheLocalEntries(false);
-        IMap<Integer, Integer> map = getNearCachedMapFromClient(nearCacheConfig);
-
-        testNearCacheEviction(map, MAX_CACHE_SIZE);
-    }
-
-    @Test
     public void testNearCacheTTLExpiration() {
         IMap<Integer, Integer> map = getNearCachedMapFromClient(newTTLNearCacheConfig());
 
@@ -886,21 +815,6 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
         IMap<Integer, Integer> map = getNearCachedMapFromClient(newMaxIdleSecondsNearCacheConfig());
 
         testNearCacheExpiration(map, MAX_CACHE_SIZE, MAX_IDLE_SECONDS);
-    }
-
-    @Test
-    public void testNearCacheMemoryCostCalculation() {
-        testNearCacheMemoryCostCalculation(1);
-    }
-
-    @Test
-    public void testNearCacheMemoryCostCalculation_withConcurrentCacheMisses() {
-        testNearCacheMemoryCostCalculation(10);
-    }
-
-    private void testNearCacheMemoryCostCalculation(int threadCount) {
-        IMap<Integer, Integer> map = getNearCachedMapFromClient(newNearCacheConfig());
-        testNearCacheMemoryCostCalculation(map, false, threadCount);
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/BasicClientReplicatedMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/BasicClientReplicatedMapNearCacheTest.java
@@ -1,0 +1,106 @@
+package com.hazelcast.client.replicatedmap.nearcache;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.impl.adapter.ReplicatedMapDataStructureAdapter;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class BasicClientReplicatedMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {InMemoryFormat.BINARY},
+                {InMemoryFormat.OBJECT},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.shutdownAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
+        Config config = getConfig();
+        config.getReplicatedMapConfig(DEFAULT_NEAR_CACHE_NAME)
+                .setInMemoryFormat(nearCacheConfig.getInMemoryFormat());
+
+        ClientConfig clientConfig = getClientConfig()
+                .addNearCacheConfig(nearCacheConfig);
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
+
+        ReplicatedMap<K, V> memberMap = member.getReplicatedMap(DEFAULT_NEAR_CACHE_NAME);
+        ReplicatedMap<K, V> clientMap = client.getReplicatedMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = client.client.getNearCacheManager();
+
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        return new NearCacheTestContext<K, V, Data, String>(
+                client.getSerializationService(),
+                client,
+                member,
+                new ReplicatedMapDataStructureAdapter<K, V>(clientMap),
+                new ReplicatedMapDataStructureAdapter<K, V>(memberMap),
+                false,
+                nearCache,
+                nearCacheManager);
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
+    public void whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_withUpdateOnNearCacheAdapter() {
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
+    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractBasicNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractBasicNearCacheTest.java
@@ -1,0 +1,425 @@
+package com.hazelcast.internal.nearcache;
+
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.internal.nearcache.impl.adapter.DataStructureAdapter;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
+import static com.hazelcast.config.EvictionPolicy.LRU;
+import static com.hazelcast.config.EvictionPolicy.NONE;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheStats;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.setEvictionConfig;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.waitForNearCacheEvictions;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.waitForNearCacheSize;
+import static java.lang.String.format;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Contains the logic code for Near Cache tests.
+ *
+ * @param <NK> key type of the tested Near Cache
+ * @param <NV> value type of the tested Near Cache
+ */
+public abstract class AbstractBasicNearCacheTest<NK, NV> extends HazelcastTestSupport {
+
+    /**
+     * The default count to be inserted into the Near Caches.
+     */
+    protected static final int DEFAULT_RECORD_COUNT = 1000;
+
+    /**
+     * The default name used for the data structures which have a Near Cache.
+     */
+    protected static final String DEFAULT_NEAR_CACHE_NAME = "defaultNearCache";
+
+    /**
+     * The {@link NearCacheConfig} used by the Near Cache tests.
+     *
+     * Needs to be set by the implementations of this class in their {@link org.junit.Before} methods.
+     */
+    protected NearCacheConfig nearCacheConfig;
+
+    /**
+     * Creates the {@link NearCacheTestContext} used by the Near Cache tests.
+     *
+     * @param <K> key type of the created {@link DataStructureAdapter}
+     * @param <V> value type of the created {@link DataStructureAdapter}
+     * @return a {@link NearCacheTestContext} used by the Near Cache tests
+     */
+    protected abstract <K, V> NearCacheTestContext<K, V, NK, NV> createContext();
+
+    protected final void populateMap(NearCacheTestContext<Integer, String, NK, NV> context) {
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            context.dataAdapter.put(i, "value-" + i);
+        }
+    }
+
+    protected final void populateNearCache(NearCacheTestContext<Integer, String, NK, NV> context) {
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            context.nearCacheAdapter.get(i);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private NK getNearCacheKey(NearCacheTestContext<Integer, String, NK, NV> context, int key) {
+        return (NK) context.serializationService.toData(key);
+    }
+
+    /**
+     * Checks that the Near Cache never returns its internal {@link NearCache#NULL_OBJECT} to the public API.
+     */
+    @Test
+    public void whenEmptyMap_thenPopulatedNearCacheShouldReturnNull_neverNULLOBJECT() {
+        NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            // populate Near Cache
+            assertNull("Expected null from original data structure for key " + i, context.nearCacheAdapter.get(i));
+            // fetch value from Near Cache
+            assertNull("Expected null from Near cached data structure for key " + i, context.nearCacheAdapter.get(i));
+
+            // fetch internal value directly from Near Cache
+            NK key = getNearCacheKey(context, i);
+            NV value = context.nearCache.get(key);
+            if (value != null) {
+                // the internal value should either be `null` or `NULL_OBJECT`
+                assertEquals("Expected NULL_OBJECT in Near Cache for key " + i,
+                        NearCache.NULL_OBJECT, context.nearCache.get(key));
+            }
+        }
+    }
+
+    /**
+     * Checks that the Near Cache updates value for keys which are already in the Near Cache,
+     * even if the Near Cache is full an the eviction is disabled (via {@link com.hazelcast.config.EvictionPolicy#NONE}.
+     *
+     * This variant uses the {@link NearCacheTestContext#nearCacheAdapter}, so there is no Near Cache invalidation necessary.
+     */
+    @Test
+    public void whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_withUpdateOnNearCacheAdapter() {
+        int size = DEFAULT_RECORD_COUNT / 2;
+        setEvictionConfig(nearCacheConfig, NONE, ENTRY_COUNT, size);
+        NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+
+        populateMap(context);
+        populateNearCache(context);
+
+        assertEquals(size, context.nearCache.size());
+        assertEquals("value-1", context.nearCacheAdapter.get(1));
+
+        context.nearCacheAdapter.put(1, "newValue");
+
+        long expectedMisses = getExpectedMissesWithLocalUpdatePolicy(context);
+        long expectedHits = getExpectedHitsWithLocalUpdatePolicy(context);
+
+        assertEquals("newValue", context.nearCacheAdapter.get(1));
+        assertEquals("newValue", context.nearCacheAdapter.get(1));
+
+        assertNearCacheStats(context, size, expectedHits, expectedMisses);
+    }
+
+    /**
+     * Checks that the Near Cache updates value for keys which are already in the Near Cache,
+     * even if the Near Cache is full an the eviction is disabled (via {@link com.hazelcast.config.EvictionPolicy#NONE}.
+     *
+     * This variant uses the {@link NearCacheTestContext#dataAdapter}, so we need to configure Near Cache invalidation.
+     */
+    @Test
+    public void whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_withUpdateOnDataAdapter() {
+        final int size = DEFAULT_RECORD_COUNT / 2;
+        setEvictionConfig(nearCacheConfig, NONE, ENTRY_COUNT, size);
+        nearCacheConfig.setInvalidateOnChange(true);
+        final NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+
+        populateMap(context);
+        populateNearCache(context);
+
+        assertEquals(size, context.nearCache.size());
+        assertEquals("value-1", context.nearCacheAdapter.get(1));
+
+        context.dataAdapter.put(1, "newValue");
+
+        // we have to use assertTrueEventually since the invalidation is done asynchronously
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                long expectedMisses = getExpectedMissesWithLocalUpdatePolicy(context);
+                long expectedHits = getExpectedHitsWithLocalUpdatePolicy(context);
+
+                assertEquals("newValue", context.nearCacheAdapter.get(1));
+                assertEquals("newValue", context.nearCacheAdapter.get(1));
+
+                assertNearCacheStats(context, size, expectedHits, expectedMisses);
+            }
+        });
+    }
+
+    private long getExpectedMissesWithLocalUpdatePolicy(NearCacheTestContext<Integer, String, NK, NV> context) {
+        if (nearCacheConfig.getLocalUpdatePolicy() == CACHE) {
+            // we expect the first and second get() to be hits, since the value should be already be cached
+            return context.stats.getMisses();
+        }
+        // we expect the first get() to be a miss, due to the replaced / invalidated value
+        return context.stats.getMisses() + 1;
+    }
+
+    private long getExpectedHitsWithLocalUpdatePolicy(NearCacheTestContext<Integer, String, NK, NV> context) {
+        if (nearCacheConfig.getLocalUpdatePolicy() == CACHE) {
+            // we expect the first and second get() to be hits, since the value should be already be cached
+            return context.stats.getHits() + 2;
+        }
+        // we expect the second get() to be a hit, since it should be served from the Near Cache
+        return context.stats.getHits() + 1;
+    }
+
+    /**
+     * Checks that the Near Cache values are eventually invalidated when {@link DataStructureAdapter#putAll(Map)} is used.
+     *
+     * This variant uses the {@link NearCacheTestContext#nearCacheAdapter}, so there is no Near Cache invalidation necessary.
+     */
+    @Test
+    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+        whenPutAllIsUsed_thenNearCacheShouldBeInvalidated(true);
+    }
+
+    /**
+     * Checks that the Near Cache values are eventually invalidated when {@link DataStructureAdapter#putAll(Map)} is used.
+     *
+     * This variant uses the {@link NearCacheTestContext#dataAdapter}, so we need to configure Near Cache invalidation.
+     */
+    @Test
+    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
+        nearCacheConfig.setInvalidateOnChange(true);
+        whenPutAllIsUsed_thenNearCacheShouldBeInvalidated(false);
+    }
+
+    private void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated(boolean useNearCacheAdapter) {
+        final NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+
+        populateMap(context);
+        populateNearCache(context);
+
+        Map<Integer, String> invalidationMap = new HashMap<Integer, String>(DEFAULT_RECORD_COUNT);
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            invalidationMap.put(i, "newValue-" + i);
+        }
+
+        // this should invalidate the Near Cache
+        DataStructureAdapter<Integer, String> adapter = useNearCacheAdapter ? context.nearCacheAdapter : context.dataAdapter;
+        adapter.putAll(invalidationMap);
+
+        assertTrueEventually(
+                new AssertTask() {
+                    @Override
+                    public void run() {
+                        assertEquals("Invalidation is not working on putAll()", 0, context.nearCache.size());
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void testGetAsyncPopulatesNearCache() throws Exception {
+        NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+
+        populateMap(context);
+
+        // populate Near Cache with getAsync()
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            Future future = context.nearCacheAdapter.getAsync(i);
+            future.get();
+        }
+
+        // generate Near Cache hits
+        populateNearCache(context);
+
+        long ownedEntryCount = context.stats.getOwnedEntryCount();
+        assertTrue(format("Near Cache should be populated but current size is %d", ownedEntryCount), ownedEntryCount > 0);
+    }
+
+    /**
+     * Checks that the Near Cache keys are correctly checked when {@link DataStructureAdapter#containsKey(Object)} is used.
+     *
+     * This variant uses the {@link NearCacheTestContext#nearCacheAdapter}, so there is no Near Cache invalidation necessary.
+     */
+    @Test
+    public void testContainsKey_withUpdateOnNearCacheAdapter() {
+        testContainsKey(true);
+    }
+
+    /**
+     * Checks that the memory costs are calculated correctly.
+     *
+     * This variant uses the {@link NearCacheTestContext#dataAdapter}, so we need to configure Near Cache invalidation.
+     */
+    @Test
+    public void testContainsKey_withUpdateOnDataAdapter() {
+        nearCacheConfig.setInvalidateOnChange(true);
+        testContainsKey(false);
+    }
+
+    private void testContainsKey(boolean useNearCacheAdapter) {
+        final NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+
+        // populate map
+        context.dataAdapter.put(1, "value1");
+        context.dataAdapter.put(2, "value2");
+        context.dataAdapter.put(3, "value3");
+
+        // populate Near Cache
+        context.nearCacheAdapter.get(1);
+        context.nearCacheAdapter.get(2);
+        context.nearCacheAdapter.get(3);
+
+        assertTrue(context.nearCacheAdapter.containsKey(1));
+        assertTrue(context.nearCacheAdapter.containsKey(2));
+        assertTrue(context.nearCacheAdapter.containsKey(3));
+        assertFalse(context.nearCacheAdapter.containsKey(5));
+
+        // remove a key which is in the Near Cache
+        DataStructureAdapter<Integer, String> adapter = useNearCacheAdapter ? context.nearCacheAdapter : context.dataAdapter;
+        adapter.remove(1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertFalse(context.nearCacheAdapter.containsKey(1));
+                assertTrue(context.nearCacheAdapter.containsKey(2));
+                assertTrue(context.nearCacheAdapter.containsKey(3));
+                assertFalse(context.nearCacheAdapter.containsKey(5));
+            }
+        });
+    }
+
+    /**
+     * Checks that the {@link com.hazelcast.monitor.NearCacheStats} are calculated correctly.
+     */
+    @Test
+    public void testNearCacheStats() {
+        NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+
+        // populate map
+        populateMap(context);
+        assertNearCacheStats(context, 0, 0, 0);
+
+        // populate Near Cache
+        populateNearCache(context);
+        assertNearCacheStats(context, DEFAULT_RECORD_COUNT, 0, DEFAULT_RECORD_COUNT);
+
+        // make some hits
+        populateNearCache(context);
+        assertNearCacheStats(context, DEFAULT_RECORD_COUNT, DEFAULT_RECORD_COUNT, DEFAULT_RECORD_COUNT);
+    }
+
+    /**
+     * Checks that the memory costs are calculated correctly.
+     *
+     * This variant uses a single-threaded approach to fill the Near Cache with data.
+     */
+    @Test
+    public void testNearCacheMemoryCostCalculation() {
+        testNearCacheMemoryCostCalculation(1);
+    }
+
+    /**
+     * Checks that the memory costs are calculated correctly.
+     *
+     * This variant uses a multi-threaded approach to fill the Near Cache with data.
+     */
+    @Test
+    public void testNearCacheMemoryCostCalculation_withConcurrentCacheMisses() {
+        testNearCacheMemoryCostCalculation(10);
+    }
+
+    private void testNearCacheMemoryCostCalculation(int threadCount) {
+        nearCacheConfig.setInvalidateOnChange(true);
+        final NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+
+        populateMap(context);
+
+        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                populateNearCache(context);
+                countDownLatch.countDown();
+            }
+        };
+
+        ExecutorService executorService = newFixedThreadPool(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(task);
+        }
+        assertOpenEventually(countDownLatch);
+
+        // the Near Cache is filled, we should see some memory costs now
+        if (context.hasLocalData && nearCacheConfig.getInMemoryFormat() != OBJECT) {
+            // the heap costs are just calculated if there is local data which is not in OBJECT in-memory-format
+            assertTrue("The Near Cache is filled, there should be some owned entry memory costs",
+                    context.stats.getOwnedEntryMemoryCost() > 0);
+            if (context.nearCacheAdapter.getLocalMapStats() != null) {
+                assertTrue("The Near Cache is filled, there should be some heap costs",
+                        context.nearCacheAdapter.getLocalMapStats().getHeapCost() > 0);
+            }
+        }
+
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            context.nearCacheAdapter.remove(i);
+        }
+        waitForNearCacheSize(context, 0);
+
+        // the Near Cache is empty, we shouldn't see memory costs anymore
+        assertEquals("The Near Cache is empty, there should be no owned entry memory costs",
+                0, context.stats.getOwnedEntryMemoryCost());
+        if (context.nearCacheAdapter.getLocalMapStats() != null) {
+            // this assert will work in all scenarios, since the default value should be 0 if no costs are calculated
+            assertEquals("The Near Cache is empty, there should be no heap costs", 0,
+                    context.nearCacheAdapter.getLocalMapStats().getHeapCost());
+        }
+    }
+
+    /**
+     * Checks that the Near Cache eviction works as expected if the Near Cache is full.
+     */
+    @Test
+    public void testNearCacheEviction() {
+        setEvictionConfig(nearCacheConfig, LRU, ENTRY_COUNT, DEFAULT_RECORD_COUNT);
+        NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+
+        // all Near Cache implementations use the same eviction algorithm, which evicts a single entry
+        int expectedEvictions = 1;
+
+        // populate map with an extra entry
+        populateMap(context);
+        context.dataAdapter.put(DEFAULT_RECORD_COUNT, "value-" + DEFAULT_RECORD_COUNT);
+
+        // populate Near Caches
+        populateNearCache(context);
+
+        // we expect (size + the extra entry - the expectedEvictions) entries in the Near Cache
+        long expectedOwnedEntryCount = DEFAULT_RECORD_COUNT + 1 - expectedEvictions;
+        long expectedHits = context.stats.getHits();
+        long expectedMisses = context.stats.getMisses() + 1;
+
+        // trigger eviction via fetching the extra entry
+        context.nearCacheAdapter.get(DEFAULT_RECORD_COUNT);
+
+        waitForNearCacheEvictions(context, expectedEvictions);
+
+        assertNearCacheStats(context, expectedOwnedEntryCount, expectedHits, expectedMisses, expectedEvictions, 0);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.internal.nearcache;
+
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.nearcache.impl.adapter.DataStructureAdapter;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import javax.cache.CacheManager;
+
+/**
+ * Context for unified Near Cache tests.
+ */
+public class NearCacheTestContext<K, V, NK, NV> {
+
+    public final SerializationService serializationService;
+    public final HazelcastInstance nearCacheInstance;
+    public final HazelcastInstance dataInstance;
+    public final DataStructureAdapter<K, V> nearCacheAdapter;
+    public final DataStructureAdapter<K, V> dataAdapter;
+    public final boolean hasLocalData;
+
+    public final NearCache<NK, NV> nearCache;
+    public final NearCacheStats stats;
+    public final NearCacheManager nearCacheManager;
+    public final CacheManager cacheManager;
+    public final HazelcastServerCacheManager memberCacheManager;
+
+    public NearCacheTestContext(SerializationService serializationService,
+                                HazelcastInstance nearCacheInstance,
+                                DataStructureAdapter<K, V> nearCacheAdapter,
+                                boolean hasLocalData,
+                                NearCache<NK, NV> nearCache,
+                                NearCacheManager nearCacheManager) {
+        this(serializationService, nearCacheInstance, nearCacheInstance, nearCacheAdapter, nearCacheAdapter, hasLocalData,
+                nearCache, nearCacheManager, null, null);
+    }
+
+    public NearCacheTestContext(SerializationService serializationService,
+                                HazelcastInstance nearCacheInstance,
+                                HazelcastInstance dataInstance,
+                                DataStructureAdapter<K, V> nearCacheAdapter,
+                                DataStructureAdapter<K, V> dataAdapter,
+                                boolean hasLocalData,
+                                NearCache<NK, NV> nearCache,
+                                NearCacheManager nearCacheManager) {
+        this(serializationService, nearCacheInstance, dataInstance, nearCacheAdapter, dataAdapter, hasLocalData,
+                nearCache, nearCacheManager, null, null);
+    }
+
+    public NearCacheTestContext(SerializationService serializationService,
+                                HazelcastInstance nearCacheInstance,
+                                HazelcastInstance dataInstance,
+                                DataStructureAdapter<K, V> nearCacheAdapter,
+                                DataStructureAdapter<K, V> dataAdapter,
+                                boolean hasLocalData,
+                                NearCache<NK, NV> nearCache,
+                                NearCacheManager nearCacheManager,
+                                CacheManager cacheManager,
+                                HazelcastServerCacheManager memberCacheManager) {
+        this.serializationService = serializationService;
+        this.nearCacheInstance = nearCacheInstance;
+        this.dataInstance = dataInstance;
+        this.nearCacheAdapter = nearCacheAdapter;
+        this.dataAdapter = dataAdapter;
+        this.hasLocalData = hasLocalData;
+
+        this.nearCache = nearCache;
+        this.stats = nearCache.getNearCacheStats();
+        this.nearCacheManager = nearCacheManager;
+        this.cacheManager = cacheManager;
+        this.memberCacheManager = memberCacheManager;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -1,0 +1,157 @@
+package com.hazelcast.internal.nearcache;
+
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionConfig.MaxSizePolicy;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastTestSupport;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
+import static com.hazelcast.config.EvictionPolicy.LRU;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Provides utility methods for unified Near Cache tests.
+ */
+public final class NearCacheTestUtils extends HazelcastTestSupport {
+
+    private NearCacheTestUtils() {
+    }
+
+    /**
+     * Creates a {@link NearCacheConfig} with a given {@link InMemoryFormat}.
+     *
+     * @param inMemoryFormat the {@link InMemoryFormat} to set
+     * @return the {@link NearCacheConfig}
+     */
+    public static NearCacheConfig createNearCacheConfig(InMemoryFormat inMemoryFormat) {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig()
+                .setName(AbstractBasicNearCacheTest.DEFAULT_NEAR_CACHE_NAME)
+                .setInMemoryFormat(inMemoryFormat)
+                .setInvalidateOnChange(false);
+
+        if (inMemoryFormat == InMemoryFormat.NATIVE) {
+            setEvictionConfig(nearCacheConfig, LRU, USED_NATIVE_MEMORY_PERCENTAGE, 90);
+        }
+
+        return nearCacheConfig;
+    }
+
+    /**
+     * Configures the {@link EvictionConfig} of the given {@link NearCacheConfig}.
+     *
+     * @param nearCacheConfig the {@link NearCacheConfig} to configure
+     * @param evictionPolicy  the {@link EvictionPolicy} to set
+     * @param maxSizePolicy   the {@link MaxSizePolicy} to set
+     * @param maxSize         the max size to set
+     */
+    public static void setEvictionConfig(NearCacheConfig nearCacheConfig, EvictionPolicy evictionPolicy,
+                                         MaxSizePolicy maxSizePolicy, int maxSize) {
+        nearCacheConfig.getEvictionConfig()
+                .setEvictionPolicy(evictionPolicy)
+                .setMaximumSizePolicy(maxSizePolicy)
+                .setSize(maxSize);
+    }
+
+    /**
+     * Returns the {@link MapNearCacheManager} from a given {@link HazelcastInstance}.
+     *
+     * @param instance the {@link HazelcastInstance} to retrieve the {@link MapNearCacheManager} frp,
+     * @return the {@link MapNearCacheManager}
+     */
+    public static MapNearCacheManager getMapNearCacheManager(HazelcastInstance instance) {
+        NodeEngineImpl nodeEngine = getNode(instance).nodeEngine;
+        MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
+
+        return service.getMapServiceContext().getMapNearCacheManager();
+    }
+
+    /**
+     * Waits until a Near Cache has a given owned entry count.
+     *
+     * @param context       the {@link NearCacheTestContext} to retrieve the owned entry count from
+     * @param nearCacheSize the expected owned entry count
+     */
+    public static void waitForNearCacheSize(final NearCacheTestContext<Integer, String, ?, ?> context,
+                                            final int nearCacheSize) {
+        assertTrueEventually(new AssertTask() {
+            public void run() {
+                long ownedEntryCount = context.stats.getOwnedEntryCount();
+                assertTrue(format("Near Cache owned entry count didn't reach the desired value (%d vs. %d) (%s)",
+                        ownedEntryCount, nearCacheSize, context.stats),
+                        ownedEntryCount >= nearCacheSize);
+            }
+        });
+    }
+
+    /**
+     * Waits until a given number of entries are evicted from a Near Cache.
+     *
+     * @param context       the {@link NearCacheTestContext} to retrieve the eviction count from
+     * @param evictionCount the expected eviction count to wait for
+     */
+    public static void waitForNearCacheEvictions(final NearCacheTestContext<Integer, String, ?, ?> context,
+                                                 final int evictionCount) {
+        assertTrueEventually(new AssertTask() {
+            public void run() {
+                long evictions = context.stats.getEvictions();
+                assertTrue(format("Near Cache eviction count didn't reach the desired value (%d vs. %d) (%s)",
+                        evictions, evictionCount, context.stats),
+                        evictions >= evictionCount);
+            }
+        });
+    }
+
+    /**
+     * Asserts the {@link NearCacheStats} for expected values.
+     *
+     * @param context                 the {@link NearCacheTestContext} to retrieve the stats from
+     * @param expectedOwnedEntryCount the expected owned entry count
+     * @param expectedHits            the expected Near Cache hits
+     * @param expectedMisses          the expected Near Cache misses
+     */
+    public static void assertNearCacheStats(NearCacheTestContext<Integer, String, ?, ?> context,
+                                            long expectedOwnedEntryCount, long expectedHits, long expectedMisses) {
+        assertNearCacheStats(context, expectedOwnedEntryCount, expectedHits, expectedMisses, 0, 0);
+    }
+
+    /**
+     * Asserts the {@link NearCacheStats} for expected values.
+     *
+     * @param context                 the {@link NearCacheTestContext} to retrieve the stats from
+     * @param expectedOwnedEntryCount the expected owned entry count
+     * @param expectedHits            the expected Near Cache hits
+     * @param expectedMisses          the expected Near Cache misses
+     * @param expectedEvictions       the expected Near Cache evictions
+     * @param expectedExpirations     the expected Near Cache expirations
+     */
+    public static void assertNearCacheStats(NearCacheTestContext<Integer, String, ?, ?> context,
+                                            long expectedOwnedEntryCount, long expectedHits, long expectedMisses,
+                                            long expectedEvictions, long expectedExpirations) {
+        NearCacheStats stats = context.stats;
+
+        assertEqualsFormat("Near Cache entry count should be %d, but was %d (%s)",
+                expectedOwnedEntryCount, stats.getOwnedEntryCount(), stats);
+        assertEqualsFormat("Near Cache hits should be %d, but were %d (%s)",
+                expectedHits, stats.getHits(), stats);
+        assertEqualsFormat("Near Cache misses should be %d, but were %d (%s)",
+                expectedMisses, stats.getMisses(), stats);
+        assertEqualsFormat("Near Cache evictions should be %d, but were %d (%s)",
+                expectedEvictions, stats.getEvictions(), stats);
+        assertEqualsFormat("Near Cache expirations should be %d, but were %d (%s)",
+                expectedExpirations, stats.getExpirations(), stats);
+    }
+
+    private static void assertEqualsFormat(String message, long expected, long actual, NearCacheStats stats) {
+        assertEquals(format(message, expected, actual, stats), expected, actual);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/BasicLiteMemberMapNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/BasicLiteMemberMapNearCacheTest.java
@@ -1,0 +1,92 @@
+package com.hazelcast.map.impl.nearcache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.impl.adapter.IMapDataStructureAdapter;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+
+/**
+ * Basic Near Cache tests for {@link IMap} on Hazelcast Lite members.
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class BasicLiteMemberMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory(2);
+
+    @Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {InMemoryFormat.BINARY},
+                {InMemoryFormat.OBJECT},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.shutdownAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(createConfig(nearCacheConfig, false));
+        HazelcastInstance liteMember = hazelcastFactory.newHazelcastInstance(createConfig(nearCacheConfig, true));
+
+        IMap<K, V> memberMap = member.getMap(DEFAULT_NEAR_CACHE_NAME);
+        IMap<K, V> liteMemberMap = liteMember.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = getMapNearCacheManager(liteMember);
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        return new NearCacheTestContext<K, V, Data, String>(
+                getSerializationService(member),
+                liteMember,
+                member,
+                new IMapDataStructureAdapter<K, V>(liteMemberMap),
+                new IMapDataStructureAdapter<K, V>(memberMap),
+                true,
+                nearCache,
+                nearCacheManager);
+    }
+
+    protected Config createConfig(NearCacheConfig nearCacheConfig, boolean liteMember) {
+        Config config = getConfig()
+                .setLiteMember(liteMember);
+
+        config.getMapConfig(DEFAULT_NEAR_CACHE_NAME).setNearCacheConfig(nearCacheConfig);
+
+        return config;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/BasicMapNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/BasicMapNearCacheTest.java
@@ -1,0 +1,82 @@
+package com.hazelcast.map.impl.nearcache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.impl.adapter.IMapDataStructureAdapter;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+
+/**
+ * Basic Near Cache tests for {@link IMap} on Hazelcast members.
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class BasicMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory(2);
+
+    @Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {InMemoryFormat.BINARY},
+                {InMemoryFormat.OBJECT},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat)
+                .setCacheLocalEntries(true);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.shutdownAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
+        Config config = getConfig();
+        config.getMapConfig(DEFAULT_NEAR_CACHE_NAME).setNearCacheConfig(nearCacheConfig);
+
+        HazelcastInstance[] instances = hazelcastFactory.newInstances(config);
+        HazelcastInstance member = instances[0];
+        IMap<K, V> map = member.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = getMapNearCacheManager(member);
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        return new NearCacheTestContext<K, V, Data, String>(
+                getSerializationService(member),
+                member,
+                new IMapDataStructureAdapter<K, V>(map),
+                true,
+                nearCache,
+                nearCacheManager);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/BasicTxnMapNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/BasicTxnMapNearCacheTest.java
@@ -1,0 +1,146 @@
+package com.hazelcast.map.impl.tx;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.impl.adapter.TransactionalMapDataStructureAdapter;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheStats;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+
+/**
+ * Basic Near Cache tests for {@link com.hazelcast.core.TransactionalMap} on Hazelcast members.
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class BasicTxnMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory(2);
+
+    @Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {InMemoryFormat.BINARY},
+                {InMemoryFormat.OBJECT},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat)
+                .setCacheLocalEntries(true)
+                // we have to configure invalidation, otherwise the Near Cache in the TransactionalMap will not be used
+                .setInvalidateOnChange(true);
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.shutdownAll();
+    }
+
+    @Override
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
+        Config config = getConfig();
+        config.getMapConfig(DEFAULT_NEAR_CACHE_NAME).setNearCacheConfig(nearCacheConfig);
+
+        HazelcastInstance[] instances = hazelcastFactory.newInstances(config);
+        HazelcastInstance member = instances[0];
+
+        // this creates the Near Cache instance
+        member.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = getMapNearCacheManager(member);
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        return new NearCacheTestContext<K, V, Data, String>(
+                getSerializationService(member),
+                member,
+                new TransactionalMapDataStructureAdapter<K, V>(member, DEFAULT_NEAR_CACHE_NAME),
+                false,
+                nearCache,
+                nearCacheManager);
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "This test doesn't work with the TransactionalMap due to its limited implementation")
+    public void whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_withUpdateOnNearCacheAdapter() {
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "This test doesn't work with the TransactionalMap due to its limited implementation")
+    public void whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_withUpdateOnDataAdapter() {
+    }
+
+    @Test
+    @Override
+    public void testNearCacheStats() {
+        // we cannot use the common test, since the Near Cache support in TransactionalMap is very limited
+        NearCacheTestContext<Integer, String, Data, String> context = createContext();
+
+        IMap<Integer, String> map = context.nearCacheInstance.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        // populate map
+        populateMap(context);
+        assertNearCacheStats(context, 0, 0, 0);
+
+        // uses txMap.get() which reads from the Near Cache, but doesn't populate it (so we just create misses)
+        populateNearCache(context);
+        assertNearCacheStats(context, 0, 0, DEFAULT_RECORD_COUNT);
+
+        // use map.get() which populates the Near Cache (but also increases the misses first)
+        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
+            map.get(i);
+        }
+        assertNearCacheStats(context, DEFAULT_RECORD_COUNT, 0, DEFAULT_RECORD_COUNT * 2);
+
+        // make some hits
+        populateNearCache(context);
+        assertNearCacheStats(context, DEFAULT_RECORD_COUNT, DEFAULT_RECORD_COUNT, DEFAULT_RECORD_COUNT * 2);
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "This test doesn't work with the TransactionalMap due to its limited implementation")
+    public void testNearCacheMemoryCostCalculation_withConcurrentCacheMisses() {
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "This test doesn't work with the TransactionalMap due to its limited implementation")
+    public void testGetAsyncPopulatesNearCache() throws Exception {
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "This test doesn't work with the TransactionalMap due to its limited implementation")
+    public void testNearCacheEviction() {
+    }
+}


### PR DESCRIPTION
* added `AbstractBasicNearCacheTest` with Near Cache test logic
* added `BasicMapNearCacheTest` with Near Cache configuration for on-heap `IMap` members
* added `BasicLiteMemberMapNearCacheTest` for on-heap `IMap` Lite members
* added `BasicTxnMapNearCacheTest` with Near Cache configuration for on-heap `TransactionalMap` members
* added `BasicClientMapNearCacheTest` with Near Cache configuration for on-heap `IMap` clients
* added `BasicClientReplicatedMapNearCacheTest` with Near Cache configuration for on-heap `ReplicatedMap` clients
* added `BasicClientNearCacheTest` with configuration for on-heap `ICache` clients
* removed distributed test code which was unified