### PR TITLE
Added DataStructureAdapter to use IMap and ICache instances with the same logic code

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/adapter/DataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/adapter/DataStructureAdapter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.nearcache.impl.adapter;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Abstracts the Hazelcast data structures with Near Cache support for the Near Cache usage.
+ */
+public interface DataStructureAdapter<K, V> {
+
+    void clear();
+
+    void set(K key, V value);
+
+    V put(K key, V value);
+
+    V get(K key);
+
+    Map<K, V> getAll(Set<K> keys);
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/adapter/ICacheDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/adapter/ICacheDataStructureAdapter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.nearcache.impl.adapter;
+
+import javax.cache.Cache;
+import java.util.Map;
+import java.util.Set;
+
+public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
+
+    private final Cache<K, V> cache;
+
+    public ICacheDataStructureAdapter(Cache<K, V> cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+    }
+
+    @Override
+    public void set(K key, V value) {
+        cache.put(key, value);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return cache.getAndPut(key, value);
+    }
+
+    @Override
+    public V get(K key) {
+        return cache.get(key);
+    }
+
+    @Override
+    public Map<K, V> getAll(Set<K> keys) {
+        return cache.getAll(keys);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/adapter/IMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/adapter/IMapDataStructureAdapter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.nearcache.impl.adapter;
+
+import com.hazelcast.core.IMap;
+
+import java.util.Map;
+import java.util.Set;
+
+public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V> {
+
+    private final IMap<K, V> map;
+
+    public IMapDataStructureAdapter(IMap<K, V> map) {
+        this.map = map;
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
+    @Override
+    public void set(K key, V value) {
+        map.set(key, value);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return map.put(key, value);
+    }
+
+    @Override
+    public V get(K key) {
+        return map.get(key);
+    }
+
+    @Override
+    public Map<K, V> getAll(Set<K> keys) {
+        return map.getAll(keys);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/adapter/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/nearcache/impl/adapter/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Data structure adapters for Near Cache.
+ */
+package com.hazelcast.cache.impl.nearcache.impl.adapter;

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/nearcache/impl/adapter/ICacheDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/nearcache/impl/adapter/ICacheDataStructureAdapterTest.java
@@ -1,0 +1,90 @@
+package com.hazelcast.cache.impl.nearcache.impl.adapter;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.CacheManager;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.hazelcast.cache.impl.HazelcastServerCachingProvider.createCachingProvider;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ICacheDataStructureAdapterTest extends HazelcastTestSupport {
+
+    private ICache<Integer, String> cache;
+    private ICacheDataStructureAdapter<Integer, String> adapter;
+
+    @Before
+    public void setUp() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hazelcastInstance = factory.newHazelcastInstance();
+        HazelcastServerCachingProvider cachingProvider = createCachingProvider(hazelcastInstance);
+        CacheManager cacheManager = cachingProvider.getCacheManager();
+
+        CacheConfig<Integer, String> cacheConfig = new CacheConfig<Integer, String>();
+
+        cache = (ICache<Integer, String>) cacheManager.createCache("CacheDataStructureAdapterTest", cacheConfig);
+        adapter = new ICacheDataStructureAdapter<Integer, String>(cache);
+    }
+
+    @Test
+    public void testClear() {
+        cache.put(23, "foobar");
+
+        adapter.clear();
+
+        assertEquals(0, cache.size());
+    }
+
+    @Test
+    public void testSet() {
+        adapter.set(23, "test");
+
+        assertEquals("test", cache.get(23));
+    }
+
+    @Test
+    public void testPut() {
+        cache.put(42, "oldValue");
+
+        String oldValue = adapter.put(42, "newValue");
+
+        assertEquals("oldValue", oldValue);
+        assertEquals("newValue", cache.get(42));
+    }
+
+    @Test
+    public void testGet() {
+        cache.put(42, "foobar");
+
+        String result = adapter.get(42);
+        assertEquals("foobar", result);
+    }
+
+    @Test
+    public void testGetAll() {
+        cache.put(23, "value-23");
+        cache.put(42, "value-42");
+
+        Map<Integer, String> expectedResult = new HashMap<Integer, String>();
+        expectedResult.put(23, "value-23");
+        expectedResult.put(42, "value-42");
+
+        Map<Integer, String> result = adapter.getAll(expectedResult.keySet());
+        assertEquals(expectedResult, result);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/nearcache/impl/adapter/IMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/nearcache/impl/adapter/IMapDataStructureAdapterTest.java
@@ -1,0 +1,81 @@
+package com.hazelcast.cache.impl.nearcache.impl.adapter;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class IMapDataStructureAdapterTest extends HazelcastTestSupport {
+
+    private IMap<Integer, String> map;
+    private IMapDataStructureAdapter<Integer, String> adapter;
+
+    @Before
+    public void setUp() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hazelcastInstance = factory.newHazelcastInstance();
+
+        map = hazelcastInstance.getMap("IMapDataStructureAdapterTest");
+        adapter = new IMapDataStructureAdapter<Integer, String>(map);
+    }
+
+    @Test
+    public void testClear() {
+        map.put(23, "foobar");
+
+        adapter.clear();
+
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    public void testSet() {
+        adapter.set(23, "test");
+
+        assertEquals("test", map.get(23));    }
+
+    @Test
+    public void testPut() {
+        map.put(42, "oldValue");
+
+        String oldValue = adapter.put(42, "newValue");
+
+        assertEquals("oldValue", oldValue);
+        assertEquals("newValue", map.get(42));
+    }
+
+    @Test
+    public void testGet() {
+        map.put(42, "foobar");
+
+        String result = adapter.get(42);
+        assertEquals("foobar", result);
+    }
+
+    @Test
+    public void testGetAll() {
+        map.put(23, "value-23");
+        map.put(42, "value-42");
+
+        Map<Integer, String> expectedResult = new HashMap<Integer, String>();
+        expectedResult.put(23, "value-23");
+        expectedResult.put(42, "value-42");
+
+        Map<Integer, String> result = adapter.getAll(expectedResult.keySet());
+        assertEquals(expectedResult, result);
+    }
+}


### PR DESCRIPTION
Will be needed for the Near Cache pre-loader and for the Near Cache test unification, so we can use the same production and test code for all kind of data structures. Eventually we may need other methods, but I'd like to have the base classes merged, so I don't have to introduce them in two different PRs.

Usage examples can be found in both of my prototype PRs:
https://github.com/hazelcast/hazelcast/pull/9054
https://github.com/hazelcast/hazelcast/pull/8938

Suggestions for betters class names are very welcome.