### PR TITLE
Packet stateless

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -49,7 +49,7 @@ public final class Packet extends HeapData implements OutboundFrame {
      */
     public static final int FLAG_OP_CONTROL = 1 << 6;
 
-    private static final int HEADER_SIZE = BYTE_SIZE_IN_BYTES + SHORT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES;
+    public static final int HEADER_SIZE = BYTE_SIZE_IN_BYTES + SHORT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES;
 
     private short flags;
     private int partitionId;
@@ -73,6 +73,12 @@ public final class Packet extends HeapData implements OutboundFrame {
         this.partitionId = partitionId;
     }
 
+    public Packet(short flags, int partitionId, byte[] payload) {
+        super(payload);
+        this.flags = flags;
+        this.partitionId = partitionId;
+    }
+
     /**
      * Gets the Connection this Packet was send with.
      *
@@ -90,8 +96,9 @@ public final class Packet extends HeapData implements OutboundFrame {
      *
      * @param conn the connection.
      */
-    public void setConn(Connection conn) {
+    public Packet setConn(Connection conn) {
         this.conn = conn;
+        return this;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberWriteHandler.java
@@ -28,9 +28,57 @@ import java.nio.ByteBuffer;
  * @see MemberReadHandler
  */
 public class MemberWriteHandler implements WriteHandler<Packet> {
+    private boolean headerComplete;
+    private int valueOffset;
+    private int size;
 
     @Override
     public boolean onWrite(Packet packet, ByteBuffer dst) {
-        return packet.writeTo(dst);
+        byte[] payload = packet.toByteArray();
+        if (!headerComplete) {
+            if (dst.remaining() < Packet.HEADER_SIZE) {
+                return false;
+            }
+
+            dst.put(Packet.VERSION);
+            dst.putShort(packet.getFlags());
+            dst.putInt(packet.getPartitionId());
+            size = payload == null ? 0 : payload.length;
+            dst.putInt(size);
+            headerComplete = true;
+        }
+
+        if (size > 0) {
+            // the number of bytes that can be written to the bb.
+            int bytesWritable = dst.remaining();
+
+            // the number of bytes that need to be written.
+            int bytesNeeded = size - valueOffset;
+
+            // the number of bytes that are going to be written
+            int bytesWriting;
+            boolean done;
+            if (bytesWritable >= bytesNeeded) {
+                // All bytes for the value are available.
+                bytesWriting = bytesNeeded;
+                done = true;
+            } else {
+                // Not all bytes for the value are available. So lets write as much as is available.
+                bytesWriting = bytesWritable;
+                done = false;
+            }
+
+            dst.put(payload, valueOffset, bytesWriting);
+            valueOffset += bytesWriting;
+
+            if (!done) {
+                return false;
+            }
+        }
+
+        headerComplete = false;
+        valueOffset = 0;
+        size = 0;
+        return true;
     }
 }


### PR DESCRIPTION
The Packet doesn't track any state for reading/writing on io. So the same
packet instance can be send to multiple connections if needed, reducing
pressure on the heap.

No further changes have been made in the system to make use of this.