### PR TITLE
[FORWARD PORT FROM 3.4.8] Prevents indefinite read of stale value from near-cache

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/ClientHeapNearCache.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/ClientHeapNearCache.java
@@ -45,8 +45,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @param <K>
  */
-public class ClientHeapNearCache<K>
-        implements NearCache<K, Object> {
+public class ClientHeapNearCache<K> implements NearCache<K, Object> {
 
     /**
      * Eviction factor
@@ -73,7 +72,6 @@ public class ClientHeapNearCache<K>
     private final Comparator<NearCacheRecord> selectedComparator;
 
     private volatile long lastCleanup;
-
 
     public ClientHeapNearCache(String mapName, ClientContext context, NearCacheConfig nearCacheConfig) {
         this.mapName = mapName;
@@ -250,7 +248,7 @@ public class ClientHeapNearCache<K>
 
     @Override
     public void destroy() {
-        cache.clear();
+        clear();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
@@ -1,0 +1,280 @@
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.nearcache.NearCacheProvider;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.fail;
+
+/**
+ * A test to ensure no lost invalidations on the near cache.
+ * <p>
+ * Issue: https://github.com/hazelcast/hazelcast/issues/4671
+ * <p>
+ * Thanks Lukas Blunschi for this test (https://github.com/lukasblu).
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientMapNearCacheStaleReadTest extends HazelcastTestSupport {
+
+    private static final Logger logger = Logger.getLogger(ClientMapNearCacheStaleReadTest.class);
+
+    private static final int numGetters = 7;
+
+    private static final int maxRuntime = 30;
+
+    private static final String mapName = "test";
+
+    private static final String key = "key123";
+
+    private IMap<String, String> map;
+
+    private AtomicInteger valuePut = new AtomicInteger(0);
+
+    private AtomicBoolean stop = new AtomicBoolean(false);
+
+    private AtomicInteger assertionViolationCount = new AtomicInteger(0);
+
+    private AtomicBoolean failed = new AtomicBoolean(false);
+
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Test
+    public void testNoLostInvalidationsEventually() throws Exception {
+        assertionViolationCount.set(0);
+        testNoLostInvalidations(false);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.shutdown();
+        member.shutdown();
+    }
+
+    private void testNoLostInvalidations(boolean strict) throws Exception {
+
+        // configure near cache
+        ClientConfig clientConfig = getClientConfig(mapName);
+
+        // enable near cache
+
+        // create Hazelcast instance
+        member = Hazelcast.newHazelcastInstance();
+        client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        // get hazelcast map
+        map = client.getMap(mapName);
+
+        // run test
+        runTestInternal();
+
+        // test eventually consistent
+        Thread.sleep(5000);
+        int valuePutLast = valuePut.get();
+        String valueMapStr = map.get(key);
+        int valueMap = Integer.parseInt(valueMapStr);
+
+        // fail if not eventually consistent
+        String msg = null;
+        if (valueMap < valuePutLast) {
+            msg = "Near cache did *not* become consistent. (valueMap = " + valueMap + ", valuePut = " + valuePutLast + ").";
+
+            // flush near cache and re-fetch value
+            flushNearCache(client);
+            String valueMap2Str = map.get(key);
+            int valueMap2 = Integer.parseInt(valueMap2Str);
+
+            // test again
+            if (valueMap2 < valuePutLast) {
+                msg += " Unexpected inconsistency! (valueMap2 = " + valueMap2 + ", valuePut = " + valuePutLast + ").";
+            } else {
+                msg += " Flushing the near cache cleared the inconsistency. (valueMap2 = " + valueMap2 + ", valuePut = " + valuePutLast + ").";
+            }
+        }
+
+        // stop hazelcast
+        client.getLifecycleService().terminate();
+
+        // fail after stopping hazelcast instance
+        if (msg != null) {
+            logger.warn(msg);
+            fail(msg);
+        }
+
+        // fail if strict is required and assertion was violated
+        if (strict && assertionViolationCount.get() > 0) {
+            msg = "Assertion violated " + assertionViolationCount.get() + " times.";
+            logger.warn(msg);
+            fail(msg);
+        }
+    }
+
+    // Overridden
+    protected ClientConfig getClientConfig(String mapName) {
+        NearCacheConfig nearCacheConfig = getNearCacheConfig(mapName);
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+        return clientConfig;
+    }
+
+    protected NearCacheConfig getNearCacheConfig(String mapName) {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig(mapName);
+        nearCacheConfig.setCacheLocalEntries(true); // this enables caching of local entries
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        return nearCacheConfig;
+    }
+
+    /**
+     * Flush near cache.
+     * <p>
+     * Warning: this uses Hazelcast internals which might change from one version to the other.
+     */
+    private void flushNearCache(HazelcastInstance hcInstance) throws Exception {
+
+        // get instance proxy
+        HazelcastInstanceProxy hcInstanceProxy = (HazelcastInstanceProxy) hcInstance;
+
+        // get internal implementation (using reflection)
+        Field originalField = HazelcastInstanceProxy.class.getDeclaredField("original");
+        originalField.setAccessible(true);
+        HazelcastInstanceImpl hcImpl = (HazelcastInstanceImpl) originalField.get(hcInstanceProxy);
+
+        // get node engine
+        NodeEngineImpl nodeEngineImpl = hcImpl.node.nodeEngine;
+
+        // get map service
+        MapService mapService = nodeEngineImpl.getService(MapService.SERVICE_NAME);
+
+        // clear near cache
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        NearCacheProvider nearCacheProvider = mapServiceContext.getNearCacheProvider();
+        nearCacheProvider.getOrCreateNearCache(mapName).clear();
+    }
+
+    private void runTestInternal() throws Exception {
+
+        // start 1 putter thread (put0)
+        Thread threadPut = new Thread(new PutRunnable(), "put0");
+        threadPut.start();
+
+        // wait for putter thread to start before starting getter threads
+        Thread.sleep(300);
+
+        // start numGetters getter threads (get0-numGetters)
+        List<Thread> threads = new ArrayList<Thread>();
+        for (int i = 0; i < numGetters; i++) {
+            Thread thread = new Thread(new GetRunnable(), "get" + i);
+            threads.add(thread);
+        }
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // stop after maxRuntime seconds
+        int i = 0;
+        while (!stop.get() && i++ < maxRuntime) {
+            Thread.sleep(1000);
+        }
+        if (!stop.get()) {
+            logger.info("Problem did not occur within " + maxRuntime + "s.");
+        }
+        stop.set(true);
+        threadPut.join();
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
+
+    private class PutRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            logger.info(Thread.currentThread().getName() + " started.");
+            int i = 0;
+            while (!stop.get()) {
+                i++;
+
+                // put new value and update last state
+                // note: the value in the map/near cache is *always* larger or equal to valuePut
+                // assertion: valueMap >= valuePut
+                map.put(key, String.valueOf(i));
+                valuePut.set(i);
+
+                // check if we see our last update
+                String valueMapStr = map.get(key);
+                if (valueMapStr == null) {
+                    continue;
+                }
+                int valueMap = Integer.parseInt(valueMapStr);
+                if (valueMap != i) {
+                    assertionViolationCount.incrementAndGet();
+                    logger.warn("Assertion violated! (valueMap = " + valueMap + ", i = " + i + ")");
+
+                    // sleep to ensure near cache invalidation is really lost
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        logger.warn("Interrupted: " + e.getMessage());
+                    }
+
+                    // test again and stop if really lost
+                    valueMapStr = map.get(key);
+                    valueMap = Integer.parseInt(valueMapStr);
+                    if (valueMap != i) {
+                        logger.warn("Near cache invalidation lost! (valueMap = " + valueMap + ", i = " + i + ")");
+                        failed.set(true);
+                        stop.set(true);
+                    }
+                }
+            }
+            logger.info(Thread.currentThread().getName() + " performed " + i + " operations.");
+        }
+
+    }
+
+    private class GetRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            logger.info(Thread.currentThread().getName() + " started.");
+            int n = 0;
+            while (!stop.get()) {
+                n++;
+
+                // blindly get the value - to trigger issue - and
+                // parse the value - to get some CPU load
+                String valueMapStr = map.get(key);
+                Integer.parseInt(valueMapStr);
+            }
+            logger.info(Thread.currentThread().getName() + " performed " + n + " operations.");
+        }
+
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStalenessTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStalenessTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.proxy.NearCachedClientMapProxy;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.util.RandomPicker.getInt;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class})
+public class ClientMapNearCacheStalenessTest extends HazelcastTestSupport {
+
+    private final int ENTRY_COUNT = 10;
+    private final int NEAR_CACHE_INVALIDATOR_THREAD_COUNT = 1;
+    private final int NEAR_CACHE_PUTTER_THREAD_COUNT = 10;
+    private final String MAP_NAME = randomMapName();
+    private final AtomicBoolean stop = new AtomicBoolean(false);
+
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    private IMap clientMap;
+    private IMap memberMap;
+
+    @Before
+    public void setUp() throws Exception {
+        ClientConfig clientConfig = getClientConfig(MAP_NAME);
+
+        member = Hazelcast.newHazelcastInstance();
+        client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        memberMap = member.getMap(MAP_NAME);
+        clientMap = client.getMap(MAP_NAME);
+    }
+
+    // overridden
+    protected ClientConfig getClientConfig(String mapName) {
+        NearCacheConfig nearCacheConfig = getNearCacheConfig(mapName);
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+        return clientConfig;
+    }
+
+    protected NearCacheConfig getNearCacheConfig(String mapName) {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig(mapName);
+        nearCacheConfig.setInvalidateOnChange(true);
+        return nearCacheConfig;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        client.shutdown();
+        member.shutdown();
+    }
+
+    @Test
+    public void testNearCache_notContainsStaleValue_whenUpdatedByMultipleThreads() throws Exception {
+        List<Thread> threads = new ArrayList<Thread>();
+
+        for (int i = 0; i < NEAR_CACHE_INVALIDATOR_THREAD_COUNT; i++) {
+            Thread putter = new NearCacheInvalidator();
+            threads.add(putter);
+        }
+
+        for (int i = 0; i < NEAR_CACHE_PUTTER_THREAD_COUNT; i++) {
+            Thread getter = new NearCachePutter();
+            threads.add(getter);
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        sleepSeconds(5);
+
+        stop.set(true);
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // give some-time to receive possible latest invalidations.
+        sleepSeconds(5);
+
+        assertNoStaleDataExistInNearCache(clientMap);
+
+    }
+
+    protected void assertNoStaleDataExistInNearCache(IMap map) {
+        // 1. Get all entries when near-cache is full, so some values will come from near-cache.
+        Map fromNearCache = getAllEntries(map);
+
+        // 2. Clear near-cache
+        ((NearCachedClientMapProxy) map).getNearCache().clear();
+
+        // 3. Get all values when near-cache is empty, these requests
+        // will go to underlying IMap directly because near-cache is empty.
+        Map fromIMap = getAllEntries(map);
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            assertEquals(fromIMap.get(i), fromNearCache.get(i));
+        }
+    }
+
+    protected HashMap getAllEntries(IMap iMap) {
+        HashMap localMap = new HashMap(ENTRY_COUNT);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            localMap.put(i, iMap.get(i));
+        }
+        return localMap;
+    }
+
+    private class NearCacheInvalidator extends Thread {
+
+        @Override
+        public void run() {
+            while (!stop.get()) {
+                for (int i = 0; i < ENTRY_COUNT; i++) {
+                    memberMap.put(i, getInt(ENTRY_COUNT));
+                }
+            }
+        }
+    }
+
+
+    private class NearCachePutter extends Thread {
+
+        @Override
+        public void run() {
+            while (!stop.get()) {
+                for (int i = 0; i < ENTRY_COUNT; i++) {
+                    clientMap.get(i);
+                }
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/KeyStateMarker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/KeyStateMarker.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache;
+
+/**
+ * Used to assign a {@link STATE} to a key.
+ *
+ * That {@link STATE} is used when deciding whether or not a key can be puttable to a near-cache.
+ * Because there is a possibility that an invalidation for a key can be received before putting that
+ * key into near-cache, in that case, key should not be put into near-cache.
+ */
+public interface KeyStateMarker {
+
+    boolean tryMark(Object key);
+
+    boolean tryUnmark(Object key);
+
+    boolean tryRemove(Object key);
+
+    void forceUnmark(Object key);
+
+    void init();
+
+    enum STATE {
+        UNMARKED(0),
+        MARKED(1),
+        REMOVED(2);
+
+        private int state;
+
+        STATE(int state) {
+            this.state = state;
+        }
+
+        public int getState() {
+            return state;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheImpl.java
@@ -41,17 +41,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.config.EvictionPolicy.NONE;
+import static com.hazelcast.instance.GroupProperty.PARTITION_COUNT;
 
 /**
  * NearCache.
  */
 public class NearCacheImpl implements NearCache<Data, Object> {
+
     public static final String NEAR_CACHE_EXECUTOR_NAME = "hz:near-cache";
+
     private static final double EVICTION_FACTOR = 0.2;
     private static final int CLEANUP_INTERVAL = 5000;
+
     private final int maxSize;
     private final String mapName;
-    private volatile long lastCleanup;
     private final long maxIdleMillis;
     private final long timeToLiveMillis;
     private final EvictionPolicy evictionPolicy;
@@ -66,6 +69,8 @@ public class NearCacheImpl implements NearCache<Data, Object> {
     private final boolean invalidateOnChange;
 
     private SizeEstimator nearCacheSizeEstimator;
+
+    private volatile long lastCleanup;
 
     /**
      * @param mapName    name of map which owns near cache.
@@ -89,6 +94,11 @@ public class NearCacheImpl implements NearCache<Data, Object> {
         this.serializationService = nodeEngine.getSerializationService();
         this.invalidateOnChange = nearCacheConfig.isInvalidateOnChange();
         this.mapName = mapName;
+        int partitionCount = getPartitionCount(nodeEngine);
+    }
+
+    private int getPartitionCount(NodeEngine nodeEngine) {
+        return nodeEngine.getGroupProperties().getInteger(PARTITION_COUNT);
     }
 
     // TODO this operation returns the given value in near-cache memory format (data or object)?
@@ -292,4 +302,5 @@ public class NearCacheImpl implements NearCache<Data, Object> {
     public void setNearCacheSizeEstimator(SizeEstimator nearCacheSizeEstimator) {
         this.nearCacheSizeEstimator = nearCacheSizeEstimator;
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.instance.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED;
 import static com.hazelcast.instance.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE;
+import static com.hazelcast.map.impl.nearcache.StaleReadPreventerNearCacheWrapper.wrapAsStaleReadPreventerNearCache;
 
 /**
  * Provides near cache specific functionality.
@@ -48,7 +49,9 @@ public class NearCacheProvider {
             SizeEstimator nearCacheSizeEstimator = mapContainer.getNearCacheSizeEstimator();
             NearCacheImpl nearCache = new NearCacheImpl(mapName, nodeEngine);
             nearCache.setNearCacheSizeEstimator(nearCacheSizeEstimator);
-            return nearCache;
+
+            int partitionCount = mapServiceContext.getNodeEngine().getPartitionService().getPartitionCount();
+            return wrapAsStaleReadPreventerNearCache(nearCache, partitionCount);
         }
     };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/StaleReadPreventerNearCacheWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/StaleReadPreventerNearCacheWrapper.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache;
+
+import com.hazelcast.cache.impl.nearcache.NearCache;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.nio.serialization.Data;
+
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+import static com.hazelcast.map.impl.nearcache.KeyStateMarker.STATE.MARKED;
+import static com.hazelcast.map.impl.nearcache.KeyStateMarker.STATE.REMOVED;
+import static com.hazelcast.map.impl.nearcache.KeyStateMarker.STATE.UNMARKED;
+import static com.hazelcast.util.HashUtil.hashToIndex;
+
+/**
+ * Guards a {@link NearCache} against stale reads by using {@link KeyStateMarker}
+ *
+ * @see KeyStateMarker
+ */
+public final class StaleReadPreventerNearCacheWrapper implements NearCache, KeyStateMarker {
+
+    private final NearCache nearCache;
+    private final int markCount;
+
+    private volatile AtomicIntegerArray marks;
+
+    private StaleReadPreventerNearCacheWrapper(NearCache nearCache, int markCount) {
+        this.nearCache = nearCache;
+        this.markCount = markCount;
+        this.marks = new AtomicIntegerArray(markCount);
+    }
+
+    public static NearCache wrapAsStaleReadPreventerNearCache(NearCache nearCache, int markerCount) {
+        return new StaleReadPreventerNearCacheWrapper(nearCache, markerCount);
+    }
+
+    @Override
+    public String getName() {
+        return nearCache.getName();
+    }
+
+    @Override
+    public Object get(Object key) {
+        return nearCache.get(key);
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        nearCache.put(key, value);
+    }
+
+    @Override
+    public boolean remove(Object key) {
+        tryRemove(key);
+        return nearCache.remove(key);
+    }
+
+    @Override
+    public boolean isInvalidateOnChange() {
+        return nearCache.isInvalidateOnChange();
+    }
+
+    @Override
+    public void clear() {
+        init();
+        nearCache.clear();
+    }
+
+    @Override
+    public void destroy() {
+        init();
+        nearCache.destroy();
+    }
+
+    @Override
+    public InMemoryFormat getInMemoryFormat() {
+        return nearCache.getInMemoryFormat();
+    }
+
+    @Override
+    public NearCacheStats getNearCacheStats() {
+        return nearCache.getNearCacheStats();
+    }
+
+    @Override
+    public Object selectToSave(Object... candidates) {
+        return nearCache.selectToSave(candidates);
+    }
+
+    @Override
+    public int size() {
+        return nearCache.size();
+    }
+
+    @Override
+    public boolean tryMark(Object key) {
+        return casState(key, UNMARKED, MARKED);
+    }
+
+    @Override
+    public boolean tryUnmark(Object key) {
+        return casState(key, MARKED, UNMARKED);
+    }
+
+    @Override
+    public boolean tryRemove(Object key) {
+        return casState(key, MARKED, REMOVED);
+    }
+
+    @Override
+    public void forceUnmark(Object key) {
+        int slot = getSlot(key);
+        marks.set(slot, UNMARKED.getState());
+    }
+
+    @Override
+    public void init() {
+        marks = new AtomicIntegerArray(markCount);
+    }
+
+    private boolean casState(Object key, STATE expect, STATE update) {
+        int slot = getSlot(key);
+        return marks.compareAndSet(slot, expect.getState(), update.getState());
+    }
+
+    private int getSlot(Object key) {
+        int hash = key instanceof Data ? ((Data) key).getPartitionHash() : key.hashCode();
+        return hashToIndex(hash, markCount);
+    }
+
+    public KeyStateMarker getKeyStateMarker() {
+        return this;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains near-cache specific classes.
+ */
+package com.hazelcast.map.impl.nearcache;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -23,7 +23,9 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.nearcache.KeyStateMarker;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
+import com.hazelcast.map.impl.nearcache.StaleReadPreventerNearCacheWrapper;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.ExecutionService;
@@ -39,6 +41,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.impl.nearcache.NearCache.NULL_OBJECT;
+import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * A server-side {@code IMap} implementation which is fronted by a near-cache.
@@ -49,6 +52,7 @@ import static com.hazelcast.cache.impl.nearcache.NearCache.NULL_OBJECT;
 public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     protected NearCache nearCache;
+    protected KeyStateMarker keyStateMarker;
     protected boolean cacheLocalEntries;
 
     public NearCachedMapProxyImpl(String name, MapService mapService, NodeEngine nodeEngine, MapConfig mapConfig) {
@@ -64,8 +68,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     protected void init() {
         NearCacheProvider nearCacheProvider = mapServiceContext.getNearCacheProvider();
-        this.nearCache = nearCacheProvider.getOrCreateNearCache(name);
-        this.cacheLocalEntries = getMapConfig().getNearCacheConfig().isCacheLocalEntries();
+        nearCache = nearCacheProvider.getOrCreateNearCache(name);
+        keyStateMarker = getKeyStateMarker();
+        cacheLocalEntries = getMapConfig().getNearCacheConfig().isCacheLocalEntries();
     }
 
     // this operation returns the object in data format except
@@ -80,15 +85,29 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
             return value;
         }
 
+        boolean marked = keyStateMarker.tryMark(key);
+
         value = super.getInternal(key);
 
-        if (!isOwn(key) || cacheLocalEntries) {
-            nearCache.put(key, toData(value));
+        if (marked) {
+            tryToPutNearCache(key, value);
         }
 
         return value;
     }
 
+    private void tryToPutNearCache(Data key, Object value) {
+        try {
+            if (!isOwn(key) || cacheLocalEntries) {
+                nearCache.put(key, value);
+            }
+        } finally {
+            if (!keyStateMarker.tryUnmark(key)) {
+                invalidateCache(key);
+                keyStateMarker.forceUnmark(key);
+            }
+        }
+    }
 
     @Override
     protected ICompletableFuture<Data> getAsyncInternal(final Data key) {
@@ -103,13 +122,14 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
                     getNodeEngine().getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR));
         }
 
+        final boolean marked = keyStateMarker.tryMark(key);
 
         ICompletableFuture<Data> future = super.getAsyncInternal(key);
         future.andThen(new ExecutionCallback<Data>() {
             @Override
             public void onResponse(Data response) {
-                if (!isOwn(key) || cacheLocalEntries) {
-                    nearCache.put(key, response);
+                if (marked) {
+                    tryToPutNearCache(key, response);
                 }
             }
 
@@ -126,100 +146,110 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     @Override
     protected Data putInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+        Data data = super.putInternal(key, value, ttl, timeunit);
         invalidateCache(key);
-        return super.putInternal(key, value, ttl, timeunit);
+        return data;
     }
 
     @Override
     protected boolean tryPutInternal(Data key, Data value, long timeout, TimeUnit timeunit) {
+        boolean putInternal = super.tryPutInternal(key, value, timeout, timeunit);
         invalidateCache(key);
-        return super.tryPutInternal(key, value, timeout, timeunit);
+        return putInternal;
     }
 
     @Override
     protected Data putIfAbsentInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+        Data data = super.putIfAbsentInternal(key, value, ttl, timeunit);
         invalidateCache(key);
-        return super.putIfAbsentInternal(key, value, ttl, timeunit);
+        return data;
     }
 
     @Override
     protected void putTransientInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
-        super.putTransientInternal(key, value, ttl, timeunit);
         invalidateCache(key);
+        super.putTransientInternal(key, value, ttl, timeunit);
     }
 
     @Override
     protected ICompletableFuture<Data> putAsyncInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
+        ICompletableFuture<Data> future = super.putAsyncInternal(key, value, ttl, timeunit);
         invalidateCache(key);
-        return super.putAsyncInternal(key, value, ttl, timeunit);
+        return future;
     }
 
     @Override
     protected boolean replaceInternal(Data key, Data expect, Data update) {
+        boolean replaceInternal = super.replaceInternal(key, expect, update);
         invalidateCache(key);
-        return super.replaceInternal(key, expect, update);
+        return replaceInternal;
     }
 
     @Override
     protected Data replaceInternal(Data key, Data value) {
+        Data replaceInternal = super.replaceInternal(key, value);
         invalidateCache(key);
-        return super.replaceInternal(key, value);
+        return replaceInternal;
     }
 
     @Override
     protected void setInternal(Data key, Data value, long ttl, TimeUnit timeunit) {
-        invalidateCache(key);
         super.setInternal(key, value, ttl, timeunit);
+        invalidateCache(key);
     }
 
     @Override
     protected boolean evictInternal(Data key) {
+        boolean evictInternal = super.evictInternal(key);
         invalidateCache(key);
-        return super.evictInternal(key);
+        return evictInternal;
     }
 
     @Override
     protected void evictAllInternal() {
-        nearCache.clear();
         super.evictAllInternal();
+        nearCache.clear();
     }
 
     @Override
     public void loadAllInternal(boolean replaceExistingValues) {
+        super.loadAllInternal(replaceExistingValues);
         if (replaceExistingValues) {
             nearCache.clear();
         }
-        super.loadAllInternal(replaceExistingValues);
     }
 
     @Override
     protected void loadInternal(Iterable keys, boolean replaceExistingValues) {
-        invalidateCache(keys);
         super.loadInternal(keys, replaceExistingValues);
+        invalidateCache(keys);
     }
 
     @Override
     protected Data removeInternal(Data key) {
+        Data data = super.removeInternal(key);
         invalidateCache(key);
-        return super.removeInternal(key);
+        return data;
     }
 
     @Override
     protected void deleteInternal(Data key) {
-        invalidateCache(key);
         super.deleteInternal(key);
+        invalidateCache(key);
     }
 
     @Override
     protected boolean removeInternal(Data key, Data value) {
+        boolean removeInternal = super.removeInternal(key, value);
         invalidateCache(key);
-        return super.removeInternal(key, value);
+        return removeInternal;
     }
 
     @Override
     protected boolean tryRemoveInternal(Data key, long timeout, TimeUnit timeunit) {
+        boolean removeInternal = super.tryRemoveInternal(key, timeout, timeunit);
         invalidateCache(key);
-        return super.tryRemoveInternal(key, timeout, timeunit);
+        return removeInternal;
     }
 
     @Override
@@ -242,6 +272,12 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     protected void getAllObjectInternal(List<Data> keys, List resultingKeyValuePairs) {
         getCachedValue(keys, resultingKeyValuePairs);
 
+        Map<Data, Boolean> keyStates = createHashMap(keys.size());
+        for (Data key : keys) {
+            keyStates.put(key, keyStateMarker.tryMark(key));
+        }
+
+
         int currentSize = resultingKeyValuePairs.size();
         super.getAllObjectInternal(keys, resultingKeyValuePairs);
 
@@ -250,8 +286,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
             Data key = toData(resultingKeyValuePairs.get(i++));
             Data value = toData(resultingKeyValuePairs.get(i++));
 
-            if (!isOwn(key) || cacheLocalEntries) {
-                nearCache.put(key, value);
+            boolean marked = keyStates.get(key);
+            if (marked) {
+                tryToPutNearCache(key, value);
             }
         }
     }
@@ -267,20 +304,23 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     @Override
     public Data executeOnKeyInternal(Data key, EntryProcessor entryProcessor) {
+        Data data = super.executeOnKeyInternal(key, entryProcessor);
         invalidateCache(key);
-        return super.executeOnKeyInternal(key, entryProcessor);
+        return data;
     }
 
     @Override
     public Map executeOnKeysInternal(Set<Data> keys, EntryProcessor entryProcessor) {
+        Map map = super.executeOnKeysInternal(keys, entryProcessor);
         invalidateCache(keys);
-        return super.executeOnKeysInternal(keys, entryProcessor);
+        return map;
     }
 
     @Override
     public ICompletableFuture executeOnKeyInternal(Data key, EntryProcessor entryProcessor, ExecutionCallback callback) {
+        ICompletableFuture future = super.executeOnKeyInternal(key, entryProcessor, callback);
         invalidateCache(key);
-        return super.executeOnKeyInternal(key, entryProcessor, callback);
+        return future;
     }
 
     @Override
@@ -344,5 +384,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     public NearCache getNearCache() {
         return nearCache;
+    }
+
+    public KeyStateMarker getKeyStateMarker() {
+        return ((StaleReadPreventerNearCacheWrapper) nearCache).getKeyStateMarker();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
@@ -17,7 +17,7 @@ import com.hazelcast.partition.InternalPartition;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.query.SqlPredicate;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class MapLoaderTest extends HazelcastTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheStaleReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheStaleReadTest.java
@@ -1,0 +1,236 @@
+package com.hazelcast.map.nearcache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.apache.log4j.Logger;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static org.junit.Assert.fail;
+
+/**
+ * A test to ensure no lost invalidations on the near cache.
+ * <p>
+ * Issue: https://github.com/hazelcast/hazelcast/issues/4671
+ * <p>
+ * Thanks Lukas Blunschi for this test (https://github.com/lukasblu).
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class NearCacheStaleReadTest extends HazelcastTestSupport {
+
+    private static final Logger logger = Logger.getLogger(NearCacheStaleReadTest.class);
+
+    private static final int numGetters = 7;
+
+    private static final int maxRuntime = 30;
+
+    private static final String mapName = "testMap" + NearCacheStaleReadTest.class.getSimpleName();
+
+    private static final String key = "key123";
+
+    private IMap<String, String> map;
+
+    private AtomicInteger valuePut = new AtomicInteger(0);
+
+    private AtomicBoolean stop = new AtomicBoolean(false);
+
+    private AtomicInteger assertionViolationCount = new AtomicInteger(0);
+
+    private AtomicBoolean failed = new AtomicBoolean(false);
+
+    @Test
+    public void testNoLostInvalidationsEventually() throws Exception {
+        assertionViolationCount.set(0);
+        testNoLostInvalidations(false);
+    }
+
+    private void testNoLostInvalidations(boolean strict) throws Exception {
+
+        // create hazelcast config
+        Config config = getConfig();
+        config.setProperty("hazelcast.logging.type", "log4j");
+
+        // we use a single node only - do not search for others
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+
+        // configure near cache
+        NearCacheConfig nearCacheConfig = getNearCacheConfig();
+
+        // enable near cache
+        MapConfig mapConfig = config.getMapConfig(mapName);
+        mapConfig.setNearCacheConfig(nearCacheConfig);
+
+        // create Hazelcast instance
+        HazelcastInstance hcInstance = Hazelcast.newHazelcastInstance(config);
+
+        // get hazelcast map
+        map = hcInstance.getMap(mapName);
+
+        // run test
+        runTestInternal();
+
+        // test eventually consistent
+        Thread.sleep(5000);
+        int valuePutLast = valuePut.get();
+        String valueMapStr = map.get(key);
+        int valueMap = Integer.parseInt(valueMapStr);
+
+        // fail if not eventually consistent
+        String msg = null;
+        if (valueMap < valuePutLast) {
+            msg = "Near cache did *not* become consistent. (valueMap = " + valueMap + ", valuePut = " + valuePutLast + ").";
+
+            // flush near cache and re-fetch value
+            ((NearCachedMapProxyImpl) map).getNearCache().clear();
+            String valueMap2Str = map.get(key);
+            int valueMap2 = Integer.parseInt(valueMap2Str);
+
+            // test again
+            if (valueMap2 < valuePutLast) {
+                msg += " Unexpected inconsistency! (valueMap2 = " + valueMap2 + ", valuePut = " + valuePutLast + ").";
+            } else {
+                msg += " Flushing the near cache cleared the inconsistency. (valueMap2 = " + valueMap2 + ", valuePut = " + valuePutLast + ").";
+            }
+        }
+
+        // stop hazelcast
+        hcInstance.getLifecycleService().terminate();
+
+        // fail after stopping hazelcast instance
+        if (msg != null) {
+            logger.warn(msg);
+            fail(msg);
+        }
+
+        // fail if strict is required and assertion was violated
+        if (strict && assertionViolationCount.get() > 0) {
+            msg = "Assertion violated " + assertionViolationCount.get() + " times.";
+            logger.warn(msg);
+            fail(msg);
+        }
+    }
+
+    protected NearCacheConfig getNearCacheConfig() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setCacheLocalEntries(true); // this enables caching of local entries
+        nearCacheConfig.setInMemoryFormat(OBJECT);
+        return nearCacheConfig;
+    }
+
+    private void runTestInternal() throws Exception {
+
+        // start 1 putter thread (put0)
+        Thread threadPut = new Thread(new PutRunnable(), "put0");
+        threadPut.start();
+
+        // wait for putter thread to start before starting getter threads
+        Thread.sleep(300);
+
+        // start numGetters getter threads (get0-numGetters)
+        List<Thread> threads = new ArrayList<Thread>();
+        for (int i = 0; i < numGetters; i++) {
+            Thread thread = new Thread(new GetRunnable(), "get" + i);
+            threads.add(thread);
+        }
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // stop after maxRuntime seconds
+        int i = 0;
+        while (!stop.get() && i++ < maxRuntime) {
+            Thread.sleep(1000);
+        }
+        if (!stop.get()) {
+            logger.info("Problem did not occur within " + maxRuntime + "s.");
+        }
+        stop.set(true);
+        threadPut.join();
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
+
+    private class PutRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            logger.info(Thread.currentThread().getName() + " started.");
+            int i = 0;
+            while (!stop.get()) {
+                i++;
+
+                // put new value and update last state
+                // note: the value in the map/near cache is *always* larger or equal to valuePut
+                // assertion: valueMap >= valuePut
+                map.put(key, String.valueOf(i));
+                valuePut.set(i);
+
+                // check if we see our last update
+                String valueMapStr = map.get(key);
+                if (valueMapStr == null) {
+                    continue;
+                }
+                int valueMap = Integer.parseInt(valueMapStr);
+                if (valueMap != i) {
+                    assertionViolationCount.incrementAndGet();
+                    logger.warn("Assertion violated! (valueMap = " + valueMap + ", i = " + i + ")");
+
+                    // sleep to ensure near cache invalidation is really lost
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        logger.warn("Interrupted: " + e.getMessage());
+                    }
+
+                    // test again and stop if really lost
+                    valueMapStr = map.get(key);
+                    valueMap = Integer.parseInt(valueMapStr);
+                    if (valueMap != i) {
+                        logger.warn("Near cache invalidation lost! (valueMap = " + valueMap + ", i = " + i + ")");
+                        failed.set(true);
+                        stop.set(true);
+                    }
+                }
+            }
+            logger.info(Thread.currentThread().getName() + " performed " + i + " operations.");
+        }
+
+    }
+
+    private class GetRunnable implements Runnable {
+
+        @Override
+        public void run() {
+            logger.info(Thread.currentThread().getName() + " started.");
+            int n = 0;
+            while (!stop.get()) {
+                n++;
+
+                // blindly get the value - to trigger issue - and
+                // parse the value - to get some CPU load
+                String valueMapStr = map.get(key);
+                Integer.parseInt(valueMapStr);
+            }
+            logger.info(Thread.currentThread().getName() + " performed " + n + " operations.");
+        }
+
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheStalenessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheStalenessTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.nearcache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.util.RandomPicker.getInt;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class})
+public class NearCacheStalenessTest extends HazelcastTestSupport {
+
+    private final int ENTRY_COUNT = 1;
+    private final int NEAR_CACHE_INVALIDATOR_THREAD_COUNT = 3;
+    private final int NEAR_CACHE_REMOVER_THREAD_COUNT = 3;
+    private final int NEAR_CACHE_PUTTER_THREAD_COUNT = 10;
+    private final String MAP_NAME = randomMapName();
+    private final AtomicBoolean stop = new AtomicBoolean(false);
+
+    private IMap map1;
+    private IMap map2;
+
+    @Before
+    public void setUp() throws Exception {
+        Config config = getConfig();
+
+        NearCacheConfig nearCacheConfig = newNearCacheConfig();
+        nearCacheConfig.setInvalidateOnChange(true).setCacheLocalEntries(true);
+
+        config.getMapConfig(MAP_NAME).setNearCacheConfig(nearCacheConfig);
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance node1 = factory.newHazelcastInstance(config);
+        HazelcastInstance node2 = factory.newHazelcastInstance(config);
+
+        map1 = node1.getMap(MAP_NAME);
+        map2 = node2.getMap(MAP_NAME);
+    }
+
+    @Test
+    public void testNearCache_notContainsStaleValue_whenUpdatedByMultipleThreads() throws Exception {
+        List<Thread> threads = new ArrayList<Thread>();
+
+        for (int i = 0; i < NEAR_CACHE_INVALIDATOR_THREAD_COUNT; i++) {
+            Thread putter = new NearCacheInvalidator();
+            threads.add(putter);
+        }
+
+        for (int i = 0; i < NEAR_CACHE_REMOVER_THREAD_COUNT; i++) {
+            Thread getter = new NearCachePutter();
+            threads.add(getter);
+        }
+
+        for (int i = 0; i < NEAR_CACHE_PUTTER_THREAD_COUNT; i++) {
+            Thread remover = new NearCacheRemover();
+            threads.add(remover);
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        sleepSeconds(15);
+
+        stop.set(true);
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // give some-time to receive possible latest invalidations.
+        sleepSeconds(10);
+
+        assertNoStaleDataExistInNearCache(map1);
+
+    }
+
+    protected void assertNoStaleDataExistInNearCache(IMap map) {
+        // 1. Get all entries when near-cache is full, so some values will come from near-cache.
+        Map fromNearCache = getAllEntries(map);
+
+        // 2. Clear near-cache
+        ((NearCachedMapProxyImpl) map).getNearCache().clear();
+
+        // 3. Get all values when near-cache is empty, these requests
+        // will go to underlying IMap directly because near-cache is empty.
+        Map fromIMap = getAllEntries(map);
+
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            assertEquals(fromIMap.get(i), fromNearCache.get(i));
+        }
+    }
+
+    protected HashMap getAllEntries(IMap iMap) {
+        HashMap localMap = new HashMap(ENTRY_COUNT);
+        for (int i = 0; i < ENTRY_COUNT; i++) {
+            localMap.put(i, iMap.get(i));
+        }
+        return localMap;
+    }
+
+    protected NearCacheConfig newNearCacheConfig() {
+        return new NearCacheConfig();
+    }
+
+
+    private class NearCacheInvalidator extends Thread {
+
+        @Override
+        public void run() {
+            while (!stop.get()) {
+                map2.put(0, getInt(ENTRY_COUNT));
+            }
+        }
+    }
+
+
+    private class NearCachePutter extends Thread {
+
+        @Override
+        public void run() {
+            while (!stop.get()) {
+                map1.get(0);
+            }
+        }
+    }
+
+    private class NearCacheRemover extends Thread {
+
+        @Override
+        public void run() {
+            while (!stop.get()) {
+                map1.remove(0);
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/nearcache/NearCacheTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.partition.InternalPartitionService;
 import com.hazelcast.query.EntryObject;
@@ -885,8 +886,14 @@ public class NearCacheTest extends HazelcastTestSupport {
         populateMapWithExpirableEntries(map, mapSize, 3, TimeUnit.SECONDS);
         pullEntriesToNearCache(map, mapSize);
 
+        int nearCacheSizeBeforeExpiration = ((NearCachedMapProxyImpl) map).getNearCache().size();
         waitUntilEvictionEventsReceived(latch);
-        assertNearCacheSize(mapSize, mapName, map);
+        // wait some extra time for possible events.
+        sleepSeconds(2);
+
+        int nearCacheSizeAfterExpiration = ((NearCachedMapProxyImpl) map).getNearCache().size();
+
+        assertEquals(nearCacheSizeBeforeExpiration, nearCacheSizeAfterExpiration);
     }
 
     protected void waitUntilEvictionEventsReceived(CountDownLatch latch) {


### PR DESCRIPTION
Fix was already applied 3.7 and 3.8, only 3.6 was missing.