### PR TITLE
Fixed NPE in Diagnostics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriter.java
@@ -104,7 +104,7 @@ public abstract class DiagnosticsLogWriter {
     }
 
     protected DiagnosticsLogWriter write(String s) {
-        printWriter.write(s);
+        printWriter.write(s == null ? "null" : s);
         return this;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriterTest.java
@@ -28,11 +28,28 @@ public class MultiLineDiagnosticsLogWriterTest extends HazelcastTestSupport {
         writer.init(new PrintWriter(out));
     }
 
+    // test for https://github.com/hazelcast/hazelcast/issues/9085
+    @Test
+    public void writeKeyValueEntry_nullValue() {
+        writer.startSection("SomeSection");
+        writer.writeKeyValueEntry("s", null);
+        writer.endSection();
+
+        String actual = out.toString();
+
+        // we need to get rid of the time/date prefix
+        actual = actual.substring(actual.indexOf("SomeSection"));
+
+        assertEquals("" +
+                "SomeSection[" + LINE_SEPARATOR +
+                "                          s=null]" + LINE_SEPARATOR, actual);
+    }
+
     @Test
     public void test() {
         writer.startSection("SomeSection");
         writer.writeKeyValueEntry("boolean", true);
-        writer.writeKeyValueEntry("long", 10l);
+        writer.writeKeyValueEntry("long", 10L);
         writer.startSection("SubSection");
         writer.writeKeyValueEntry("integer", 10);
         writer.endSection();


### PR DESCRIPTION
Fix #9085

The problem was that the printWriter was called with a print(null). So the fix is to do a simple null check and write "null" in case of null.