### PR TITLE
Cache recordsStores should be cleaned up during service shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionSegment.java
@@ -114,6 +114,7 @@ public class CachePartitionSegment implements ConstructorFunction<String, ICache
                 store.close(true);
             }
         }
+        recordStores.clear();
     }
 
     void clearHavingLesserBackupCountThan(int backupCount) {


### PR DESCRIPTION
Otherwise during a force-start during hot-restart, these recordstores
will leak closed hot-restart store refs.