### PR TITLE
Backport https://github.com/hazelcast/hazelcast/pull/8782 Lifecycle listeners event ordering may be incorrect

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -170,6 +170,10 @@ public final class HazelcastClientCacheManager
         }
     }
 
+    @Override
+    protected void onShuttingDown() {
+    }
+
     /**
      * Gets the related {@link NearCacheManager} with the underlying client instance.
      *

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -686,13 +686,13 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         transactionManager.shutdown();
         invocationService.shutdown();
         listenerService.shutdown();
-        ((InternalSerializationService) serializationService).dispose();
         nearCacheManager.destroyAllNearCaches();
         if (discoveryService != null) {
             discoveryService.destroy();
         }
         metricsRegistry.shutdown();
         diagnostics.shutdown();
+        ((InternalSerializationService) serializationService).dispose();
     }
 
     public ClientLockReferenceIdGenerator getLockReferenceIdGenerator() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -25,7 +25,6 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.LifecycleServiceImpl;
 import com.hazelcast.client.impl.client.ClientPrincipal;
 import com.hazelcast.client.spi.ClientClusterService;
-import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
@@ -205,14 +204,8 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     }
 
     private void fireConnectionEvent(final LifecycleEvent.LifecycleState state) {
-        ClientExecutionService executionService = client.getClientExecutionService();
-        executionService.execute(new Runnable() {
-            @Override
-            public void run() {
-                final LifecycleServiceImpl lifecycleService = (LifecycleServiceImpl) client.getLifecycleService();
-                lifecycleService.fireLifecycleEvent(state);
-            }
-        });
+        final LifecycleServiceImpl lifecycleService = (LifecycleServiceImpl) client.getLifecycleService();
+        lifecycleService.fireLifecycleEvent(state);
     }
 
     @Override
@@ -223,11 +216,12 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
     public void connectionRemoved(Connection connection) {
         if (connection.getEndPoint().equals(ownerConnectionAddress)) {
             if (client.getLifecycleService().isRunning()) {
+                fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED);
+
                 clusterExecutor.execute(new Runnable() {
                     @Override
                     public void run() {
                         try {
-                            fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED);
                             connectToCluster();
                         } catch (Exception e) {
                             logger.warning("Could not re-connect to cluster shutting down the client", e);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -89,7 +89,6 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
     }
 
     public void shutdown() {
-        eventExecutor.shutdown();
         ClientExecutionServiceImpl.shutdownExecutor("registrationExecutor", registrationExecutor, logger);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -34,6 +34,7 @@ import com.hazelcast.core.ILock;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.nio.ObjectDataInput;
@@ -245,14 +246,23 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         list.offer(LifecycleState.CLIENT_CONNECTED);
         list.offer(LifecycleState.CLIENT_DISCONNECTED);
         list.offer(LifecycleState.CLIENT_CONNECTED);
+        list.offer(LifecycleState.CLIENT_DISCONNECTED);
+        list.offer(LifecycleState.SHUTTING_DOWN);
+        list.offer(LifecycleState.SHUTDOWN);
 
         final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         final CountDownLatch latch = new CountDownLatch(list.size());
+        final CountDownLatch connectedLatch = new CountDownLatch(2);
         LifecycleListener listener = new LifecycleListener() {
             public void stateChanged(LifecycleEvent event) {
+                Logger.getLogger(getClass()).info("stateChanged: " + event);
                 final LifecycleState state = list.poll();
-                if (state != null && state.equals(event.getState())) {
+                LifecycleState eventState = event.getState();
+                if (state != null && state.equals(eventState)) {
                     latch.countDown();
+                }
+                if (LifecycleState.CLIENT_CONNECTED.equals(eventState)) {
+                    connectedLatch.countDown();
                 }
             }
         };
@@ -260,11 +270,17 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         final ClientConfig clientConfig = new ClientConfig();
         clientConfig.addListenerConfig(listenerConfig);
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(100);
-        hazelcastFactory.newHazelcastClient(clientConfig);
+        HazelcastInstance hazelcastClient = hazelcastFactory.newHazelcastClient(clientConfig);
 
         hazelcastFactory.shutdownAllMembers();
 
         hazelcastFactory.newHazelcastInstance();
+
+        assertTrue("LifecycleState failed. Expected two CLIENT_CONNECTED events!" , connectedLatch.await(60, TimeUnit.SECONDS));
+
+        hazelcastFactory.shutdownAllMembers();
+
+        hazelcastClient.shutdown();
 
         assertTrue("LifecycleState failed" , latch.await(60, TimeUnit.SECONDS));
     }
@@ -469,7 +485,8 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         final IMap<Object, Object> map = client.getMap(mapName);
 
         map.put("a", "b");
-        map.get("a"); //put to nearCache
+        // populate Near Cache
+        map.get("a");
 
         instance.shutdown();
         hazelcastFactory.newHazelcastInstance();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -309,7 +309,7 @@ public abstract class AbstractHazelcastCacheManager
             @Override
             public void stateChanged(LifecycleEvent event) {
                 if (event.getState() == LifecycleEvent.LifecycleState.SHUTTING_DOWN) {
-                    close();
+                    onShuttingDown();
                 }
             }
         });
@@ -455,5 +455,7 @@ public abstract class AbstractHazelcastCacheManager
                                                                String simpleCacheName);
 
     protected abstract void postClose();
+
+    protected abstract void onShuttingDown();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -216,6 +216,11 @@ public class HazelcastServerCacheManager
         }
     }
 
+    @Override
+    protected void onShuttingDown() {
+        close();
+    }
+
     public ICacheService getCacheService() {
         return cacheService;
     }


### PR DESCRIPTION
Backports https://github.com/hazelcast/hazelcast/pull/8782 Client Lifecycle listener may not receive events in expected order (#8782) and https://github.com/hazelcast/hazelcast/pull/9104

* Fixes lifecycle state listener call ordering. Fixes issue #6991

* The LifecycleService owns the executor itself.