### PR TITLE
Make client-side map queries tolerant to cluster migrations

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientQueryDuringMigrationsStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientQueryDuringMigrationsStressTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.spi.properties.ClientProperty;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.test.TimeConstants.MINUTE;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+/**
+ * Test querying a cluster while members are shutting down and joining.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class ClientQueryDuringMigrationsStressTest extends HazelcastTestSupport {
+
+    private static final ILogger LOGGER = Logger.getLogger(ClientQueryDuringMigrationsStressTest.class);
+
+    private static final String TEST_MAP_NAME = "employees";
+    private static final int CONCURRENT_QUERYING_CLIENTS = 10;
+    private static final int CLUSTER_SIZE = 6;
+
+    private TestHazelcastFactory factory;
+    // members[0] stays up all the time during the test, the rest are shutdown/started during the test
+    private HazelcastInstance[] members;
+    private HazelcastInstance[] clients;
+    private ExecutorService queriesExecutor;
+
+    final AtomicBoolean testRunning = new AtomicBoolean();
+    final AtomicBoolean testFailed = new AtomicBoolean();
+    final StringBuilder failureMessageBuilder = new StringBuilder();
+
+    @Before
+    public void setup() {
+        Config config = getConfig();
+        factory = new TestHazelcastFactory();
+        members = new HazelcastInstance[CLUSTER_SIZE];
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            members[i] = factory.newHazelcastInstance(config);
+        }
+
+        clients = new HazelcastInstance[CONCURRENT_QUERYING_CLIENTS];
+        for (int i = 0; i < CONCURRENT_QUERYING_CLIENTS; i++) {
+            clients[i] = factory.newHazelcastClient(getClientConfig(members[0]));
+        }
+
+        testRunning.set(true);
+        testFailed.set(false);
+        queriesExecutor = Executors.newFixedThreadPool(CONCURRENT_QUERYING_CLIENTS);
+    }
+
+    @After
+    public void teardown() {
+        queriesExecutor.shutdown();
+        factory.shutdownAll();
+    }
+
+    // Test on a cluster where members shutdown & startup, map without indexes
+    @Test(timeout = 4 * MINUTE)
+    public void testQueryMapWithoutIndexes_whileShutdownStartup() throws InterruptedException {
+        IMap<String, SampleObjects.Employee> map = getMapWithoutIndexes();
+        populateMap(map, 100000);
+        queryDuringMigrations(map);
+    }
+
+    // Test on a cluster where members shutdown & startup, map with indexes
+    // Currently ignored, as indexed queries during migrations are not executed
+    // safely.
+    // see also https://github.com/hazelcast/hazelcast/issues/8931, https://github.com/hazelcast/hazelcast/issues/8046
+    // and https://github.com/hazelcast/hazelcast/issues/9043
+    @Ignore
+    @Test(timeout = 4 * MINUTE)
+    public void testQueryMapWithIndexes_whileShutdownStartup() throws InterruptedException {
+        IMap<String, SampleObjects.Employee> map = getMapWithIndexes();
+        populateMap(map, 100000);
+        queryDuringMigrations(map);
+    }
+
+    private void queryDuringMigrations(IMap<String, SampleObjects.Employee> map)
+            throws InterruptedException {
+
+        Future[] queryingFutures = queryContinuously(clients, queriesExecutor, CONCURRENT_QUERYING_CLIENTS);
+
+        shuffleMembers(factory, members);
+
+        // let the test run for 3 minutes or until failed, whichever comes first
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertFalse(failureMessageBuilder.toString(), testFailed.get());
+            }
+        }, MINUTES.toSeconds(3));
+
+        // stop querying threads
+        testRunning.set(false);
+
+        for (Future f : queryingFutures) {
+            try {
+                f.get();
+            } catch (ExecutionException e) {
+                fail("A querying thread failed with exception " + e.getMessage());
+            }
+        }
+    }
+
+    private void shuffleMembers(TestHazelcastFactory nodeFactory, HazelcastInstance[] instances) {
+        Thread t = new Thread(new MemberUpDownMonkey(nodeFactory, instances));
+        t.start();
+    }
+
+    private void populateMap(IMap<String, SampleObjects.Employee> map, int numberOfEntries) {
+        for (int i = 0; i < numberOfEntries; i++) {
+            SampleObjects.Employee e = new SampleObjects.Employee(i, "name" + i, i, true, i);
+            map.put("name" + i, e);
+        }
+        LOGGER.info("Done populating map with " + numberOfEntries + " entries.");
+    }
+
+    private Future[] queryContinuously(HazelcastInstance[] instances, ExecutorService executor, int concurrency) {
+        Future[] futures = new Future[concurrency];
+        for (int i = 0; i < instances.length; i++) {
+            futures[i] = executor.submit(new QueryRunnable(instances[i]));
+        }
+        return futures;
+    }
+
+    public class QueryRunnable implements Runnable {
+
+        // query age min-max range, min is randomized, max = min+1000
+        private final Random random = new Random();
+        private final IMap map;
+
+        public QueryRunnable(HazelcastInstance hz) {
+            this.map = hz.getMap(TEST_MAP_NAME);
+        }
+
+        @Override
+        public void run() {
+            int min, max, correctResultsCount = 0;
+            while (testRunning.get()) {
+                try {
+                    min = random.nextInt(99000);
+                    max = min + 1000;
+                    Collection<SampleObjects.Employee> employees = map.values(new SqlPredicate("age >= " + min +
+                            " AND age < " + max));
+                    if (employees.size() != 1000) {
+                        // error
+                        failureMessageBuilder.append("Obtained " + employees.size() + " results for query \"age >= " + min +
+                                " AND age < " + max + "\"");
+                        testFailed.set(true);
+                        testRunning.set(false);
+                    } else {
+                        correctResultsCount++;
+                        if (correctResultsCount % 20 == 0) {
+                            LOGGER.info("Obtained " + correctResultsCount + " correct results");
+                        }
+                    }
+                } catch (RuntimeException e) {
+                    // runtime exception caught, fail the test and rethrow
+                    testFailed.set(true);
+                    testRunning.set(false);
+                    failureMessageBuilder.append("A query thread failed with: " + e.getMessage());
+                    LOGGER.severe("Query thread failed with exception", e);
+                    throw e;
+                }
+            }
+        }
+    }
+
+    public class MemberUpDownMonkey
+            implements Runnable {
+        private final TestHazelcastFactory nodeFactory;
+        private final HazelcastInstance[] instances;
+
+        public MemberUpDownMonkey(TestHazelcastFactory nodeFactory, HazelcastInstance[] instances) {
+            this.nodeFactory = nodeFactory;
+            this.instances = new HazelcastInstance[instances.length - 1];
+            // exclude 0-index instance
+            System.arraycopy(instances, 1, this.instances, 0, instances.length - 1);
+        }
+
+        @Override
+        public void run() {
+            int i = 0;
+            int nextInstance = 1;
+            while (testRunning.get()) {
+                instances[i].shutdown();
+                nextInstance = (i + 1) % instances.length;
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+                instances[i] = nodeFactory.newHazelcastInstance();
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+                // move to next member
+                i = nextInstance;
+            }
+        }
+    }
+
+    // get client configuration that guarantees our client will connect to the specific member
+    private ClientConfig getClientConfig(HazelcastInstance member) {
+        ClientConfig config = new ClientConfig();
+        config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
+        config.getNetworkConfig().setSmartRouting(false);
+
+        InetSocketAddress socketAddress = member.getCluster().getLocalMember().getSocketAddress();
+
+        config.getNetworkConfig().
+                addAddress(socketAddress.getHostName() + ":" + socketAddress.getPort());
+
+        return config;
+    }
+
+    // obtain a reference to test map from 0-th member with indexes created for Employee attributes
+    private IMap<String, SampleObjects.Employee> getMapWithIndexes() {
+        IMap<String, SampleObjects.Employee> map = members[0].getMap(TEST_MAP_NAME);
+        map.addIndex("name", false);
+        map.addIndex("age", true);
+        map.addIndex("active", false);
+        return map;
+
+    }
+
+    // obtain a reference to test map from 0-th member without indexes
+    private IMap<String, SampleObjects.Employee> getMapWithoutIndexes() {
+        IMap<String, SampleObjects.Employee> map = members[0].getMap(TEST_MAP_NAME);
+        return map;
+
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
+import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.QueryOperation;
 import com.hazelcast.map.impl.query.QueryPartitionOperation;
@@ -31,7 +32,6 @@ import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.BitSetUtils;
-import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.IterationType;
 
 import java.security.Permission;
@@ -42,10 +42,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.logging.Level;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.BitSetUtils.hasAtLeastOneBitSet;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 public abstract class AbstractMapQueryMessageTask<P> extends AbstractCallableMessageTask<P> {
 
@@ -79,7 +81,7 @@ public abstract class AbstractMapQueryMessageTask<P> extends AbstractCallableMes
             BitSet finishedPartitions = invokeOnMembers(result, predicate, partitionCount);
             invokeOnMissingPartitions(result, predicate, finishedPartitions, partitionCount);
         } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
+            throw rethrow(t);
         }
         return reduce(result);
     }
@@ -98,7 +100,7 @@ public abstract class AbstractMapQueryMessageTask<P> extends AbstractCallableMes
             List<Integer> missingList = findMissingPartitions(finishedPartitions, partitionCount);
             List<Future> missingFutures = new ArrayList<Future>(missingList.size());
             createInvocationsForMissingPartitions(missingList, missingFutures, predicate);
-            collectResultsFromMissingPartitions(result, missingFutures);
+            collectResultsFromMissingPartitions(finishedPartitions, result, missingFutures);
         }
     }
 
@@ -106,10 +108,22 @@ public abstract class AbstractMapQueryMessageTask<P> extends AbstractCallableMes
         List<Future> futures = new ArrayList<Future>(members.size());
         final InternalOperationService operationService = nodeEngine.getOperationService();
         for (Member member : members) {
-            Future future = operationService.createInvocationBuilder(SERVICE_NAME,
-                    new QueryOperation(getDistributedObjectName(), predicate, getIterationType()),
-                    member.getAddress()).invoke();
-            futures.add(future);
+            try {
+                Future future = operationService.createInvocationBuilder(SERVICE_NAME,
+                        new QueryOperation(getDistributedObjectName(), predicate, getIterationType()), member.getAddress())
+                                                .invoke();
+                futures.add(future);
+            } catch (Throwable t) {
+                if (t.getCause() instanceof QueryResultSizeExceededException) {
+                    rethrow(t);
+                } else {
+                    // log failure to invoke query on member at fine level
+                    // the missing partition IDs will be queried anyway, so it's not a terminal failure
+                    if (logger.isFineEnabled()) {
+                        logger.log(Level.FINE, "Query invocation failed on member " + member, t);
+                    }
+                }
+            }
         }
         return futures;
     }
@@ -119,16 +133,28 @@ public abstract class AbstractMapQueryMessageTask<P> extends AbstractCallableMes
             throws InterruptedException, ExecutionException {
         BitSet finishedPartitions = new BitSet(partitionCount);
         for (Future future : futures) {
-            QueryResult queryResult = (QueryResult) future.get();
-            if (queryResult != null) {
-                Collection<Integer> partitionIds = queryResult.getPartitionIds();
-                if (partitionIds != null && !hasAtLeastOneBitSet(finishedPartitions, partitionIds)) {
-                    //Collect results only if there is no overlap with already collected partitions.
-                    //If there is an overlap it means there was a partition migration while QueryOperation(s) were
-                    //running. In this case we discard all results from this member and will target the missing
-                    //partition separately later.
-                    BitSetUtils.setBits(finishedPartitions, partitionIds);
-                    result.addAll(queryResult.getRows());
+            try {
+                QueryResult queryResult = (QueryResult) future.get();
+                if (queryResult != null) {
+                    Collection<Integer> partitionIds = queryResult.getPartitionIds();
+                    if (partitionIds != null && !hasAtLeastOneBitSet(finishedPartitions, partitionIds)) {
+                        // Collect results only if there is no overlap with already collected partitions.
+                        // If there is an overlap it means there was a partition migration while QueryOperation(s) were
+                        // running. In this case we discard all results from this member and will target the missing
+                        // partition separately later.
+                        BitSetUtils.setBits(finishedPartitions, partitionIds);
+                        result.addAll(queryResult.getRows());
+                    }
+                }
+            } catch (Throwable t) {
+                if (t.getCause() instanceof QueryResultSizeExceededException) {
+                    rethrow(t);
+                } else {
+                    // log failure to invoke query on member at fine level
+                    // the missing partition IDs will be queried anyway, so it's not a terminal failure
+                    if (logger.isFineEnabled()) {
+                        logger.log(Level.FINE, "Query on member failed with exception", t);
+                    }
                 }
             }
         }
@@ -162,16 +188,21 @@ public abstract class AbstractMapQueryMessageTask<P> extends AbstractCallableMes
                         queryPartitionOperation, partitionId);
                 futures.add(future);
             } catch (Throwable t) {
-                throw ExceptionUtil.rethrow(t);
+                throw rethrow(t);
             }
         }
     }
 
-    private void collectResultsFromMissingPartitions(Collection<QueryResultRow> result, List<Future> futures)
+    private void collectResultsFromMissingPartitions(BitSet finishedPartitions, Collection<QueryResultRow> result,
+                                                     List<Future> futures)
             throws InterruptedException, java.util.concurrent.ExecutionException {
         for (Future future : futures) {
             QueryResult queryResult = (QueryResult) future.get();
-            result.addAll(queryResult.getRows());
+            if (queryResult.getPartitionIds() != null && queryResult.getPartitionIds().size() > 0
+                    && !hasAtLeastOneBitSet(finishedPartitions, queryResult.getPartitionIds())) {
+                result.addAll(queryResult.getRows());
+                BitSetUtils.setBits(finishedPartitions, queryResult.getPartitionIds());
+            }
         }
     }
 }


### PR DESCRIPTION
While invoking queries on members, it is possible that the
query might fail during migrations with exceptions like
TargetNotMemberException, MemberLeftException etc. These
exceptions are normal during migrations and should not be
propagated back to the user, since in any case we will be able
to recover by querying the specific partitions with
QueryPartitionOperations.

This PR aligns the behaviour of the client-side map proxy with the member-side proxy.