### PR TITLE
Fixing interaction between ring buffer store getLastSequence and backup ops

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
@@ -62,7 +62,7 @@ public class RingbufferConfig {
     private int asyncBackupCount = DEFAULT_ASYNC_BACKUP_COUNT;
     private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
     private InMemoryFormat inMemoryFormat = DEFAULT_IN_MEMORY_FORMAT;
-    private RingbufferStoreConfig ringbufferStoreConfig;
+    private RingbufferStoreConfig ringbufferStoreConfig = new RingbufferStoreConfig().setEnabled(false);
 
     /**
      * Creates a RingbufferConfig with the provided name.
@@ -88,9 +88,9 @@ public class RingbufferConfig {
         this.asyncBackupCount = config.asyncBackupCount;
         this.timeToLiveSeconds = config.timeToLiveSeconds;
         this.inMemoryFormat = config.inMemoryFormat;
-        this.ringbufferStoreConfig = config.ringbufferStoreConfig == null
-                ? null
-                : new RingbufferStoreConfig(config.ringbufferStoreConfig);
+        if (config.ringbufferStoreConfig != null) {
+            this.ringbufferStoreConfig = new RingbufferStoreConfig(config.ringbufferStoreConfig);
+        }
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -70,6 +70,7 @@ public class ArrayRingbuffer implements Ringbuffer {
     }
 
     @Override
+    // not used in the codebase, here just for future API usage
     public boolean isEmpty() {
         return size() == 0;
     }
@@ -96,6 +97,8 @@ public class ArrayRingbuffer implements Ringbuffer {
     }
 
     @Override
+    // This method is not used since the RingbufferContainer also checks if the ring buffer store is enabled before
+    // throwing a StaleSequenceException
     public void checkBlockableReadSequence(long readSequence) {
         if (readSequence > tailSequence + 1) {
             throw new IllegalArgumentException("sequence:" + readSequence
@@ -110,6 +113,7 @@ public class ArrayRingbuffer implements Ringbuffer {
     }
 
     @Override
+    // the sequence is usually in the right range since the RingbufferContainer checks it too
     public void checkReadSequence(long sequence) {
         if (sequence > tailSequence) {
             throw new IllegalArgumentException("sequence:" + sequence

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
@@ -125,8 +125,8 @@ public interface Ringbuffer<T> {
      * oportunity to block until the item is added into the ring buffer.
      *
      * @param readSequence the sequence wanting to be read
-     * @throws StaleSequenceException if the requested sequence is greater than the {@link #tailSequence()} + 1 or smaller
-     *                                than the {@link #headSequence()}
+     * @throws StaleSequenceException   if the requested sequence is smaller than the {@link #headSequence()}
+     * @throws IllegalArgumentException if the requested sequence is greater than the {@link #tailSequence()} + 1
      */
     void checkBlockableReadSequence(long readSequence);
 
@@ -134,8 +134,8 @@ public interface Ringbuffer<T> {
      * Check if the sequence can be read from the ring buffer.
      *
      * @param sequence the sequence wanting to be read
-     * @throws StaleSequenceException if the requested sequence is greater than the {@link #tailSequence()} or smaller than the
-     *                                {@link #headSequence()}
+     * @throws StaleSequenceException   if the requested sequence is smaller than the {@link #headSequence()}
+     * @throws IllegalArgumentException if the requested sequence is greater than the {@link #tailSequence()}
      */
     void checkReadSequence(long sequence);
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
@@ -29,6 +29,14 @@ import java.io.IOException;
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.F_ID;
 import static com.hazelcast.ringbuffer.impl.RingbufferService.SERVICE_NAME;
 
+/**
+ * Common logic for all ring buffer operations :
+ * <ul>
+ * <li>getting the ring buffer container or creating a new one if necessary</li>
+ * <li>serialization/deserialization of ring buffer name</li>
+ * <li>defines the factory ID for the {@link IdentifiedDataSerializable}</li>
+ * </ul>
+ */
 public abstract class AbstractRingBufferOperation extends Operation
         implements IdentifiedDataSerializable, PartitionAwareOperation {
 
@@ -47,6 +55,13 @@ public abstract class AbstractRingBufferOperation extends Operation
         return SERVICE_NAME;
     }
 
+    /**
+     * Returns an {@link RingbufferContainer} or creates a new one if necessary by calling
+     * {@link RingbufferService#getContainer(String)}. Also calls the {@link RingbufferContainer#cleanup()} before returning
+     * the container. This will currently remove any expired items.
+     *
+     * @return the ring buffer container
+     */
     RingbufferContainer getRingBufferContainer() {
         if (ringbuffer != null) {
             return ringbuffer;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddBackupOperation.java
@@ -19,29 +19,31 @@ package com.hazelcast.ringbuffer.impl.operations;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.spi.BackupOperation;
 
 import java.io.IOException;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.ADD_BACKUP_OPERATION;
 
+/**
+ * Backup operation for ring buffer {@link AddOperation}. Puts the item under the sequence ID that the master generated.
+ */
 public class AddBackupOperation extends AbstractRingBufferOperation implements BackupOperation {
-
+    private long sequenceId;
     private Data item;
 
     public AddBackupOperation() {
     }
 
-    public AddBackupOperation(String name, Data item) {
+    public AddBackupOperation(String name, long sequenceId, Data item) {
         super(name);
+        this.sequenceId = sequenceId;
         this.item = item;
     }
 
     @Override
     public void run() throws Exception {
-        RingbufferContainer ringbuffer = getRingBufferContainer();
-        ringbuffer.add(item);
+        getRingBufferContainer().set(sequenceId, item);
     }
 
     @Override
@@ -52,12 +54,14 @@ public class AddBackupOperation extends AbstractRingBufferOperation implements B
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
+        out.writeLong(sequenceId);
         out.writeData(item);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
+        sequenceId = in.readLong();
         item = in.readData();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AddOperation.java
@@ -31,6 +31,11 @@ import java.io.IOException;
 import static com.hazelcast.ringbuffer.OverflowPolicy.FAIL;
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.ADD_OPERATION;
 
+/**
+ * Adds a new ring buffer item. The master node will add the item into the ring buffer, generating a new sequence id while
+ * the backup operation will put the item under the sequence ID that the master generated. This is to avoid differences
+ * in ring buffer data structures.
+ */
 public class AddOperation extends AbstractRingBufferOperation
         implements Notifier, BackupAwareOperation {
 
@@ -92,7 +97,7 @@ public class AddOperation extends AbstractRingBufferOperation
 
     @Override
     public Operation getBackupOperation() {
-        return new AddBackupOperation(name, item);
+        return new AddBackupOperation(name, resultSequence, item);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/GenericOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/GenericOperation.java
@@ -24,6 +24,10 @@ import java.io.IOException;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferDataSerializerHook.GENERIC_OPERATION;
 
+/**
+ * Ring buffer operations which don't need to send any parameters and which can be determined by only sending the operation
+ * type which is a byte of information. Typically these are read operations and/or getters.
+ */
 public class GenericOperation extends AbstractRingBufferOperation {
 
     public static final byte OPERATION_SIZE = 0;

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
@@ -12,9 +12,9 @@ import static com.hazelcast.config.RingbufferConfig.DEFAULT_CAPACITY;
 import static com.hazelcast.config.RingbufferConfig.DEFAULT_SYNC_BACKUP_COUNT;
 import static com.hazelcast.internal.partition.InternalPartition.MAX_BACKUP_COUNT;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
@@ -190,11 +190,10 @@ public class RingbufferConfigTest {
 
     @Test
     public void getRingbufferStoreConfig() {
-        RingbufferConfig config = new RingbufferConfig(NAME);
-
-        RingbufferStoreConfig ringbufferConfig = config.getRingbufferStoreConfig();
-
-        assertNull(ringbufferConfig);
+        final RingbufferConfig config = new RingbufferConfig(NAME);
+        final RingbufferStoreConfig ringbufferConfig = config.getRingbufferStoreConfig();
+        assertNotNull(ringbufferConfig);
+        assertFalse(ringbufferConfig.isEnabled());
     }
 
     @Test
@@ -293,6 +292,7 @@ public class RingbufferConfigTest {
         original.setRingbufferStoreConfig(null);
         readonly = original.getAsReadOnly();
 
-        assertNull(readonly.getRingbufferStoreConfig());
+        assertNotNull(readonly.getRingbufferStoreConfig());
+        assertFalse(readonly.getRingbufferStoreConfig().isEnabled());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/ArrayRingbufferTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/ArrayRingbufferTest.java
@@ -1,0 +1,42 @@
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.ringbuffer.StaleSequenceException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ArrayRingbufferTest {
+    @Test(expected = StaleSequenceException.class)
+    public void testStaleSequenceThrowsException() {
+        final ArrayRingbuffer rb = new ArrayRingbuffer(5);
+        for (int i = 0; i < rb.getCapacity(); i++) {
+            rb.add("");
+        }
+        rb.read(rb.headSequence() - 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFutureSequenceThrowsException() {
+        final ArrayRingbuffer rb = new ArrayRingbuffer(5);
+        for (int i = 0; i < rb.getCapacity(); i++) {
+            rb.add("");
+        }
+        rb.read(rb.tailSequence() + 1);
+    }
+
+    @Test
+    public void testIsEmpty() {
+        final ArrayRingbuffer rb = new ArrayRingbuffer(5);
+        assertTrue(rb.isEmpty());
+        rb.add("");
+        assertFalse(rb.isEmpty());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
@@ -20,10 +20,12 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.RingbufferStoreConfig;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.core.RingbufferStoreFactory;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -31,24 +33,29 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.config.InMemoryFormat.BINARY;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.config.RingbufferConfig.DEFAULT_CAPACITY;
+import static com.hazelcast.instance.TestUtil.terminateInstance;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -81,6 +88,7 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
         final Config config = getConfig("testRingbufferStore", DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
 
+        // add items to the ring buffer and the store and shut down
         final HazelcastInstance instance = factory.newHazelcastInstance(config);
         final Ringbuffer<Object> ringbuffer = instance.getRingbuffer("testRingbufferStore");
         for (int i = 0; i < numItems; i++) {
@@ -88,11 +96,13 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
         }
         instance.shutdown();
 
+        // now get a new ring buffer and read the items from the store
         final HazelcastInstance instance2 = factory.newHazelcastInstance(config);
         final Ringbuffer<Object> ringbuffer2 = instance2.getRingbuffer("testRingbufferStore");
 
         // the actual ring buffer is empty but we can still load items from it
         assertEquals(0, ringbuffer2.size());
+        assertEquals(DEFAULT_CAPACITY, ringbuffer2.remainingCapacity());
         assertEquals(numItems, rbStore.store.size());
 
         for (int i = 0; i < numItems; i++) {
@@ -100,6 +110,38 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
         }
 
         rbStore.assertAwait(3);
+    }
+
+    @Test
+    public void testRingbufferStoreAllAndReadFromMemory() throws Exception {
+        final int numItems = 200;
+        final WriteOnlyRingbufferStore<Integer> rbStore = new WriteOnlyRingbufferStore<Integer>();
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setEnabled(true)
+                .setStoreImplementation(rbStore);
+        final Config config = getConfig("testRingbufferStore", DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        final HazelcastInstance instance = factory.newHazelcastInstance(config);
+        final HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        // add items to both ring buffers (master and backup) and shut down the master
+        final Ringbuffer<Object> ringbuffer = instance.getRingbuffer("testRingbufferStore");
+        final ArrayList<Integer> items = new ArrayList<Integer>();
+        for (int i = 0; i < numItems; i++) {
+            items.add(i);
+        }
+        ringbuffer.addAllAsync(items, OverflowPolicy.OVERWRITE).get();
+        terminateInstance(instance);
+
+        // now read items from the backup
+        final Ringbuffer<Object> ringbuffer2 = instance2.getRingbuffer("testRingbufferStore");
+        assertEquals(numItems, ringbuffer2.size());
+        assertEquals(numItems, rbStore.store.size());
+
+        // assert that the backup has all items in memory, without loading from the store
+        for (int i = 0; i < numItems; i++) {
+            assertEquals(i, ringbuffer2.readOne(i));
+        }
     }
 
     @Test
@@ -130,9 +172,7 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
     }
 
     @Test
-    @Ignore(value = "Since the RingBufferStoreConfig is now propagated correctly to the read-only config the test runs" +
-            " into a NPE while casting `null` to `long` in `IdCheckerRingbufferStore.getLargestSequence()`")
-    public void testStoreId_whenNodeDown() {
+    public void testStoreId_whenNodeDown() throws InterruptedException {
         final IdCheckerRingbufferStore rbStore = new IdCheckerRingbufferStore();
         final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
                 .setEnabled(true)
@@ -145,13 +185,49 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
 
         final String name = generateKeyOwnedBy(instance1);
         final Ringbuffer<Object> ringbuffer = instance2.getRingbuffer(name);
-        ringbuffer.add(randomString());
-        ringbuffer.add(randomString());
-        ringbuffer.add(randomString());
+        final HashMap<Long, String> addedItems = new HashMap<Long, String>();
 
+        for (int i = 0; i < 3; i++) {
+            final String item = randomString();
+            addedItems.put(ringbuffer.add(item), item);
+        }
         instance1.shutdown();
 
-        ringbuffer.add(randomString());
+        final String item = randomString();
+        addedItems.put(ringbuffer.add(item), item);
+
+        for (Entry<Long, String> e : addedItems.entrySet()) {
+            assertEquals("The ring buffer returned a different object than the one which was stored",
+                    e.getValue(), ringbuffer.readOne(e.getKey()));
+        }
+    }
+
+    @Test
+    public void testStoreId_writeToMasterAndReadFromBackup() throws InterruptedException {
+        final IdCheckerRingbufferStore rbStore = new IdCheckerRingbufferStore();
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setEnabled(true)
+                .setStoreImplementation(rbStore);
+        final Config config = getConfig("default", DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
+
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        final HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        final String name = generateKeyOwnedBy(instance1);
+        final Ringbuffer<Object> masterRB = instance1.getRingbuffer(name);
+        final HashMap<Long, Integer> addedItems = new HashMap<Long, Integer>();
+
+        for (int i = 0; i < 100; i++) {
+            addedItems.put(masterRB.add(i), i);
+        }
+        terminateInstance(instance1);
+
+        final Ringbuffer<Object> backupRB = instance2.getRingbuffer(name);
+        for (Entry<Long, Integer> e : addedItems.entrySet()) {
+            assertEquals("The ring buffer returned a different object than the one which was stored",
+                    e.getValue(), backupRB.readOne(e.getKey()));
+        }
     }
 
     @Test
@@ -208,6 +284,45 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
         assertEquals(3, ringbuffer.readOne(lastSequence));
     }
 
+    @Test(expected = HazelcastException.class)
+    public void testRingbufferStore_addThrowsException() throws InterruptedException {
+        final String ringbufferName = randomString();
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setStoreImplementation(new ExceptionThrowingRingbufferStore())
+                .setEnabled(true);
+        final Config config = getConfig(ringbufferName, DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
+
+        final HazelcastInstance node = createHazelcastInstance(config);
+        final Ringbuffer<Object> ringbuffer = node.getRingbuffer(ringbufferName);
+        ringbuffer.add(1);
+    }
+
+    @Test(expected = ExecutionException.class)
+    public void testRingbufferStore_addAllThrowsException() throws Exception {
+        final String ringbufferName = randomString();
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setStoreImplementation(new ExceptionThrowingRingbufferStore())
+                .setEnabled(true);
+        final Config config = getConfig(ringbufferName, DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
+
+        final HazelcastInstance node = createHazelcastInstance(config);
+        final Ringbuffer<Object> ringbuffer = node.getRingbuffer(ringbufferName);
+        ringbuffer.addAllAsync(Arrays.asList(1, 2), OverflowPolicy.OVERWRITE).get();
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void testRingbufferStore_getLargestSequenceThrowsException() throws Exception {
+        final String ringbufferName = randomString();
+        final RingbufferStoreConfig rbStoreConfig = new RingbufferStoreConfig()
+                .setStoreImplementation(new ExceptionThrowingRingbufferStore(true))
+                .setEnabled(true);
+        final Config config = getConfig(ringbufferName, DEFAULT_CAPACITY, OBJECT, rbStoreConfig);
+
+        final HazelcastInstance node = createHazelcastInstance(config);
+        node.getRingbuffer(ringbufferName).size();
+    }
+
+
     static class SimpleRingbufferStoreFactory implements RingbufferStoreFactory<Integer> {
 
         private final ConcurrentMap<String, RingbufferStore> stores = new ConcurrentHashMap<String, RingbufferStore>();
@@ -224,30 +339,67 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
         }
     }
 
-    static class IdCheckerRingbufferStore implements RingbufferStore {
-        Long lastKey;
+    static class IdCheckerRingbufferStore<T> implements RingbufferStore<T> {
+        long lastKey = -1;
+        final Map<Long, T> store = new LinkedHashMap<Long, T>();
 
         @Override
-        public void store(final long sequence, final Object value) {
-            if (lastKey != null && lastKey >= sequence) {
+        public void store(final long sequence, final T value) {
+            if (lastKey >= sequence) {
                 throw new RuntimeException("key[" + sequence + "] is already stored");
             }
             lastKey = sequence;
+            store.put(sequence, value);
         }
 
         @Override
-        public void storeAll(long firstItemSequence, Object[] items) {
-
+        public void storeAll(long firstItemSequence, T[] items) {
+            throw new UnsupportedOperationException();
         }
 
         @Override
-        public Object load(final long sequence) {
-            return null;
+        public T load(final long sequence) {
+            return store.get(sequence);
         }
 
         @Override
         public long getLargestSequence() {
             return lastKey;
+        }
+    }
+
+    static class ExceptionThrowingRingbufferStore<T> implements RingbufferStore<T> {
+        private final boolean getLargestSequenceThrowsException;
+
+        public ExceptionThrowingRingbufferStore() {
+            this(false);
+        }
+
+        ExceptionThrowingRingbufferStore(boolean getLargestSequenceThrowsException) {
+            this.getLargestSequenceThrowsException = getLargestSequenceThrowsException;
+        }
+
+        @Override
+        public void store(long sequence, T data) {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public void storeAll(long firstItemSequence, T[] items) {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public T load(long sequence) {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public long getLargestSequence() {
+            if (getLargestSequenceThrowsException) {
+                throw new RuntimeException();
+            }
+            return -1;
         }
     }
 
@@ -281,7 +433,7 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
             assertTrue("Load remaining: " + latchLoad.getCount(), latchLoad.await(seconds, SECONDS));
         }
 
-        Map getStore() {
+        Map<Long, T> getStore() {
             return store;
         }
 
@@ -306,6 +458,42 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
             callCount.incrementAndGet();
             latchLoad.countDown();
             return store.get(sequence);
+        }
+
+        @Override
+        public long getLargestSequence() {
+            final Set<Long> coll = store.keySet();
+            return coll.isEmpty() ? -1 : Collections.max(coll);
+        }
+    }
+
+    static class WriteOnlyRingbufferStore<T> implements RingbufferStore<T> {
+
+        final Map<Long, T> store = new LinkedHashMap<Long, T>();
+
+
+        public WriteOnlyRingbufferStore() {
+        }
+
+        Map<Long, T> getStore() {
+            return store;
+        }
+
+        @Override
+        public void store(long sequence, T data) {
+            store.put(sequence, data);
+        }
+
+        @Override
+        public void storeAll(long firstItemSequence, T[] items) {
+            for (int i = 0; i < items.length; i++) {
+                store.put(firstItemSequence + i, items[i]);
+            }
+        }
+
+        @Override
+        public T load(long sequence) {
+            throw new UnsupportedOperationException();
         }
 
         @Override


### PR DESCRIPTION
The `getLastSequence` method of the RB store allowed the in-memory ring buffer to be created with a head and tail sequence larger than 0 so that newly added items would not have sequence IDs which are already stored in the RB store. Unfortunately, this caused a bug. When an item is added, the receiving node will increase the tail sequence, assign the item and store it under that sequence in the RB store. It will then send a backup op to an another node which will first initialise the in-memory store. The backup node will ask the RB store for the last sequence ID and receive the sequence ID of the item which was just added to the store. After that the backup node will add the item to the ring buffer under a sequence which is exactly one larger. This causes differences between the master and the backup ring buffer which could cause different items to be returned from different nodes.

This PR fixes this since it also sends the sequence ID from the master whenever backing up items. The backup node will then put the item in the exact same position and NOT save the item in the store again.

The only part which I am unsure of is when the item is put on the backup node, the head and tail sequences are moved if necessary to accommodate for the new item. Otherwise the item could be put into the RB but since the head and tail sequences are not moved, the RB could report that it is empty. We could instead send the head and tail sequences from the master node with the item data and set them on the backup node but that is just more data being sent.

Also, added more Javadoc and added tests for storeAll to increase coverage.