### PR TITLE
HiDensityClientNearCacheTest is failing after  PR https://github.com/hazelcast/hazelcast/pull/8782, on EE side

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -169,6 +169,10 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
         }
     }
 
+    @Override
+    protected void onShuttingDown() {
+    }
+
     /**
      * Gets the related {@link NearCacheManager} with the underlying client instance.
      *

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -696,13 +696,13 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         transactionManager.shutdown();
         invocationService.shutdown();
         listenerService.shutdown();
-        ((InternalSerializationService) serializationService).dispose();
         nearCacheManager.destroyAllNearCaches();
         if (discoveryService != null) {
             discoveryService.destroy();
         }
         metricsRegistry.shutdown();
         diagnostics.shutdown();
+        ((InternalSerializationService) serializationService).dispose();
     }
 
     public ClientLockReferenceIdGenerator getLockReferenceIdGenerator() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
@@ -128,22 +128,26 @@ public final class LifecycleServiceImpl implements LifecycleService {
         client.doShutdown();
         fireLifecycleEvent(SHUTDOWN);
 
-        executor.shutdown();
-        try {
-            boolean success = executor.awaitTermination(TERMINATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            if (!success) {
-                getLogger().warning("Lifecycle service executor awaitTermination could not completed gracefully in "
-                        + TERMINATE_TIMEOUT_SECONDS + " seconds. Terminating forcefully.");
-                executor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            getLogger().warning("LifecycleService executor await termination is interrupted. Terminating forcefully.", e);
-            executor.shutdownNow();
-        }
+        shutdownExecutor();
     }
 
     @Override
     public void terminate() {
         shutdown();
+    }
+
+    private void shutdownExecutor() {
+        executor.shutdown();
+        try {
+            boolean success = executor.awaitTermination(TERMINATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (!success) {
+                getLogger().warning("LifecycleService executor awaitTermination could not completed gracefully in "
+                        + TERMINATE_TIMEOUT_SECONDS + " seconds. Terminating forcefully.");
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            getLogger().warning("LifecycleService executor awaitTermination is interrupted. Terminating forcefully.", e);
+            executor.shutdownNow();
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -309,7 +309,7 @@ public abstract class AbstractHazelcastCacheManager
             @Override
             public void stateChanged(LifecycleEvent event) {
                 if (event.getState() == LifecycleEvent.LifecycleState.SHUTTING_DOWN) {
-                    close();
+                    onShuttingDown();
                 }
             }
         });
@@ -455,5 +455,7 @@ public abstract class AbstractHazelcastCacheManager
                                                                String simpleCacheName);
 
     protected abstract void postClose();
+
+    protected abstract void onShuttingDown();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -216,6 +216,11 @@ public class HazelcastServerCacheManager
         }
     }
 
+    @Override
+    protected void onShuttingDown() {
+        close();
+    }
+
     public ICacheService getCacheService() {
         return cacheService;
     }


### PR DESCRIPTION
The PR https://github.com/hazelcast/hazelcast/pull/8782 made the enterprise tests fail. The memory manager should not be accessed after it is closed. Since when using the executor for delivering the SHUTTING_DOWN event to AbstractHazelcastCacheManager lifecycle listener, it is possible that the listener is called after the memory manager destruction. We also realized that there is no need for cache manager close while the client is shutting down. Hence, the solution is to remove cachemanager close for client but just leave it for the server side (and server side does not use executor for lifecycle event deliveries it just works fine).