### PR TITLE
Specific commit id versions can not compile due to protocol 1.3.0-snapshot dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.3.0-SNAPSHOT</client.protocol.version>
+        <client.protocol.version>1.3.0-20161010.162137-8</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
Changed the protocol dependency to a specific snapshot version (dated version).