### PR TITLE
Introduced LoggingScheduledExecutor

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 import com.hazelcast.util.executor.CompletableFutureTask;
+import com.hazelcast.util.executor.LoggingScheduledExecutor;
 import com.hazelcast.util.executor.PoolExecutorThreadFactory;
 
 import java.util.concurrent.Callable;
@@ -32,7 +33,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -58,7 +58,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
             executorPoolSize = Runtime.getRuntime().availableProcessors();
         }
         logger = loggingService.getLogger(ClientExecutionService.class);
-        internalExecutor = new ScheduledThreadPoolExecutor(internalPoolSize,
+        internalExecutor = new LoggingScheduledExecutor(logger, internalPoolSize,
                 new PoolExecutorThreadFactory(threadGroup, name + ".internal-", classLoader),
                 new RejectedExecutionHandler() {
                     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
@@ -110,7 +110,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
 
     /**
      * Utilized when given command needs to make a remote call.
-     *
+     * <p>
      * The response of the remote call is not handled in the {@link Runnable} itself, but rather
      * in the execution callback so that executor is not blocked because of a remote operation.
      *

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/CompletableFutureTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/CompletableFutureTask.java
@@ -85,4 +85,9 @@ class CompletableFutureTask implements Runnable {
         }
         return copy;
     }
+
+    @Override
+    public String toString() {
+        return "CompletableFutureTask{}";
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -31,6 +31,7 @@ import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.executor.CachedExecutorServiceDelegate;
 import com.hazelcast.util.executor.ExecutorType;
+import com.hazelcast.util.executor.LoggingScheduledExecutor;
 import com.hazelcast.util.executor.ManagedExecutorService;
 import com.hazelcast.util.executor.NamedThreadPoolExecutor;
 import com.hazelcast.util.executor.PoolExecutorThreadFactory;
@@ -47,7 +48,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -119,7 +119,8 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
         }
         );
 
-        scheduledExecutorService = new ScheduledThreadPoolExecutor(1, new SingleExecutorThreadFactory(threadGroup, "scheduled"));
+        ThreadFactory singleExecutorThreadFactory = new SingleExecutorThreadFactory(threadGroup, "scheduled");
+        scheduledExecutorService = new LoggingScheduledExecutor(logger, 1, singleExecutorThreadFactory);
         enableRemoveOnCancelIfAvailable();
 
         final int coreSize = Runtime.getRuntime().availableProcessors();

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CompletableFutureTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CompletableFutureTask.java
@@ -89,4 +89,11 @@ public class CompletableFutureTask<V> extends AbstractCompletableFuture<V> imple
         }
     }
 
+    @Override
+    public String toString() {
+        return "CompletableFutureTask{"
+                + "callable=" + callable
+                + ", runner=" + runner
+                + '}';
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/LoggingScheduledExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/LoggingScheduledExecutorTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.executor;
+
+import com.hazelcast.logging.AbstractLogger;
+import com.hazelcast.logging.LogEvent;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+
+import static junit.framework.TestCase.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LoggingScheduledExecutorTest extends HazelcastTestSupport {
+
+    @Test
+    public void logs_task_execution_exception() throws Exception {
+        final TestLogger logger = new TestLogger();
+        ScheduledExecutorService executor = new LoggingScheduledExecutor(logger, 1, new TestThreadFactory());
+        executor.execute(new FailedRunnable());
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertInstanceOf(RuntimeException.class, logger.getThrowable());
+                String message = logger.getMessage();
+                assertTrue("Found message: '" + message + "'", message.contains("FailedRunnable"));
+            }
+        });
+    }
+
+    class FailedRunnable implements Runnable {
+        @Override
+        public void run() {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public String toString() {
+            return "FailedRunnable{}";
+        }
+    }
+
+    class TestThreadFactory implements ThreadFactory {
+        public Thread newThread(Runnable r) {
+            return new Thread(r);
+        }
+    }
+
+    class TestLogger extends AbstractLogger {
+
+        private final AtomicReference<Throwable> throwableHolder = new AtomicReference<Throwable>();
+        private final AtomicReference<String> messageHolder = new AtomicReference<String>();
+
+        @Override
+        public void log(Level level, String message) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void log(Level level, String message, Throwable thrown) {
+            throwableHolder.set(thrown);
+            messageHolder.set(message);
+        }
+
+        @Override
+        public void log(LogEvent logEvent) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Level getLevel() {
+            return null;
+        }
+
+        @Override
+        public boolean isLoggable(Level level) {
+            return false;
+        }
+
+        public Throwable getThrowable() {
+            return throwableHolder.get();
+        }
+
+        public String getMessage() {
+            return messageHolder.get();
+        }
+    }
+}


### PR DESCRIPTION
Logging helps to see what went wrong, otherwise scheduled executor stops runnable silently.

According to [javaDocs:](http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/ScheduledExecutorService.html#scheduleAtFixedRate%28java.lang.Runnable,%20long,%20long,%20java.util.concurrent.TimeUnit%29) `If any execution of the task encounters an exception, subsequent executions are suppressed`