### PR TITLE
Convert Cache DataSerializable classes to IdentifiedDataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -19,6 +19,8 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.cache.HazelcastExpiryPolicy;
 import com.hazelcast.cache.impl.client.CacheBatchInvalidationMessage;
 import com.hazelcast.cache.impl.client.CacheSingleInvalidationMessage;
+import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
+import com.hazelcast.cache.impl.merge.entry.DefaultCacheEntryView;
 import com.hazelcast.cache.impl.operation.CacheBackupEntryProcessorOperation;
 import com.hazelcast.cache.impl.operation.CacheClearBackupOperation;
 import com.hazelcast.cache.impl.operation.CacheClearOperation;
@@ -51,8 +53,12 @@ import com.hazelcast.cache.impl.operation.CacheRemoveAllOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheRemoveBackupOperation;
 import com.hazelcast.cache.impl.operation.CacheRemoveOperation;
 import com.hazelcast.cache.impl.operation.CacheReplaceOperation;
+import com.hazelcast.cache.impl.operation.CacheReplicationOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperationFactory;
+import com.hazelcast.cache.impl.operation.PostJoinCacheOperation;
+import com.hazelcast.cache.impl.record.CacheDataRecord;
+import com.hazelcast.cache.impl.record.CacheObjectRecord;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
@@ -115,8 +121,14 @@ public final class CacheDataSerializerHook
     public static final short BATCH_INVALIDATION_MESSAGE = 40;
     public static final short ENTRY_ITERATOR = 41;
     public static final short ENTRY_ITERATION_RESULT = 42;
+    public static final short CACHE_PARTITION_LOST_EVENT_FILTER = 43;
+    public static final short DEFAULT_CACHE_ENTRY_VIEW = 44;
+    public static final short CACHE_REPLICATION = 45;
+    public static final short CACHE_POST_JOIN = 46;
+    public static final short CACHE_DATA_RECORD = 47;
+    public static final short CACHE_OBJECT_RECORD = 48;
 
-    private static final int LEN = 43;
+    private static final int LEN = 49;
 
     public int getFactoryId() {
         return F_ID;
@@ -335,6 +347,36 @@ public final class CacheDataSerializerHook
         constructors[ENTRY_ITERATION_RESULT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new CacheEntryIterationResult();
+            }
+        };
+        constructors[CACHE_PARTITION_LOST_EVENT_FILTER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CachePartitionLostEventFilter();
+            }
+        };
+        constructors[DEFAULT_CACHE_ENTRY_VIEW] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new DefaultCacheEntryView();
+            }
+        };
+        constructors[CACHE_REPLICATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheReplicationOperation();
+            }
+        };
+        constructors[CACHE_POST_JOIN] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PostJoinCacheOperation();
+            }
+        };
+        constructors[CACHE_DATA_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheDataRecord();
+            }
+        };
+        constructors[CACHE_OBJECT_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheObjectRecord();
             }
         };
         return new ArrayDataSerializableFactory(constructors);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEventFilter.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.cache.impl.event;
 
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.EventFilter;
 
 import java.io.IOException;
@@ -27,7 +28,7 @@ import java.io.IOException;
  * Used to filter partition lost listener events
  * @since 3.6
  */
-public class CachePartitionLostEventFilter implements EventFilter, DataSerializable {
+public class CachePartitionLostEventFilter implements EventFilter, IdentifiedDataSerializable {
 
     @Override
     public boolean eval(Object arg) {
@@ -52,4 +53,13 @@ public class CachePartitionLostEventFilter implements EventFilter, DataSerializa
         return 0;
     }
 
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.CACHE_PARTITION_LOST_EVENT_FILTER;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
@@ -17,10 +17,11 @@
 package com.hazelcast.cache.impl.merge.entry;
 
 import com.hazelcast.cache.CacheEntryView;
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
@@ -28,7 +29,7 @@ import java.io.IOException;
  * Default heap based implementation of {@link com.hazelcast.cache.CacheEntryView}.
  */
 public class DefaultCacheEntryView
-        implements CacheEntryView<Data, Data>, DataSerializable {
+        implements CacheEntryView<Data, Data>, IdentifiedDataSerializable {
 
     private Data key;
     private Data value;
@@ -100,4 +101,13 @@ public class DefaultCacheEntryView
         value = in.readData();
     }
 
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.DEFAULT_CACHE_ENTRY_VIEW;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl.operation;
 
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.CachePartitionSegment;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
@@ -24,6 +25,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.util.Clock;
 
@@ -49,7 +51,7 @@ import java.util.Map;
  * </p>
  * <p><b>Note:</b> This operation is a per partition operation.</p>
  */
-public class CacheReplicationOperation extends Operation {
+public class CacheReplicationOperation extends Operation implements IdentifiedDataSerializable {
 
     protected Map<String, Map<Data, CacheRecord>> data;
 
@@ -178,4 +180,13 @@ public class CacheReplicationOperation extends Operation {
         return (configs == null || configs.isEmpty()) && (data == null || data.isEmpty());
     }
 
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.CACHE_REPLICATION;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
@@ -16,17 +16,19 @@
 
 package com.hazelcast.cache.impl.operation;
 
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PostJoinCacheOperation extends Operation {
+public class PostJoinCacheOperation extends Operation implements IdentifiedDataSerializable {
 
     private List<CacheConfig> configs = new ArrayList<CacheConfig>();
 
@@ -66,4 +68,13 @@ public class PostJoinCacheOperation extends Operation {
         }
     }
 
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.CACHE_POST_JOIN;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.cache.impl.record;
 
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import java.io.IOException;
  *
  * @param <V> the type of the value stored by this {@link AbstractCacheRecord}
  */
-public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, DataSerializable {
+public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, IdentifiedDataSerializable {
 
     protected long creationTime = TIME_NOT_AVAILABLE;
     protected volatile long expirationTime = TIME_NOT_AVAILABLE;
@@ -115,5 +116,10 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, DataSeri
         expirationTime = in.readLong();
         accessTime = in.readLong();
         accessHit = in.readInt();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheDataRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheDataRecord.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl.record;
 
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -58,5 +59,10 @@ public class CacheDataRecord extends AbstractCacheRecord<Data> {
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
         value = in.readData();
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.CACHE_DATA_RECORD;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheObjectRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheObjectRecord.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cache.impl.record;
 
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
@@ -56,5 +57,10 @@ public class CacheObjectRecord extends AbstractCacheRecord<Object> {
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
         value = in.readObject();
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.CACHE_OBJECT_RECORD;
     }
 }


### PR DESCRIPTION
These `cache` classes are not used in client-member communication and can be safely converted to `IdentifiedDataSerializable`. No EE changes are required.