### PR TITLE
Diagnostics Store Latency plugin

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -56,7 +56,9 @@ public class CacheService extends AbstractCacheService {
 
     @Override
     protected ICacheRecordStore createNewRecordStore(String name, int partitionId) {
-        return new CacheRecordStore(name, partitionId, nodeEngine, this);
+        CacheRecordStore recordStore = new CacheRecordStore(name, partitionId, nodeEngine, this);
+        recordStore.instrument(nodeEngine);
+        return recordStore;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/LatencyTrackingCacheLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/LatencyTrackingCacheLoader.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbe;
+
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CacheLoaderException;
+import java.util.Map;
+
+public class LatencyTrackingCacheLoader<K, V> implements CacheLoader<K, V> {
+
+    static final String KEY = "CacheLoaderLatency";
+
+    private final CacheLoader<K, V> delegate;
+    private final LatencyProbe loadProbe;
+    private final LatencyProbe loadAllProbe;
+
+    public LatencyTrackingCacheLoader(CacheLoader<K, V> delegate, StoreLatencyPlugin plugin, String cacheName) {
+        this.delegate = delegate;
+        this.loadProbe = plugin.newProbe(KEY, cacheName, "load");
+        this.loadAllProbe = plugin.newProbe(KEY, cacheName, "loadAll");
+    }
+
+    @Override
+    public V load(K k) throws CacheLoaderException {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.load(k);
+        } finally {
+            loadProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public Map<K, V> loadAll(Iterable<? extends K> iterable) throws CacheLoaderException {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.loadAll(iterable);
+        } finally {
+            loadAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/LatencyTrackingCacheWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/LatencyTrackingCacheWriter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbe;
+
+import javax.cache.Cache;
+import javax.cache.integration.CacheWriter;
+import javax.cache.integration.CacheWriterException;
+import java.util.Collection;
+
+public class LatencyTrackingCacheWriter<K, V> implements CacheWriter<K, V> {
+
+    static final String KEY = "CacheStoreLatency";
+
+    private final CacheWriter<K, V> delegate;
+    private final LatencyProbe writeProbe;
+    private final LatencyProbe writeAllProbe;
+    private final LatencyProbe deleteProbe;
+    private final LatencyProbe deleteAllProbe;
+
+    public LatencyTrackingCacheWriter(CacheWriter<K, V> delegate, StoreLatencyPlugin plugin, String cacheName) {
+        this.delegate = delegate;
+        this.writeProbe = plugin.newProbe(KEY, cacheName, "write");
+        this.writeAllProbe = plugin.newProbe(KEY, cacheName, "writeAll");
+        this.deleteProbe = plugin.newProbe(KEY, cacheName, "delete");
+        this.deleteAllProbe = plugin.newProbe(KEY, cacheName, "deleteAll");
+    }
+
+    @Override
+    public void write(Cache.Entry<? extends K, ? extends V> entry) throws CacheWriterException {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.write(entry);
+        } finally {
+            writeProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void writeAll(Collection<Cache.Entry<? extends K, ? extends V>> collection) throws CacheWriterException {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.writeAll(collection);
+        } finally {
+            writeAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void delete(Object o) throws CacheWriterException {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.delete(o);
+        } finally {
+            deleteProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void deleteAll(Collection<?> collection) throws CacheWriterException {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.deleteAll(collection);
+        } finally {
+            deleteAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStore.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.queue;
+
+import com.hazelcast.core.QueueStore;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbe;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public class LatencyTrackingQueueStore<T> implements QueueStore<T> {
+    static final String KEY = "QueueStoreLatency";
+
+    private final LatencyProbe loadProbe;
+    private final LatencyProbe loadAllKeysProbe;
+    private final LatencyProbe loadAllProbe;
+    private final LatencyProbe deleteProbe;
+    private final LatencyProbe deleteAllProbe;
+    private final LatencyProbe storeProbe;
+    private final LatencyProbe storeAllProbe;
+    private final QueueStore<T> delegate;
+
+    public LatencyTrackingQueueStore(QueueStore<T> delegate, StoreLatencyPlugin plugin, String queueName) {
+        this.delegate = delegate;
+        this.loadProbe = plugin.newProbe(KEY, queueName, "load");
+        this.loadAllProbe = plugin.newProbe(KEY, queueName, "loadAll");
+        this.loadAllKeysProbe = plugin.newProbe(KEY, queueName, "loadAllKeys");
+        this.deleteProbe = plugin.newProbe(KEY, queueName, "delete");
+        this.deleteAllProbe = plugin.newProbe(KEY, queueName, "deleteAll");
+        this.storeProbe = plugin.newProbe(KEY, queueName, "store");
+        this.storeAllProbe = plugin.newProbe(KEY, queueName, "storeAll");
+    }
+
+    @Override
+    public void store(Long key, T value) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.store(key, value);
+        } finally {
+            storeProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void storeAll(Map<Long, T> map) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.storeAll(map);
+        } finally {
+            storeAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void delete(Long key) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.delete(key);
+        } finally {
+            deleteProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void deleteAll(Collection<Long> keys) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.deleteAll(keys);
+        } finally {
+            deleteAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public T load(Long key) {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.load(key);
+        } finally {
+            loadProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public Map<Long, T> loadAll(Collection<Long> keys) {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.loadAll(keys);
+        } finally {
+            loadAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public Set<Long> loadAllKeys() {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.loadAllKeys();
+        } finally {
+            loadAllKeysProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -121,7 +121,10 @@ public class QueueContainer implements IdentifiedDataSerializable {
         }
     }
 
-    //TX Methods
+    public QueueStoreWrapper getStore() {
+        return store;
+    }
+//TX Methods
 
     public boolean txnCheckReserve(long itemId) {
         if (txMap.get(itemId) == null) {

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -134,6 +134,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
             container = existing;
         } else {
             container.init(fromBackup);
+            container.getStore().instrument(nodeEngine);
         }
         return container;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MultiLineDiagnosticsLogWriter.java
@@ -33,6 +33,7 @@ class MultiLineDiagnosticsLogWriter extends DiagnosticsLogWriter {
             LINE_SEPARATOR + "                                  ",
             LINE_SEPARATOR + "                                          ",
             LINE_SEPARATOR + "                                                  ",
+            LINE_SEPARATOR + "                                                            ",
     };
 
     private final StringBuffer tmpSb = new StringBuffer();

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/StoreLatencyPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/StoreLatencyPlugin.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
+import com.hazelcast.util.ConcurrentReferenceHashMap;
+import com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType;
+import com.hazelcast.util.ConstructorFunction;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
+
+/**
+ * A {@link DiagnosticsPlugin} that helps to detect if there are any performance issues with Stores/Loaders like e.g.
+ * {@link com.hazelcast.core.MapStore}. This is done by instrumenting these Stores/Loaders with latency tracking probes,
+ * so that per Store/Loader all kinds of statistics like count, avg, mag, latency distribution etc is available.
+ *
+ * One of the main purposes of this plugin is to make sure that e.g. a Database is the cause of slow performance. This
+ * plugin is useful to be combined with {@link SlowOperationPlugin} to get idea about where the threads are spending
+ * their time.
+ *
+ * If this plugin is not enabled, there is no performance hit since the Stores/Loaders don't get decorated.
+ */
+public class StoreLatencyPlugin extends DiagnosticsPlugin {
+
+    /**
+     * The period in seconds this plugin runs.
+     *
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERIOD_SECONDS
+            = new HazelcastProperty(PREFIX + ".storeLatency.period.seconds", 0, SECONDS);
+
+    private static final int LOW_WATERMARK_MICROS = 100;
+
+    private static final int LATENCY_BUCKET_COUNT = 32;
+
+    private static final String[] LATENCY_KEYS;
+
+    static {
+        LATENCY_KEYS = new String[LATENCY_BUCKET_COUNT];
+        long maxDurationForBucket = LOW_WATERMARK_MICROS;
+        long p = 0;
+        for (int k = 0; k < LATENCY_KEYS.length; k++) {
+            LATENCY_KEYS[k] = p + ".." + (maxDurationForBucket - 1) + "us";
+            p = maxDurationForBucket;
+            maxDurationForBucket *= 2;
+        }
+    }
+
+    private final long periodMillis;
+
+    private final ConcurrentMap<String, ServiceProbes> metricsPerServiceMap
+            = new ConcurrentHashMap<String, ServiceProbes>();
+
+    private final ConstructorFunction<String, ServiceProbes> metricsPerServiceConstructorFunction
+            = new ConstructorFunction<String, ServiceProbes>() {
+        @Override
+        public ServiceProbes createNew(String serviceName) {
+            return new ServiceProbes(serviceName);
+        }
+    };
+
+    private final ConstructorFunction<String, InstanceProbes> instanceProbesConstructorFunction
+            = new ConstructorFunction<String, InstanceProbes>() {
+        @Override
+        public InstanceProbes createNew(String dataStructureName) {
+            return new InstanceProbes(dataStructureName);
+        }
+    };
+
+    public StoreLatencyPlugin(NodeEngineImpl nodeEngine) {
+        this(nodeEngine.getLogger(StoreLatencyPlugin.class), nodeEngine.getProperties());
+    }
+
+    public StoreLatencyPlugin(ILogger logger, HazelcastProperties properties) {
+        super(logger);
+        this.periodMillis = properties.getMillis(PERIOD_SECONDS);
+    }
+
+    @Override
+    public long getPeriodMillis() {
+        return periodMillis;
+    }
+
+    @Override
+    public void onStart() {
+        logger.info("Plugin:active: period-millis:" + periodMillis);
+    }
+
+    @Override
+    public void run(DiagnosticsLogWriter writer) {
+        for (ServiceProbes serviceProbes : metricsPerServiceMap.values()) {
+            serviceProbes.render(writer);
+        }
+    }
+
+    // just for testing
+    public long count(String serviceName, String dataStructureName, String methodName) {
+        return ((LatencyProbeImpl) newProbe(serviceName, dataStructureName, methodName)).count;
+    }
+
+    public LatencyProbe newProbe(String serviceName, String dataStructureName, String methodName) {
+        ServiceProbes serviceProbes = getOrPutIfAbsent(
+                metricsPerServiceMap, serviceName, metricsPerServiceConstructorFunction);
+        return serviceProbes.newProbe(dataStructureName, methodName);
+    }
+
+    private final class ServiceProbes {
+        private final String serviceName;
+
+        // the InstanceProbes are stored in a weak reference. So that if the store/loader is gc'ed, the probes are gc'ed
+        // and therefor there is no strong reference to the InstanceProbes and they get gc'ed.
+        private final ConcurrentReferenceHashMap<String, InstanceProbes> instanceProbesMap
+                = new ConcurrentReferenceHashMap<String, InstanceProbes>(ReferenceType.STRONG, ReferenceType.WEAK);
+
+        private ServiceProbes(String serviceName) {
+            this.serviceName = serviceName;
+        }
+
+        private LatencyProbe newProbe(String dataStructureName, String methodName) {
+            InstanceProbes instanceProbes = getOrPutIfAbsent(
+                    instanceProbesMap, dataStructureName, instanceProbesConstructorFunction);
+            return instanceProbes.newProbe(methodName);
+        }
+
+        private void render(DiagnosticsLogWriter writer) {
+            writer.startSection(serviceName);
+
+            for (InstanceProbes instanceProbes : instanceProbesMap.values()) {
+                instanceProbes.render(writer);
+            }
+            writer.endSection();
+        }
+    }
+
+    // contains all probe for given instance, e.g. for a IMap 'employees' instance.
+    private final class InstanceProbes {
+        private final String dataStructureName;
+        // key is the name of the probe, e.g. load.
+        private final ConcurrentMap<String, LatencyProbeImpl> probes = new ConcurrentHashMap<String, LatencyProbeImpl>();
+
+        InstanceProbes(String dataStructureName) {
+            this.dataStructureName = dataStructureName;
+        }
+
+        LatencyProbe newProbe(String methodName) {
+            LatencyProbeImpl probe = probes.get(methodName);
+            if (probe == null) {
+                LatencyProbeImpl newProbe = new LatencyProbeImpl(methodName, this);
+                LatencyProbeImpl found = probes.putIfAbsent(methodName, newProbe);
+                probe = found == null ? newProbe : found;
+            }
+            return probe;
+        }
+
+        private void render(DiagnosticsLogWriter writer) {
+            writer.startSection(dataStructureName);
+            for (LatencyProbeImpl probe : probes.values()) {
+                probe.render(writer);
+            }
+            writer.endSection();
+        }
+    }
+
+    // public for testing.
+    static final class LatencyProbeImpl implements LatencyProbe {
+
+        private static final AtomicLongFieldUpdater<LatencyProbeImpl> COUNT
+                = newUpdater(LatencyProbeImpl.class, "count");
+        private static final AtomicLongFieldUpdater<LatencyProbeImpl> TOTAL_MICROS
+                = newUpdater(LatencyProbeImpl.class, "totalMicros");
+        private static final AtomicLongFieldUpdater<LatencyProbeImpl> MAX_MICROS
+                = newUpdater(LatencyProbeImpl.class, "maxMicros");
+
+
+        volatile long count;
+        volatile long maxMicros;
+        volatile long totalMicros;
+
+        private final AtomicLongArray latencyDistribution = new AtomicLongArray(LATENCY_BUCKET_COUNT);
+
+        // a strong reference to prevent garbage collection.
+        private final InstanceProbes instanceProbes;
+
+        private final String methodName;
+
+        private LatencyProbeImpl(String methodName, InstanceProbes instanceProbes) {
+            this.methodName = methodName;
+            this.instanceProbes = instanceProbes;
+        }
+
+        @Override
+        public void recordValue(long durationNanos) {
+            long durationMicros = NANOSECONDS.toMicros(durationNanos);
+
+            COUNT.addAndGet(this, 1);
+            TOTAL_MICROS.addAndGet(this, durationMicros);
+
+            for (; ; ) {
+                long currentMax = maxMicros;
+                if (durationMicros <= currentMax) {
+                    break;
+                }
+
+                if (MAX_MICROS.compareAndSet(this, currentMax, durationMicros)) {
+                    break;
+                }
+            }
+
+            int bucketIndex = 0;
+            long maxDurationForBucket = LOW_WATERMARK_MICROS;
+            for (int k = 0; k < latencyDistribution.length() - 1; k++) {
+                if (durationMicros >= maxDurationForBucket) {
+                    bucketIndex++;
+                    maxDurationForBucket *= 2;
+                } else {
+                    break;
+                }
+            }
+
+            latencyDistribution.incrementAndGet(bucketIndex);
+        }
+
+        private void render(DiagnosticsLogWriter writer) {
+            long invocations = this.count;
+            long totalMicros = this.totalMicros;
+            long avgMicros = invocations == 0 ? 0 : totalMicros / invocations;
+            long maxMicros = this.maxMicros;
+
+            if (invocations == 0) {
+                return;
+            }
+
+            writer.startSection(methodName);
+            writer.writeKeyValueEntry("count", invocations);
+            writer.writeKeyValueEntry("totalTime(us)", totalMicros);
+            writer.writeKeyValueEntry("avg(us)", avgMicros);
+            writer.writeKeyValueEntry("max(us)", maxMicros);
+
+            writer.startSection("latency-distribution");
+            for (int k = 0; k < latencyDistribution.length(); k++) {
+                long value = latencyDistribution.get(k);
+                if (value > 0) {
+                    writer.writeKeyValueEntry(LATENCY_KEYS[k], value);
+                }
+            }
+            writer.endSection();
+
+            writer.endSection();
+        }
+    }
+
+    public interface LatencyProbe {
+        void recordValue(long latencyNanos);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LatencyTrackingMapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LatencyTrackingMapLoader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbe;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class LatencyTrackingMapLoader<K, V> implements MapLoader<K, V> {
+
+    static final String KEY = "MapStoreLatency";
+
+    private final LatencyProbe loadProbe;
+    private final LatencyProbe loadAllKeysProbe;
+    private final LatencyProbe loadAllProbe;
+    private final MapLoader<K, V> delegate;
+
+    public LatencyTrackingMapLoader(MapLoader<K, V> delegate, StoreLatencyPlugin plugin, String mapName) {
+        this.delegate = delegate;
+        this.loadProbe = plugin.newProbe(KEY, mapName, "load");
+        this.loadAllProbe = plugin.newProbe(KEY, mapName, "loadAll");
+        this.loadAllKeysProbe = plugin.newProbe(KEY, mapName, "loadAllKeys");
+    }
+
+    @Override
+    public V load(K key) {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.load(key);
+        } finally {
+            loadProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public Map<K, V> loadAll(Collection<K> keys) {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.loadAll(keys);
+        } finally {
+            loadAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public Iterable<K> loadAllKeys() {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.loadAllKeys();
+        } finally {
+            loadAllKeysProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LatencyTrackingMapStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LatencyTrackingMapStore.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.MapStore;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbe;
+
+import java.util.Collection;
+import java.util.Map;
+
+@SuppressWarnings("unchecked")
+public class LatencyTrackingMapStore<K, V> implements MapStore<K, V> {
+    static final String KEY = "MapStoreLatency";
+
+    private final LatencyProbe deleteProbe;
+    private final LatencyProbe deleteAllProbe;
+    private final LatencyProbe storeProbe;
+    private final LatencyProbe storeAllProbe;
+    private final MapStore<K, V> delegate;
+
+    public LatencyTrackingMapStore(MapStore<K, V> delegate, StoreLatencyPlugin plugin, String mapName) {
+        this.delegate = delegate;
+        this.deleteProbe = plugin.newProbe(KEY, mapName, "delete");
+        this.deleteAllProbe = plugin.newProbe(KEY, mapName, "deleteAll");
+        this.storeProbe = plugin.newProbe(KEY, mapName, "store");
+        this.storeAllProbe = plugin.newProbe(KEY, mapName, "storeAll");
+    }
+
+    @Override
+    public V load(K key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<K, V> loadAll(Collection<K> keys) {
+        throw new UnsupportedOperationException();
+    }
+
+
+    @Override
+    public Iterable<K> loadAllKeys() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void store(K key, V value) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.store(key, value);
+        } finally {
+            storeProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void storeAll(Map<K, V> map) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.storeAll(map);
+        } finally {
+            storeAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void delete(K key) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.delete(key);
+        } finally {
+            deleteProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void deleteAll(Collection<K> keys) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.deleteAll(keys);
+        } finally {
+            deleteAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/BasicMapStoreContext.java
@@ -123,6 +123,7 @@ final class BasicMapStoreContext implements MapStoreContext {
         // create store.
         final Object store = createStore(mapName, mapStoreConfig, configClassLoader);
         final MapStoreWrapper storeWrapper = new MapStoreWrapper(mapName, store);
+        storeWrapper.instrument(nodeEngine);
 
         setStoreImplToWritableMapStoreConfig(nodeEngine, mapName, store);
 

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStore.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.core.RingbufferStore;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbe;
+
+/**
+ * A {@link RingbufferStore} that decorates an RingbufferStore with latency tracking instrumentation.
+ *
+ * @param <T>
+ */
+class LatencyTrackingRingbufferStore<T> implements RingbufferStore<T> {
+    static final String KEY = "RingbufferStoreLatency";
+
+    private final LatencyProbe loadProbe;
+    private final LatencyProbe getLargestSequenceProbe;
+    private final LatencyProbe storeProbe;
+    private final LatencyProbe storeAllProbe;
+    private final RingbufferStore<T> delegate;
+
+    LatencyTrackingRingbufferStore(RingbufferStore<T> delegate, StoreLatencyPlugin plugin, String ringbufferName) {
+        this.delegate = delegate;
+        this.loadProbe = plugin.newProbe(KEY, ringbufferName, "load");
+        this.getLargestSequenceProbe = plugin.newProbe(KEY, ringbufferName, "getLargestSequence");
+        this.storeProbe = plugin.newProbe(KEY, ringbufferName, "store");
+        this.storeAllProbe = plugin.newProbe(KEY, ringbufferName, "storeAll");
+    }
+
+    @Override
+    public void store(long sequence, T data) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.store(sequence, data);
+        } finally {
+            storeProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public void storeAll(long firstItemSequence, T[] items) {
+        long startNanos = System.nanoTime();
+        try {
+            delegate.storeAll(firstItemSequence, items);
+        } finally {
+            storeAllProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public T load(long sequence) {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.load(sequence);
+        } finally {
+            loadProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+
+    @Override
+    public long getLargestSequence() {
+        long startNanos = System.nanoTime();
+        try {
+            return delegate.getLargestSequence();
+        } finally {
+            getLargestSequenceProbe.recordValue(System.nanoTime() - startNanos);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -122,6 +122,10 @@ public class RingbufferContainer implements DataSerializable {
         }
     }
 
+    public RingbufferStoreWrapper getStore() {
+        return store;
+    }
+
     /**
      * Gets the wait/notify key for the blocking operations of reading from the ring buffer.
      *

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -165,8 +165,12 @@ public class RingbufferService implements ManagedService, RemoteService, Migrati
         }
 
         RingbufferConfig ringbufferConfig = getRingbufferConfig(name);
-        ringbuffer = new RingbufferContainer(name, ringbufferConfig,
-                nodeEngine.getSerializationService(), nodeEngine.getConfigClassLoader());
+        ringbuffer = new RingbufferContainer(
+                name,
+                ringbufferConfig,
+                nodeEngine.getSerializationService(),
+                nodeEngine.getConfigClassLoader());
+        ringbuffer.getStore().instrument(nodeEngine);
         containers.put(name, ringbuffer);
         return ringbuffer;
     }
@@ -181,7 +185,12 @@ public class RingbufferService implements ManagedService, RemoteService, Migrati
         checkNotNull(ringbuffer, "ringbuffer can't be null");
         final RingbufferConfig config = nodeEngine.getConfig().getRingbufferConfig(name);
         final SerializationService serializationService = nodeEngine.getSerializationService();
-        ringbuffer.init(name, config, serializationService, nodeEngine.getConfigClassLoader());
+        ringbuffer.init(
+                name,
+                config,
+                serializationService,
+                nodeEngine.getConfigClassLoader());
+        ringbuffer.getStore().instrument(nodeEngine);
         containers.put(name, ringbuffer);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -32,6 +32,7 @@ import com.hazelcast.internal.diagnostics.MetricsPlugin;
 import com.hazelcast.internal.diagnostics.OverloadedConnectionsPlugin;
 import com.hazelcast.internal.diagnostics.PendingInvocationsPlugin;
 import com.hazelcast.internal.diagnostics.SlowOperationPlugin;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
 import com.hazelcast.internal.diagnostics.SystemLogPlugin;
 import com.hazelcast.internal.diagnostics.SystemPropertiesPlugin;
 import com.hazelcast.internal.management.ManagementCenterService;
@@ -208,6 +209,11 @@ public class NodeEngineImpl implements NodeEngine {
         diagnostics.register(new InvocationPlugin(this));
         diagnostics.register(new MemberHazelcastInstanceInfoPlugin(this));
         diagnostics.register(new SystemLogPlugin(this));
+        diagnostics.register(new StoreLatencyPlugin(this));
+    }
+
+    public Diagnostics getDiagnostics() {
+        return diagnostics;
     }
 
     public ServiceManager getServiceManager() {

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/LatencyTrackingCacheLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/LatencyTrackingCacheLoaderTest.java
@@ -1,0 +1,75 @@
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.integration.CacheLoader;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LatencyTrackingCacheLoaderTest extends HazelcastTestSupport {
+
+    private static final String NAME = "somecache";
+
+    private HazelcastInstance hz;
+    private StoreLatencyPlugin plugin;
+    private CacheLoader<String, String> delegate;
+    private LatencyTrackingCacheLoader<String, String> cacheLoader;
+
+    @Before
+    public void setup() {
+        hz = createHazelcastInstance();
+        plugin = new StoreLatencyPlugin(getNodeEngineImpl(hz));
+        delegate = mock(CacheLoader.class);
+        cacheLoader = new LatencyTrackingCacheLoader<String, String>(delegate, plugin, NAME);
+    }
+
+    @Test
+    public void load() {
+        String key = "key";
+        String value = "value";
+
+        when(delegate.load(key)).thenReturn(value);
+
+        String result = cacheLoader.load(key);
+
+        assertSame(value, result);
+        assertProbeCalledOnce("load");
+    }
+
+    @Test
+    public void loadAll() {
+        Collection<String> keys = asList("key1", "key2");
+        Map<String, String> values = new HashMap<String, String>();
+        values.put("key1", "value1");
+        values.put("key2", "value2");
+
+        when(delegate.loadAll(keys)).thenReturn(values);
+
+        Map<String, String> result = cacheLoader.loadAll(keys);
+
+        assertSame(values, result);
+        assertProbeCalledOnce("loadAll");
+    }
+
+    public void assertProbeCalledOnce(String methodName) {
+        assertEquals(1, plugin.count(LatencyTrackingCacheLoader.KEY, NAME, methodName));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/LatencyTrackingCacheWriterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/LatencyTrackingCacheWriterTest.java
@@ -1,0 +1,64 @@
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.integration.CacheWriter;
+import java.util.Collection;
+import java.util.LinkedList;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LatencyTrackingCacheWriterTest extends HazelcastTestSupport {
+
+    private static final String NAME = "somecache";
+
+    private HazelcastInstance hz;
+    private StoreLatencyPlugin plugin;
+    private CacheWriter delegate;
+    private LatencyTrackingCacheWriter cacheWriter;
+
+    @Before
+    public void setup() {
+        hz = createHazelcastInstance();
+        plugin = new StoreLatencyPlugin(getNodeEngineImpl(hz));
+        delegate = mock(CacheWriter.class);
+        cacheWriter = new LatencyTrackingCacheWriter(delegate, plugin, NAME);
+    }
+
+    @Test
+    public void write() {
+        Cache.Entry entry = new CacheEntry(1, "peter");
+        cacheWriter.write(entry);
+
+        verify(delegate).write(entry);
+        assertProbeCalledOnce("write");
+    }
+
+    @Test
+    public void writeAll() {
+        Collection c = new LinkedList();
+
+        cacheWriter.writeAll(c);
+
+        verify(delegate).writeAll(c);
+        assertProbeCalledOnce("writeAll");
+    }
+
+    public void assertProbeCalledOnce(String methodName) {
+        assertEquals(1, plugin.count(LatencyTrackingCacheWriter.KEY, NAME, methodName));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/LatencyTrackingQueueStoreTest.java
@@ -1,0 +1,133 @@
+package com.hazelcast.collection.impl.queue;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.QueueStore;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.map.impl.LatencyTrackingMapLoader;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestCollectionUtils;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.primitives.Longs.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LatencyTrackingQueueStoreTest extends HazelcastTestSupport {
+    private static final String NAME = "somequeue";
+
+    private HazelcastInstance hz;
+    private StoreLatencyPlugin plugin;
+    private QueueStore<String> delegate;
+    private LatencyTrackingQueueStore<String> queueStore;
+
+    @Before
+    public void setup() {
+        hz = createHazelcastInstance();
+        plugin = new StoreLatencyPlugin(getNodeEngineImpl(hz));
+        delegate = mock(QueueStore.class);
+        queueStore = new LatencyTrackingQueueStore<String>(delegate, plugin, NAME);
+    }
+
+    @Test
+    public void load() {
+        Long key = 1L;
+        String value = "somevalue";
+
+        when(delegate.load(key)).thenReturn(value);
+
+        String result = queueStore.load(key);
+
+        assertEquals(result, value);
+        assertProbeCalledOnce("load");
+    }
+
+    @Test
+    public void loadAll() {
+        Collection<Long> keys = Arrays.asList(1L, 2L);
+        Map<Long, String> values = new HashMap<Long, String>();
+        values.put(1L, "value1");
+        values.put(2L, "value2");
+
+        when(delegate.loadAll(keys)).thenReturn(values);
+
+        Map<Long, String> result = queueStore.loadAll(keys);
+
+        assertEquals(values, result);
+        assertProbeCalledOnce("loadAll");
+    }
+
+    @Test
+    public void loadAllKeys() {
+        Set<Long> keys = TestCollectionUtils.setOf(1L, 2L);
+
+        when(delegate.loadAllKeys()).thenReturn(keys);
+
+        Set<Long> result = queueStore.loadAllKeys();
+
+        assertEquals(keys, result);
+        assertProbeCalledOnce("loadAllKeys");
+    }
+
+    @Test
+    public void delete() {
+        Long key = 1L;
+
+        queueStore.delete(key);
+
+        verify(delegate).delete(key);
+        assertProbeCalledOnce("delete");
+    }
+
+    @Test
+    public void deleteAll() {
+        Collection<Long> keys = asList(1L, 2L);
+
+        queueStore.deleteAll(keys);
+
+        verify(delegate).deleteAll(keys);
+        assertProbeCalledOnce("deleteAll");
+    }
+
+    @Test
+    public void store() {
+        Long key = 1L;
+        String value = "value1";
+
+        queueStore.store(key, value);
+
+        verify(delegate).store(key,value);
+        assertProbeCalledOnce("store");
+    }
+
+    @Test
+    public void storeAll() {
+        Map<Long, String> values = new HashMap<Long, String>();
+        values.put(1L, "value1");
+        values.put(2L, "value2");
+
+        queueStore.storeAll(values);
+
+        verify(delegate).storeAll(values);
+        assertProbeCalledOnce("storeAll");
+    }
+
+    public void assertProbeCalledOnce(String methodName) {
+        assertEquals(1, plugin.count(LatencyTrackingQueueStore.KEY, NAME, methodName));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/StoreLatencyPlugin_QueueIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/StoreLatencyPlugin_QueueIntegrationTest.java
@@ -1,0 +1,129 @@
+package com.hazelcast.collection.impl.queue;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.QueueConfig;
+import com.hazelcast.config.QueueStoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.core.QueueStore;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static com.hazelcast.test.TestStringUtils.fileAsText;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class StoreLatencyPlugin_QueueIntegrationTest extends HazelcastTestSupport {
+
+    private HazelcastInstance hz;
+    private IQueue queue;
+
+    @Before
+    public void setup() throws Exception {
+        Config config = new Config()
+                .setProperty("hazelcast.diagnostics.enabled", "true")
+                .setProperty("hazelcast.diagnostics.storeLatency.period.seconds", "1");
+
+        QueueConfig queueConfig = addQueueConfig(config);
+
+        hz = createHazelcastInstance(config);
+        queue = hz.getQueue(queueConfig.getName());
+    }
+
+    @After
+    public void after(){
+        File file = getNodeEngineImpl(hz).getDiagnostics().currentFile();
+        file.delete();
+    }
+
+
+    @Test
+    public void test() throws Exception {
+        for (int k = 0; k < 100; k++) {
+            queue.put(k);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                File file = getNodeEngineImpl(hz).getDiagnostics().currentFile();
+                String content = fileAsText(file);
+                assertTrue(content.contains("somequeue"));
+            }
+        });
+    }
+
+    private static QueueConfig addQueueConfig(Config config) {
+        QueueConfig queueConfig = config.getQueueConfig("somequeue");
+        QueueStoreConfig queueStoreConfig = new QueueStoreConfig();
+        queueConfig.setQueueStoreConfig(queueStoreConfig);
+        queueStoreConfig.setEnabled(true).setStoreImplementation(new QueueStore() {
+            private final Random random = new Random();
+
+            @Override
+            public void store(Long key, Object value) {
+                randomSleep();
+            }
+
+            @Override
+            public void delete(Long key) {
+                randomSleep();
+            }
+
+            @Override
+            public void storeAll(Map map) {
+                randomSleep();
+            }
+
+            @Override
+            public void deleteAll(Collection keys) {
+                randomSleep();
+            }
+
+            @Override
+            public Map loadAll(Collection keys) {
+                randomSleep();
+                return new HashMap();
+            }
+
+            @Override
+            public Set<Long> loadAllKeys() {
+                return new HashSet<Long>();
+            }
+
+            @Override
+            public Object load(Long key) {
+                randomSleep();
+                return key;
+            }
+
+            private void randomSleep() {
+                long delay = random.nextInt(100);
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+        return queueConfig;
+    }
+}
+

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginTest.java
@@ -1,0 +1,95 @@
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbe;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin.LatencyProbeImpl;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class StoreLatencyPluginTest extends AbstractDiagnosticsPluginTest {
+
+    private StoreLatencyPlugin plugin;
+
+    @Before
+    public void setup() {
+        HazelcastProperties properties = new HazelcastProperties(new Properties());
+        plugin = new StoreLatencyPlugin(Logger.getLogger(StoreLatencyPlugin.class), properties);
+    }
+
+    @Test
+    public void getProbe() {
+        LatencyProbe probe = plugin.newProbe("foo", "queue", "somemethod");
+        assertNotNull(probe);
+    }
+
+    @Test
+    public void getProbe_whenSameProbeRequestedMoreThanOnce() {
+        LatencyProbe probe1 = plugin.newProbe("foo", "queue", "somemethod");
+        LatencyProbe probe2 = plugin.newProbe("foo", "queue", "somemethod");
+        assertSame(probe1, probe2);
+    }
+
+    @Test
+    public void testMaxMicros() {
+        LatencyProbeImpl probe = (LatencyProbeImpl) plugin.newProbe("foo", "queue", "somemethod");
+        probe.recordValue(MICROSECONDS.toNanos(10));
+        probe.recordValue(MICROSECONDS.toNanos(1000));
+        probe.recordValue(MICROSECONDS.toNanos(4));
+
+        assertEquals(1000, probe.maxMicros);
+    }
+
+    @Test
+    public void testCount() {
+        LatencyProbeImpl probe = (LatencyProbeImpl) plugin.newProbe("foo", "queue", "somemethod");
+        probe.recordValue(MICROSECONDS.toNanos(10));
+        probe.recordValue(MICROSECONDS.toNanos(10));
+        probe.recordValue(MICROSECONDS.toNanos(10));
+
+        assertEquals(3, probe.count);
+    }
+
+    @Test
+    public void testTotalMicros() {
+        LatencyProbeImpl probe = (LatencyProbeImpl) plugin.newProbe("foo", "queue", "somemethod");
+        probe.recordValue(MICROSECONDS.toNanos(10));
+        probe.recordValue(MICROSECONDS.toNanos(20));
+        probe.recordValue(MICROSECONDS.toNanos(30));
+
+        assertEquals(60, probe.totalMicros);
+    }
+
+    @Test
+    public void render() {
+        LatencyProbeImpl probe = (LatencyProbeImpl) plugin.newProbe("foo", "queue", "somemethod");
+        probe.recordValue(MICROSECONDS.toNanos(100));
+        probe.recordValue(MICROSECONDS.toNanos(200));
+        probe.recordValue(MICROSECONDS.toNanos(300));
+
+        plugin.run(logWriter);
+
+        assertContains("foo");
+        assertContains("queue");
+        assertContains("somemethod");
+        assertContains("count=3");
+        assertContains("totalTime(us)=600");
+        assertContains("avg(us)=200");
+        assertContains("max(us)=300");
+        assertContains("100..199us=1");
+        assertContains("200..399us=2");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/LatencyTrackingMapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/LatencyTrackingMapLoaderTest.java
@@ -1,0 +1,87 @@
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LatencyTrackingMapLoaderTest extends HazelcastTestSupport {
+
+    private static final String NAME = "somemap";
+
+    private HazelcastInstance hz;
+    private StoreLatencyPlugin plugin;
+    private MapLoader<String, String> delegate;
+    private LatencyTrackingMapLoader<String, String> cacheLoader;
+
+    @Before
+    public void setup() {
+        hz = createHazelcastInstance();
+        plugin = new StoreLatencyPlugin(getNodeEngineImpl(hz));
+        delegate = mock(MapLoader.class);
+        cacheLoader = new LatencyTrackingMapLoader<String, String>(delegate, plugin, NAME);
+    }
+
+    @Test
+    public void load() {
+        String key = "key";
+        String value = "value";
+
+        when(delegate.load(key)).thenReturn(value);
+
+        String result = cacheLoader.load(key);
+
+        assertSame(value, result);
+        assertProbeCalledOnce("load");
+    }
+
+    @Test
+    public void loadAll() {
+        Collection<String> keys = asList("key1", "key2");
+        Map<String, String> values = new HashMap<String, String>();
+        values.put("key1", "value1");
+        values.put("key2", "value2");
+
+        when(delegate.loadAll(keys)).thenReturn(values);
+
+        Map<String, String> result = cacheLoader.loadAll(keys);
+
+        assertSame(values, result);
+        assertProbeCalledOnce("loadAll");
+    }
+
+    @Test
+    public void loadAllKeys() {
+        Collection<String> keys = asList("key1", "key2");
+
+        when(delegate.loadAllKeys()).thenReturn(keys);
+
+        Iterable<String> result = cacheLoader.loadAllKeys();
+
+        assertSame(keys, result);
+        assertProbeCalledOnce("loadAllKeys");
+    }
+
+    public void assertProbeCalledOnce(String methodName) {
+        assertEquals(1, plugin.count(LatencyTrackingMapLoader.KEY, NAME, methodName));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/LatencyTrackingMapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/LatencyTrackingMapStoreTest.java
@@ -1,0 +1,105 @@
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MapStore;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LatencyTrackingMapStoreTest extends HazelcastTestSupport {
+
+    private static final String NAME = "somemap";
+
+    private HazelcastInstance hz;
+    private StoreLatencyPlugin plugin;
+    private MapStore<String, String> delegate;
+    private LatencyTrackingMapStore<String, String> cacheStore;
+
+    @Before
+    public void setup() {
+        hz = createHazelcastInstance();
+        plugin = new StoreLatencyPlugin(getNodeEngineImpl(hz));
+        delegate = mock(MapStore.class);
+        cacheStore = new LatencyTrackingMapStore<String, String>(delegate, plugin, NAME);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void load() {
+        cacheStore.load("somekey");
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void loadAll() {
+        cacheStore.loadAll(asList("1", "2"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void loadAllKeys() {
+        cacheStore.loadAllKeys();
+    }
+
+    @Test
+    public void store() {
+        String key = "somekey";
+        String value = "somevalue";
+
+        cacheStore.store(key, value);
+
+        verify(delegate).store(key, value);
+        assertProbeCalledOnce("store");
+    }
+
+    @Test
+    public void storeAll() {
+        Map<String, String> values = new HashMap<String, String>();
+        values.put("1", "value1");
+        values.put("2", "value2");
+
+        cacheStore.storeAll(values);
+
+        verify(delegate).storeAll(values);
+        assertProbeCalledOnce("storeAll");
+    }
+
+    @Test
+    public void delete() {
+        String key = "somekey";
+
+        cacheStore.delete(key);
+
+        verify(delegate).delete(key);
+        assertProbeCalledOnce("delete");
+    }
+
+    @Test
+    public void deleteAll() {
+        List<String> keys = Arrays.asList("1", "2");
+
+        cacheStore.deleteAll(keys);
+
+        verify(delegate).deleteAll(keys);
+        assertProbeCalledOnce("deleteAll");
+    }
+
+    public void assertProbeCalledOnce(String methodName) {
+        assertEquals(1, plugin.count(LatencyTrackingMapLoader.KEY, NAME, methodName));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/StoreLatencyPlugin_MapIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/StoreLatencyPlugin_MapIntegrationTest.java
@@ -1,0 +1,122 @@
+package com.hazelcast.map.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MapStore;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Random;
+
+import static com.hazelcast.test.TestStringUtils.fileAsText;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class StoreLatencyPlugin_MapIntegrationTest extends HazelcastTestSupport {
+
+    private HazelcastInstance hz;
+    private Map<String, String> map;
+
+    @Before
+    public void setup() throws Exception {
+        setLoggingLog4j();
+
+        Config config = new Config()
+                .setProperty("hazelcast.diagnostics.enabled", "true")
+                .setProperty("hazelcast.diagnostics.storeLatency.period.seconds", "1");
+
+        MapConfig mapConfig = addMapConfig(config);
+
+        hz = createHazelcastInstance(config);
+        map = hz.getMap(mapConfig.getName());
+    }
+
+    @After
+    public void after(){
+        File file = getNodeEngineImpl(hz).getDiagnostics().currentFile();
+        file.delete();
+    }
+
+    @Test
+    public void test() throws Exception {
+        for (int k = 0; k < 100; k++) {
+            map.get(k);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                File file = getNodeEngineImpl(hz).getDiagnostics().currentFile();
+                String content = fileAsText(file);
+                assertTrue(content.contains("mappy"));
+            }
+        });
+    }
+
+    private static MapConfig addMapConfig(Config config) {
+        MapConfig mapConfig = config.getMapConfig("mappy");
+        mapConfig.getMapStoreConfig().setEnabled(true).setImplementation(new MapStore() {
+            private final Random random = new Random();
+
+            @Override
+            public void store(Object key, Object value) {
+
+            }
+
+            @Override
+            public Object load(Object key) {
+                randomSleep();
+                return null;
+            }
+
+            private void randomSleep() {
+                long delay = random.nextInt(100);
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            @Override
+            public Map loadAll(Collection keys) {
+                return null;
+            }
+
+            @Override
+            public void storeAll(Map map) {
+
+            }
+
+            @Override
+            public void delete(Object key) {
+
+            }
+
+            @Override
+            public Iterable loadAllKeys() {
+                return null;
+            }
+
+            @Override
+            public void deleteAll(Collection keys) {
+
+            }
+        });
+        return mapConfig;
+    }
+}
+

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/LatencyTrackingRingbufferStoreTest.java
@@ -1,0 +1,87 @@
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.RingbufferStore;
+import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LatencyTrackingRingbufferStoreTest extends HazelcastTestSupport {
+    private static final String NAME = "somerb";
+
+    private HazelcastInstance hz;
+    private StoreLatencyPlugin plugin;
+    private RingbufferStore<String> delegate;
+    private LatencyTrackingRingbufferStore<String> ringbufferStore;
+
+    @Before
+    public void setup() {
+        hz = createHazelcastInstance();
+        plugin = new StoreLatencyPlugin(getNodeEngineImpl(hz));
+        delegate = mock(RingbufferStore.class);
+        ringbufferStore = new LatencyTrackingRingbufferStore<String>(delegate, plugin, NAME);
+    }
+
+    @Test
+    public void load() {
+        long sequence = 1L;
+        String value = "somevalue";
+
+        when(delegate.load(sequence)).thenReturn(value);
+
+        String result = ringbufferStore.load(sequence);
+
+        assertEquals(result, value);
+        assertProbeCalledOnce("load");
+    }
+
+    @Test
+    public void getLargestSequence() {
+        long largestSequence = 100L;
+        when(delegate.getLargestSequence()).thenReturn(largestSequence);
+
+        long result = ringbufferStore.getLargestSequence();
+
+        assertEquals(largestSequence, result);
+        assertProbeCalledOnce("getLargestSequence");
+    }
+
+    @Test
+    public void store() {
+        long sequence = 1L;
+        String value = "value1";
+
+        ringbufferStore.store(sequence, value);
+
+        verify(delegate).store(sequence, value);
+        assertProbeCalledOnce("store");
+    }
+
+    @Test
+    public void storeAll() {
+        String[] items = new String[]{"1", "2"};
+
+        ringbufferStore.storeAll(100, items);
+
+        verify(delegate).storeAll(100, items);
+        assertProbeCalledOnce("storeAll");
+    }
+
+    public void assertProbeCalledOnce(String methodName) {
+        assertEquals(1, plugin.count(LatencyTrackingRingbufferStore.KEY, NAME, methodName));
+    }
+}
+

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/StoreLatencyPlugin_RingbufferIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/StoreLatencyPlugin_RingbufferIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.RingbufferConfig;
+import com.hazelcast.config.RingbufferStoreConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.RingbufferStore;
+import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Random;
+
+import static com.hazelcast.test.TestStringUtils.fileAsText;
+import static org.junit.Assert.assertTrue;
+
+public class StoreLatencyPlugin_RingbufferIntegrationTest extends HazelcastTestSupport {
+
+    private HazelcastInstance hz;
+    private Ringbuffer<Object> rb;
+
+    @Before
+    public void setup() throws Exception {
+        Config config = new Config()
+                .setProperty("hazelcast.diagnostics.enabled", "true")
+                .setProperty("hazelcast.diagnostics.storeLatency.period.seconds", "1");
+
+        RingbufferConfig rbConfig = addRingbufferConfig(config);
+
+        hz = createHazelcastInstance(config);
+        rb = hz.getRingbuffer(rbConfig.getName());
+    }
+
+    @After
+    public void after(){
+        File file = getNodeEngineImpl(hz).getDiagnostics().currentFile();
+        file.delete();
+    }
+
+    @Test
+    public void test() throws Exception {
+        for (long k = 0; k <= rb.tailSequence(); k++) {
+            rb.readOne(k);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                File file = getNodeEngineImpl(hz).getDiagnostics().currentFile();
+                String content = fileAsText(file);
+                assertTrue(content.contains("ringworm"));
+            }
+        });
+    }
+
+    private static RingbufferConfig addRingbufferConfig(Config config) {
+        RingbufferStore store = new RingbufferStore() {
+            private final Random random = new Random();
+
+            @Override
+            public void store(long sequence, Object data) {
+
+            }
+
+            @Override
+            public void storeAll(long firstItemSequence, Object[] items) {
+
+            }
+
+            @Override
+            public Object load(long sequence) {
+                randomSleep();
+                return sequence;
+            }
+
+            @Override
+            public long getLargestSequence() {
+                randomSleep();
+                return 100;
+            }
+
+            private void randomSleep() {
+                long delay = 1 + random.nextInt(100);
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+
+        return config.getRingbufferConfig("ringworm")
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+                .setRingbufferStoreConfig(new RingbufferStoreConfig().setStoreImplementation(store));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/TestStringUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestStringUtils.java
@@ -1,0 +1,38 @@
+package com.hazelcast.test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static com.hazelcast.nio.IOUtil.closeResource;
+
+public class TestStringUtils {
+    private static final int READ_BUFFER_SIZE = 8192;
+
+    public static String fileAsText(File file) {
+        FileInputStream stream = null;
+        InputStreamReader streamReader = null;
+        BufferedReader reader = null;
+        try {
+            stream = new FileInputStream(file);
+            streamReader = new InputStreamReader(stream);
+            reader = new BufferedReader(streamReader);
+
+            StringBuilder builder = new StringBuilder();
+            char[] buffer = new char[READ_BUFFER_SIZE];
+            int read;
+            while ((read = reader.read(buffer, 0, buffer.length)) > 0) {
+                builder.append(buffer, 0, read);
+            }
+            return builder.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            closeResource(reader);
+            closeResource(streamReader);
+            closeResource(stream);
+        }
+    }
+}


### PR DESCRIPTION
Added a plugin for the the different store like MapStore to provide information about latencies. All kinds of different statistics are available like count, max, avg, and latency distribution.

Example output:

```
17-9-2016 13:12:34 MapStoreLatency[
                          map[
                                  loadAllKeys[
                                          count=1
                                          totalTime(us)=8
                                          avg(us)=8
                                          max(us)=8
                                          latency-distribution[
                                                  0..99us=1]]
                                  load[
                                          count=100
                                          totalTime(us)=4,632,190
                                          avg(us)=46,321
                                          max(us)=99,178
                                          latency-distribution[
                                                  0..99us=1
                                                  1600..3199us=3
                                                  3200..6399us=3
                                                  6400..12799us=7
                                                  12800..25599us=13
                                                  25600..51199us=32
                                                  51200..102399us=41]]]]
17-9-2016 13:12:34 RingbufferStoreLatency[
                          ring[
                                  load[
                                          count=47
                                          totalTime(us)=2,366,188
                                          avg(us)=50,344
                                          max(us)=96,176
                                          latency-distribution[
                                                  1600..3199us=1
                                                  6400..12799us=7
                                                  12800..25599us=3
                                                  25600..51199us=12
                                                  51200..102399us=24]]
                                  getLargestSequenceProbe[
                                          count=1
                                          totalTime(us)=38,186
                                          avg(us)=38,186
                                          max(us)=38,186
                                          latency-distribution[
                                                  25600..51199us=1]]]]

```

The approach used is decorate the Store/Loader with a Latency tracking decorator. This proxy is dynamically wrapped around the original Store/Loader. If the LatencyStorePlugin is disabled, the decorator is not added; and therefor there is no performance penalty.

The main purpose of this plugin is to provide solid information if e.g. a database is causing problems. We want to see which Store/Loader was running into problems and we want to have all kinds of statistics to determine what is happening.

