### PR TITLE
Convert Map DataSerializable classes to IdentifiedDataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryEventFilter.java
@@ -19,12 +19,12 @@ package com.hazelcast.map.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.EventFilter;
 
 import java.io.IOException;
 
-public class EntryEventFilter implements EventFilter, DataSerializable {
+public class EntryEventFilter implements EventFilter, IdentifiedDataSerializable {
 
     protected boolean includeValue;
     protected Data key;
@@ -95,5 +95,15 @@ public class EntryEventFilter implements EventFilter, DataSerializable {
                 + "includeValue=" + includeValue
                 + ", key=" + key
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.ENTRY_EVENT_FILTER;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EventListenerFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EventListenerFilter.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
 
@@ -47,7 +47,7 @@ import static com.hazelcast.map.impl.MapListenerFlagOperator.SET_ALL_LISTENER_FL
  * @see com.hazelcast.map.listener.MapListener
  * @since 3.6
  */
-public class EventListenerFilter implements EventFilter, DataSerializable {
+public class EventListenerFilter implements EventFilter, IdentifiedDataSerializable {
 
     /**
      * Flags of implemented listeners.
@@ -92,5 +92,15 @@ public class EventListenerFilter implements EventFilter, DataSerializable {
                 + "listenerFlags=" + listenerFlags
                 + ", eventFilter=" + eventFilter
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.EVENT_LISTENER_FILTER;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -21,8 +21,13 @@ import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
 import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
+import com.hazelcast.map.impl.nearcache.invalidation.BatchNearCacheInvalidation;
+import com.hazelcast.map.impl.nearcache.invalidation.ClearNearCacheInvalidation;
+import com.hazelcast.map.impl.nearcache.invalidation.SingleNearCacheInvalidation;
+import com.hazelcast.map.impl.nearcache.invalidation.UuidFilter;
 import com.hazelcast.map.impl.operation.AddIndexOperation;
 import com.hazelcast.map.impl.operation.AddIndexOperationFactory;
+import com.hazelcast.map.impl.operation.AddInterceptorOperation;
 import com.hazelcast.map.impl.operation.AddInterceptorOperationFactory;
 import com.hazelcast.map.impl.operation.AwaitMapFlushOperation;
 import com.hazelcast.map.impl.operation.ClearBackupOperation;
@@ -55,6 +60,7 @@ import com.hazelcast.map.impl.operation.MapFlushOperationFactory;
 import com.hazelcast.map.impl.operation.MapGetAllOperationFactory;
 import com.hazelcast.map.impl.operation.MapIsEmptyOperation;
 import com.hazelcast.map.impl.operation.MapLoadAllOperationFactory;
+import com.hazelcast.map.impl.operation.MapReplicationOperation;
 import com.hazelcast.map.impl.operation.MapSizeOperation;
 import com.hazelcast.map.impl.operation.MergeOperation;
 import com.hazelcast.map.impl.operation.MultipleEntryBackupOperation;
@@ -70,6 +76,7 @@ import com.hazelcast.map.impl.operation.PartitionWideEntryOperation;
 import com.hazelcast.map.impl.operation.PartitionWideEntryOperationFactory;
 import com.hazelcast.map.impl.operation.PartitionWideEntryWithPredicateBackupOperation;
 import com.hazelcast.map.impl.operation.PartitionWideEntryWithPredicateOperation;
+import com.hazelcast.map.impl.operation.PostJoinMapOperation;
 import com.hazelcast.map.impl.operation.PutAllBackupOperation;
 import com.hazelcast.map.impl.operation.PutAllOperation;
 import com.hazelcast.map.impl.operation.PutAllPartitionAwareOperationFactory;
@@ -81,6 +88,7 @@ import com.hazelcast.map.impl.operation.PutOperation;
 import com.hazelcast.map.impl.operation.PutTransientOperation;
 import com.hazelcast.map.impl.operation.RemoveBackupOperation;
 import com.hazelcast.map.impl.operation.RemoveIfSameOperation;
+import com.hazelcast.map.impl.operation.RemoveInterceptorOperation;
 import com.hazelcast.map.impl.operation.RemoveInterceptorOperationFactory;
 import com.hazelcast.map.impl.operation.RemoveOperation;
 import com.hazelcast.map.impl.operation.ReplaceIfSameOperation;
@@ -89,10 +97,13 @@ import com.hazelcast.map.impl.operation.SetOperation;
 import com.hazelcast.map.impl.operation.SizeOperationFactory;
 import com.hazelcast.map.impl.operation.TryPutOperation;
 import com.hazelcast.map.impl.operation.TryRemoveOperation;
+import com.hazelcast.map.impl.query.QueryEventFilter;
 import com.hazelcast.map.impl.query.QueryOperation;
 import com.hazelcast.map.impl.query.QueryPartitionOperation;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
+import com.hazelcast.map.impl.record.RecordInfo;
+import com.hazelcast.map.impl.record.RecordReplicationInfo;
 import com.hazelcast.map.impl.tx.TxnDeleteOperation;
 import com.hazelcast.map.impl.tx.TxnLockAndGetOperation;
 import com.hazelcast.map.impl.tx.TxnPrepareBackupOperation;
@@ -102,6 +113,10 @@ import com.hazelcast.map.impl.tx.TxnRollbackOperation;
 import com.hazelcast.map.impl.tx.TxnSetOperation;
 import com.hazelcast.map.impl.tx.TxnUnlockBackupOperation;
 import com.hazelcast.map.impl.tx.TxnUnlockOperation;
+import com.hazelcast.map.merge.HigherHitsMapMergePolicy;
+import com.hazelcast.map.merge.LatestUpdateMapMergePolicy;
+import com.hazelcast.map.merge.PassThroughMergePolicy;
+import com.hazelcast.map.merge.PutIfAbsentMapMergePolicy;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.impl.operation.ClearOperationFactory;
@@ -205,8 +220,28 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int REMOVE_INTERCEPTOR_FACTORY = 88;
     public static final int SIZE_FACTORY = 89;
     public static final int MULTIPLE_ENTRY_FACTORY = 90;
+    public static final int ENTRY_EVENT_FILTER = 91;
+    public static final int EVENT_LISTENER_FILTER = 92;
+    public static final int PARTITION_LOST_EVENT_FILTER = 93;
+    public static final int NEAR_CACHE_CLEAR_INVALIDATION = 94;
+    public static final int ADD_INTERCEPTOR = 95;
+    public static final int MAP_REPLICATION = 96;
+    public static final int POST_JOIN_MAP_OPERATION = 97;
+    public static final int INDEX_INFO = 98;
+    public static final int MAP_INDEX_INFO = 99;
+    public static final int INTERCEPTOR_INFO = 100;
+    public static final int REMOVE_INTERCEPTOR = 101;
+    public static final int QUERY_EVENT_FILTER = 102;
+    public static final int RECORD_INFO = 103;
+    public static final int RECORD_REPLICATION_INFO = 104;
+    public static final int HIGHER_HITS_MERGE_POLICY = 105;
+    public static final int LATEST_UPDATE_MERGE_POLICY = 106;
+    public static final int PASS_THROUGH_MERGE_POLICY = 107;
+    public static final int PUT_IF_ABSENT_MERGE_POLICY = 108;
+    public static final int UUID_FILTER = 109;
+    public static final int CLEAR_NEAR_CACHE_INVALIDATION = 110;
 
-    private static final int LEN = MULTIPLE_ENTRY_FACTORY + 1;
+    private static final int LEN = CLEAR_NEAR_CACHE_INVALIDATION + 1;
 
     @Override
     public int getFactoryId() {
@@ -655,6 +690,116 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[MULTIPLE_ENTRY_FACTORY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new MultipleEntryOperationFactory();
+            }
+        };
+        constructors[ENTRY_EVENT_FILTER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new EntryEventFilter();
+            }
+        };
+        constructors[EVENT_LISTENER_FILTER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new EventListenerFilter();
+            }
+        };
+        constructors[PARTITION_LOST_EVENT_FILTER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapPartitionLostEventFilter();
+            }
+        };
+        constructors[NEAR_CACHE_SINGLE_INVALIDATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new SingleNearCacheInvalidation();
+            }
+        };
+        constructors[NEAR_CACHE_BATCH_INVALIDATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new BatchNearCacheInvalidation();
+            }
+        };
+        constructors[NEAR_CACHE_CLEAR_INVALIDATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new ClearNearCacheInvalidation();
+            }
+        };
+        constructors[ADD_INTERCEPTOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new AddInterceptorOperation();
+            }
+        };
+        constructors[MAP_REPLICATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapReplicationOperation();
+            }
+        };
+        constructors[POST_JOIN_MAP_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PostJoinMapOperation();
+            }
+        };
+        constructors[INDEX_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PostJoinMapOperation.MapIndexInfo.IndexInfo();
+            }
+        };
+        constructors[MAP_INDEX_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PostJoinMapOperation.MapIndexInfo();
+            }
+        };
+        constructors[INTERCEPTOR_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PostJoinMapOperation.InterceptorInfo();
+            }
+        };
+        constructors[REMOVE_INTERCEPTOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new RemoveInterceptorOperation();
+            }
+        };
+        constructors[QUERY_EVENT_FILTER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new QueryEventFilter();
+            }
+        };
+        constructors[RECORD_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new RecordInfo();
+            }
+        };
+        constructors[RECORD_REPLICATION_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new RecordReplicationInfo();
+            }
+        };
+        constructors[HIGHER_HITS_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new HigherHitsMapMergePolicy();
+            }
+        };
+        constructors[LATEST_UPDATE_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new LatestUpdateMapMergePolicy();
+            }
+        };
+        constructors[PASS_THROUGH_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PassThroughMergePolicy();
+            }
+        };
+        constructors[PUT_IF_ABSENT_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PutIfAbsentMapMergePolicy();
+            }
+        };
+        constructors[UUID_FILTER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new UuidFilter();
+            }
+        };
+        constructors[CLEAR_NEAR_CACHE_INVALIDATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new ClearNearCacheInvalidation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionLostEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionLostEventFilter.java
@@ -18,12 +18,12 @@ package com.hazelcast.map.impl;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.EventFilter;
 
 import java.io.IOException;
 
-public class MapPartitionLostEventFilter implements EventFilter, DataSerializable {
+public class MapPartitionLostEventFilter implements EventFilter, IdentifiedDataSerializable {
 
     @Override
     public boolean eval(Object arg) {
@@ -51,5 +51,15 @@ public class MapPartitionLostEventFilter implements EventFilter, DataSerializabl
     @Override
     public String toString() {
         return "MapPartitionLostEventFilter{}";
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.PARTITION_LOST_EVENT_FILTER;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/BatchNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/BatchNearCacheInvalidation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.nearcache.invalidation;
 
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
@@ -80,5 +81,10 @@ public class BatchNearCacheInvalidation extends Invalidation {
             str.append(invalidation.toString());
         }
         return str.toString();
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.NEAR_CACHE_BATCH_INVALIDATION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/ClearNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/ClearNearCacheInvalidation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.nearcache.invalidation;
 
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
@@ -69,5 +70,10 @@ public class ClearNearCacheInvalidation extends Invalidation {
                 + "mapName='" + mapName + '\''
                 + ", sourceUuid='" + sourceUuid + '\''
                 + '}';
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.CLEAR_NEAR_CACHE_INVALIDATION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/Invalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/Invalidation.java
@@ -19,9 +19,10 @@ package com.hazelcast.map.impl.nearcache.invalidation;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.IMapEvent;
 import com.hazelcast.core.Member;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
@@ -30,7 +31,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 /**
  * Root interface for Near Cache invalidation data.
  */
-public abstract class Invalidation implements IMapEvent, DataSerializable {
+public abstract class Invalidation implements IMapEvent, IdentifiedDataSerializable {
 
     protected String mapName;
 
@@ -70,5 +71,10 @@ public abstract class Invalidation implements IMapEvent, DataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         mapName = in.readUTF();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/SingleNearCacheInvalidation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/SingleNearCacheInvalidation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.nearcache.invalidation;
 
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -79,5 +80,10 @@ public class SingleNearCacheInvalidation extends Invalidation {
                 + ", sourceUuid='" + sourceUuid + '\''
                 + ", key='" + key + '\''
                 + '}';
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.NEAR_CACHE_SINGLE_INVALIDATION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/UuidFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/UuidFilter.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.map.impl.nearcache.invalidation;
 
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.EventFilter;
 
 import java.io.IOException;
@@ -27,7 +28,7 @@ import java.io.IOException;
  * Compares supplied uuid with this filters' uuid to prevent unneeded delivery of an invalidation event to operation caller.
  * Operation caller invalidates its own local near-cache, no need to send an extra invalidation from remote.
  */
-public class UuidFilter implements EventFilter, DataSerializable {
+public class UuidFilter implements EventFilter, IdentifiedDataSerializable {
 
     private String uuid;
 
@@ -60,5 +61,15 @@ public class UuidFilter implements EventFilter, DataSerializable {
         return "UuidFilter{"
                 + "uuid='" + uuid + '\''
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.UUID_FILTER;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
@@ -18,16 +18,18 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.NamedOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class AddInterceptorOperation extends Operation implements MutatingOperation, NamedOperation {
+public class AddInterceptorOperation extends Operation implements MutatingOperation, NamedOperation, IdentifiedDataSerializable {
 
     private MapService mapService;
     private String id;
@@ -86,5 +88,15 @@ public class AddInterceptorOperation extends Operation implements MutatingOperat
     @Override
     public String getName() {
         return mapName;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.ADD_INTERCEPTOR;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
@@ -35,7 +36,8 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Clear expired records.
  */
-public class ClearExpiredOperation extends Operation implements PartitionAwareOperation, MutatingOperation {
+public class ClearExpiredOperation extends Operation implements PartitionAwareOperation, MutatingOperation,
+                                                                IdentifiedDataSerializable {
 
     private int expirationPercentage;
 
@@ -85,12 +87,12 @@ public class ClearExpiredOperation extends Operation implements PartitionAwareOp
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("ClearExpiredOperation is only used locally.");
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("ClearExpiredOperation is only used locally.");
     }
 
     @Override
@@ -98,5 +100,15 @@ public class ClearExpiredOperation extends Operation implements PartitionAwareOp
         super.toString(sb);
 
         sb.append(", expirationPercentage=").append(expirationPercentage);
+    }
+
+    @Override
+    public int getFactoryId() {
+        throw new UnsupportedOperationException("ClearExpiredOperation is only used locally.");
+    }
+
+    @Override
+    public int getId() {
+        throw new UnsupportedOperationException("ClearExpiredOperation is only used locally.");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.PartitionContainer;
@@ -33,6 +34,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
@@ -56,7 +58,7 @@ import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
 /**
  * Replicates all IMap-states of this partition to a replica partition.
  */
-public class MapReplicationOperation extends Operation implements MutatingOperation {
+public class MapReplicationOperation extends Operation implements MutatingOperation, IdentifiedDataSerializable {
 
     // keep these fields `protected`, extended in another context.
     protected final MapReplicationStateHolder mapReplicationStateHolder = new MapReplicationStateHolder();
@@ -343,5 +345,15 @@ public class MapReplicationOperation extends Operation implements MutatingOperat
             }
 
         }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.MAP_REPLICATION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -19,11 +19,12 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.InterceptorRegistry;
 import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.spi.Operation;
@@ -35,7 +36,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-public class PostJoinMapOperation extends Operation {
+public class PostJoinMapOperation extends Operation implements IdentifiedDataSerializable {
 
     private List<MapIndexInfo> indexInfoList = new LinkedList<MapIndexInfo>();
     private List<InterceptorInfo> interceptorInfoList = new LinkedList<InterceptorInfo>();
@@ -71,7 +72,7 @@ public class PostJoinMapOperation extends Operation {
         interceptorInfoList.add(interceptorInfo);
     }
 
-    static class InterceptorInfo implements DataSerializable {
+    public static class InterceptorInfo implements IdentifiedDataSerializable {
 
         private String mapName;
         private final List<Map.Entry<String, MapInterceptor>> interceptors = new LinkedList<Map.Entry<String, MapInterceptor>>();
@@ -80,7 +81,7 @@ public class PostJoinMapOperation extends Operation {
             this.mapName = mapName;
         }
 
-        InterceptorInfo() {
+        public InterceptorInfo() {
         }
 
         void addInterceptor(String id, MapInterceptor interceptor) {
@@ -106,6 +107,16 @@ public class PostJoinMapOperation extends Operation {
                 MapInterceptor interceptor = in.readObject();
                 interceptors.add(new AbstractMap.SimpleImmutableEntry<String, MapInterceptor>(id, interceptor));
             }
+        }
+
+        @Override
+        public int getFactoryId() {
+            return MapDataSerializerHook.F_ID;
+        }
+
+        @Override
+        public int getId() {
+            return MapDataSerializerHook.INTERCEPTOR_INFO;
         }
     }
 
@@ -163,7 +174,7 @@ public class PostJoinMapOperation extends Operation {
         }
     }
 
-    static class MapIndexInfo implements DataSerializable {
+    public static class MapIndexInfo implements IdentifiedDataSerializable {
         private String mapName;
         private List<MapIndexInfo.IndexInfo> lsIndexes = new LinkedList<MapIndexInfo.IndexInfo>();
 
@@ -174,11 +185,11 @@ public class PostJoinMapOperation extends Operation {
         public MapIndexInfo() {
         }
 
-        static class IndexInfo implements DataSerializable {
+        public static class IndexInfo implements IdentifiedDataSerializable {
             private String attributeName;
             private boolean ordered;
 
-            IndexInfo() {
+            public IndexInfo() {
             }
 
             IndexInfo(String attributeName, boolean ordered) {
@@ -196,6 +207,16 @@ public class PostJoinMapOperation extends Operation {
             public void readData(ObjectDataInput in) throws IOException {
                 attributeName = in.readUTF();
                 ordered = in.readBoolean();
+            }
+
+            @Override
+            public int getFactoryId() {
+                return MapDataSerializerHook.F_ID;
+            }
+
+            @Override
+            public int getId() {
+                return MapDataSerializerHook.INDEX_INFO;
             }
         }
 
@@ -222,5 +243,25 @@ public class PostJoinMapOperation extends Operation {
                 lsIndexes.add(indexInfo);
             }
         }
+
+        @Override
+        public int getFactoryId() {
+            return MapDataSerializerHook.F_ID;
+        }
+
+        @Override
+        public int getId() {
+            return MapDataSerializerHook.MAP_INDEX_INFO;
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.POST_JOIN_MAP_OPERATION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
@@ -17,17 +17,20 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.NamedOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class RemoveInterceptorOperation extends Operation implements MutatingOperation, NamedOperation {
+public class RemoveInterceptorOperation extends Operation implements MutatingOperation, NamedOperation,
+                                                                     IdentifiedDataSerializable {
 
     private MapService mapService;
     private String mapName;
@@ -79,5 +82,15 @@ public class RemoveInterceptorOperation extends Operation implements MutatingOpe
 
         sb.append(", mapName=").append(mapName);
         sb.append(", id=").append(id);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.REMOVE_INTERCEPTOR;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.map.impl.EntryEventFilter;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -91,5 +92,10 @@ public class QueryEventFilter extends EntryEventFilter {
         return "QueryEventFilter{"
                 + "predicate=" + predicate
                 + '}';
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.QUERY_EVENT_FILTER;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordInfo.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.map.impl.record;
 
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
@@ -27,7 +28,7 @@ import static com.hazelcast.map.impl.record.Record.NOT_AVAILABLE;
 /**
  * Record info.
  */
-public class RecordInfo implements DataSerializable {
+public class RecordInfo implements IdentifiedDataSerializable {
     protected long version;
     protected long ttl;
     protected long creationTime;
@@ -164,5 +165,15 @@ public class RecordInfo implements DataSerializable {
                 + ", lastStoredTime=" + lastStoredTime
                 + ", expirationTime=" + expirationTime
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.RECORD_INFO;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordReplicationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordReplicationInfo.java
@@ -16,14 +16,14 @@
 
 package com.hazelcast.map.impl.record;
 
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.DataSerializable;
 
 import java.io.IOException;
 
-public class RecordReplicationInfo extends RecordInfo implements DataSerializable {
+public class RecordReplicationInfo extends RecordInfo {
 
     private Data key;
     private Data value;
@@ -66,5 +66,10 @@ public class RecordReplicationInfo extends RecordInfo implements DataSerializabl
                 + "key=" + key
                 + ", value=" + value
                 + "} " + super.toString();
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.RECORD_REPLICATION_INFO;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/HigherHitsMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/HigherHitsMapMergePolicy.java
@@ -17,9 +17,10 @@
 package com.hazelcast.map.merge;
 
 import com.hazelcast.core.EntryView;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
@@ -28,7 +29,7 @@ import java.io.IOException;
  * HigherHitsMapMergePolicy causes the merging entry to be merged from source to destination map
  * if source entry has more hits than the destination one.
  */
-public class HigherHitsMapMergePolicy implements MapMergePolicy, DataSerializable {
+public class HigherHitsMapMergePolicy implements MapMergePolicy, IdentifiedDataSerializable {
 
     @Override
     public Object merge(String mapName, EntryView mergingEntry, EntryView existingEntry) {
@@ -44,5 +45,15 @@ public class HigherHitsMapMergePolicy implements MapMergePolicy, DataSerializabl
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.HIGHER_HITS_MERGE_POLICY;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/LatestUpdateMapMergePolicy.java
@@ -17,8 +17,10 @@
 package com.hazelcast.map.merge;
 
 import com.hazelcast.core.EntryView;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
@@ -28,7 +30,7 @@ import java.io.IOException;
  *
  * This policy can only be used of the clocks of the machines are in sync.
  */
-public class LatestUpdateMapMergePolicy implements MapMergePolicy {
+public class LatestUpdateMapMergePolicy implements MapMergePolicy, IdentifiedDataSerializable {
 
     @Override
     public Object merge(String mapName, EntryView mergingEntry, EntryView existingEntry) {
@@ -44,5 +46,15 @@ public class LatestUpdateMapMergePolicy implements MapMergePolicy {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.LATEST_UPDATE_MERGE_POLICY;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/PassThroughMergePolicy.java
@@ -17,8 +17,10 @@
 package com.hazelcast.map.merge;
 
 import com.hazelcast.core.EntryView;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
@@ -27,7 +29,7 @@ import java.io.IOException;
  * PassThroughMergePolicy causes the merging entry to be merged from source to destination map
  * unless merging entry is null.
  */
-public class PassThroughMergePolicy implements MapMergePolicy {
+public class PassThroughMergePolicy implements MapMergePolicy, IdentifiedDataSerializable {
 
     @Override
     public Object merge(String mapName, EntryView mergingEntry, EntryView existingEntry) {
@@ -40,5 +42,15 @@ public class PassThroughMergePolicy implements MapMergePolicy {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.PASS_THROUGH_MERGE_POLICY;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
@@ -17,9 +17,10 @@
 package com.hazelcast.map.merge;
 
 import com.hazelcast.core.EntryView;
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
@@ -28,7 +29,7 @@ import java.io.IOException;
  * PutIfAbsentMapMergePolicy causes the merging entry to be merged from source to destination map
  * if it does not exist in the destination map.
  */
-public class PutIfAbsentMapMergePolicy implements MapMergePolicy, DataSerializable {
+public class PutIfAbsentMapMergePolicy implements MapMergePolicy, IdentifiedDataSerializable {
 
     @Override
     public Object merge(String mapName, EntryView mergingEntry, EntryView existingEntry) {
@@ -44,5 +45,15 @@ public class PutIfAbsentMapMergePolicy implements MapMergePolicy, DataSerializab
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.PUT_IF_ABSENT_MERGE_POLICY;
     }
 }


### PR DESCRIPTION
Converts following classes from `DataSerializable` to `IdentifiedDataSerializable`:
```
com.hazelcast.map.impl.EntryEventFilter
com.hazelcast.map.impl.EventListenerFilter
com.hazelcast.map.impl.MapPartitionLostEventFilter
com.hazelcast.map.impl.nearcache.invalidation.BatchNearCacheInvalidation
com.hazelcast.map.impl.nearcache.invalidation.ClearNearCacheInvalidation
com.hazelcast.map.impl.nearcache.invalidation.Invalidation
com.hazelcast.map.impl.nearcache.invalidation.SingleNearCacheInvalidation
com.hazelcast.map.impl.nearcache.invalidation.UuidFilter
com.hazelcast.map.impl.operation.AddInterceptorOperation
com.hazelcast.map.impl.operation.ClearExpiredOperation
com.hazelcast.map.impl.operation.MapReplicationOperation
com.hazelcast.map.impl.operation.PostJoinMapOperation
com.hazelcast.map.impl.operation.PostJoinMapOperation$InterceptorInfo
com.hazelcast.map.impl.operation.PostJoinMapOperation$MapIndexInfo
com.hazelcast.map.impl.operation.PostJoinMapOperation$MapIndexInfo$IndexInfo
com.hazelcast.map.impl.operation.RemoveInterceptorOperation
com.hazelcast.map.impl.query.QueryEventFilter
com.hazelcast.map.impl.querycache.event.DefaultQueryCacheEventData
com.hazelcast.map.impl.record.RecordInfo
com.hazelcast.map.impl.record.RecordReplicationInfo
com.hazelcast.map.merge.HigherHitsMapMergePolicy
com.hazelcast.map.merge.LatestUpdateMapMergePolicy
com.hazelcast.map.merge.PassThroughMergePolicy
com.hazelcast.map.merge.PutIfAbsentMapMergePolicy
```

The following `map` package classes were not converted, as they are used in client-member communication and should be marked as @ClientProtocol
```
com.hazelcast.map.impl.event.AbstractEventData
com.hazelcast.map.impl.event.EntryEventData
com.hazelcast.map.impl.event.MapEventData
com.hazelcast.map.impl.event.MapPartitionEventData
```

The following inner classes read/mutate the internal state of MapReplicationOperation, so some more refactoring is required:
```
com.hazelcast.map.impl.operation.MapReplicationOperation$MapReplicationStateHolder
com.hazelcast.map.impl.operation.MapReplicationOperation$WriteBehindStateHolder
```

The following classes will be considered in a separate PR concerning transaction classes in general:
```
com.hazelcast.map.impl.tx.MapTransactionLogRecord
com.hazelcast.map.impl.tx.VersionedValue
```

No EE-side PR is required to merge these changes