### PR TITLE
Added AbstractLocalOperation to reduce boilerplate code

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
@@ -16,10 +16,7 @@
 
 package com.hazelcast.internal.management;
 
-import com.hazelcast.internal.management.operation.ChangeWanStateOperation;
-import com.hazelcast.internal.management.operation.GetMapConfigOperation;
 import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
-import com.hazelcast.internal.management.operation.ThreadDumpOperation;
 import com.hazelcast.internal.management.operation.UpdateManagementCenterUrlOperation;
 import com.hazelcast.internal.management.operation.UpdateMapConfigOperation;
 import com.hazelcast.internal.serialization.DataSerializerHook;
@@ -36,41 +33,26 @@ public class ManagementDataSerializerHook implements DataSerializerHook {
 
     public static final int F_ID = FactoryIdHelper.getFactoryId(MANAGEMENT_DS_FACTORY, MANAGEMENT_DS_FACTORY_ID);
 
-    public static final int CHANGE_WAN = 0;
-    public static final int GET_MAP_CONFIG = 1;
-    public static final int SCRIPT_EXECUTOR = 2;
-    public static final int THREAD_DUMP = 3;
-    public static final int UPDATE_MANAGEMENT_CENTER_URL = 4;
-    public static final int UPDATE_MAP_CONFIG = 5;
+    public static final int SCRIPT_EXECUTOR = 0;
+    public static final int UPDATE_MANAGEMENT_CENTER_URL = 1;
+    public static final int UPDATE_MAP_CONFIG = 2;
 
     private static final int LEN = UPDATE_MAP_CONFIG + 1;
 
+    @Override
     public int getFactoryId() {
         return F_ID;
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
     public DataSerializableFactory createFactory() {
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors
                 = new ConstructorFunction[LEN];
 
-        constructors[CHANGE_WAN] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ChangeWanStateOperation();
-            }
-        };
-        constructors[GET_MAP_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new GetMapConfigOperation();
-            }
-        };
         constructors[SCRIPT_EXECUTOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new ScriptExecutorOperation();
-            }
-        };
-        constructors[THREAD_DUMP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ThreadDumpOperation();
             }
         };
         constructors[UPDATE_MANAGEMENT_CENTER_URL] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AbstractManagementOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AbstractManagementOperation.java
@@ -26,5 +26,4 @@ public abstract class AbstractManagementOperation extends Operation implements I
     public int getFactoryId() {
         return ManagementDataSerializerHook.F_ID;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.management.operation;
 
-import com.hazelcast.internal.management.ManagementDataSerializerHook;
+import com.hazelcast.spi.AbstractLocalOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.wan.WanReplicationService;
 
@@ -24,14 +24,11 @@ import com.hazelcast.wan.WanReplicationService;
  * Enables/Disable publishing events to target cluster in WAN Replication {@link com.hazelcast.wan.WanReplicationService}
  * on a node. This operation does not block adding new events to event queue.
  */
-public class ChangeWanStateOperation extends AbstractManagementOperation {
+public class ChangeWanStateOperation extends AbstractLocalOperation {
 
     private String schemeName;
     private String publisherName;
     private boolean start;
-
-    public ChangeWanStateOperation() {
-    }
 
     public ChangeWanStateOperation(String schemeName, String publisherName, boolean start) {
         this.schemeName = schemeName;
@@ -49,10 +46,5 @@ public class ChangeWanStateOperation extends AbstractManagementOperation {
         } else {
             wanReplicationService.pause(schemeName, publisherName);
         }
-    }
-
-    @Override
-    public int getId() {
-        return ManagementDataSerializerHook.CHANGE_WAN;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/GetMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/GetMapConfigOperation.java
@@ -17,24 +17,16 @@
 package com.hazelcast.internal.management.operation;
 
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-
-import java.io.IOException;
+import com.hazelcast.spi.AbstractLocalOperation;
 
 /**
  *  Operation to fetch Map configuration.
  */
-public class GetMapConfigOperation extends AbstractManagementOperation {
+public class GetMapConfigOperation extends AbstractLocalOperation {
 
     private String mapName;
     private MapConfig mapConfig;
-
-    @SuppressWarnings("unused")
-    public GetMapConfigOperation() {
-    }
 
     public GetMapConfigOperation(String mapName) {
         this.mapName = mapName;
@@ -49,20 +41,5 @@ public class GetMapConfigOperation extends AbstractManagementOperation {
     @Override
     public Object getResponse() {
         return mapConfig;
-    }
-
-    @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeUTF(mapName);
-    }
-
-    @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
-        mapName = in.readUTF();
-    }
-
-    @Override
-    public int getId() {
-        return ManagementDataSerializerHook.GET_MAP_CONFIG;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ThreadDumpOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ThreadDumpOperation.java
@@ -16,25 +16,16 @@
 
 package com.hazelcast.internal.management.operation;
 
-import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.internal.management.ThreadDumpGenerator;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-
-import java.io.IOException;
+import com.hazelcast.spi.AbstractLocalOperation;
 
 /**
  *  Operation for generating thread dumps.
  */
-public class ThreadDumpOperation extends AbstractManagementOperation {
+public class ThreadDumpOperation extends AbstractLocalOperation {
 
     private boolean dumpDeadlocks;
     private String result;
-
-    @SuppressWarnings("unused")
-    public ThreadDumpOperation() {
-        this(false);
-    }
 
     public ThreadDumpOperation(boolean dumpDeadlocks) {
         this.dumpDeadlocks = dumpDeadlocks;
@@ -45,20 +36,8 @@ public class ThreadDumpOperation extends AbstractManagementOperation {
         result = dumpDeadlocks ? ThreadDumpGenerator.dumpDeadlocks() : ThreadDumpGenerator.dumpAllThreads();
     }
 
+    @Override
     public Object getResponse() {
         return result;
-    }
-
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeBoolean(dumpDeadlocks);
-    }
-
-    protected void readInternal(ObjectDataInput in) throws IOException {
-        dumpDeadlocks = in.readBoolean();
-    }
-
-    @Override
-    public int getId() {
-        return ManagementDataSerializerHook.THREAD_DUMP;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
@@ -60,9 +60,7 @@ public class ChangeWanStateRequest implements ConsoleRequest {
 
     @Override
     public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
-        ChangeWanStateOperation changeWanStateOperation =
-                new ChangeWanStateOperation(schemeName, publisherName, start);
-        Object operationResult = mcs.callOnThis(changeWanStateOperation);
+        Object operationResult = mcs.callOnThis(new ChangeWanStateOperation(schemeName, publisherName, start));
         JsonObject result = new JsonObject();
         if (operationResult == null) {
             result.add("result", SUCCESS);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
@@ -26,5 +26,4 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
     public final int getFactoryId() {
         return PartitionDataSerializerHook.F_ID;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPromotionOperation.java
@@ -79,15 +79,17 @@ abstract class AbstractPromotionOperation extends AbstractPartitionOperation
     }
 
     @Override
-    protected void readInternal(ObjectDataInput in)
-            throws IOException {
+    protected void readInternal(ObjectDataInput in) throws IOException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out)
-            throws IOException {
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public int getId() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
@@ -51,9 +51,4 @@ final class BeforePromotionOperation extends AbstractPromotionOperation {
             }
         }
     }
-
-    @Override
-    public int getId() {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
@@ -134,9 +134,4 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
         final InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(getPartitionId());
         partition.setMigrating(false);
     }
-
-    @Override
-    public int getId() {
-        throw new UnsupportedOperationException();
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -21,23 +21,20 @@ import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.AbstractLocalOperation;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.util.Clock;
 
-import java.io.IOException;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * Clear expired records.
+ * Clears expired records.
  */
-public class ClearExpiredOperation extends Operation implements PartitionAwareOperation, MutatingOperation,
-                                                                IdentifiedDataSerializable {
+public class ClearExpiredOperation extends AbstractLocalOperation implements PartitionAwareOperation, MutatingOperation,
+        IdentifiedDataSerializable {
 
     private int expirationPercentage;
 
@@ -86,29 +83,9 @@ public class ClearExpiredOperation extends Operation implements PartitionAwareOp
     }
 
     @Override
-    protected void writeInternal(ObjectDataOutput out) throws IOException {
-        throw new UnsupportedOperationException("ClearExpiredOperation is only used locally.");
-    }
-
-    @Override
-    protected void readInternal(ObjectDataInput in) throws IOException {
-        throw new UnsupportedOperationException("ClearExpiredOperation is only used locally.");
-    }
-
-    @Override
     protected void toString(StringBuilder sb) {
         super.toString(sb);
 
         sb.append(", expirationPercentage=").append(expirationPercentage);
-    }
-
-    @Override
-    public int getFactoryId() {
-        throw new UnsupportedOperationException("ClearExpiredOperation is only used locally.");
-    }
-
-    @Override
-    public int getId() {
-        throw new UnsupportedOperationException("ClearExpiredOperation is only used locally.");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractLocalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractLocalOperation.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * Abstract class for local operations, which should not be serializable.
+ */
+public abstract class AbstractLocalOperation extends Operation implements IdentifiedDataSerializable {
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+
+    @Override
+    public int getFactoryId() {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+
+    @Override
+    public int getId() {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/ParkedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/ParkedOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.impl.operationparker.impl;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.AbstractLocalOperation;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
@@ -35,7 +36,8 @@ import java.util.logging.Level;
 
 import static com.hazelcast.util.EmptyStatement.ignore;
 
-class ParkedOperation extends Operation implements Delayed, PartitionAwareOperation, IdentifiedDataSerializable {
+class ParkedOperation extends AbstractLocalOperation implements Delayed, PartitionAwareOperation, IdentifiedDataSerializable {
+
     final Queue<ParkedOperation> queue;
     final Operation op;
     final BlockingOperation blockingOperation;
@@ -143,7 +145,7 @@ class ParkedOperation extends Operation implements Delayed, PartitionAwareOperat
         }
     }
 
-    //If you don't think instances of this class will ever be inserted into a HashMap/HashTable,
+    // if you don't think instances of this class will ever be inserted into a HashMap/HashTable,
     // the recommended hashCode implementation to use is:
     @Override
     public int hashCode() {
@@ -199,15 +201,5 @@ class ParkedOperation extends Operation implements Delayed, PartitionAwareOperat
         sb.append(", op=").append(op);
         sb.append(", expirationTime=").append(expirationTime);
         sb.append(", valid=").append(valid);
-    }
-
-    @Override
-    public int getFactoryId() {
-        throw new UnsupportedOperationException("local operation only");
-    }
-
-    @Override
-    public int getId() {
-        throw new UnsupportedOperationException("local operation only");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
@@ -2,7 +2,6 @@ package com.hazelcast.internal.management;
 
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.management.operation.ChangeWanStateOperation;
 import com.hazelcast.internal.management.request.ChangeWanStateRequest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -15,7 +14,6 @@ import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -27,12 +25,6 @@ public class ChangeWanStateRequestTest extends HazelcastTestSupport {
     public void setUp() {
         HazelcastInstance hz = createHazelcastInstance();
         managementCenterService = getNode(hz).getManagementCenterService();
-    }
-
-    @Test
-    public void testOperationDefaultConstructor() {
-        ChangeWanStateOperation operation = new ChangeWanStateOperation();
-        assertNotNull(operation);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/AbstractLocalOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/AbstractLocalOperationTest.java
@@ -1,0 +1,39 @@
+package com.hazelcast.spi;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractLocalOperationTest {
+
+    private AbstractLocalOperation operation = new AbstractLocalOperation() {
+        @Override
+        public void run() throws Exception {
+        }
+    };
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testWriteInternal() throws Exception {
+        operation.writeInternal(null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testReadInternal() throws Exception {
+        operation.readInternal(null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetFactoryId() {
+        operation.getFactoryId();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetId() {
+        operation.getId();
+    }
+}


### PR DESCRIPTION
* removed boilerplate code of local operations which directly extend `Operation`
* removed serialization code of local MC operations
* increased code coverage of `ChangeWanStateOperation`, `GetMapConfigOperation` and `ThreadDumpOperation`
* increased code coverage of `ManagementDataSerializerHook`

The modified operations are just used in a local context, so it's impossible to trigger their serialization code:
```
mcs.callOnThis(new ChangeWanStateOperation(schemeName, publisherName, start));
mcs.callOnThis(new GetMapConfigOperation(mapName));
mcs.callOnThis(new ThreadDumpOperation(dumpDeadlocks));
```