### PR TITLE
AbstractCallableTaskOperation made IdentifiedDataSerializable.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -18,12 +18,14 @@ package com.hazelcast.executor.impl.operations;
 
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.executor.impl.DistributedExecutorService;
+import com.hazelcast.executor.impl.ExecutorDataSerializerHook;
 import com.hazelcast.executor.impl.RunnableAdapter;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
@@ -31,7 +33,7 @@ import com.hazelcast.util.ExceptionUtil;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
-abstract class AbstractCallableTaskOperation extends Operation  {
+abstract class AbstractCallableTaskOperation extends Operation implements IdentifiedDataSerializable {
 
     protected String name;
     protected String uuid;
@@ -125,5 +127,10 @@ abstract class AbstractCallableTaskOperation extends Operation  {
         super.toString(sb);
 
         sb.append(", name=").append(name);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ExecutorDataSerializerHook.F_ID;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/CallableTaskOperation.java
@@ -31,11 +31,6 @@ public final class CallableTaskOperation extends AbstractCallableTaskOperation
     }
 
     @Override
-    public int getFactoryId() {
-        return ExecutorDataSerializerHook.F_ID;
-    }
-
-    @Override
     public int getId() {
         return ExecutorDataSerializerHook.CALLABLE_TASK;
     }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/MemberCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/MemberCallableTaskOperation.java
@@ -42,11 +42,6 @@ public final class MemberCallableTaskOperation extends AbstractCallableTaskOpera
     }
 
     @Override
-    public int getFactoryId() {
-        return ExecutorDataSerializerHook.F_ID;
-    }
-
-    @Override
     public int getId() {
         return ExecutorDataSerializerHook.MEMBER_CALLABLE_TASK;
     }


### PR DESCRIPTION
All of its final subclasses were already implementing `IdentifiedDataSerializable`.