### PR TITLE
Convert TransactionLogRecord hierarchy to IdentifiedDataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
@@ -41,6 +41,7 @@ import com.hazelcast.collection.impl.list.operations.ListSetOperation;
 import com.hazelcast.collection.impl.list.operations.ListSubOperation;
 import com.hazelcast.collection.impl.set.SetContainer;
 import com.hazelcast.collection.impl.set.operations.SetReplicationOperation;
+import com.hazelcast.collection.impl.txncollection.CollectionTransactionLogRecord;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionCommitBackupOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionCommitOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionPrepareBackupOperation;
@@ -54,6 +55,7 @@ import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnAddBa
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnAddOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnRemoveBackupOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTxnRemoveOperation;
+import com.hazelcast.collection.impl.txnqueue.QueueTransactionLogRecord;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
@@ -117,6 +119,8 @@ public class CollectionDataSerializerHook implements DataSerializerHook {
 
     public static final int SET_CONTAINER = 41;
     public static final int LIST_CONTAINER = 42;
+    public static final int COLLECTION_TRANSACTION_LOG_RECORD = 43;
+    public static final int QUEUE_TRANSACTION_LOG_RECORD = 43;
 
     @Override
     public int getFactoryId() {
@@ -126,7 +130,7 @@ public class CollectionDataSerializerHook implements DataSerializerHook {
     @Override
     public DataSerializableFactory createFactory() {
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors
-                = new ConstructorFunction[LIST_CONTAINER + 1];
+                = new ConstructorFunction[QUEUE_TRANSACTION_LOG_RECORD + 1];
 
         constructors[COLLECTION_ADD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
@@ -338,6 +342,16 @@ public class CollectionDataSerializerHook implements DataSerializerHook {
         constructors[LIST_CONTAINER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new ListContainer();
+            }
+        };
+        constructors[COLLECTION_TRANSACTION_LOG_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CollectionTransactionLogRecord();
+            }
+        };
+        constructors[QUEUE_TRANSACTION_LOG_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new QueueTransactionLogRecord();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/CollectionTransactionLogRecord.java
@@ -17,6 +17,7 @@
 package com.hazelcast.collection.impl.txncollection;
 
 import com.hazelcast.collection.impl.CollectionTxnUtil;
+import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionCommitOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionPrepareOperation;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionRollbackOperation;
@@ -126,5 +127,13 @@ public class CollectionTransactionLogRecord implements TransactionLogRecord {
         operationList = CollectionTxnUtil.read(in);
     }
 
+    @Override
+    public int getFactoryId() {
+        return CollectionDataSerializerHook.F_ID;
+    }
 
+    @Override
+    public int getId() {
+        return CollectionDataSerializerHook.COLLECTION_TRANSACTION_LOG_RECORD;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/QueueTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/QueueTransactionLogRecord.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.collection.impl.txnqueue;
 
+import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.collection.impl.txncollection.CollectionTransactionLogRecord;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnCommitOperation;
@@ -50,5 +51,10 @@ public class QueueTransactionLogRecord extends CollectionTransactionLogRecord {
     public Operation newRollbackOperation() {
         long[] itemIds = createItemIdArray();
         return new TxnRollbackOperation(partitionId, name, itemIds);
+    }
+
+    @Override
+    public int getId() {
+        return CollectionDataSerializerHook.QUEUE_TRANSACTION_LOG_RECORD;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -79,8 +79,9 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public static final int SET_MASTER = 24;
     public static final int SHUTDOWN_NODE = 25;
     public static final int TRIGGER_MEMBER_LIST_PUBLISH = 26;
+    public static final int CLUSTER_STATE_TRANSACTION_LOG_RECORD = 27;
 
-    private static final int LEN = TRIGGER_MEMBER_LIST_PUBLISH + 1;
+    private static final int LEN = CLUSTER_STATE_TRANSACTION_LOG_RECORD + 1;
 
     @Override
     public int getFactoryId() {
@@ -224,6 +225,11 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
         constructors[TRIGGER_MEMBER_LIST_PUBLISH] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new TriggerMemberListPublishOperation();
+            }
+        };
+        constructors[CLUSTER_STATE_TRANSACTION_LOG_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new ClusterStateTransactionLogRecord();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -114,4 +114,14 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         partitionStateVersion = in.readInt();
         isTransient = in.readBoolean();
     }
+
+    @Override
+    public int getFactoryId() {
+        return ClusterDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.CLUSTER_STATE_TRANSACTION_LOG_RECORD;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -104,6 +104,7 @@ import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
 import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.map.impl.record.RecordReplicationInfo;
+import com.hazelcast.map.impl.tx.MapTransactionLogRecord;
 import com.hazelcast.map.impl.tx.TxnDeleteOperation;
 import com.hazelcast.map.impl.tx.TxnLockAndGetOperation;
 import com.hazelcast.map.impl.tx.TxnPrepareBackupOperation;
@@ -240,8 +241,9 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int PUT_IF_ABSENT_MERGE_POLICY = 108;
     public static final int UUID_FILTER = 109;
     public static final int CLEAR_NEAR_CACHE_INVALIDATION = 110;
+    public static final int MAP_TRANSACTION_LOG_RECORD = 111;
 
-    private static final int LEN = CLEAR_NEAR_CACHE_INVALIDATION + 1;
+    private static final int LEN = MAP_TRANSACTION_LOG_RECORD + 1;
 
     @Override
     public int getFactoryId() {
@@ -800,6 +802,11 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[CLEAR_NEAR_CACHE_INVALIDATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new ClearNearCacheInvalidation();
+            }
+        };
+        constructors[MAP_TRANSACTION_LOG_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapTransactionLogRecord();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/MapTransactionLogRecord.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.tx;
 
+import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapRecordKey;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -116,5 +117,15 @@ public class MapTransactionLogRecord implements TransactionLogRecord {
                 + ", ownerUuid='" + ownerUuid + '\''
                 + ", op=" + op
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.MAP_TRANSACTION_LOG_RECORD;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapDataSerializerHook.java
@@ -35,6 +35,7 @@ import com.hazelcast.multimap.impl.operations.RemoveBackupOperation;
 import com.hazelcast.multimap.impl.operations.RemoveOperation;
 import com.hazelcast.multimap.impl.operations.SizeOperation;
 import com.hazelcast.multimap.impl.operations.ValuesOperation;
+import com.hazelcast.multimap.impl.txn.MultiMapTransactionLogRecord;
 import com.hazelcast.multimap.impl.txn.TxnCommitBackupOperation;
 import com.hazelcast.multimap.impl.txn.TxnCommitOperation;
 import com.hazelcast.multimap.impl.txn.TxnGenerateRecordIdOperation;
@@ -103,6 +104,7 @@ public class MultiMapDataSerializerHook implements DataSerializerHook {
     public static final int TXN_ROLLBACK = 39;
     public static final int TXN_ROLLBACK_BACKUP = 40;
     public static final int MULTIMAP_OP_FACTORY = 41;
+    public static final int MULTIMAP_TRANSACTION_LOG_RECORD = 42;
 
 
     public int getFactoryId() {
@@ -111,7 +113,7 @@ public class MultiMapDataSerializerHook implements DataSerializerHook {
 
     public DataSerializableFactory createFactory() {
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors
-                = new ConstructorFunction[MULTIMAP_OP_FACTORY + 1];
+                = new ConstructorFunction[MULTIMAP_TRANSACTION_LOG_RECORD + 1];
         constructors[CLEAR_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new ClearBackupOperation();
@@ -262,6 +264,11 @@ public class MultiMapDataSerializerHook implements DataSerializerHook {
         constructors[MULTIMAP_OP_FACTORY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new MultiMapOperationFactory();
+            }
+        };
+        constructors[MULTIMAP_TRANSACTION_LOG_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MultiMapTransactionLogRecord();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/MultiMapTransactionLogRecord.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.txn;
 
+import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -155,4 +156,13 @@ public class MultiMapTransactionLogRecord implements TransactionLogRecord {
                 + '}';
     }
 
+    @Override
+    public int getFactoryId() {
+        return MultiMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MultiMapDataSerializerHook.MULTIMAP_TRANSACTION_LOG_RECORD;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionLogRecord.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.transaction.impl;
 
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
 /**
@@ -24,7 +24,7 @@ import com.hazelcast.spi.Operation;
  *
  * @see Transaction
  */
-public interface TransactionLogRecord extends DataSerializable {
+public interface TransactionLogRecord extends IdentifiedDataSerializable {
 
     /**
      * Gets the transaction-log-key that uniquely identifies the {@link TransactionLogRecord} within the {@link TransactionLog}.

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionStressTest.java
@@ -368,6 +368,16 @@ public class MapTransactionStressTest extends HazelcastTestSupport {
         public String toString() {
             return "SleepyTransactionLogRecord{}";
         }
+
+        @Override
+        public int getFactoryId() {
+            return 0;
+        }
+
+        @Override
+        public int getId() {
+            return 0;
+        }
     }
 
     static class TxnIncrementor implements Runnable {

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
@@ -1,9 +1,14 @@
 package com.hazelcast.transaction.impl;
 
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.util.ConstructorFunction;
 
 import java.io.IOException;
 
@@ -11,8 +16,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class MockTransactionLogRecord implements TransactionLogRecord {
-
-    //public final static ConcurrentMap<String, AtomicInteger> prepare
 
     private boolean failPrepare;
     private boolean failCommit;
@@ -137,6 +140,40 @@ public class MockTransactionLogRecord implements TransactionLogRecord {
         @Override
         protected void readInternal(ObjectDataInput in) throws IOException {
             fail = in.readBoolean();
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MockTransactionLogRecordSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MockTransactionLogRecordSerializerHook.MOCK_TRANSACTION_LOG_RECORD;
+    }
+
+    public static class MockTransactionLogRecordSerializerHook implements DataSerializerHook {
+        public static final int F_ID = 1;
+        public static final int MOCK_TRANSACTION_LOG_RECORD = 0;
+        public static final int LEN = MOCK_TRANSACTION_LOG_RECORD + 1;
+
+        @Override
+        public int getFactoryId() {
+            return F_ID;
+        }
+
+        @Override
+        public DataSerializableFactory createFactory() {
+            ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
+
+            constructors[MOCK_TRANSACTION_LOG_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                public IdentifiedDataSerializable createNew(Integer arg) {
+                    return new MockTransactionLogRecord();
+                }
+            };
+
+            return new ArrayDataSerializableFactory(constructors);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_OnePhaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_OnePhaseTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.transaction.impl;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.util.counters.MwCounter;
@@ -126,5 +127,14 @@ public class TransactionImpl_OnePhaseTest extends HazelcastTestSupport {
 
         tx.rollback();
         assertEquals(ROLLED_BACK, tx.getState());
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = new Config();
+        config.getSerializationConfig().addDataSerializableFactory(
+                MockTransactionLogRecord.MockTransactionLogRecordSerializerHook.F_ID,
+                new MockTransactionLogRecord.MockTransactionLogRecordSerializerHook().createFactory());
+        return config;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.transaction.impl;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
@@ -41,7 +42,7 @@ public class TransactionImpl_TwoPhaseIntegrationTest extends HazelcastTestSuppor
     @Before
     public void setup() {
         setLoggingLog4j();
-        cluster = createHazelcastInstanceFactory(2).newInstances();
+        cluster = createHazelcastInstanceFactory(2).newInstances(getConfig());
         localNodeEngine = getNodeEngineImpl(cluster[0]);
         localTxService = getTransactionManagerService(cluster[0]);
         remoteTxService = getTransactionManagerService(cluster[1]);
@@ -321,4 +322,12 @@ public class TransactionImpl_TwoPhaseIntegrationTest extends HazelcastTestSuppor
         });
     }
 
+    @Override
+    protected Config getConfig() {
+        Config config = new Config();
+        config.getSerializationConfig().addDataSerializableFactory(
+                MockTransactionLogRecord.MockTransactionLogRecordSerializerHook.F_ID,
+                new MockTransactionLogRecord.MockTransactionLogRecordSerializerHook().createFactory());
+        return config;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseTest.java
@@ -1,5 +1,6 @@
 package com.hazelcast.transaction.impl;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.util.counters.MwCounter;
@@ -221,5 +222,15 @@ public class TransactionImpl_TwoPhaseTest extends HazelcastTestSupport {
 
         tx.rollback();
         assertEquals(ROLLED_BACK, tx.getState());
+    }
+
+
+    @Override
+    protected Config getConfig() {
+        Config config = new Config();
+        config.getSerializationConfig().addDataSerializableFactory(
+                MockTransactionLogRecord.MockTransactionLogRecordSerializerHook.F_ID,
+                new MockTransactionLogRecord.MockTransactionLogRecordSerializerHook().createFactory());
+        return config;
     }
 }


### PR DESCRIPTION
TransactionLogRecord and subclasses converted to `IdentifiedDataSerializable`