### PR TITLE
Findbugs failure - Load of known null value in com.hazelcast.client.impl.protocol.task.cache.AbstractCacheMessageTask.serializeCacheConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheMessageTask.java
@@ -75,13 +75,8 @@ public abstract class AbstractCacheMessageTask<P>
     }
 
     protected Data serializeCacheConfig(Object response) {
-        if (null == response) {
-            return nodeEngine.toData(response);
-        }
-
         Data responseData = null;
-        int clientVersion = getClientVersion();
-        if (BuildInfo.UNKNOWN_HAZELCAST_VERSION == clientVersion) {
+        if (BuildInfo.UNKNOWN_HAZELCAST_VERSION == getClientVersion()) {
             boolean compatibilityEnabled = nodeEngine.getProperties().getBoolean(GroupProperty.COMPATIBILITY_3_6_CLIENT_ENABLED);
             if (compatibilityEnabled) {
                 responseData = nodeEngine.toData(new LegacyCacheConfig((CacheConfig) response));


### PR DESCRIPTION
Findbugs fix for : Load of known null value in com.hazelcast.client.impl.protocol.task.cache.AbstractCacheMessageTask.serializeCacheConfig(Object) [com.hazelcast.client.impl.protocol.task.cache.AbstractCacheMessageTask] At AbstractCacheMessageTask.java:[line 79]