### PR TITLE
Internal classes converted to IdentifiedDataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextProtocolsDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextProtocolsDataSerializerHook.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.internal.ascii.memcache.MemcacheEntry;
+import com.hazelcast.internal.ascii.rest.RestValue;
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.TEXT_PROTOCOLS_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.TEXT_PROTOCOLS_DS_FACTORY_ID;
+
+/**
+ * DataSerializerHook for memcache & REST protocol support classes
+ */
+public final class TextProtocolsDataSerializerHook implements DataSerializerHook {
+    public static final int F_ID = FactoryIdHelper.getFactoryId(TEXT_PROTOCOLS_DS_FACTORY, TEXT_PROTOCOLS_DS_FACTORY_ID);
+
+    public static final int MEMCACHE_ENTRY = 0;
+    public static final int REST_VALUE = 1;
+
+    public static final int LEN = REST_VALUE + 1;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
+
+        constructors[MEMCACHE_ENTRY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MemcacheEntry();
+            }
+        };
+        constructors[REST_VALUE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new RestValue();
+            }
+        };
+
+        return new ArrayDataSerializableFactory(constructors);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheEntry.java
@@ -17,9 +17,10 @@
 package com.hazelcast.internal.ascii.memcache;
 
 import com.hazelcast.internal.ascii.TextCommandConstants;
+import com.hazelcast.internal.ascii.TextProtocolsDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import static com.hazelcast.util.StringUtil.bytesToString;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
 @SuppressFBWarnings("EI_EXPOSE_REP")
-public class MemcacheEntry implements DataSerializable {
+public class MemcacheEntry implements IdentifiedDataSerializable {
     private byte[] bytes;
     private byte[] value;
     private int flag;
@@ -147,5 +148,15 @@ public class MemcacheEntry implements DataSerializable {
                 + ", flag="
                 + flag
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return TextProtocolsDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return TextProtocolsDataSerializerHook.MEMCACHE_ENTRY;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/RestValue.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.internal.ascii.rest;
 
+import com.hazelcast.internal.ascii.TextProtocolsDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -26,7 +27,7 @@ import java.io.IOException;
 import static com.hazelcast.util.StringUtil.bytesToString;
 
 @SuppressFBWarnings("EI_EXPOSE_REP")
-public class RestValue implements DataSerializable {
+public class RestValue implements IdentifiedDataSerializable {
     private byte[] value;
     private byte[] contentType;
 
@@ -88,5 +89,15 @@ public class RestValue implements DataSerializable {
                 + contentTypeStr
                 + "', " + valueStr
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return TextProtocolsDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return TextProtocolsDataSerializerHook.REST_VALUE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -17,17 +17,18 @@
 package com.hazelcast.internal.cluster;
 
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class MemberInfo implements DataSerializable {
+public class MemberInfo implements IdentifiedDataSerializable {
 
     private Address address;
     private String uuid;
@@ -147,5 +148,15 @@ public class MemberInfo implements DataSerializable {
                 + ", uuid=" + uuid
                 + ", liteMember=" + liteMember
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClusterDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.MEMBER_INFO;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.operations.AuthenticationFailureOperation;
 import com.hazelcast.internal.cluster.impl.operations.AuthorizationOperation;
 import com.hazelcast.internal.cluster.impl.operations.BeforeJoinCheckFailureOperation;
@@ -40,6 +41,7 @@ import com.hazelcast.internal.cluster.impl.operations.RollbackClusterStateOperat
 import com.hazelcast.internal.cluster.impl.operations.SetMasterOperation;
 import com.hazelcast.internal.cluster.impl.operations.ShutdownNodeOperation;
 import com.hazelcast.internal.cluster.impl.operations.TriggerMemberListPublishOperation;
+import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.nio.Address;
@@ -66,7 +68,7 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public static final int CONFIG_MISMATCH = 11;
     public static final int GROUP_MISMATCH = 12;
     public static final int JOIN_CHECK = 13;
-    public static final int JOIN_REQUEST = 14;
+    public static final int JOIN_REQUEST_OP = 14;
     public static final int LOCK_CLUSTER_STATE = 15;
     public static final int MASTER_CLAIM = 16;
     public static final int MASTER_CONFIRM = 17;
@@ -80,8 +82,12 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public static final int SHUTDOWN_NODE = 25;
     public static final int TRIGGER_MEMBER_LIST_PUBLISH = 26;
     public static final int CLUSTER_STATE_TRANSACTION_LOG_RECORD = 27;
+    public static final int MEMBER_INFO = 28;
+    public static final int JOIN_MESSAGE = 29;
+    public static final int JOIN_REQUEST = 30;
+    public static final int MIGRATION_INFO = 31;
 
-    private static final int LEN = CLUSTER_STATE_TRANSACTION_LOG_RECORD + 1;
+    private static final int LEN = MIGRATION_INFO + 1;
 
     @Override
     public int getFactoryId() {
@@ -162,7 +168,7 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
                 return new JoinCheckOperation();
             }
         };
-        constructors[JOIN_REQUEST] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+        constructors[JOIN_REQUEST_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new JoinRequestOperation();
             }
@@ -230,6 +236,26 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
         constructors[CLUSTER_STATE_TRANSACTION_LOG_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new ClusterStateTransactionLogRecord();
+            }
+        };
+        constructors[MEMBER_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MemberInfo();
+            }
+        };
+        constructors[JOIN_MESSAGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new JoinMessage();
+            }
+        };
+        constructors[JOIN_REQUEST] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new JoinRequest();
+            }
+        };
+        constructors[MIGRATION_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MigrationInfo();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessage.java
@@ -19,14 +19,14 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-public class JoinMessage implements DataSerializable {
+public class JoinMessage implements IdentifiedDataSerializable {
 
     protected byte packetVersion;
     protected int buildNumber;
@@ -146,4 +146,13 @@ public class JoinMessage implements DataSerializable {
                 + '}';
     }
 
+    @Override
+    public int getFactoryId() {
+        return ClusterDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.JOIN_MESSAGE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -20,14 +20,13 @@ import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.security.Credentials;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class JoinRequest extends JoinMessage implements DataSerializable {
+public class JoinRequest extends JoinMessage {
 
     private Credentials credentials;
     private int tryCount;
@@ -106,4 +105,8 @@ public class JoinRequest extends JoinMessage implements DataSerializable {
                 + '}';
     }
 
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.JOIN_REQUEST;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOperation.java
@@ -65,6 +65,6 @@ public class JoinRequestOperation extends AbstractClusterOperation implements Jo
 
     @Override
     public int getId() {
-        return ClusterDataSerializerHook.JOIN_REQUEST;
+        return ClusterDataSerializerHook.JOIN_REQUEST_OP;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.management;
 
+import com.hazelcast.internal.management.dto.MapConfigDTO;
 import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
 import com.hazelcast.internal.management.operation.UpdateManagementCenterUrlOperation;
 import com.hazelcast.internal.management.operation.UpdateMapConfigOperation;
@@ -36,8 +37,9 @@ public class ManagementDataSerializerHook implements DataSerializerHook {
     public static final int SCRIPT_EXECUTOR = 0;
     public static final int UPDATE_MANAGEMENT_CENTER_URL = 1;
     public static final int UPDATE_MAP_CONFIG = 2;
+    public static final int MAP_CONFIG_DTO = 3;
 
-    private static final int LEN = UPDATE_MAP_CONFIG + 1;
+    private static final int LEN = MAP_CONFIG_DTO + 1;
 
     @Override
     public int getFactoryId() {
@@ -63,6 +65,11 @@ public class ManagementDataSerializerHook implements DataSerializerHook {
         constructors[UPDATE_MAP_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new UpdateMapConfigOperation();
+            }
+        };
+        constructors[MAP_CONFIG_DTO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapConfigDTO();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/MapConfigDTO.java
@@ -22,9 +22,10 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.internal.management.JsonSerializable;
+import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
@@ -36,7 +37,7 @@ import static com.hazelcast.util.JsonUtil.getString;
 /**
  * Serializable adapter for {@link com.hazelcast.config.MapConfig}
  */
-public class MapConfigDTO implements JsonSerializable, DataSerializable {
+public class MapConfigDTO implements JsonSerializable, IdentifiedDataSerializable {
 
     private MapConfig config;
 
@@ -122,5 +123,15 @@ public class MapConfigDTO implements JsonSerializable, DataSerializable {
 
     public MapConfig getMapConfig() {
         return config;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ManagementDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ManagementDataSerializerHook.MAP_CONFIG_DTO;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
@@ -16,10 +16,11 @@
 
 package com.hazelcast.internal.partition;
 
+import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.util.UuidUtil;
 
 import java.io.DataInput;
@@ -27,7 +28,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class MigrationInfo implements DataSerializable {
+public class MigrationInfo implements IdentifiedDataSerializable {
 
     public enum MigrationStatus {
 
@@ -263,5 +264,15 @@ public class MigrationInfo implements DataSerializable {
         sb.append(", status=").append(status);
         sb.append('}');
         return sb.toString();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClusterDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.MIGRATION_INFO;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -112,6 +112,10 @@ public final class FactoryIdHelper {
 
     public static final String MANAGEMENT_DS_FACTORY = "hazelcast.serialization.ds.management";
     public static final int MANAGEMENT_DS_FACTORY_ID = -36;
+
+    public static final String TEXT_PROTOCOLS_DS_FACTORY = "hazelcast.serialization.ds.text.protocols";
+    public static final int TEXT_PROTOCOLS_DS_FACTORY_ID = -37;
+
     // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -24,4 +24,4 @@ com.hazelcast.query.impl.predicates.PredicateDataSerializerHook
 com.hazelcast.cardinality.impl.CardinalityEstimatorDataSerializerHook
 com.hazelcast.client.impl.ClientDataSerializerHook
 com.hazelcast.internal.management.ManagementDataSerializerHook
-
+com.hazelcast.internal.ascii.TextProtocolsDataSerializerHook


### PR DESCRIPTION
Introduces new `TextProtocolsDataSerializerHook` for REST & Memcache protocol support classes.
Converts `com.hazelcast.internal` classes from `DataSerializable` to `IdentifiedDataSerializable`.
After merge, requires an EE-side counterpart to register the new `DataSerializerHook`.