### PR TITLE
Fix QueueTransactionLogRecord type ID

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
@@ -120,7 +120,7 @@ public class CollectionDataSerializerHook implements DataSerializerHook {
     public static final int SET_CONTAINER = 41;
     public static final int LIST_CONTAINER = 42;
     public static final int COLLECTION_TRANSACTION_LOG_RECORD = 43;
-    public static final int QUEUE_TRANSACTION_LOG_RECORD = 43;
+    public static final int QUEUE_TRANSACTION_LOG_RECORD = 44;
 
     @Override
     public int getFactoryId() {


### PR DESCRIPTION
QueueTransactionLogRecord ID slipped through being the same with CollectionTransactionLogRecord one.
A test to verify `IdentifiedDataSerializable`s have unique {factoryId, id} combinations will be provided in #9102 along with other related tests once conversion to `IdentifiedDataSerializable` is done.