### PR TITLE
Delegate resolution of ValueRetrievalException in inner delegate

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/cache/HazelcastCache.java
@@ -91,7 +91,7 @@ public class HazelcastCache implements Cache {
         try {
             value = valueLoader.call();
         } catch (Exception ex) {
-            throw new ValueRetrievalException(key, valueLoader, ex);
+            throw ValueRetrievalExceptionResolver.resolveException(key, valueLoader, ex);
         }
         put(key, value);
         return value;
@@ -158,4 +158,13 @@ public class HazelcastCache implements Cache {
             return 0;
         }
     }
+
+    private static class ValueRetrievalExceptionResolver {
+
+        static RuntimeException resolveException(Object key, Callable<?> valueLoader,
+                Throwable ex) {
+            return new ValueRetrievalException(key, valueLoader, ex);
+        }
+    }
+
 }


### PR DESCRIPTION
This commit fixes a `ClassNotFoundException` on
`Cache$ValueRetrievalException` when using the cache abstraction with
Spring Framework prior to 4.3.

`ValueRetrievalException` is an inner exception class introduced in
Spring Framework 4.3. Throwing that exception in the body of a method
should have been working fine but for some reason the body of the method
is resolved upfront when the class is loaded.

This commits moves the resolution to an inner class to enforce that such
type is not going to be loaded unless the class is invoked explicitly and
this only happens if the `sync` attribute is used (new in 4.3).

Closes gh-9023