### PR TITLE
Refactoring of the MapQueryEngine required by the fast-aggregations and projections

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -24,6 +24,7 @@ import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.eviction.ExpirationManager;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
+import com.hazelcast.map.impl.query.MapLocalQueryRunner;
 import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.merge.MergePolicyProvider;
@@ -131,6 +132,8 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     MapEventPublisher getMapEventPublisher();
 
     MapQueryEngine getMapQueryEngine(String name);
+
+    MapLocalQueryRunner getMapQueryRunner();
 
     QueryOptimizer getQueryOptimizer();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -133,7 +133,7 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     MapQueryEngine getMapQueryEngine(String name);
 
-    MapLocalQueryRunner getMapQueryRunner();
+    MapLocalQueryRunner getMapQueryRunner(String name);
 
     QueryOptimizer getQueryOptimizer();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -34,7 +34,7 @@ import com.hazelcast.map.impl.operation.GetOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.map.impl.operation.MapOperationProviders;
 import com.hazelcast.map.impl.operation.MapPartitionDestroyTask;
-import com.hazelcast.map.impl.query.MapLocalParallerQueryRunner;
+import com.hazelcast.map.impl.query.MapLocalParallelQueryRunner;
 import com.hazelcast.map.impl.query.MapLocalQueryRunner;
 import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.query.MapQueryEngineImpl;
@@ -155,7 +155,7 @@ class MapServiceContextImpl implements MapServiceContext {
         boolean parallelEvaluation = nodeEngine.getProperties().getBoolean(QUERY_PREDICATE_PARALLEL_EVALUATION);
         if (parallelEvaluation) {
             ManagedExecutorService queryExecutorService = nodeEngine.getExecutionService().getExecutor(QUERY_EXECUTOR);
-            return new MapLocalParallerQueryRunner(this, queryOptimizer, queryExecutorService);
+            return new MapLocalParallelQueryRunner(this, queryOptimizer, queryExecutorService);
         } else {
             return new MapLocalQueryRunner(this, queryOptimizer);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -136,22 +136,30 @@ class MapServiceContextImpl implements MapServiceContext {
         this.partitioningStrategyFactory = new PartitioningStrategyFactory(nodeEngine.getConfigClassLoader());
     }
 
+    // this method is overridden in another context.
     MapOperationProviders createOperationProviders() {
         return new MapOperationProviders(this);
     }
 
     // this method is overridden in another context.
-    LocalMapStatsProvider createLocalMapStatsProvider() {
+    NearCacheProvider createNearCacheProvider() {
+        return new NearCacheProvider(this);
+    }
+
+    // this method is overridden in another context.
+    MapEventPublisherImpl createMapEventPublisherSupport() {
+        return new MapEventPublisherImpl(this);
+    }
+
+    private LocalMapStatsProvider createLocalMapStatsProvider() {
         return new LocalMapStatsProvider(this);
     }
 
-    // this method is overridden in another context.
-    MapQueryEngineImpl createMapQueryEngine() {
+    private MapQueryEngineImpl createMapQueryEngine() {
         return new MapQueryEngineImpl(this);
     }
 
-    // this method is overridden in another context.
-    MapLocalQueryRunner createMapQueryRunner(NodeEngine nodeEngine, QueryOptimizer queryOptimizer) {
+    private MapLocalQueryRunner createMapQueryRunner(NodeEngine nodeEngine, QueryOptimizer queryOptimizer) {
         boolean parallelEvaluation = nodeEngine.getProperties().getBoolean(QUERY_PREDICATE_PARALLEL_EVALUATION);
         if (parallelEvaluation) {
             ManagedExecutorService queryExecutorService = nodeEngine.getExecutionService().getExecutor(QUERY_EXECUTOR);
@@ -161,19 +169,9 @@ class MapServiceContextImpl implements MapServiceContext {
         }
     }
 
-    // this method is overridden in another context.
-    NearCacheProvider createNearCacheProvider() {
-        return new NearCacheProvider(this);
-    }
-
-    PartitionContainer[] createPartitionContainers() {
+    private PartitionContainer[] createPartitionContainers() {
         int partitionCount = nodeEngine.getPartitionService().getPartitionCount();
         return new PartitionContainer[partitionCount];
-    }
-
-    // this method is overridden.
-    MapEventPublisherImpl createMapEventPublisherSupport() {
-        return new MapEventPublisherImpl(this);
     }
 
     @Override
@@ -386,7 +384,7 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
-    public MapLocalQueryRunner getMapQueryRunner() {
+    public MapLocalQueryRunner getMapQueryRunner(String name) {
         return mapQueryRunner;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -34,6 +34,8 @@ import com.hazelcast.map.impl.operation.GetOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.map.impl.operation.MapOperationProviders;
 import com.hazelcast.map.impl.operation.MapPartitionDestroyTask;
+import com.hazelcast.map.impl.query.MapLocalParallerQueryRunner;
+import com.hazelcast.map.impl.query.MapLocalQueryRunner;
 import com.hazelcast.map.impl.query.MapQueryEngine;
 import com.hazelcast.map.impl.query.MapQueryEngineImpl;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
@@ -56,6 +58,7 @@ import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ContextMutexFactory;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.executor.ManagedExecutorService;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -74,6 +77,8 @@ import static com.hazelcast.map.impl.ListenerAdapters.createListenerAdapter;
 import static com.hazelcast.map.impl.MapListenerFlagOperator.setAndGetListenerFlags;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.query.impl.predicates.QueryOptimizerFactory.newOptimizer;
+import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
+import static com.hazelcast.spi.properties.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
 
 /**
  * Default implementation of map service context.
@@ -104,6 +109,7 @@ class MapServiceContextImpl implements MapServiceContext {
     protected final LocalMapStatsProvider localMapStatsProvider;
     protected final MergePolicyProvider mergePolicyProvider;
     protected final MapQueryEngine mapQueryEngine;
+    protected final MapLocalQueryRunner mapQueryRunner;
     protected final QueryOptimizer queryOptimizer;
     protected final ContextMutexFactory contextMutexFactory = new ContextMutexFactory();
     protected final PartitioningStrategyFactory partitioningStrategyFactory;
@@ -123,7 +129,8 @@ class MapServiceContextImpl implements MapServiceContext {
         this.mergePolicyProvider = new MergePolicyProvider(nodeEngine);
         this.mapEventPublisher = createMapEventPublisherSupport();
         this.queryOptimizer = newOptimizer(nodeEngine.getProperties());
-        this.mapQueryEngine = createMapQueryEngine(queryOptimizer);
+        this.mapQueryEngine = createMapQueryEngine();
+        this.mapQueryRunner = createMapQueryRunner(nodeEngine, queryOptimizer);
         this.eventService = nodeEngine.getEventService();
         this.operationProviders = createOperationProviders();
         this.partitioningStrategyFactory = new PartitioningStrategyFactory(nodeEngine.getConfigClassLoader());
@@ -139,8 +146,19 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     // this method is overridden in another context.
-    MapQueryEngineImpl createMapQueryEngine(QueryOptimizer queryOptimizer) {
-        return new MapQueryEngineImpl(this, queryOptimizer);
+    MapQueryEngineImpl createMapQueryEngine() {
+        return new MapQueryEngineImpl(this);
+    }
+
+    // this method is overridden in another context.
+    MapLocalQueryRunner createMapQueryRunner(NodeEngine nodeEngine, QueryOptimizer queryOptimizer) {
+        boolean parallelEvaluation = nodeEngine.getProperties().getBoolean(QUERY_PREDICATE_PARALLEL_EVALUATION);
+        if (parallelEvaluation) {
+            ManagedExecutorService queryExecutorService = nodeEngine.getExecutionService().getExecutor(QUERY_EXECUTOR);
+            return new MapLocalParallerQueryRunner(this, queryOptimizer, queryExecutorService);
+        } else {
+            return new MapLocalQueryRunner(this, queryOptimizer);
+        }
     }
 
     // this method is overridden in another context.
@@ -365,6 +383,11 @@ class MapServiceContextImpl implements MapServiceContext {
     @Override
     public MapQueryEngine getMapQueryEngine(String mapName) {
         return mapQueryEngine;
+    }
+
+    @Override
+    public MapLocalQueryRunner getMapQueryRunner() {
+        return mapQueryRunner;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -639,7 +639,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
         MapQueryEngine queryEngine = getMapQueryEngine();
         if (predicate instanceof PagingPredicate) {
-            return queryEngine.queryAllPartitionsWithPagingPredicate(name, (PagingPredicate) predicate, iterationType);
+            return queryEngine.runQueryOnAllPartitionsWithPagingPredicate(name, (PagingPredicate) predicate, iterationType);
         }
 
         QueryResult result;
@@ -647,10 +647,10 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
             PartitionPredicate partitionPredicate = (PartitionPredicate) predicate;
             Data key = toData(partitionPredicate.getPartitionKey());
             int partitionId = getNodeEngine().getPartitionService().getPartitionId(key);
-            result = queryEngine.invokeQuerySinglePartition(
+            result = queryEngine.runQueryOnSinglePartition(
                     name, partitionPredicate.getTarget(), iterationType, partitionId);
         } else {
-            result = queryEngine.invokeQueryAllPartitions(name, predicate, iterationType);
+            result = queryEngine.runQueryOnAllPartitions(name, predicate, iterationType);
         }
         return new QueryResultCollection<Map.Entry<K, V>>(
                 getNodeEngine().getSerializationService(), iterationType, false, unique, result);
@@ -668,9 +668,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
         MapQueryEngine queryEngine = getMapQueryEngine();
         if (predicate instanceof PagingPredicate) {
-            return queryEngine.queryLocalPartitionsWithPagingPredicate(name, (PagingPredicate) predicate, IterationType.KEY);
+            return queryEngine.runQueryOnLocalPartitionsWithPagingPredicate(name, (PagingPredicate) predicate, IterationType.KEY);
         } else {
-            QueryResult result = queryEngine.invokeQueryLocalPartitions(name, predicate, IterationType.KEY);
+            QueryResult result = queryEngine.runQueryOnLocalPartitions(name, predicate, IterationType.KEY);
             // TODO: unique is not needed since map keys are unique by nature
             return new QueryResultCollection<K>(
                     getNodeEngine().getSerializationService(), IterationType.KEY, false, true, result);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunner.java
@@ -48,7 +48,7 @@ import static com.hazelcast.util.SortingUtil.getSortedSubList;
  */
 public class MapLocalParallelQueryRunner extends MapLocalQueryRunner {
 
-    private static final int QUERY_EXECUTION_TIMEOUT_MINUTES = 5;
+    protected static final int QUERY_EXECUTION_TIMEOUT_MINUTES = 5;
 
     private final ManagedExecutorService executor;
     private final int timeoutInMinutes;
@@ -81,7 +81,7 @@ public class MapLocalParallelQueryRunner extends MapLocalQueryRunner {
         }
     }
 
-    private List<QueryableEntry> runUsingPartitionScanWithPaging(
+    protected List<QueryableEntry> runUsingPartitionScanWithPaging(
             String name, PagingPredicate predicate, Collection<Integer> partitions)
             throws InterruptedException, ExecutionException {
 
@@ -90,7 +90,7 @@ public class MapLocalParallelQueryRunner extends MapLocalQueryRunner {
         return getSortedSubList(result, predicate, nearestAnchorEntry);
     }
 
-    private List<QueryableEntry> runUsingPartitionScanWithoutPaging(
+    protected List<QueryableEntry> runUsingPartitionScanWithoutPaging(
             String name, Predicate predicate, Collection<Integer> partitions)
             throws InterruptedException, ExecutionException {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunner.java
@@ -40,7 +40,7 @@ import static com.hazelcast.util.SortingUtil.getSortedSubList;
  * Specialization of the {@link MapLocalQueryRunner} - the only difference is that
  * the query evaluation per partition is run in a PARALLEL fashion.
  * <p>
- * Runs query operations in the calling thread (thus blucking it)
+ * Runs query operations in the calling thread (thus blocking it)
  * Query evaluation per partition is run in a PARALLEL fashion.
  * <p>
  * Used by query operations only: QueryOperation & QueryPartitionOperation

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalParallerQueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalParallerQueryRunner.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.query.PagingPredicate;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.predicates.QueryOptimizer;
+import com.hazelcast.util.executor.ManagedExecutorService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static com.hazelcast.map.impl.query.MapQueryEngineUtils.waitForResult;
+import static com.hazelcast.query.PagingPredicateAccessor.getNearestAnchorEntry;
+import static com.hazelcast.util.SortingUtil.getSortedSubList;
+
+/**
+ * Specialization of the {@link MapLocalQueryRunner} - the only difference is that
+ * the query evaluation per partition is run in a PARALLEL fashion.
+ *
+ * Runs query operations in the calling thread (thus blucking it)
+ * Query evaluation per partition is run in a PARALLEL fashion.
+ * <p>
+ * Used by query operations only: QueryOperation & QueryPartitionOperation
+ * Should not be used by proxies or any other query related objects.
+ */
+public class MapLocalParallerQueryRunner extends MapLocalQueryRunner {
+
+    protected static final int QUERY_EXECUTION_TIMEOUT_MINUTES = 5;
+
+    private final ManagedExecutorService executor;
+    private final int timeoutInMinutes;
+
+    public MapLocalParallerQueryRunner(MapServiceContext mapServiceContext, QueryOptimizer optimizer,
+                                       ManagedExecutorService executor, int timeoutInMinutes) {
+        super(mapServiceContext, optimizer);
+        this.executor = executor;
+        this.timeoutInMinutes = timeoutInMinutes;
+    }
+
+    public MapLocalParallerQueryRunner(MapServiceContext mapServiceContext, QueryOptimizer optimizer,
+                                       ManagedExecutorService executor) {
+        this(mapServiceContext, optimizer, executor, QUERY_EXECUTION_TIMEOUT_MINUTES);
+    }
+
+    @Override
+    protected Collection<QueryableEntry> runPartitionScanQuery(
+            String mapName, Predicate predicate, Collection<Integer> partitions) {
+        try {
+            if (predicate instanceof PagingPredicate) {
+                return runParallelFullPartitionScanQueryWithPaging(mapName, (PagingPredicate) predicate, partitions);
+            } else {
+                return runParallelFullPartitionScanQueryWithoutPaging(mapName, predicate, partitions);
+            }
+        } catch (InterruptedException e) {
+            throw new HazelcastException(e.getMessage(), e);
+        } catch (ExecutionException e) {
+            throw new HazelcastException(e.getMessage(), e);
+        }
+    }
+
+    private List<QueryableEntry> runParallelFullPartitionScanQueryWithPaging(
+            String name, PagingPredicate predicate, Collection<Integer> partitions)
+            throws InterruptedException, ExecutionException {
+
+        List<QueryableEntry> result = runParallelFullPartitionScanQueryWithoutPaging(name, predicate, partitions);
+        Map.Entry<Integer, Map.Entry> nearestAnchorEntry = getNearestAnchorEntry(predicate);
+        return getSortedSubList(result, predicate, nearestAnchorEntry);
+    }
+
+    private List<QueryableEntry> runParallelFullPartitionScanQueryWithoutPaging(
+            String name, Predicate predicate, Collection<Integer> partitions)
+            throws InterruptedException, ExecutionException {
+
+        List<Future<Collection<QueryableEntry>>> futures = new ArrayList<Future<Collection<QueryableEntry>>>(partitions.size());
+
+        for (Integer partitionId : partitions) {
+            QueryPartitionCallable task = new QueryPartitionCallable(name, predicate, partitionId);
+            Future<Collection<QueryableEntry>> future = executor.submit(task);
+            futures.add(future);
+        }
+
+        Collection<Collection<QueryableEntry>> returnedResults = waitForResult(futures, timeoutInMinutes);
+        List<QueryableEntry> result = new ArrayList<QueryableEntry>();
+        for (Collection<QueryableEntry> returnedResult : returnedResults) {
+            result.addAll(returnedResult);
+        }
+        return result;
+    }
+
+    private final class QueryPartitionCallable implements Callable<Collection<QueryableEntry>> {
+        protected final int partition;
+        protected final String name;
+        protected final Predicate predicate;
+
+        private QueryPartitionCallable(String name, Predicate predicate, int partitionId) {
+            this.name = name;
+            this.predicate = predicate;
+            this.partition = partitionId;
+        }
+
+        @Override
+        public Collection<QueryableEntry> call() throws Exception {
+            return runPartitionScanQueryOnSinglePartition(name, predicate, partition);
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalParallerQueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalParallerQueryRunner.java
@@ -70,9 +70,9 @@ public class MapLocalParallerQueryRunner extends MapLocalQueryRunner {
             String mapName, Predicate predicate, Collection<Integer> partitions) {
         try {
             if (predicate instanceof PagingPredicate) {
-                return runParallelFullPartitionScanQueryWithPaging(mapName, (PagingPredicate) predicate, partitions);
+                return runFullPartitionScanQueryWithPaging(mapName, (PagingPredicate) predicate, partitions);
             } else {
-                return runParallelFullPartitionScanQueryWithoutPaging(mapName, predicate, partitions);
+                return runFullPartitionScanQueryWithoutPaging(mapName, predicate, partitions);
             }
         } catch (InterruptedException e) {
             throw new HazelcastException(e.getMessage(), e);
@@ -81,16 +81,16 @@ public class MapLocalParallerQueryRunner extends MapLocalQueryRunner {
         }
     }
 
-    private List<QueryableEntry> runParallelFullPartitionScanQueryWithPaging(
+    private List<QueryableEntry> runFullPartitionScanQueryWithPaging(
             String name, PagingPredicate predicate, Collection<Integer> partitions)
             throws InterruptedException, ExecutionException {
 
-        List<QueryableEntry> result = runParallelFullPartitionScanQueryWithoutPaging(name, predicate, partitions);
+        List<QueryableEntry> result = runFullPartitionScanQueryWithoutPaging(name, predicate, partitions);
         Map.Entry<Integer, Map.Entry> nearestAnchorEntry = getNearestAnchorEntry(predicate);
         return getSortedSubList(result, predicate, nearestAnchorEntry);
     }
 
-    private List<QueryableEntry> runParallelFullPartitionScanQueryWithoutPaging(
+    private List<QueryableEntry> runFullPartitionScanQueryWithoutPaging(
             String name, Predicate predicate, Collection<Integer> partitions)
             throws InterruptedException, ExecutionException {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalQueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalQueryRunner.java
@@ -221,11 +221,12 @@ public class MapLocalQueryRunner {
         Extractors extractors = mapServiceContext.getExtractors(mapName);
         while (iterator.hasNext()) {
             Record record = iterator.next();
-            Object value = useCachedValues ? Records.getValueOrCachedValue(record, serializationService) : record.getValue();
+            Data key = (Data) toData(record.getKey());
+            Object value = toData(
+                    useCachedValues ? Records.getValueOrCachedValue(record, serializationService) : record.getValue());
             if (value == null) {
                 continue;
             }
-            Data key = record.getKey();
             //we want to always use CachedQueryEntry as these are short-living objects anyway
             QueryableEntry queryEntry = new CachedQueryEntry(serializationService, key, value, extractors);
 
@@ -234,6 +235,10 @@ public class MapLocalQueryRunner {
             }
         }
         return getSortedSubList(resultList, pagingPredicate, nearestAnchorEntry);
+    }
+
+    protected <T> Object toData(T input) {
+        return input;
     }
 
     protected boolean isUseCachedDeserializedValuesEnabled(MapContainer mapContainer) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalQueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapLocalQueryRunner.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.config.CacheDeserializedValues;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.impl.LocalMapStatsProvider;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.PartitionContainer;
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.record.Records;
+import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.PagingPredicate;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.CachedQueryEntry;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.query.impl.predicates.QueryOptimizer;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.partition.IPartitionService;
+import com.hazelcast.util.Clock;
+import com.hazelcast.util.IterationType;
+import com.hazelcast.util.executor.ManagedExecutorService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static com.hazelcast.map.impl.query.MapQueryEngineUtils.newQueryResult;
+import static com.hazelcast.map.impl.query.MapQueryEngineUtils.newQueryResultForSinglePartition;
+import static com.hazelcast.query.PagingPredicateAccessor.getNearestAnchorEntry;
+import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
+import static com.hazelcast.util.SortingUtil.compareAnchor;
+import static com.hazelcast.util.SortingUtil.getSortedSubList;
+
+/**
+ * Runs query operations in the calling thread (thus blucking it)
+ * Query evaluation per partition is run in a sequential fashion.
+ * <p>
+ * Used by query operations only: QueryOperation & QueryPartitionOperation
+ * Should not be used by proxies or any other query related objects.
+ */
+public class MapLocalQueryRunner {
+
+    protected final MapServiceContext mapServiceContext;
+    protected final NodeEngine nodeEngine;
+    protected final ILogger logger;
+    protected final QueryResultSizeLimiter queryResultSizeLimiter;
+    protected final InternalSerializationService serializationService;
+    protected final IPartitionService partitionService;
+    protected final QueryOptimizer queryOptimizer;
+    protected final OperationService operationService;
+    protected final ClusterService clusterService;
+    protected final LocalMapStatsProvider localMapStatsProvider;
+    protected final ManagedExecutorService executor;
+
+    public MapLocalQueryRunner(MapServiceContext mapServiceContext, QueryOptimizer optimizer) {
+        this.mapServiceContext = mapServiceContext;
+        this.nodeEngine = mapServiceContext.getNodeEngine();
+        this.serializationService = (InternalSerializationService) nodeEngine.getSerializationService();
+        this.partitionService = nodeEngine.getPartitionService();
+        this.logger = nodeEngine.getLogger(getClass());
+        this.queryResultSizeLimiter = new QueryResultSizeLimiter(mapServiceContext, logger);
+        this.queryOptimizer = optimizer;
+        this.operationService = nodeEngine.getOperationService();
+        this.clusterService = nodeEngine.getClusterService();
+        this.localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
+        this.executor = nodeEngine.getExecutionService().getExecutor(QUERY_EXECUTOR);
+    }
+
+    // full query = index query (if possible), then partition-scan query
+    public QueryResult runFullQuery(String mapName, Predicate predicate, IterationType iterationType)
+            throws ExecutionException, InterruptedException {
+
+        int initialPartitionStateVersion = partitionService.getPartitionStateVersion();
+        Collection<Integer> initialPartitions = mapServiceContext.getOwnedPartitions();
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+
+        // first we optimize the query
+        predicate = queryOptimizer.optimize(predicate, mapContainer.getIndexes());
+
+        // then we try to run using an index, but if that doesn't work, we'll try a full table scan
+        // This would be the point where a query-plan should be added. It should determine if a full table scan
+        // or an index should be used.
+        Collection<QueryableEntry> entries = runIndexQuerySafely(predicate, mapContainer, initialPartitionStateVersion);
+        if (entries == null) {
+            entries = runPartitionScanQuerySafely(mapName, predicate, initialPartitions, initialPartitionStateVersion);
+        }
+
+        QueryResult result = newQueryResult(initialPartitions.size(), iterationType, queryResultSizeLimiter);
+
+
+        if (hasPartitionVersion(initialPartitionStateVersion, predicate)) {
+            // if results have been returned and partition state version has not changed, set the partition IDs
+            // so that caller is aware of partitions from which results were obtained.
+            result.addAll(entries);
+            result.setPartitionIds(initialPartitions);
+        }
+        // else: if fallback to full table scan also failed to return any results due to migrations,
+        // then return empty result set without any partition IDs set (so that it is ignored by callers).
+
+        updateStatistics(mapContainer);
+
+        return result;
+    }
+
+    protected Collection<QueryableEntry> runIndexQuerySafely(
+            Predicate predicate, MapContainer mapContainer, int initialPartitionStateVersion) {
+        // if a migration is in progress, do not attempt to use an index as they may have not been created yet.
+        // MapService.getMigrationsInFlight() returns the number of currently executing migrations (for which
+        // beforeMigration has been executed but commit/rollback is not yet executed).
+        // This is a temporary fix for 3.7, the actual issue will be addressed with an additional migration hook in 3.8.
+        // see https://github.com/hazelcast/hazelcast/issues/6471 & https://github.com/hazelcast/hazelcast/issues/8046
+        if (hasOwnerMigrationsInFlight()) {
+            return null;
+        }
+
+        Collection<QueryableEntry> entries = runIndexQuery(predicate, mapContainer);
+        if (entries == null) {
+            return null;
+        }
+
+        // If partition state version has changed in the meanwhile, this means migrations were executed and we may
+        // return stale data, so we should rather return null and let the query run with a full table scan.
+        // Also make sure there are no long migrations in flight which may have started after starting the query
+        // but not completed yet.
+        if (isResultSafe(initialPartitionStateVersion)) {
+            return entries;
+        } else {
+            return null;
+        }
+    }
+
+    protected Collection<QueryableEntry> runIndexQuery(Predicate predicate, MapContainer mapContainer) {
+        return mapContainer.getIndexes().query(predicate);
+    }
+
+    protected Collection<QueryableEntry> runPartitionScanQuerySafely(
+            String name, Predicate predicate, Collection<Integer> partitions, int initialPartitionStateVersion)
+            throws InterruptedException, ExecutionException {
+
+        Collection<QueryableEntry> entries;
+        if (hasOwnerMigrationsInFlight()) {
+            return null;
+        }
+
+        entries = runPartitionScanQuery(name, predicate, partitions);
+
+        // If partition state version has changed in the meanwhile, this means migrations were executed and we may
+        // return stale data, so we should rather return null.
+        // Also make sure there are no long migrations in flight which may have started after starting the query
+        // but not completed yet.
+        if (isResultSafe(initialPartitionStateVersion)) {
+            return entries;
+        } else {
+            return null;
+        }
+    }
+
+    protected Collection<QueryableEntry> runPartitionScanQuery(
+            String mapName, Predicate predicate, Collection<Integer> partitions) {
+        RetryableHazelcastException storedException = null;
+        Collection<QueryableEntry> result = new ArrayList<QueryableEntry>();
+        for (Integer partitionId : partitions) {
+            try {
+                result.addAll(runPartitionScanQueryOnSinglePartition(mapName, predicate, partitionId));
+            } catch (RetryableHazelcastException e) {
+                // RetryableHazelcastException are stored and re-thrown later. this is to ensure all partitions
+                // are touched as when the parallel execution was used.
+                // see discussion at https://github.com/hazelcast/hazelcast/pull/5049#discussion_r28773099 for details.
+                if (storedException == null) {
+                    storedException = e;
+                }
+            }
+        }
+        if (storedException != null) {
+            throw storedException;
+        }
+        return result;
+    }
+
+    public QueryResult runPartitionScanQueryOnSinglePartition(
+            String mapName, Predicate predicate, int partitionId, IterationType iterationType) {
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+        predicate = queryOptimizer.optimize(predicate, mapContainer.getIndexes());
+        Collection<QueryableEntry> entries = runPartitionScanQueryOnSinglePartition(mapName, predicate, partitionId);
+        return newQueryResultForSinglePartition(entries, partitionId, iterationType, queryResultSizeLimiter);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Collection<QueryableEntry> runPartitionScanQueryOnSinglePartition(
+            String mapName, Predicate predicate, int partitionId) {
+        PagingPredicate pagingPredicate = predicate instanceof PagingPredicate ? (PagingPredicate) predicate : null;
+        List<QueryableEntry> resultList = new LinkedList<QueryableEntry>();
+
+        PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(partitionId);
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+        Iterator<Record> iterator = partitionContainer.getRecordStore(mapName).loadAwareIterator(getNow(), false);
+        Map.Entry<Integer, Map.Entry> nearestAnchorEntry = getNearestAnchorEntry(pagingPredicate);
+        boolean useCachedValues = isUseCachedDeserializedValuesEnabled(mapContainer);
+        Extractors extractors = mapServiceContext.getExtractors(mapName);
+        while (iterator.hasNext()) {
+            Record record = iterator.next();
+            Object value = useCachedValues ? Records.getValueOrCachedValue(record, serializationService) : record.getValue();
+            if (value == null) {
+                continue;
+            }
+            Data key = record.getKey();
+            //we want to always use CachedQueryEntry as these are short-living objects anyway
+            QueryableEntry queryEntry = new CachedQueryEntry(serializationService, key, value, extractors);
+
+            if (predicate.apply(queryEntry) && compareAnchor(pagingPredicate, queryEntry, nearestAnchorEntry)) {
+                resultList.add(queryEntry);
+            }
+        }
+        return getSortedSubList(resultList, pagingPredicate, nearestAnchorEntry);
+    }
+
+    protected boolean isUseCachedDeserializedValuesEnabled(MapContainer mapContainer) {
+        CacheDeserializedValues cacheDeserializedValues = mapContainer.getMapConfig().getCacheDeserializedValues();
+        switch (cacheDeserializedValues) {
+            case NEVER:
+                return false;
+            case ALWAYS:
+                return true;
+            default:
+                //if index exists then cached value is already set -> let's use it
+                return mapContainer.getIndexes().hasIndex();
+        }
+    }
+
+    protected long getNow() {
+        return Clock.currentTimeMillis();
+    }
+
+    /**
+     * Check whether migrations of owner partition are currently executed.
+     * If a migration is in progress, do not attempt to use an index as they may have not been created yet.
+     * MapService.getMigrationsInFlight() returns the number of currently executing migrations (for which
+     * beforeMigration has been executed but commit/rollback is not yet executed).
+     * This check is a temporary fix for 3.7, the actual issue will be addressed with an additional migration hook in 3.8.
+     * see https://github.com/hazelcast/hazelcast/issues/6471 & https://github.com/hazelcast/hazelcast/issues/8046
+     *
+     * @return {@code true} if owner partition migrations are currently being executed, otherwise false.
+     * @see com.hazelcast.spi.impl.CountingMigrationAwareService
+     */
+    protected boolean hasOwnerMigrationsInFlight() {
+        return mapServiceContext.getService().getOwnerMigrationsInFlight() > 0;
+    }
+
+    /**
+     * Check whether partition state version has changed since {@code initialPartitionStateVersion}.
+     *
+     * @param initialPartitionStateVersion the initial partition state version to compare against
+     * @return {@code true} if current partition state version is not equal to {@code initialPartitionStateVersion}
+     */
+    protected boolean hasPartitionStateVersionChanged(int initialPartitionStateVersion) {
+        return initialPartitionStateVersion != partitionService.getPartitionStateVersion();
+    }
+
+    /**
+     * Check whether results obtained since partition state version was at {@code initialPartitionStateVersion} are safe
+     * to be returned to the caller. Effectively this method checks:
+     * <ul>
+     * <li>whether owner migrations are currently in flight; if there are any, then results are considered flawed</li>
+     * <li>whether current partition state version has changed, implying that some migrations were executed in the
+     * meanwhile, so results are again considered flawed</li>
+     * </ul>
+     *
+     * @param initialPartitionStateVersion
+     * @return {@code true} if no owner migrations are currently executing and {@code initialPartitionStateVersion} is
+     * the same as the current partition state version, otherwise {@code false}.
+     */
+    protected boolean isResultSafe(int initialPartitionStateVersion) {
+        return !hasOwnerMigrationsInFlight() && !hasPartitionStateVersionChanged(initialPartitionStateVersion);
+    }
+
+    protected boolean hasPartitionVersion(int expectedVersion, Predicate predicate) {
+        if (hasPartitionStateVersionChanged(expectedVersion)) {
+            logger.info("Partition assignments changed while executing query: " + predicate);
+            return false;
+        }
+        return true;
+    }
+
+    protected void updateStatistics(MapContainer mapContainer) {
+        if (mapContainer.getMapConfig().isStatisticsEnabled()) {
+            LocalMapStatsImpl localStats = localMapStatsProvider.getLocalMapStatsImpl(mapContainer.getName());
+            localStats.incrementOtherOperations();
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryDispatcher.java
@@ -45,6 +45,10 @@ import static java.util.Collections.singletonList;
 
 /**
  * Dispatches query operations.
+ * Main responsibility is to:
+ * - invoke proper query operation (QueryOperation or QueryPartitionOperation)
+ * - invoke those operations on the proper member (local, remote, single, all, etc.)
+ * <p>
  * Does not contain any query logic. Relies on query operations only.
  * Should be used by query engine only!
  */

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryDispatcher.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.impl.LocalMapStatsProvider;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.partition.IPartitionService;
+import com.hazelcast.util.IterationType;
+import com.hazelcast.util.executor.ManagedExecutorService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+import static com.hazelcast.map.impl.query.MapQueryEngineUtils.shouldSkipPartitionsQuery;
+import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+
+/**
+ * Dispatches query operations.
+ * Does not contain any query logic. Relies on query operations only.
+ * Should be used by query engine only!
+ */
+final class MapQueryDispatcher {
+
+    protected final MapServiceContext mapServiceContext;
+    protected final NodeEngine nodeEngine;
+    protected final ILogger logger;
+    protected final InternalSerializationService serializationService;
+    protected final IPartitionService partitionService;
+    protected final OperationService operationService;
+    protected final ClusterService clusterService;
+    protected final LocalMapStatsProvider localMapStatsProvider;
+    protected final ManagedExecutorService executor;
+
+    protected MapQueryDispatcher(MapServiceContext mapServiceContext) {
+        this.mapServiceContext = mapServiceContext;
+        this.nodeEngine = mapServiceContext.getNodeEngine();
+        this.serializationService = (InternalSerializationService) nodeEngine.getSerializationService();
+        this.partitionService = nodeEngine.getPartitionService();
+        this.logger = nodeEngine.getLogger(getClass());
+        this.operationService = nodeEngine.getOperationService();
+        this.clusterService = nodeEngine.getClusterService();
+        this.localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
+        this.executor = nodeEngine.getExecutionService().getExecutor(QUERY_EXECUTOR);
+    }
+
+    protected Future<QueryResult> dispatchFullQueryOnLocalMemberOnQueryThread(
+            String mapName, Predicate predicate, IterationType iterationType) {
+        Operation operation = new QueryOperation(mapName, predicate, iterationType);
+        return operationService.invokeOnTarget(MapService.SERVICE_NAME, operation, nodeEngine.getThisAddress());
+    }
+
+    protected List<Future<QueryResult>> dispatchFullQueryOnAllMembersOnQueryThread(
+            String mapName, Predicate predicate, IterationType iterationType) {
+        Collection<Member> members = clusterService.getMembers(DATA_MEMBER_SELECTOR);
+        List<Future<QueryResult>> futures = new ArrayList<Future<QueryResult>>(members.size());
+        for (Member member : members) {
+            Operation operation = new QueryOperation(mapName, predicate, iterationType);
+            Future<QueryResult> future = operationService.invokeOnTarget(MapService.SERVICE_NAME, operation, member.getAddress());
+            futures.add(future);
+        }
+        return futures;
+    }
+
+    protected List<Future<QueryResult>> dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
+            String mapName, Predicate predicate, Collection<Integer> partitionIds, IterationType iterationType) {
+        if (shouldSkipPartitionsQuery(partitionIds)) {
+            return Collections.emptyList();
+        }
+
+        List<Future<QueryResult>> futures = new ArrayList<Future<QueryResult>>(partitionIds.size());
+        for (Integer partitionId : partitionIds) {
+            futures.add(dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(mapName, predicate, partitionId, iterationType));
+        }
+        return futures;
+    }
+
+    protected Future<QueryResult> dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
+            String mapName, Predicate predicate, Integer partitionId, IterationType iterationType) {
+        Operation op = new QueryPartitionOperation(mapName, predicate, iterationType);
+        op.setPartitionId(partitionId);
+        try {
+            return operationService.invokeOnPartition(MapService.SERVICE_NAME, op, partitionId);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.query;
 
-import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.util.IterationType;
 
@@ -27,72 +26,11 @@ import java.util.Set;
  */
 public interface MapQueryEngine {
 
-    /**
-     * Query all local partitions.
-     * <p>
-     * - Does NOT accept PagingPredicate
-     * - Query executed in an Operation on this member (NOT in the calling thread)
-     * - Calls {@link #runLocalFullQuery(String, Predicate, IterationType)} in an operation
-     *
-     * @param mapName       map name.
-     * @param predicate     except paging predicate.
-     * @param iterationType the IterationType
-     */
-    QueryResult runQueryOnLocalPartitions(String mapName, Predicate predicate, IterationType iterationType);
+    Set runQueryOnAllPartitions(String mapName, Predicate predicate, IterationType iterationType, boolean uniqueResult);
 
-    /**
-     * Queries a single partition. Paging predicates are not allowed.
-     *
-     * @param mapName mape name
-     * @param predicate except paging predicate
-     * @param iterationType the IterationType
-     * @param partitionId the id of the partition
-     * @return the result
-     */
-    QueryResult runQueryOnSinglePartition(String mapName, Predicate predicate, IterationType iterationType, int partitionId);
+    Set runQueryOnLocalPartitions(String mapName, Predicate predicate, IterationType iterationType, boolean uniqueResult);
 
-    /**
-     * Query all local partitions with a paging predicate.
-     * <p>
-     * - Query executed in an Operation on this member (or other members if some partitions are not local)
-     * <p>
-     * TODO:
-     * it would be better to have a single queryLocal... method and let the implementation figure out how to deal
-     * with a regular predicate and a paging predicate. No need to have that in the interface. The problem is that currently
-     * the signatures don't match up. This implementation detail should not be exposed through the interface.
-     *
-     * @param mapName       map name.
-     * @param predicate     to queryOnMembers.
-     * @param iterationType type of {@link IterationType}
-     * @return {@link SortedQueryResultSet}
-     */
-    Set runQueryOnLocalPartitionsWithPagingPredicate(String mapName, PagingPredicate predicate, IterationType iterationType);
+    Set runQueryOnGivenPartition(String mapName, Predicate predicate, IterationType iterationType, boolean uniqueResult,
+                                 int partitionId);
 
-    /**
-     * Queries all partitions. Paging predicates are not allowed.
-     * - Does NOT accept PagingPredicate
-     * - Query executed in an Operation on each member (NOT in the calling thread)
-     * - Calls {@link #runLocalFullQuery(String, Predicate, IterationType)} in an operation
-     *
-     * @param mapName       map name.
-     * @param predicate     except paging predicate.
-     * @param iterationType the IterationType
-     */
-    QueryResult runQueryOnAllPartitions(String mapName, Predicate predicate, IterationType iterationType);
-
-    /**
-     * Queries all partitions with a paging predicate.
-     * <p>
-     * - Query executed in an Operation on each member (NOT in the calling thread)
-     * <p>
-     * TODO:
-     * it would be better to have single queryAll method and let the implementation figure out how to deal
-     * with a paging predicate. See comment in {@link #runQueryOnLocalPartitionsWithPagingPredicate}
-     *
-     * @param mapName         map name.
-     * @param predicate to queryOnMembers.
-     * @param iterationType   type of {@link IterationType}
-     * @return {@link SortedQueryResultSet}
-     */
-    Set runQueryOnAllPartitionsWithPagingPredicate(String mapName, PagingPredicate predicate, IterationType iterationType);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -19,18 +19,15 @@ package com.hazelcast.map.impl.query;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.util.IterationType;
 
-import java.util.Set;
-
 /**
  * Responsible for executing queries on the IMap.
  */
 public interface MapQueryEngine {
 
-    Set runQueryOnAllPartitions(String mapName, Predicate predicate, IterationType iterationType, boolean uniqueResult);
+    QueryResult runQueryOnAllPartitions(String mapName, Predicate predicate, IterationType iterationType);
 
-    Set runQueryOnLocalPartitions(String mapName, Predicate predicate, IterationType iterationType, boolean uniqueResult);
+    QueryResult runQueryOnLocalPartitions(String mapName, Predicate predicate, IterationType iterationType);
 
-    Set runQueryOnGivenPartition(String mapName, Predicate predicate, IterationType iterationType, boolean uniqueResult,
-                                 int partitionId);
+    QueryResult runQueryOnGivenPartition(String mapName, Predicate predicate, IterationType iterationType, int partitionId);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngine.java
@@ -21,7 +21,6 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.util.IterationType;
 
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Responsible for executing queries on the IMap.
@@ -29,67 +28,17 @@ import java.util.concurrent.ExecutionException;
 public interface MapQueryEngine {
 
     /**
-     * Executes a query on all the local partitions.
-     * <p>
-     * - Uses Indexes
-     * - Accepts PagingPredicate
-     * - Query executed in the calling thread
-     * - predicate evaluation will be parallelized if QUERY_PREDICATE_PARALLEL_EVALUATION is enabled or a PagingPredicate is used.
-     * - may return empty QueryResult (with a properly initialized result limit size) if query is executed during migrations and
-     * migration conditions do not allow for safe retrieval of results (ie. there are migrations in flight or partition state
-     * version is different at the end of query vs the version observed at the beginning of query). In this case, partitionIds
-     * are not set on the QueryResult, so callers will ignore these results and fallback to {@code QueryPartitionOperation}s.
-     *
-     * @param mapName   the name of the map
-     * @param predicate the predicate
-     * @return the QueryResult
-     * @throws ExecutionException
-     * @throws InterruptedException
-     */
-    QueryResult queryLocalPartitions(String mapName, Predicate predicate, IterationType iterationType)
-            throws ExecutionException, InterruptedException;
-
-    /**
-     * Executes a query on a specific local partition.
-     * <p>
-     * - Does NOT use Indexes
-     * - Accepts PagingPredicate
-     * - Sequential full table scan
-     * - Query executed in the calling thread
-     * <p>
-     * todo: what happens when the partition is not local?
-     *
-     * @param mapName     map name.
-     * @param predicate   any predicate.
-     * @param partitionId partition id.
-     * @return result of query
-     */
-    QueryResult queryLocalPartition(String mapName, Predicate predicate, int partitionId, IterationType iterationType);
-
-    /**
      * Query all local partitions.
      * <p>
      * - Does NOT accept PagingPredicate
      * - Query executed in an Operation on this member (NOT in the calling thread)
-     * - Calls {@link #queryLocalPartitions(String, Predicate, IterationType)} in an operation
+     * - Calls {@link #runLocalFullQuery(String, Predicate, IterationType)} in an operation
      *
      * @param mapName       map name.
      * @param predicate     except paging predicate.
      * @param iterationType the IterationType
      */
-    QueryResult invokeQueryLocalPartitions(String mapName, Predicate predicate, IterationType iterationType);
-
-    /**
-     * Queries all partitions. Paging predicates are not allowed.
-     * - Does NOT accept PagingPredicate
-     * - Query executed in an Operation on each member (NOT in the calling thread)
-     * - Calls {@link #queryLocalPartitions(String, Predicate, IterationType)} in an operation
-     *
-     * @param mapName       map name.
-     * @param predicate     except paging predicate.
-     * @param iterationType the IterationType
-     */
-    QueryResult invokeQueryAllPartitions(String mapName, Predicate predicate, IterationType iterationType);
+    QueryResult runQueryOnLocalPartitions(String mapName, Predicate predicate, IterationType iterationType);
 
     /**
      * Queries a single partition. Paging predicates are not allowed.
@@ -100,7 +49,7 @@ public interface MapQueryEngine {
      * @param partitionId the id of the partition
      * @return the result
      */
-    QueryResult invokeQuerySinglePartition(String mapName, Predicate predicate, IterationType iterationType, int partitionId);
+    QueryResult runQueryOnSinglePartition(String mapName, Predicate predicate, IterationType iterationType, int partitionId);
 
     /**
      * Query all local partitions with a paging predicate.
@@ -112,12 +61,24 @@ public interface MapQueryEngine {
      * with a regular predicate and a paging predicate. No need to have that in the interface. The problem is that currently
      * the signatures don't match up. This implementation detail should not be exposed through the interface.
      *
-     * @param mapName         map name.
-     * @param pagingPredicate to queryOnMembers.
-     * @param iterationType   type of {@link IterationType}
+     * @param mapName       map name.
+     * @param predicate     to queryOnMembers.
+     * @param iterationType type of {@link IterationType}
      * @return {@link SortedQueryResultSet}
      */
-    Set queryLocalPartitionsWithPagingPredicate(String mapName, PagingPredicate pagingPredicate, IterationType iterationType);
+    Set runQueryOnLocalPartitionsWithPagingPredicate(String mapName, PagingPredicate predicate, IterationType iterationType);
+
+    /**
+     * Queries all partitions. Paging predicates are not allowed.
+     * - Does NOT accept PagingPredicate
+     * - Query executed in an Operation on each member (NOT in the calling thread)
+     * - Calls {@link #runLocalFullQuery(String, Predicate, IterationType)} in an operation
+     *
+     * @param mapName       map name.
+     * @param predicate     except paging predicate.
+     * @param iterationType the IterationType
+     */
+    QueryResult runQueryOnAllPartitions(String mapName, Predicate predicate, IterationType iterationType);
 
     /**
      * Queries all partitions with a paging predicate.
@@ -126,12 +87,12 @@ public interface MapQueryEngine {
      * <p>
      * TODO:
      * it would be better to have single queryAll method and let the implementation figure out how to deal
-     * with a paging predicate. See comment in {@link #queryLocalPartitionsWithPagingPredicate}
+     * with a paging predicate. See comment in {@link #runQueryOnLocalPartitionsWithPagingPredicate}
      *
      * @param mapName         map name.
-     * @param pagingPredicate to queryOnMembers.
+     * @param predicate to queryOnMembers.
      * @param iterationType   type of {@link IterationType}
      * @return {@link SortedQueryResultSet}
      */
-    Set queryAllPartitionsWithPagingPredicate(String mapName, PagingPredicate pagingPredicate, IterationType iterationType);
+    Set runQueryOnAllPartitionsWithPagingPredicate(String mapName, PagingPredicate predicate, IterationType iterationType);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -16,376 +16,82 @@
 
 package com.hazelcast.map.impl.query;
 
-import com.hazelcast.config.CacheDeserializedValues;
-import com.hazelcast.core.Member;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.LocalMapStatsProvider;
-import com.hazelcast.map.impl.MapContainer;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.map.impl.PartitionContainer;
-import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.map.impl.record.Records;
-import com.hazelcast.monitor.impl.LocalMapStatsImpl;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.query.impl.CachedQueryEntry;
-import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.query.impl.predicates.QueryOptimizer;
-import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.partition.IPartitionService;
-import com.hazelcast.util.Clock;
 import com.hazelcast.util.IterationType;
 import com.hazelcast.util.executor.ManagedExecutorService;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
-import static com.hazelcast.query.PagingPredicateAccessor.getNearestAnchorEntry;
+import static com.hazelcast.map.impl.query.MapQueryEngineUtils.addResultsOfPagingPredicate;
+import static com.hazelcast.map.impl.query.MapQueryEngineUtils.addResultsOfPredicate;
+import static com.hazelcast.map.impl.query.MapQueryEngineUtils.newQueryResult;
 import static com.hazelcast.spi.ExecutionService.QUERY_EXECUTOR;
-import static com.hazelcast.spi.properties.GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
-import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
-import static com.hazelcast.util.FutureUtil.returnWithDeadline;
-import static com.hazelcast.util.SortingUtil.compareAnchor;
 import static com.hazelcast.util.SortingUtil.getSortedQueryResultSet;
-import static com.hazelcast.util.SortingUtil.getSortedSubList;
 import static java.util.Collections.singletonList;
-import static java.util.concurrent.TimeUnit.MINUTES;
 
 /**
- * The {@link MapQueryEngine} implementation.
+ * Invokes query logic using the QueryDispatcher.
+ * Knows nothing about query logic or how to dispatch query operations. It relies on query dispatcher only.
+ * It never dispatches query operations directly.
  */
 public class MapQueryEngineImpl implements MapQueryEngine {
 
-    protected static final long QUERY_EXECUTION_TIMEOUT_MINUTES = 5;
+    protected MapServiceContext mapServiceContext;
+    protected NodeEngine nodeEngine;
+    protected ILogger logger;
+    protected QueryResultSizeLimiter queryResultSizeLimiter;
+    protected InternalSerializationService serializationService;
+    protected IPartitionService partitionService;
+    protected OperationService operationService;
+    protected ClusterService clusterService;
+    protected LocalMapStatsProvider localMapStatsProvider;
+    protected ManagedExecutorService executor;
+    protected MapQueryDispatcher queryDispatcher;
 
-    protected final MapServiceContext mapServiceContext;
-    protected final NodeEngine nodeEngine;
-    protected final ILogger logger;
-    protected final QueryResultSizeLimiter queryResultSizeLimiter;
-    protected final InternalSerializationService serializationService;
-    protected final IPartitionService partitionService;
-    protected final QueryOptimizer queryOptimizer;
-    protected final OperationService operationService;
-    protected final ClusterService clusterService;
-    protected final LocalMapStatsProvider localMapStatsProvider;
-    protected final boolean parallelEvaluation;
-    protected final ManagedExecutorService executor;
-
-    public MapQueryEngineImpl(MapServiceContext mapServiceContext, QueryOptimizer optimizer) {
+    public MapQueryEngineImpl(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
         this.nodeEngine = mapServiceContext.getNodeEngine();
         this.serializationService = (InternalSerializationService) nodeEngine.getSerializationService();
         this.partitionService = nodeEngine.getPartitionService();
         this.logger = nodeEngine.getLogger(getClass());
         this.queryResultSizeLimiter = new QueryResultSizeLimiter(mapServiceContext, logger);
-        this.queryOptimizer = optimizer;
         this.operationService = nodeEngine.getOperationService();
         this.clusterService = nodeEngine.getClusterService();
         this.localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
-        this.parallelEvaluation = nodeEngine.getProperties().getBoolean(QUERY_PREDICATE_PARALLEL_EVALUATION);
         this.executor = nodeEngine.getExecutionService().getExecutor(QUERY_EXECUTOR);
+        this.queryDispatcher = new MapQueryDispatcher(mapServiceContext);
     }
 
-    QueryResultSizeLimiter getQueryResultSizeLimiter() {
-        return queryResultSizeLimiter;
-    }
-
+    // invoked from proxy layer
+    // query thread
+    // partition thread
     @Override
-    public QueryResult queryLocalPartitions(String mapName, Predicate predicate, IterationType iterationType)
-            throws ExecutionException, InterruptedException {
-
-        int initialPartitionStateVersion = partitionService.getPartitionStateVersion();
-        Collection<Integer> initialPartitions = mapServiceContext.getOwnedPartitions();
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-
-        // first we optimize the query
-        predicate = queryOptimizer.optimize(predicate, mapContainer.getIndexes());
-
-        // then we try to run using an index, but if that doesn't work, we'll try a full table scan
-        // This would be the point where a query-plan should be added. It should determine if a full table scan
-        // or an index should be used.
-        QueryResult result = tryQueryUsingIndexes(predicate, initialPartitions, mapContainer, iterationType,
-                initialPartitionStateVersion);
-        if (result == null) {
-            result = querySafelyUsingFullTableScan(mapName, predicate, initialPartitions, iterationType,
-                    initialPartitionStateVersion);
-        }
-
-        if (result == null) {
-            // if fallback to full table scan also failed to return any results due to migrations,
-            // then return empty result set without any partition IDs set (so that it is ignored by callers).
-            result = newQueryResult(initialPartitions.size(), iterationType);
-        } else if (hasPartitionVersion(initialPartitionStateVersion, predicate)) {
-            // if results have been returned and partition state version has not changed, set the partition IDs
-            // so that caller is aware of partitions from which results were obtained.
-            result.setPartitionIds(initialPartitions);
-        }
-
-        updateStatistics(mapContainer);
-
-        return result;
-    }
-
-    protected QueryResult tryQueryUsingIndexes(Predicate predicate, Collection<Integer> partitions, MapContainer mapContainer,
-                                               IterationType iterationType, int initialPartitionStateVersion) {
-
-        // if a migration is in progress, do not attempt to use an index as they may have not been created yet.
-        // MapService.getMigrationsInFlight() returns the number of currently executing migrations (for which
-        // beforeMigration has been executed but commit/rollback is not yet executed).
-        // This is a temporary fix for 3.7, the actual issue will be addressed with an additional migration hook in 3.8.
-        // see https://github.com/hazelcast/hazelcast/issues/6471 & https://github.com/hazelcast/hazelcast/issues/8046
-        if (hasOwnerMigrationsInFlight()) {
-            return null;
-        }
-
-        Set<QueryableEntry> entries = mapContainer.getIndexes().query(predicate);
-        if (entries == null) {
-            return null;
-        }
-
-        QueryResult result = newQueryResult(partitions.size(), iterationType);
-        // If partition state version has changed in the meanwhile, this means migrations were executed and we may
-        // return stale data, so we should rather return null and let the query run with a full table scan.
-        // Also make sure there are no long migrations in flight which may have started after starting the query
-        // but not completed yet.
-        if (isResultSafe(initialPartitionStateVersion)) {
-            result.addAll(entries);
-            return result;
-        } else {
-            return null;
-        }
-    }
-
-    protected void updateStatistics(MapContainer mapContainer) {
-        if (mapContainer.getMapConfig().isStatisticsEnabled()) {
-            LocalMapStatsImpl localStats = localMapStatsProvider.getLocalMapStatsImpl(mapContainer.getName());
-            localStats.incrementOtherOperations();
-        }
-    }
-
-    /**
-     * Wraps {@link #queryUsingFullTableScan(String, Predicate, Collection, IterationType)} to avoid returning potentially
-     * flawed results.
-     * <ul>
-     * <li>if owner partition migrations are executing before running the query, then return immediately {@code null}, as
-     * results cannot be reliably obtained</li>
-     * <li>execute the query using full table scan</li>
-     * <li>if after the query has been executed migrations are in-flight or partition state version has changed, then
-     * results are not considered reliable</li>
-     * </ul>
-     *
-     * @param name
-     * @param predicate
-     * @param partitions
-     * @param iterationType
-     * @param initialPartitionStateVersion
-     * @return query results or {@code null} if results are considered potentially flawed.
-     * @throws InterruptedException
-     * @throws ExecutionException
-     */
-    protected QueryResult querySafelyUsingFullTableScan(String name, Predicate predicate, Collection<Integer> partitions,
-                                                        IterationType iterationType, int initialPartitionStateVersion)
-            throws InterruptedException, ExecutionException {
-
-        QueryResult result;
-
-        if (hasOwnerMigrationsInFlight()) {
-            return null;
-        }
-
-        result = queryUsingFullTableScan(name, predicate, partitions, iterationType);
-
-        // If partition state version has changed in the meanwhile, this means migrations were executed and we may
-        // return stale data, so we should rather return null.
-        // Also make sure there are no long migrations in flight which may have started after starting the query
-        // but not completed yet.
-        if (isResultSafe(initialPartitionStateVersion)) {
-            return result;
-        } else {
-            return null;
-        }
-    }
-
-    protected QueryResult queryUsingFullTableScan(String name, Predicate predicate, Collection<Integer> partitions,
-                                                  IterationType iterationType)
-            throws InterruptedException, ExecutionException {
-
-        if (predicate instanceof PagingPredicate) {
-            return queryParallelForPaging(name, (PagingPredicate) predicate, partitions, iterationType);
-        } else if (parallelEvaluation) {
-            return queryParallel(name, predicate, partitions, iterationType);
-        } else {
-            return querySequential(name, predicate, partitions, iterationType);
-        }
-    }
-
-    protected QueryResult querySequential(String name, Predicate predicate, Collection<Integer> partitions,
-                                          IterationType iterationType) {
-
-        QueryResult result = newQueryResult(partitions.size(), iterationType);
-        RetryableHazelcastException storedException = null;
-        for (Integer partitionId : partitions) {
-            try {
-                Collection<QueryableEntry> entries = queryTheLocalPartition(name, predicate, partitionId);
-                result.addAll(entries);
-            } catch (RetryableHazelcastException e) {
-                // RetryableHazelcastException are stored and re-thrown later. this is to ensure all partitions
-                // are touched as when the parallel execution was used.
-                // see discussion at https://github.com/hazelcast/hazelcast/pull/5049#discussion_r28773099 for details.
-                if (storedException == null) {
-                    storedException = e;
-                }
-            }
-        }
-        if (storedException != null) {
-            throw storedException;
-        }
-        return result;
-    }
-
-    protected QueryResult queryParallel(String name, Predicate predicate, Collection<Integer> partitions,
-                                        IterationType iterationType) throws InterruptedException, ExecutionException {
-        QueryResult result = newQueryResult(partitions.size(), iterationType);
-
-        List<Future<Collection<QueryableEntry>>> futures
-                = new ArrayList<Future<Collection<QueryableEntry>>>(partitions.size());
-
-        for (Integer partitionId : partitions) {
-            QueryPartitionCallable task = new QueryPartitionCallable(name, predicate, partitionId);
-            Future<Collection<QueryableEntry>> future = executor.submit(task);
-            futures.add(future);
-        }
-
-        Collection<Collection<QueryableEntry>> returnedResults = getResult(futures);
-        for (Collection<QueryableEntry> returnedResult : returnedResults) {
-            if (returnedResult == null) {
-                continue;
-            }
-            result.addAll(returnedResult);
-        }
-
-        return result;
-    }
-
-    protected QueryResult queryParallelForPaging(String name, PagingPredicate predicate, Collection<Integer> partitions,
-                                                 IterationType iterationType) throws InterruptedException, ExecutionException {
-        QueryResult result = newQueryResult(partitions.size(), iterationType);
-
-        List<Future<Collection<QueryableEntry>>> futures =
-                new ArrayList<Future<Collection<QueryableEntry>>>(partitions.size());
-        for (Integer partitionId : partitions) {
-            QueryPartitionCallable task = new QueryPartitionCallable(name, predicate, partitionId);
-            Future<Collection<QueryableEntry>> future = executor.submit(task);
-            futures.add(future);
-        }
-
-        List<QueryableEntry> toMerge = new LinkedList<QueryableEntry>();
-        Collection<Collection<QueryableEntry>> returnedResults = getResult(futures);
-        for (Collection<QueryableEntry> returnedResult : returnedResults) {
-            toMerge.addAll(returnedResult);
-        }
-
-        Map.Entry<Integer, Map.Entry> nearestAnchorEntry = getNearestAnchorEntry(predicate);
-        List<QueryableEntry> sortedSubList = getSortedSubList(toMerge, predicate, nearestAnchorEntry);
-        result.addAll(sortedSubList);
-        return result;
-    }
-
-    protected static Collection<Collection<QueryableEntry>> getResult(List<Future<Collection<QueryableEntry>>> lsFutures) {
-        return returnWithDeadline(lsFutures, QUERY_EXECUTION_TIMEOUT_MINUTES, MINUTES, RETHROW_EVERYTHING);
-    }
-
-    protected boolean hasPartitionVersion(int expectedVersion, Predicate predicate) {
-        if (hasPartitionStateVersionChanged(expectedVersion)) {
-            logger.info("Partition assignments changed while executing query: " + predicate);
-            return false;
-        }
-        return true;
-    }
-
-    @SuppressWarnings("unchecked")
-    protected Collection<QueryableEntry> queryTheLocalPartition(String mapName, Predicate predicate, int partitionId) {
-        PagingPredicate pagingPredicate = predicate instanceof PagingPredicate ? (PagingPredicate) predicate : null;
-        List<QueryableEntry> resultList = new LinkedList<QueryableEntry>();
-
-        PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(partitionId);
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        Iterator<Record> iterator = partitionContainer.getRecordStore(mapName).loadAwareIterator(getNow(), false);
-        Map.Entry<Integer, Map.Entry> nearestAnchorEntry = getNearestAnchorEntry(pagingPredicate);
-        boolean useCachedVersion = shouldUseCachedValue(mapContainer);
-        Extractors extractors = mapServiceContext.getExtractors(mapName);
-        while (iterator.hasNext()) {
-            Record record = iterator.next();
-            Object value = useCachedVersion ? Records.getValueOrCachedValue(record, serializationService) : record.getValue();
-            if (value == null) {
-                continue;
-            }
-            Data key = record.getKey();
-            //we want to always use CachedQueryEntry as these are short-living objects anyway
-            QueryableEntry queryEntry = new CachedQueryEntry(serializationService, key, value, extractors);
-
-            if (predicate.apply(queryEntry) && compareAnchor(pagingPredicate, queryEntry, nearestAnchorEntry)) {
-                resultList.add(queryEntry);
-            }
-        }
-        return getSortedSubList(resultList, pagingPredicate, nearestAnchorEntry);
-    }
-
-    private boolean shouldUseCachedValue(MapContainer mapContainer) {
-        CacheDeserializedValues cacheDeserializedValues = mapContainer.getMapConfig().getCacheDeserializedValues();
-        switch (cacheDeserializedValues) {
-            case NEVER:
-                return false;
-            case ALWAYS:
-                return true;
-            default:
-                //if index exists then cached value is already set -> let's use it
-                return mapContainer.getIndexes().hasIndex();
-        }
-    }
-
-    @Override
-    public QueryResult queryLocalPartition(String mapName, Predicate predicate, int partitionId, IterationType iterationType) {
-        Collection<QueryableEntry> queryableEntries = queryTheLocalPartition(mapName, predicate, partitionId);
-        QueryResult result = newQueryResult(1, iterationType);
-        result.addAll(queryableEntries);
-        result.setPartitionIds(singletonList(partitionId));
-        return result;
-    }
-
-    @Override
-    public QueryResult invokeQueryLocalPartitions(String mapName, Predicate predicate, IterationType iterationType) {
+    public QueryResult runQueryOnLocalPartitions(String mapName, Predicate predicate, IterationType iterationType) {
         checkNotPagingPredicate(predicate);
 
         List<Integer> partitionIds = getLocalPartitionIds();
-        QueryResult result = newQueryResult(partitionIds.size(), iterationType);
+        QueryResult result = newQueryResult(partitionIds.size(), iterationType, queryResultSizeLimiter);
 
         try {
-            Future<QueryResult> future = queryOnLocalMember(mapName, predicate, iterationType);
+            Future<QueryResult> future = queryDispatcher
+                    .dispatchFullQueryOnLocalMemberOnQueryThread(mapName, predicate, iterationType);
             List<Future<QueryResult>> futures = singletonList(future);
             addResultsOfPredicate(futures, result, partitionIds);
             if (partitionIds.isEmpty()) {
@@ -399,7 +105,8 @@ public class MapQueryEngineImpl implements MapQueryEngine {
         }
 
         try {
-            List<Future<QueryResult>> futures = queryPartitions(mapName, predicate, partitionIds, iterationType);
+            List<Future<QueryResult>> futures = queryDispatcher.dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
+                    mapName, predicate, partitionIds, iterationType);
             addResultsOfPredicate(futures, result, partitionIds);
         } catch (Throwable t) {
             throw rethrow(t);
@@ -408,8 +115,12 @@ public class MapQueryEngineImpl implements MapQueryEngine {
         return result;
     }
 
+    // invoked from proxy layer
+    // query thread
+    // partition thread
     @Override
-    public Set queryLocalPartitionsWithPagingPredicate(String mapName, PagingPredicate predicate, IterationType iterationType) {
+    public Set runQueryOnLocalPartitionsWithPagingPredicate(
+            String mapName, PagingPredicate predicate, IterationType iterationType) {
         predicate.setIterationType(iterationType);
         ArrayList<Map.Entry> resultList = new ArrayList<Map.Entry>();
         List<Integer> partitionIds = getLocalPartitionIds();
@@ -419,10 +130,11 @@ public class MapQueryEngineImpl implements MapQueryEngine {
 
         // query the local partitions
         try {
-            Future<QueryResult> future = queryOnLocalMember(mapName, predicate, retrievalIterationType);
+            Future<QueryResult> future = queryDispatcher
+                    .dispatchFullQueryOnLocalMemberOnQueryThread(mapName, predicate, retrievalIterationType);
             List<Future<QueryResult>> futures = singletonList(future);
             // modifies partitionIds list!
-            addResultsOfPagingPredicate(futures, resultList, partitionIds);
+            addResultsOfPagingPredicate(serializationService, futures, resultList, partitionIds);
             if (partitionIds.isEmpty()) {
                 return getSortedQueryResultSet(resultList, predicate, iterationType);
             }
@@ -435,73 +147,32 @@ public class MapQueryEngineImpl implements MapQueryEngine {
 
         // query the remaining partitions that are not local to the member
         try {
-            List<Future<QueryResult>> futures = queryPartitions(mapName, predicate, partitionIds, retrievalIterationType);
-            addResultsOfPagingPredicate(futures, resultList, partitionIds);
+            List<Future<QueryResult>> futures = queryDispatcher.dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
+                    mapName, predicate, partitionIds, retrievalIterationType);
+            addResultsOfPagingPredicate(serializationService, futures, resultList, partitionIds);
         } catch (Throwable t) {
             throw rethrow(t);
         }
         return getSortedQueryResultSet(resultList, predicate, iterationType);
     }
 
+    // invoked from proxy layer
+    // query thread
+    // partition thread
     @Override
-    public Set queryAllPartitionsWithPagingPredicate(String mapName, PagingPredicate predicate, IterationType iterationType) {
-        predicate.setIterationType(iterationType);
-        ArrayList<Map.Entry> resultList = new ArrayList<Map.Entry>();
-        Set<Integer> partitionIds = getAllPartitionIds();
-
-        // in case of value, we also need to get the keys for sorting.
-        IterationType retrievalIterationType = iterationType == IterationType.VALUE ? IterationType.ENTRY : iterationType;
-
-        // query the local partitions
-        try {
-            List<Future<QueryResult>> futures = queryOnMembers(mapName, predicate, retrievalIterationType);
-            // modifies partitionIds list!
-            addResultsOfPagingPredicate(futures, resultList, partitionIds);
-            if (partitionIds.isEmpty()) {
-                return getSortedQueryResultSet(resultList, predicate, iterationType);
-            }
-        } catch (Throwable t) {
-            if (t.getCause() instanceof QueryResultSizeExceededException) {
-                throw rethrow(t);
-            }
-            logger.warning("Could not get results", t);
-        }
-
-        // query the remaining partitions that are not local to the member
-        try {
-            List<Future<QueryResult>> futures = queryPartitions(mapName, predicate, partitionIds, retrievalIterationType);
-            addResultsOfPagingPredicate(futures, resultList, partitionIds);
-        } catch (Throwable t) {
-            throw rethrow(t);
-        }
-
-        return getSortedQueryResultSet(resultList, predicate, iterationType);
-    }
-
-    @Override
-    public QueryResult invokeQuerySinglePartition(
-            String mapName, Predicate predicate, IterationType iterationType, int partitionId) {
-        checkNotPagingPredicate(predicate);
-
-        Operation op = new QueryPartitionOperation(mapName, predicate, iterationType)
-                .setPartitionId(partitionId);
-        InternalCompletableFuture<QueryResult> future = operationService.invokeOnPartition(op);
-        return future.join();
-    }
-
-    @Override
-    public QueryResult invokeQueryAllPartitions(String mapName, Predicate predicate, IterationType iterationType) {
+    public QueryResult runQueryOnAllPartitions(String mapName, Predicate predicate, IterationType iterationType) {
         checkNotPagingPredicate(predicate);
         if (predicate == TruePredicate.INSTANCE) {
             queryResultSizeLimiter.checkMaxResultLimitOnLocalPartitions(mapName);
         }
 
         Set<Integer> partitionIds = getAllPartitionIds();
-        QueryResult result = newQueryResult(partitionIds.size(), iterationType);
+        QueryResult result = newQueryResult(partitionIds.size(), iterationType, queryResultSizeLimiter);
 
         // query the local partitions
         try {
-            List<Future<QueryResult>> futures = queryOnMembers(mapName, predicate, iterationType);
+            List<Future<QueryResult>> futures = queryDispatcher.dispatchFullQueryOnAllMembersOnQueryThread(
+                    mapName, predicate, iterationType);
             // modifies partitionIds list!
             addResultsOfPredicate(futures, result, partitionIds);
             if (partitionIds.isEmpty()) {
@@ -516,7 +187,8 @@ public class MapQueryEngineImpl implements MapQueryEngine {
 
         // query the remaining partitions that are not local to the member
         try {
-            List<Future<QueryResult>> futures = queryPartitions(mapName, predicate, partitionIds, iterationType);
+            List<Future<QueryResult>> futures = queryDispatcher.dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
+                    mapName, predicate, partitionIds, iterationType);
             addResultsOfPredicate(futures, result, partitionIds);
         } catch (Throwable t) {
             throw rethrow(t);
@@ -525,117 +197,67 @@ public class MapQueryEngineImpl implements MapQueryEngine {
         return result;
     }
 
-    /**
-     * Creates a {@link QueryResult} with configured result limit (according to the number of partitions) if feature is enabled.
-     *
-     * @param numberOfPartitions number of partitions to calculate result limit
-     * @return {@link QueryResult}
-     */
-    protected QueryResult newQueryResult(int numberOfPartitions, IterationType iterationType) {
-        return new QueryResult(iterationType, queryResultSizeLimiter.getNodeResultLimit(numberOfPartitions));
+    // invoked from proxy layer
+    // query thread
+    // partition thread
+    @Override
+    public Set runQueryOnAllPartitionsWithPagingPredicate(
+            String mapName, PagingPredicate predicate, IterationType iterationType) {
+        predicate.setIterationType(iterationType);
+        ArrayList<Map.Entry> resultList = new ArrayList<Map.Entry>();
+        Set<Integer> partitionIds = getAllPartitionIds();
+
+        // in case of value, we also need to get the keys for sorting.
+        IterationType retrievalIterationType = iterationType == IterationType.VALUE ? IterationType.ENTRY : iterationType;
+
+        // query the local partitions
+        try {
+            List<Future<QueryResult>> futures = queryDispatcher
+                    .dispatchFullQueryOnAllMembersOnQueryThread(mapName, predicate, retrievalIterationType);
+            // modifies partitionIds list!
+            addResultsOfPagingPredicate(serializationService, futures, resultList, partitionIds);
+            if (partitionIds.isEmpty()) {
+                return getSortedQueryResultSet(resultList, predicate, iterationType);
+            }
+        } catch (Throwable t) {
+            if (t.getCause() instanceof QueryResultSizeExceededException) {
+                throw rethrow(t);
+            }
+            logger.warning("Could not get results", t);
+        }
+
+        // query the remaining partitions that are not local to the member
+        try {
+            List<Future<QueryResult>> futures = queryDispatcher.dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(
+                    mapName, predicate, partitionIds, retrievalIterationType);
+            addResultsOfPagingPredicate(serializationService, futures, resultList, partitionIds);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+
+        return getSortedQueryResultSet(resultList, predicate, iterationType);
+    }
+
+    // invoked from proxy layer
+    // partition thread ONLY
+    @Override
+    public QueryResult runQueryOnSinglePartition(
+            String mapName, Predicate predicate, IterationType iterationType, int partitionId) {
+        checkNotPagingPredicate(predicate);
+
+        try {
+            Future<QueryResult> result = queryDispatcher
+                    .dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(mapName, predicate, partitionId, iterationType);
+            return result.get();
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
     }
 
     protected void checkNotPagingPredicate(Predicate predicate) {
         if (predicate instanceof PagingPredicate) {
             throw new IllegalArgumentException("Predicate should not be a paging predicate");
         }
-    }
-
-    protected Future<QueryResult> queryOnLocalMember(String mapName, Predicate predicate, IterationType iterationType) {
-        Operation operation = new QueryOperation(mapName, predicate, iterationType);
-        return operationService.invokeOnTarget(MapService.SERVICE_NAME, operation, nodeEngine.getThisAddress());
-    }
-
-    protected List<Future<QueryResult>> queryOnMembers(String mapName, Predicate predicate, IterationType iterationType) {
-        Collection<Member> members = clusterService.getMembers(DATA_MEMBER_SELECTOR);
-        List<Future<QueryResult>> futures = new ArrayList<Future<QueryResult>>(members.size());
-        for (Member member : members) {
-            Operation operation = new QueryOperation(mapName, predicate, iterationType);
-            Future<QueryResult> future = operationService.invokeOnTarget(MapService.SERVICE_NAME, operation, member.getAddress());
-            futures.add(future);
-        }
-        return futures;
-    }
-
-    protected List<Future<QueryResult>> queryPartitions(String mapName, Predicate predicate,
-                                                        Collection<Integer> partitionIds, IterationType iterationType) {
-        if (partitionIds == null || partitionIds.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        List<Future<QueryResult>> futures = new ArrayList<Future<QueryResult>>(partitionIds.size());
-        for (Integer partitionId : partitionIds) {
-            Operation op = new QueryPartitionOperation(mapName, predicate, iterationType);
-            op.setPartitionId(partitionId);
-            try {
-                Future<QueryResult> future = operationService
-                        .invokeOnPartition(MapService.SERVICE_NAME, op, partitionId);
-                futures.add(future);
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
-        }
-        return futures;
-    }
-
-    /**
-     * Adds results of paging predicates to result set and removes queried partition ids.
-     */
-    @SuppressWarnings("unchecked")
-    protected void addResultsOfPagingPredicate(List<Future<QueryResult>> futures, Collection result,
-                                               Collection<Integer> partitionIds)
-            throws ExecutionException, InterruptedException {
-        for (Future<QueryResult> future : futures) {
-            QueryResult queryResult = future.get();
-            if (queryResult == null) {
-                continue;
-            }
-
-            Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
-            if (queriedPartitionIds != null) {
-                if (!partitionIds.containsAll(queriedPartitionIds)) {
-                    // results for at least one partition have already been added, so discard these results
-                    // see https://github.com/hazelcast/hazelcast/issues/6471
-                    continue;
-                }
-                partitionIds.removeAll(queriedPartitionIds);
-                for (QueryResultRow row : queryResult.getRows()) {
-                    Object key = toObject(row.getKey());
-                    Object value = toObject(row.getValue());
-                    result.add(new AbstractMap.SimpleImmutableEntry<Object, Object>(key, value));
-                }
-            }
-        }
-    }
-
-    /**
-     * Adds results of non-paging predicates to result set and removes queried partition ids.
-     */
-    @SuppressWarnings("unchecked")
-    protected void addResultsOfPredicate(List<Future<QueryResult>> futures, QueryResult result,
-                                         Collection<Integer> partitionIds) throws ExecutionException, InterruptedException {
-
-        for (Future<QueryResult> future : futures) {
-            QueryResult queryResult = future.get();
-            if (queryResult == null) {
-                continue;
-            }
-            Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
-            if (queriedPartitionIds != null) {
-                if (!partitionIds.containsAll(queriedPartitionIds)) {
-                    // do not take into account results that contain partition IDs already removed from partitionIds collection
-                    // as this means that we will count results from a single partition twice
-                    // see also https://github.com/hazelcast/hazelcast/issues/6471
-                    continue;
-                }
-                partitionIds.removeAll(queriedPartitionIds);
-                result.addAllRows(queryResult.getRows());
-            }
-        }
-    }
-
-    protected Object toObject(Object obj) {
-        return serializationService.toObject(obj);
     }
 
     protected List<Integer> getLocalPartitionIds() {
@@ -655,68 +277,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
         return partitionIds;
     }
 
-    protected long getNow() {
-        return Clock.currentTimeMillis();
-    }
-
-    protected final class QueryPartitionCallable implements Callable<Collection<QueryableEntry>> {
-
-        protected final int partition;
-        protected final String name;
-        protected final Predicate predicate;
-
-        protected QueryPartitionCallable(String name, Predicate predicate, int partitionId) {
-            this.name = name;
-            this.predicate = predicate;
-            this.partition = partitionId;
-        }
-
-        @Override
-        public Collection<QueryableEntry> call() throws Exception {
-            MapQueryEngineImpl queryEngine = (MapQueryEngineImpl) mapServiceContext.getMapQueryEngine(name);
-            return queryEngine.queryTheLocalPartition(name, predicate, partition);
-        }
-    }
-
-    /**
-     * Check whether migrations of owner partition are currently executed.
-     * If a migration is in progress, do not attempt to use an index as they may have not been created yet.
-     * MapService.getMigrationsInFlight() returns the number of currently executing migrations (for which
-     * beforeMigration has been executed but commit/rollback is not yet executed).
-     * This check is a temporary fix for 3.7, the actual issue will be addressed with an additional migration hook in 3.8.
-     * see https://github.com/hazelcast/hazelcast/issues/6471 & https://github.com/hazelcast/hazelcast/issues/8046
-     *
-     * @return {@code true} if owner partition migrations are currently being executed, otherwise false.
-     * @see com.hazelcast.spi.impl.CountingMigrationAwareService
-     */
-    protected boolean hasOwnerMigrationsInFlight() {
-        return mapServiceContext.getService().getOwnerMigrationsInFlight() > 0;
-    }
-
-    /**
-     * Check whether partition state version has changed since {@code initialPartitionStateVersion}.
-     *
-     * @param initialPartitionStateVersion the initial partition state version to compare against
-     * @return {@code true} if current partition state version is not equal to {@code initialPartitionStateVersion}
-     */
-    protected boolean hasPartitionStateVersionChanged(int initialPartitionStateVersion) {
-        return initialPartitionStateVersion != partitionService.getPartitionStateVersion();
-    }
-
-    /**
-     * Check whether results obtained since partition state version was at {@code initialPartitionStateVersion} are safe to be
-     * returned to the caller. Effectively this method checks:
-     * <ul>
-     * <li>whether owner migrations are currently in flight; if there are any, then results are considered flawed</li>
-     * <li>whether current partition state version has changed, implying that some migrations were executed in the
-     * meanwhile, so results are again considered flawed</li>
-     * </ul>
-     *
-     * @param initialPartitionStateVersion
-     * @return {@code true} if no owner migrations are currently executing and {@code initialPartitionStateVersion} is the same
-     * as the current partition state version, otherwise {@code false}.
-     */
-    protected boolean isResultSafe(int initialPartitionStateVersion) {
-        return !hasOwnerMigrationsInFlight() && !hasPartitionStateVersionChanged(initialPartitionStateVersion);
+    protected QueryResultSizeLimiter getQueryResultSizeLimiter() {
+        return queryResultSizeLimiter;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -49,6 +49,11 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
  * Should never invoke any query operations directly.
  * <p>
  * Should be used from top-level proxy-layer only (e.g. MapProxy, etc.).
+ * <p>
+ * Top level-query actors:
+ * - QueryEngine orchestrates the queries by dispatching query operations using QueryDispatcher and merging the result
+ * - QueryDispatcher invokes query operations on the given members and partitions
+ * - QueryRunner -> runs the query logic in the calling thread (so like evaluates the predicates and asks the index)
  */
 public class MapQueryEngineImpl implements MapQueryEngine {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineUtils.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.IterationType;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
+import static com.hazelcast.util.FutureUtil.returnWithDeadline;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+final class MapQueryEngineUtils {
+
+    private MapQueryEngineUtils() {
+    }
+
+    static QueryResult newQueryResult(int numberOfPartitions, IterationType iterationType,
+                                      QueryResultSizeLimiter resultSizeLimiter) {
+        return new QueryResult(iterationType, resultSizeLimiter.getNodeResultLimit(numberOfPartitions));
+    }
+
+    static QueryResult newQueryResultForSinglePartition(
+            Collection<QueryableEntry> queryableEntries, int partitionId, IterationType iterationType,
+            QueryResultSizeLimiter queryResultSizeLimiter) {
+        QueryResult result = newQueryResult(1, iterationType, queryResultSizeLimiter);
+        result.addAll(queryableEntries);
+        result.setPartitionIds(singletonList(partitionId));
+        return result;
+    }
+
+
+    static Object toObject(SerializationService ss, Object obj) {
+        return ss.toObject(obj);
+    }
+
+    /**
+     * Adds results of paging predicates to result set and removes queried partition ids.
+     */
+    @SuppressWarnings("unchecked")
+    static void addResultsOfPagingPredicate(
+            SerializationService ss, List<Future<QueryResult>> futures, Collection result, Collection<Integer> partitionIds)
+            throws ExecutionException, InterruptedException {
+        for (Future<QueryResult> future : futures) {
+            QueryResult queryResult = future.get();
+            if (queryResult == null) {
+                continue;
+            }
+
+            Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
+            if (queriedPartitionIds != null) {
+                if (!partitionIds.containsAll(queriedPartitionIds)) {
+                    // results for at least one partition have already been added, so discard these results
+                    // see https://github.com/hazelcast/hazelcast/issues/6471
+                    continue;
+                }
+                partitionIds.removeAll(queriedPartitionIds);
+                for (QueryResultRow row : queryResult.getRows()) {
+                    Object key = toObject(ss, row.getKey());
+                    Object value = toObject(ss, row.getValue());
+                    result.add(new AbstractMap.SimpleImmutableEntry<Object, Object>(key, value));
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds results of non-paging predicates to result set and removes queried partition ids.
+     */
+    @SuppressWarnings("unchecked")
+    static void addResultsOfPredicate(List<Future<QueryResult>> futures, QueryResult result,
+                                      Collection<Integer> partitionIds) throws ExecutionException, InterruptedException {
+
+        for (Future<QueryResult> future : futures) {
+            QueryResult queryResult = future.get();
+            if (queryResult == null) {
+                continue;
+            }
+            Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
+            if (queriedPartitionIds != null) {
+                if (!partitionIds.containsAll(queriedPartitionIds)) {
+                    // do not take into account results that contain partition IDs already removed from partitionIds
+                    // collection as this means that we will count results from a single partition twice
+                    // see also https://github.com/hazelcast/hazelcast/issues/6471
+                    continue;
+                }
+                partitionIds.removeAll(queriedPartitionIds);
+                result.addAllRows(queryResult.getRows());
+            }
+        }
+    }
+
+    static boolean shouldSkipPartitionsQuery(Collection<Integer> partitionIds) {
+        return partitionIds == null || partitionIds.isEmpty();
+    }
+
+    static <T> Collection<Collection<T>> waitForResult(List<Future<Collection<T>>> lsFutures, int timeoutInMinutes) {
+        return returnWithDeadline(lsFutures, timeoutInMinutes, MINUTES, RETHROW_EVERYTHING);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineUtils.java
@@ -17,13 +17,12 @@
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.IterationType;
 
-import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
@@ -50,73 +49,20 @@ final class MapQueryEngineUtils {
         return result;
     }
 
-
-    static Object toObject(SerializationService ss, Object obj) {
-        return ss.toObject(obj);
-    }
-
-    /**
-     * Adds results of paging predicates to result set and removes queried partition ids.
-     */
-    @SuppressWarnings("unchecked")
-    static void addResultsOfPagingPredicate(
-            SerializationService ss, List<Future<QueryResult>> futures, Collection result, Collection<Integer> partitionIds)
-            throws ExecutionException, InterruptedException {
-        for (Future<QueryResult> future : futures) {
-            QueryResult queryResult = future.get();
-            if (queryResult == null) {
-                continue;
-            }
-
-            Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
-            if (queriedPartitionIds != null) {
-                if (!partitionIds.containsAll(queriedPartitionIds)) {
-                    // results for at least one partition have already been added, so discard these results
-                    // see https://github.com/hazelcast/hazelcast/issues/6471
-                    continue;
-                }
-                partitionIds.removeAll(queriedPartitionIds);
-                for (QueryResultRow row : queryResult.getRows()) {
-                    Object key = toObject(ss, row.getKey());
-                    Object value = toObject(ss, row.getValue());
-                    result.add(new AbstractMap.SimpleImmutableEntry<Object, Object>(key, value));
-                }
-            }
-        }
-    }
-
-    /**
-     * Adds results of non-paging predicates to result set and removes queried partition ids.
-     */
-    @SuppressWarnings("unchecked")
-    static void addResultsOfPredicate(List<Future<QueryResult>> futures, QueryResult result,
-                                      Collection<Integer> partitionIds) throws ExecutionException, InterruptedException {
-
-        for (Future<QueryResult> future : futures) {
-            QueryResult queryResult = future.get();
-            if (queryResult == null) {
-                continue;
-            }
-            Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
-            if (queriedPartitionIds != null) {
-                if (!partitionIds.containsAll(queriedPartitionIds)) {
-                    // do not take into account results that contain partition IDs already removed from partitionIds
-                    // collection as this means that we will count results from a single partition twice
-                    // see also https://github.com/hazelcast/hazelcast/issues/6471
-                    continue;
-                }
-                partitionIds.removeAll(queriedPartitionIds);
-                result.addAllRows(queryResult.getRows());
-            }
-        }
-    }
-
     static boolean shouldSkipPartitionsQuery(Collection<Integer> partitionIds) {
         return partitionIds == null || partitionIds.isEmpty();
     }
 
     static <T> Collection<Collection<T>> waitForResult(List<Future<Collection<T>>> lsFutures, int timeoutInMinutes) {
         return returnWithDeadline(lsFutures, timeoutInMinutes, MINUTES, RETHROW_EVERYTHING);
+    }
+
+    static Set<Integer> createSetWithPopulatedPartitionIds(int partitionCount) {
+        Set<Integer> partitionIds = new HashSet<Integer>(partitionCount);
+        for (int i = 0; i < partitionCount; i++) {
+            partitionIds.add(i);
+        }
+        return partitionIds;
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -48,8 +48,8 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
 
     @Override
     public void run() throws Exception {
-        MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
-        result = queryEngine.queryLocalPartitions(name, predicate, iterationType);
+        MapLocalQueryRunner queryRunner = mapServiceContext.getMapQueryRunner();
+        result = queryRunner.runFullQuery(name, predicate, iterationType);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -49,7 +49,7 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
     @Override
     public void run() throws Exception {
         MapLocalQueryRunner queryRunner = mapServiceContext.getMapQueryRunner();
-        result = queryRunner.runFullQuery(name, predicate, iterationType);
+        result = queryRunner.run(name, predicate, iterationType);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -48,7 +48,7 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
 
     @Override
     public void run() throws Exception {
-        MapLocalQueryRunner queryRunner = mapServiceContext.getMapQueryRunner();
+        MapLocalQueryRunner queryRunner = mapServiceContext.getMapQueryRunner(getName());
         result = queryRunner.run(name, predicate, iterationType);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -44,8 +44,8 @@ public class QueryPartitionOperation extends MapOperation implements PartitionAw
 
     @Override
     public void run() {
-        MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
-        result = queryEngine.queryLocalPartition(name, predicate, getPartitionId(), iterationType);
+        MapLocalQueryRunner queryRunner = mapServiceContext.getMapQueryRunner();
+        result = queryRunner.runPartitionScanQueryOnSinglePartition(name, predicate, getPartitionId(), iterationType);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -44,7 +44,7 @@ public class QueryPartitionOperation extends MapOperation implements PartitionAw
 
     @Override
     public void run() {
-        MapLocalQueryRunner queryRunner = mapServiceContext.getMapQueryRunner();
+        MapLocalQueryRunner queryRunner = mapServiceContext.getMapQueryRunner(getName());
         result = queryRunner.runUsingPartitionScanOnSinglePartition(name, predicate, getPartitionId(), iterationType);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -45,7 +45,7 @@ public class QueryPartitionOperation extends MapOperation implements PartitionAw
     @Override
     public void run() {
         MapLocalQueryRunner queryRunner = mapServiceContext.getMapQueryRunner();
-        result = queryRunner.runPartitionScanQueryOnSinglePartition(name, predicate, getPartitionId(), iterationType);
+        result = queryRunner.runUsingPartitionScanOnSinglePartition(name, predicate, getPartitionId(), iterationType);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.query.PagingPredicate;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.IterationType;
+
+import java.util.ArrayList;
+import java.util.Set;
+
+import static com.hazelcast.util.SortingUtil.getSortedQueryResultSet;
+
+public final class QueryResultUtils {
+
+    private QueryResultUtils() {
+    }
+
+    public static Set transformToSet(
+            SerializationService ss, QueryResult queryResult, Predicate predicate, IterationType iterationType, boolean unique) {
+        if (predicate instanceof PagingPredicate) {
+            Set result = new QueryResultCollection(ss, IterationType.ENTRY, false, unique, queryResult);
+            return getSortedQueryResultSet(new ArrayList(result), (PagingPredicate) predicate, iterationType);
+        } else {
+            return new QueryResultCollection(ss, iterationType, false, unique, queryResult);
+        }
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -312,7 +312,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
         SerializationService serializationService = getNodeEngine().getSerializationService();
 
-        QueryResult result = queryEngine.invokeQueryAllPartitions(name, predicate, IterationType.KEY);
+        QueryResult result = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.KEY);
         Set<Object> queryResult = new QueryResultCollection(serializationService, IterationType.KEY, false, true, result);
 
         // TODO: Can't we just use the original set?
@@ -356,7 +356,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
         SerializationService serializationService = getNodeEngine().getSerializationService();
 
-        QueryResult result = queryEngine.invokeQueryAllPartitions(name, predicate, IterationType.ENTRY);
+        QueryResult result = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.ENTRY);
         QueryResultCollection<Map.Entry> queryResult
                 = new QueryResultCollection<Map.Entry>(serializationService, IterationType.ENTRY, false, true, result);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -20,8 +20,6 @@ import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.MapQueryEngine;
-import com.hazelcast.map.impl.query.QueryResult;
-import com.hazelcast.map.impl.query.QueryResultCollection;
 import com.hazelcast.map.impl.tx.TxnValueWrapper.Type;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.PagingPredicate;
@@ -312,8 +310,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
         SerializationService serializationService = getNodeEngine().getSerializationService();
 
-        QueryResult result = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.KEY);
-        Set<Object> queryResult = new QueryResultCollection(serializationService, IterationType.KEY, false, true, result);
+        Set queryResult = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.KEY, true);
 
         // TODO: Can't we just use the original set?
         Set<Object> keySet = new HashSet<Object>(queryResult);
@@ -356,9 +353,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
         SerializationService serializationService = getNodeEngine().getSerializationService();
 
-        QueryResult result = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.ENTRY);
-        QueryResultCollection<Map.Entry> queryResult
-                = new QueryResultCollection<Map.Entry>(serializationService, IterationType.ENTRY, false, true, result);
+        Set queryResult = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.ENTRY, true);
 
         // TODO: Can't we just use the original set?
         List<Object> valueSet = new ArrayList<Object>();
@@ -399,7 +394,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         return wrapper == null || wrapper.type == Type.REMOVED ? null : wrapper.value;
     }
 
-    private void removeFromResultSet(QueryResultCollection<Map.Entry> queryResultSet, List<Object> valueSet,
+    private void removeFromResultSet(Set<Map.Entry> queryResultSet, List<Object> valueSet,
                                      Set<Object> keyWontBeIncluded) {
         for (Map.Entry entry : queryResultSet) {
             if (keyWontBeIncluded.contains(entry.getKey())) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -20,6 +20,8 @@ import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.MapQueryEngine;
+import com.hazelcast.map.impl.query.QueryResult;
+import com.hazelcast.map.impl.query.QueryResultUtils;
 import com.hazelcast.map.impl.tx.TxnValueWrapper.Type;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.PagingPredicate;
@@ -310,10 +312,11 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
         SerializationService serializationService = getNodeEngine().getSerializationService();
 
-        Set queryResult = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.KEY, true);
+        QueryResult queryResult = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.KEY);
+        Set result = QueryResultUtils.transformToSet(serializationService, queryResult, predicate, IterationType.KEY, true);
 
         // TODO: Can't we just use the original set?
-        Set<Object> keySet = new HashSet<Object>(queryResult);
+        Set<Object> keySet = new HashSet<Object>(result);
         Extractors extractors = mapServiceContext.getExtractors(name);
         for (Map.Entry<Data, TxnValueWrapper> entry : txMap.entrySet()) {
             Data keyData = entry.getKey();
@@ -353,7 +356,8 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
         SerializationService serializationService = getNodeEngine().getSerializationService();
 
-        Set queryResult = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.ENTRY, true);
+        QueryResult queryResylt = queryEngine.runQueryOnAllPartitions(name, predicate, IterationType.ENTRY);
+        Set result = QueryResultUtils.transformToSet(serializationService, queryResylt, predicate, IterationType.ENTRY, true);
 
         // TODO: Can't we just use the original set?
         List<Object> valueSet = new ArrayList<Object>();
@@ -380,7 +384,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
                 }
             }
         }
-        removeFromResultSet(queryResult, valueSet, keyWontBeIncluded);
+        removeFromResultSet(result, valueSet, keyWontBeIncluded);
         return valueSet;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunnerTest.java
@@ -1,0 +1,84 @@
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class MapLocalParallelQueryRunnerTest extends HazelcastTestSupport {
+
+    private HazelcastInstance instance;
+    private IMap<String, String> map;
+    private MapLocalQueryRunner queryRunner;
+
+    private int partitionId;
+    private String key;
+    private String value;
+
+
+    @Before
+    public void before() {
+        instance = createHazelcastInstance();
+        map = instance.getMap(randomName());
+        queryRunner = getQueryRunner();
+
+        partitionId = 100;
+        key = generateKeyForPartition(instance, partitionId);
+        value = randomString();
+
+        map.put(key, value);
+    }
+
+    @After
+    public void after() {
+        if (instance != null) {
+            instance.shutdown();
+        }
+    }
+
+    @Test
+    public void runFullQuery() throws ExecutionException, InterruptedException {
+        Predicate predicate = Predicates.equal("this", value);
+        QueryResult result = queryRunner.runFullQuery(map.getName(), predicate, IterationType.ENTRY);
+
+        assertEquals(1, result.getRows().size());
+        assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
+    }
+
+    @Test
+    public void runPartitionScanQueryOnSinglePartition() throws ExecutionException, InterruptedException {
+        Predicate predicate = Predicates.equal("this", value);
+        QueryResult result = queryRunner.runPartitionScanQueryOnSinglePartition(map.getName(), predicate, partitionId, IterationType.ENTRY);
+
+        assertEquals(1, result.getRows().size());
+        assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
+    }
+
+
+    private MapLocalQueryRunner getQueryRunner() {
+        MapService mapService = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
+        return mapService.getMapServiceContext().getMapQueryRunner();
+    }
+
+    private Object toObject(Data data) {
+        return getSerializationService(instance).toObject(data);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunnerTest.java
@@ -56,7 +56,7 @@ public class MapLocalParallelQueryRunnerTest extends HazelcastTestSupport {
     @Test
     public void runFullQuery() throws ExecutionException, InterruptedException {
         Predicate predicate = Predicates.equal("this", value);
-        QueryResult result = queryRunner.runFullQuery(map.getName(), predicate, IterationType.ENTRY);
+        QueryResult result = queryRunner.run(map.getName(), predicate, IterationType.ENTRY);
 
         assertEquals(1, result.getRows().size());
         assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
@@ -65,7 +65,7 @@ public class MapLocalParallelQueryRunnerTest extends HazelcastTestSupport {
     @Test
     public void runPartitionScanQueryOnSinglePartition() throws ExecutionException, InterruptedException {
         Predicate predicate = Predicates.equal("this", value);
-        QueryResult result = queryRunner.runPartitionScanQueryOnSinglePartition(map.getName(), predicate, partitionId, IterationType.ENTRY);
+        QueryResult result = queryRunner.runUsingPartitionScanOnSinglePartition(map.getName(), predicate, partitionId, IterationType.ENTRY);
 
         assertEquals(1, result.getRows().size());
         assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalParallelQueryRunnerTest.java
@@ -74,7 +74,7 @@ public class MapLocalParallelQueryRunnerTest extends HazelcastTestSupport {
 
     private MapLocalQueryRunner getQueryRunner() {
         MapService mapService = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
-        return mapService.getMapServiceContext().getMapQueryRunner();
+        return mapService.getMapServiceContext().getMapQueryRunner("");
     }
 
     private Object toObject(Data data) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalQueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalQueryRunnerTest.java
@@ -61,7 +61,7 @@ public class MapLocalQueryRunnerTest extends HazelcastTestSupport {
     @Test
     public void runFullQuery() throws ExecutionException, InterruptedException {
         Predicate predicate = Predicates.equal("this", value);
-        QueryResult result = queryRunner.runFullQuery(map.getName(), predicate, IterationType.ENTRY);
+        QueryResult result = queryRunner.run(map.getName(), predicate, IterationType.ENTRY);
 
         assertEquals(1, result.getRows().size());
         assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
@@ -70,7 +70,7 @@ public class MapLocalQueryRunnerTest extends HazelcastTestSupport {
     @Test
     public void runPartitionScanQueryOnSinglePartition() throws ExecutionException, InterruptedException {
         Predicate predicate = Predicates.equal("this", value);
-        QueryResult result = queryRunner.runPartitionScanQueryOnSinglePartition(map.getName(), predicate, partitionId, IterationType.ENTRY);
+        QueryResult result = queryRunner.runUsingPartitionScanOnSinglePartition(map.getName(), predicate, partitionId, IterationType.ENTRY);
 
         assertEquals(1, result.getRows().size());
         assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalQueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalQueryRunnerTest.java
@@ -1,0 +1,88 @@
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class MapLocalQueryRunnerTest extends HazelcastTestSupport {
+
+    private HazelcastInstance instance;
+    private IMap<String, String> map;
+    private MapLocalQueryRunner queryRunner;
+
+    private int partitionId;
+    private String key;
+    private String value;
+
+
+    @Before
+    public void before() {
+        instance = createHazelcastInstance();
+        map = instance.getMap(randomName());
+        queryRunner = getQueryRunner();
+
+        partitionId = 100;
+        key = generateKeyForPartition(instance, partitionId);
+        value = randomString();
+
+        map.put(key, value);
+    }
+
+    @After
+    public void after() {
+        if (instance != null) {
+            instance.shutdown();
+        }
+    }
+
+    @Test
+    public void assertSequentialQueryRunner() {
+        assertEquals(MapLocalQueryRunner.class, getQueryRunner().getClass());
+    }
+
+    @Test
+    public void runFullQuery() throws ExecutionException, InterruptedException {
+        Predicate predicate = Predicates.equal("this", value);
+        QueryResult result = queryRunner.runFullQuery(map.getName(), predicate, IterationType.ENTRY);
+
+        assertEquals(1, result.getRows().size());
+        assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
+    }
+
+    @Test
+    public void runPartitionScanQueryOnSinglePartition() throws ExecutionException, InterruptedException {
+        Predicate predicate = Predicates.equal("this", value);
+        QueryResult result = queryRunner.runPartitionScanQueryOnSinglePartition(map.getName(), predicate, partitionId, IterationType.ENTRY);
+
+        assertEquals(1, result.getRows().size());
+        assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
+    }
+
+    private MapLocalQueryRunner getQueryRunner() {
+        MapService mapService = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
+        return mapService.getMapServiceContext().getMapQueryRunner();
+    }
+
+    private Object toObject(Data data) {
+        return getSerializationService(instance).toObject(data);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalQueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapLocalQueryRunnerTest.java
@@ -78,7 +78,7 @@ public class MapLocalQueryRunnerTest extends HazelcastTestSupport {
 
     private MapLocalQueryRunner getQueryRunner() {
         MapService mapService = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
-        return mapService.getMapServiceContext().getMapQueryRunner();
+        return mapService.getMapServiceContext().getMapQueryRunner("");
     }
 
     private Object toObject(Data data) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryDispatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryDispatcherTest.java
@@ -1,0 +1,117 @@
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.map.impl.query.MapQueryDispatcher.DispatchTarget.ALL_MEMBERS;
+import static com.hazelcast.map.impl.query.MapQueryDispatcher.DispatchTarget.LOCAL_MEMBER;
+import static com.hazelcast.util.FutureUtil.returnWithDeadline;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class MapQueryDispatcherTest extends HazelcastTestSupport {
+
+    private HazelcastInstance instance;
+    private IMap<String, String> map;
+    private MapQueryDispatcher queryDispatcher;
+
+    private int partitionId;
+    private String key;
+    private String value;
+
+    @Before
+    public void before() {
+        instance = createHazelcastInstance();
+        map = instance.getMap(randomName());
+        MapService mapService = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
+        queryDispatcher = new MapQueryDispatcher(mapService.getMapServiceContext());
+
+        partitionId = 100;
+        key = generateKeyForPartition(instance, partitionId);
+        value = randomString();
+
+        map.put(key, value);
+    }
+
+    @After
+    public void after() {
+        if (instance != null) {
+            instance.shutdown();
+        }
+    }
+
+    @Test
+    public void dispatchFullQueryOnQueryThread_localMembers() throws ExecutionException, InterruptedException {
+        dispatchFullQueryOnQueryThread(LOCAL_MEMBER);
+    }
+
+    @Test
+    public void dispatchFullQueryOnQueryThread_allMembers() throws ExecutionException, InterruptedException {
+        dispatchFullQueryOnQueryThread(ALL_MEMBERS);
+    }
+
+    private void dispatchFullQueryOnQueryThread(MapQueryDispatcher.DispatchTarget target) {
+        List<Future<QueryResult>> futures = queryDispatcher
+                .dispatchFullQueryOnQueryThread(map.getName(), Predicates.equal("this", value), IterationType.ENTRY, target);
+        Collection<QueryResult> results = returnWithDeadline(futures, 1, TimeUnit.MINUTES);
+        QueryResult result = results.iterator().next();
+
+        assertEquals(1, results.size());
+        assertEquals(1, result.size());
+        assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
+    }
+
+    @Test
+    public void dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread_singlePartition() throws ExecutionException, InterruptedException {
+        Predicate predicate = Predicates.equal("this", value);
+        Future<QueryResult> future = queryDispatcher
+                .dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(map.getName(), predicate, partitionId, IterationType.ENTRY);
+        Collection<QueryResult> results = returnWithDeadline(Collections.singletonList(future), 1, TimeUnit.MINUTES);
+        QueryResult result = results.iterator().next();
+
+        assertEquals(1, results.size());
+        assertEquals(1, result.size());
+        assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
+    }
+
+    @Test
+    public void dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread_multiplePartitions() throws ExecutionException, InterruptedException {
+        Predicate predicate = Predicates.equal("this", value);
+        List<Future<QueryResult>> futures = queryDispatcher
+                .dispatchPartitionScanQueryOnOwnerMemberOnPartitionThread(map.getName(), predicate, asList(partitionId), IterationType.ENTRY);
+        ArrayList<QueryResult> results = new ArrayList<QueryResult>(returnWithDeadline(futures, 1, TimeUnit.MINUTES));
+        QueryResult result = results.iterator().next();
+
+        assertEquals(1, results.size());
+        assertEquals(1, result.size());
+        assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
+    }
+
+    private Object toObject(Data data) {
+        return getSerializationService(instance).toObject(data);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImplTest.java
@@ -1,0 +1,101 @@
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
+public class MapQueryEngineImplTest extends HazelcastTestSupport {
+
+    private HazelcastInstance instance;
+    private IMap<String, String> map;
+    private MapQueryEngine queryEngine;
+
+    private int partitionId;
+    private String key;
+    private String value;
+
+    @Before
+    public void before() {
+        instance = createHazelcastInstance();
+        map = instance.getMap(randomName());
+        MapService mapService = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
+        queryEngine = mapService.getMapServiceContext().getMapQueryEngine(map.getName());
+
+        partitionId = 100;
+        key = generateKeyForPartition(instance, partitionId);
+        value = randomString();
+
+        map.put(key, value);
+    }
+
+    @After
+    public void after() {
+        if (instance != null) {
+            instance.shutdown();
+        }
+    }
+
+    @Test
+    public void runQueryOnAllPartitions() throws ExecutionException, InterruptedException {
+        Set result = queryEngine
+                .runQueryOnLocalPartitions(map.getName(), Predicates.equal("this", value), IterationType.KEY, false);
+
+        assertEquals(1, result.size());
+        assertEquals(key, result.iterator().next());
+    }
+
+    @Test
+    public void runQueryOnLocalPartitions() throws ExecutionException, InterruptedException {
+        Set result = queryEngine
+                .runQueryOnAllPartitions(map.getName(), Predicates.equal("this", value), IterationType.KEY, false);
+
+        assertEquals(1, result.size());
+        assertEquals(key, result.iterator().next());
+    }
+
+    @Test
+    public void runQueryOnAllPartitions_key() throws ExecutionException, InterruptedException {
+        Set result = queryEngine
+                .runQueryOnLocalPartitions(map.getName(), Predicates.equal("this", value), IterationType.KEY, false);
+
+        assertEquals(1, result.size());
+        assertEquals(key, result.iterator().next());
+    }
+
+    @Test
+    public void runQueryOnAllPartitions_value() throws ExecutionException, InterruptedException {
+        Set result = queryEngine
+                .runQueryOnLocalPartitions(map.getName(), Predicates.equal("this", value), IterationType.VALUE, false);
+
+        assertEquals(1, result.size());
+        assertEquals(value, result.iterator().next());
+    }
+
+    @Test
+    public void runQueryOnGivenPartition() throws ExecutionException, InterruptedException {
+        Set result = queryEngine
+                .runQueryOnGivenPartition(map.getName(), Predicates.equal("this", value), IterationType.ENTRY, false, partitionId);
+
+        assertEquals(1, result.size());
+        assertEquals(map.get(key), ((Map.Entry) result.iterator().next()).getValue());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImplTest.java
@@ -15,7 +15,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
@@ -55,47 +54,52 @@ public class MapQueryEngineImplTest extends HazelcastTestSupport {
 
     @Test
     public void runQueryOnAllPartitions() throws ExecutionException, InterruptedException {
-        Set result = queryEngine
-                .runQueryOnLocalPartitions(map.getName(), Predicates.equal("this", value), IterationType.KEY, false);
+        QueryResult result = queryEngine
+                .runQueryOnLocalPartitions(map.getName(), Predicates.equal("this", value), IterationType.KEY);
 
         assertEquals(1, result.size());
-        assertEquals(key, result.iterator().next());
+        assertEquals(key, toObject(result.iterator().next().getKey()));
     }
 
     @Test
     public void runQueryOnLocalPartitions() throws ExecutionException, InterruptedException {
-        Set result = queryEngine
-                .runQueryOnAllPartitions(map.getName(), Predicates.equal("this", value), IterationType.KEY, false);
+        QueryResult result = queryEngine
+                .runQueryOnAllPartitions(map.getName(), Predicates.equal("this", value), IterationType.KEY);
 
         assertEquals(1, result.size());
-        assertEquals(key, result.iterator().next());
+        assertEquals(key, toObject(result.iterator().next().getKey()));
     }
 
     @Test
     public void runQueryOnAllPartitions_key() throws ExecutionException, InterruptedException {
-        Set result = queryEngine
-                .runQueryOnLocalPartitions(map.getName(), Predicates.equal("this", value), IterationType.KEY, false);
+        QueryResult result = queryEngine
+                .runQueryOnLocalPartitions(map.getName(), Predicates.equal("this", value), IterationType.KEY);
 
         assertEquals(1, result.size());
-        assertEquals(key, result.iterator().next());
+        assertEquals(key, toObject(result.iterator().next().getKey()));
     }
 
     @Test
     public void runQueryOnAllPartitions_value() throws ExecutionException, InterruptedException {
-        Set result = queryEngine
-                .runQueryOnLocalPartitions(map.getName(), Predicates.equal("this", value), IterationType.VALUE, false);
+        QueryResult result = queryEngine
+                .runQueryOnLocalPartitions(map.getName(), Predicates.equal("this", value), IterationType.VALUE);
 
         assertEquals(1, result.size());
-        assertEquals(value, result.iterator().next());
+        assertEquals(value, toObject(result.iterator().next().getValue()));
     }
 
     @Test
     public void runQueryOnGivenPartition() throws ExecutionException, InterruptedException {
-        Set result = queryEngine
-                .runQueryOnGivenPartition(map.getName(), Predicates.equal("this", value), IterationType.ENTRY, false, partitionId);
+        QueryResult result = queryEngine
+                .runQueryOnGivenPartition(map.getName(), Predicates.equal("this", value), IterationType.ENTRY, partitionId);
 
         assertEquals(1, result.size());
-        assertEquals(map.get(key), ((Map.Entry) result.iterator().next()).getValue());
+        assertEquals(key, toObject(((Map.Entry) result.iterator().next()).getKey()));
+        assertEquals(map.get(key), toObject(((Map.Entry) result.iterator().next()).getValue()));
+    }
+
+    private Object toObject(Object data) {
+        return getSerializationService(instance).toObject(data);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
@@ -6,7 +6,6 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.query.impl.predicates.RuleBasedQueryOptimizer;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -16,6 +15,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import java.util.Set;
 
 import static com.hazelcast.util.IterationType.ENTRY;
 import static org.junit.Assert.assertEquals;
@@ -52,35 +53,28 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     }
 
     @Test
-    public void checkResultLimit() throws Exception {
-        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
-
-        assertEquals(limit * PARTITION_COUNT, result.getResultLimit());
-    }
-
-    @Test
     public void checkResultSize_limitNotExceeded() throws Exception {
         fillPartition(limit - 1);
 
-        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
 
-        assertEquals(limit - 1, result.getRows().size());
+        assertEquals(limit - 1, result.size());
     }
 
     @Test
     public void checkResultSize_limitNotEquals() throws Exception {
         fillPartition(limit);
 
-        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
 
-        assertEquals(limit, result.getRows().size());
+        assertEquals(limit, result.size());
     }
 
     @Test(expected = QueryResultSizeExceededException.class)
     public void checkResultSize_limitExceeded() throws Exception {
         fillPartition(limit + 1);
 
-        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
     }
 
     private void fillPartition(int count) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
@@ -16,8 +16,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Set;
-
 import static com.hazelcast.util.IterationType.ENTRY;
 import static org.junit.Assert.assertEquals;
 
@@ -56,7 +54,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     public void checkResultSize_limitNotExceeded() throws Exception {
         fillPartition(limit - 1);
 
-        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit - 1, result.size());
     }
@@ -65,7 +63,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     public void checkResultSize_limitNotEquals() throws Exception {
         fillPartition(limit);
 
-        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit, result.size());
     }
@@ -74,7 +72,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     public void checkResultSize_limitExceeded() throws Exception {
         fillPartition(limit + 1);
 
-        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
+        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
     }
 
     private void fillPartition(int count) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
@@ -44,7 +44,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
         map = hz.getMap(randomName());
 
         MapService mapService = getNodeEngineImpl(hz).getService(MapService.SERVICE_NAME);
-        queryEngine = new MapQueryEngineImpl(mapService.getMapServiceContext(), new RuleBasedQueryOptimizer());
+        queryEngine = new MapQueryEngineImpl(mapService.getMapServiceContext());
 
         // we just fill a single partition, so we get the NodeResultLimit for a single partition as well
         QueryResultSizeLimiter resultSizeLimiter = queryEngine.getQueryResultSizeLimiter();
@@ -53,7 +53,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
 
     @Test
     public void checkResultLimit() throws Exception {
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit * PARTITION_COUNT, result.getResultLimit());
     }
@@ -62,7 +62,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     public void checkResultSize_limitNotExceeded() throws Exception {
         fillPartition(limit - 1);
 
-        QueryResult result = queryEngine.queryLocalPartition(map.getName(), TruePredicate.INSTANCE, PARTITION_ID, ENTRY);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit - 1, result.getRows().size());
     }
@@ -71,7 +71,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     public void checkResultSize_limitNotEquals() throws Exception {
         fillPartition(limit);
 
-        QueryResult result = queryEngine.queryLocalPartition(map.getName(), TruePredicate.INSTANCE, PARTITION_ID, ENTRY);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit, result.getRows().size());
     }
@@ -80,7 +80,7 @@ public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends 
     public void checkResultSize_limitExceeded() throws Exception {
         fillPartition(limit + 1);
 
-        queryEngine.queryLocalPartition(map.getName(), TruePredicate.INSTANCE, PARTITION_ID, ENTRY);
+        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
     }
 
     private void fillPartition(int count) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
@@ -6,7 +6,6 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.query.impl.predicates.RuleBasedQueryOptimizer;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -41,7 +40,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
         map = hz.getMap(randomName());
 
         MapService mapService = getNodeEngineImpl(hz).getService(MapService.SERVICE_NAME);
-        queryEngine = new MapQueryEngineImpl(mapService.getMapServiceContext(), new RuleBasedQueryOptimizer());
+        queryEngine = new MapQueryEngineImpl(mapService.getMapServiceContext());
 
         // we fill all partitions, so we get the NodeResultLimit for all partitions as well
         QueryResultSizeLimiter resultSizeLimiter = queryEngine.getQueryResultSizeLimiter();
@@ -50,7 +49,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
 
     @Test
     public void checkResultLimit() throws Exception {
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit, result.getResultLimit());
     }
@@ -59,7 +58,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     public void checkResultSize_limitNotExceeded() throws Exception {
         fillMap(limit - 1);
 
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit - 1, result.getRows().size());
     }
@@ -68,7 +67,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     public void checkResultSize_limitEquals() throws Exception {
         fillMap(limit);
 
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit, result.getRows().size());
     }
@@ -77,7 +76,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     public void checkResultSize_limitExceeded() throws Exception {
         fillMap(limit + 1);
 
-        queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
     }
 
     private void fillMap(long count) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
@@ -16,6 +16,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Set;
+
 import static com.hazelcast.util.IterationType.ENTRY;
 import static org.junit.Assert.assertEquals;
 
@@ -48,35 +50,28 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     }
 
     @Test
-    public void checkResultLimit() throws Exception {
-        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
-
-        assertEquals(limit, result.getResultLimit());
-    }
-
-    @Test
     public void checkResultSize_limitNotExceeded() throws Exception {
         fillMap(limit - 1);
 
-        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
 
-        assertEquals(limit - 1, result.getRows().size());
+        assertEquals(limit - 1, result.size());
     }
 
     @Test
     public void checkResultSize_limitEquals() throws Exception {
         fillMap(limit);
 
-        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
 
-        assertEquals(limit, result.getRows().size());
+        assertEquals(limit, result.size());
     }
 
     @Test(expected = QueryResultSizeExceededException.class)
     public void checkResultSize_limitExceeded() throws Exception {
         fillMap(limit + 1);
 
-        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
     }
 
     private void fillMap(long count) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
@@ -16,8 +16,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Set;
-
 import static com.hazelcast.util.IterationType.ENTRY;
 import static org.junit.Assert.assertEquals;
 
@@ -53,7 +51,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     public void checkResultSize_limitNotExceeded() throws Exception {
         fillMap(limit - 1);
 
-        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit - 1, result.size());
     }
@@ -62,7 +60,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     public void checkResultSize_limitEquals() throws Exception {
         fillMap(limit);
 
-        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(limit, result.size());
     }
@@ -71,7 +69,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends
     public void checkResultSize_limitExceeded() throws Exception {
         fillMap(limit + 1);
 
-        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
+        queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
     }
 
     private void fillMap(long count) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
@@ -4,7 +4,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.query.impl.predicates.RuleBasedQueryOptimizer;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -30,12 +29,12 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest exten
         map = hz.getMap(randomName());
 
         MapService mapService = getNodeEngineImpl(hz).getService(MapService.SERVICE_NAME);
-        queryEngine = new MapQueryEngineImpl(mapService.getMapServiceContext(), new RuleBasedQueryOptimizer());
+        queryEngine = new MapQueryEngineImpl(mapService.getMapServiceContext());
     }
 
     @Test
     public void checkResultLimit() throws Exception {
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(Long.MAX_VALUE, result.getResultLimit());
     }
@@ -44,7 +43,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest exten
     public void checkResultSize() throws Exception {
         fillMap(10000);
 
-        QueryResult result = queryEngine.queryLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(10000, result.getRows().size());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Set;
+
 import static com.hazelcast.util.IterationType.ENTRY;
 import static org.junit.Assert.assertEquals;
 
@@ -33,19 +35,12 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest exten
     }
 
     @Test
-    public void checkResultLimit() throws Exception {
-        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
-
-        assertEquals(Long.MAX_VALUE, result.getResultLimit());
-    }
-
-    @Test
     public void checkResultSize() throws Exception {
         fillMap(10000);
 
-        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
+        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
 
-        assertEquals(10000, result.getRows().size());
+        assertEquals(10000, result.size());
     }
 
     private void fillMap(long count) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
@@ -13,8 +13,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Set;
-
 import static com.hazelcast.util.IterationType.ENTRY;
 import static org.junit.Assert.assertEquals;
 
@@ -38,7 +36,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest exten
     public void checkResultSize() throws Exception {
         fillMap(10000);
 
-        Set result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY, false);
+        QueryResult result = queryEngine.runQueryOnLocalPartitions(map.getName(), TruePredicate.INSTANCE, ENTRY);
 
         assertEquals(10000, result.size());
     }


### PR DESCRIPTION
The problem:
In the previous approach the MapQueryEngine contained the following:
- logic how to run a query (full-partition-scan or index query)
- logic scheduling query operations 
- logic orchestrating queries (first query thread, later partition thread)

So, the proxies like a MapProxy used MapQueryEngine to schedule a query. In this call the MapQueryEngine dispatched operations which called (surprise, surprise) the MapQueryEngine to run the query logic. This was a mess and a lot of spaghetti...

There was also a lot of inconsistencies how difference scenarios of queries were run, e.g. query-optimizations, or queries with or without a PagingPredicate.
Finally, there was a big mess when it comes to the method names, to name some fancy ones: queryLocationPartition, queryTheLocalPartition, queryLocalPartitions.

Currently there are 3 entities separating main concerns:
- MapQueryRunner -> (local and parallel) runs the query logic in the caller thread.
- MapQueryDispatcher -> dispatches query operations (QueryOperation and QueryPartitionOperation). Does not know about the queryRunner and queryDispatcher.
- MapQueryEngine -> orchestrates the query by dispatching the query operations using the MapQueryDispatcher and merges thee result. (does not know about the queryRunner)

In this way there's no cycles and spaghetti bindings. It's also possible to read the code...

Furthermore:
- in the new approach there's no special path for PagingPredicate and non-paging predicate. Most of the stuff has been abstracted away and generalized.
- It's been fixed that the queries executed on the partitionThreads are optimized now (earlier the optimisation was not executed)

Important:

- This refactoring is the first one of a series.  It's not meant to fix all the problems. In my opinion it brings the query engine code to a next level.
- The result of this refactoring is consistent and does not limit us in any way.
- It opens possibilities to refactor further. 

I'll be working on fast-aggregations and projections next, thus the MapQueryEngine will be refactored further. Test coverage will also significantly increase.

The commits will be squashed at merge.