### PR TITLE
[DONT MERGE] Drop Packet writing side

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -28,7 +28,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionType;
-import com.hazelcast.nio.OutboundFrame;
 import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.tcp.IOThreadingModel;
 import com.hazelcast.nio.tcp.SocketChannelWrapper;
@@ -109,6 +108,11 @@ public class ClientConnection implements SocketConnection, DiscardableMetricsPro
     }
 
     @Override
+    public boolean write(byte[] frame, boolean urgent) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void provideMetrics(MetricsRegistry registry) {
         Socket socket = socketChannel.socket();
         String connectionName = "tcp.connection["
@@ -151,18 +155,18 @@ public class ClientConnection implements SocketConnection, DiscardableMetricsPro
     public int getPendingPacketCount() {
         return pendingPacketCount.get();
     }
-
-    @Override
-    public boolean write(OutboundFrame frame) {
-        if (!alive.get()) {
-            if (logger.isFinestEnabled()) {
-                logger.finest("Connection is closed, dropping frame -> " + frame);
-            }
-            return false;
-        }
-        writer.write(frame);
-        return true;
-    }
+//
+//    @Override
+//    public boolean write(OutboundFrame frame) {
+//        if (!alive.get()) {
+//            if (logger.isFinestEnabled()) {
+//                logger.finest("Connection is closed, dropping frame -> " + frame);
+//            }
+//            return false;
+//        }
+//        writer.write(frame);
+//        return true;
+//    }
 
     public void start() throws IOException {
         ByteBuffer buffer = ByteBuffer.allocate(3);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -134,7 +134,8 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
 
     private boolean writeToConnection(ClientConnection connection, ClientMessage clientMessage) {
         clientMessage.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
-        return connection.write(clientMessage);
+       // return connection.write(clientMessage);
+        return true;
     }
 
     private boolean isAllowedToSendRequest(ClientConnection connection, ClientInvocation invocation) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -232,17 +232,19 @@ public class TestClientRegistry {
             return stateMap.get(remoteAddress);
         }
 
-        @Override
-        public boolean write(OutboundFrame frame) {
-            Node node = serverNodeEngine.getNode();
-            if (node.getState() == NodeState.SHUT_DOWN) {
-                return false;
-            }
-            ClientMessage newPacket = readFromPacket((ClientMessage) frame);
-            lastWriteTime = System.currentTimeMillis();
-            node.clientEngine.handleClientMessage(newPacket, serverSideConnection);
-            return true;
-        }
+//
+//
+//        @Override
+//        public boolean write(OutboundFrame frame) {
+//            Node node = serverNodeEngine.getNode();
+//            if (node.getState() == NodeState.SHUT_DOWN) {
+//                return false;
+//            }
+//            ClientMessage newPacket = readFromPacket((ClientMessage) frame);
+//            lastWriteTime = System.currentTimeMillis();
+//            node.clientEngine.handleClientMessage(newPacket, serverSideConnection);
+//            return true;
+//        }
 
         private ClientMessage readFromPacket(ClientMessage packet) {
             return ClientMessage.createForDecode(packet.buffer(), 0);
@@ -317,16 +319,16 @@ public class TestClientRegistry {
             node.getConnectionManager().registerConnection(getEndPoint(), this);
         }
 
-        @Override
-        public boolean write(OutboundFrame frame) {
-            final ClientMessage packet = (ClientMessage) frame;
-            if (isAlive()) {
-                ClientMessage newPacket = readFromPacket(packet);
-                responseConnection.handleClientMessage(newPacket);
-                return true;
-            }
-            return false;
-        }
+//        @Override
+//        public boolean write(OutboundFrame frame) {
+//            final ClientMessage packet = (ClientMessage) frame;
+//            if (isAlive()) {
+//                ClientMessage newPacket = readFromPacket(packet);
+//                responseConnection.handleClientMessage(newPacket);
+//                return true;
+//            }
+//            return false;
+//        }
 
         @Override
         public boolean isClient() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -205,7 +205,7 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
         resultClientMessage.setVersion(ClientMessage.VERSION);
         final Connection connection = endpoint.getConnection();
         // TODO: framing not implemented yet, should be split into frames before writing to connection
-        connection.write(resultClientMessage);
+        //connection.write(resultClientMessage);
     }
 
     protected void sendClientMessage(Object key, ClientMessage resultClientMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/NoOpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/NoOpCommand.java
@@ -22,11 +22,13 @@ import static com.hazelcast.util.StringUtil.bytesToString;
 
 public class NoOpCommand extends AbstractTextCommand {
 
-    private final ByteBuffer response;
+   // private final ByteBuffer response;
+    private final byte[] response;
 
     public NoOpCommand(byte[] response) {
         super(TextCommandConstants.TextCommandType.NO_OP);
-        this.response = ByteBuffer.wrap(response);
+        this.response = response;
+   //     this.response = ByteBuffer.wrap(response);
     }
 
     @Override
@@ -35,15 +37,20 @@ public class NoOpCommand extends AbstractTextCommand {
     }
 
     @Override
-    public boolean writeTo(ByteBuffer dst) {
-        while (dst.hasRemaining() && response.hasRemaining()) {
-            dst.put(response.get());
-        }
-        return !response.hasRemaining();
+    public byte[] toBytes() {
+        return response;
     }
+
+//    @Override
+//    public boolean writeTo(ByteBuffer dst) {
+//        while (dst.hasRemaining() && response.hasRemaining()) {
+//            dst.put(response.get());
+//        }
+//        return !response.hasRemaining();
+//    }
 
     @Override
     public String toString() {
-        return "NoOpCommand {" + bytesToString(response.array()) + "}";
+        return "NoOpCommand {" + bytesToString(response) + "}";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
@@ -36,7 +36,7 @@ public interface TextCommand extends OutboundFrame {
 
     boolean shouldReply();
 
-    boolean readFrom(ByteBuffer src);
+    byte[] toBytes();
 
-    boolean writeTo(ByteBuffer dst);
+    boolean readFrom(ByteBuffer src);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -398,9 +398,14 @@ public class TextCommandServiceImpl implements TextCommandService {
                             return true;
                         }
 
+//                        @Override
+//                        public boolean writeTo(ByteBuffer dst) {
+//                            return true;
+//                        }
+
                         @Override
-                        public boolean writeTo(ByteBuffer dst) {
-                            return true;
+                        public byte[] toBytes() {
+                            throw new UnsupportedOperationException();
                         }
                     });
                     //noinspection WaitNotInLoop

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommand.java
@@ -44,15 +44,20 @@ public class DeleteCommand extends AbstractTextCommand {
     }
 
     @Override
-    public boolean writeTo(ByteBuffer dst) {
-        if (response == null) {
-            response = ByteBuffer.wrap(TextCommandConstants.STORED);
-        }
-        while (dst.hasRemaining() && response.hasRemaining()) {
-            dst.put(response.get());
-        }
-        return !response.hasRemaining();
+    public byte[] toBytes() {
+        return TextCommandConstants.STORED;
     }
+
+//    @Override
+//    public boolean writeTo(ByteBuffer dst) {
+//        if (response == null) {
+//            response = ByteBuffer.wrap(TextCommandConstants.STORED);
+//        }
+//        while (dst.hasRemaining() && response.hasRemaining()) {
+//            dst.put(response.get());
+//        }
+//        return !response.hasRemaining();
+//    }
 
     @Override
     public boolean shouldReply() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/ErrorCommand.java
@@ -26,7 +26,6 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.ERROR;
 import static com.hazelcast.internal.ascii.TextCommandConstants.SERVER_ERROR;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_SERVER;
-import static com.hazelcast.nio.IOUtil.copyToHeapBuffer;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
 public class ErrorCommand extends AbstractTextCommand {
@@ -67,10 +66,15 @@ public class ErrorCommand extends AbstractTextCommand {
     }
 
     @Override
-    public boolean writeTo(ByteBuffer dst) {
-        copyToHeapBuffer(response, dst);
-        return !response.hasRemaining();
+    public byte[] toBytes() {
+        return response.array();
     }
+
+//    @Override
+//    public boolean writeTo(ByteBuffer dst) {
+//        copyToHeapBuffer(response, dst);
+//        return !response.hasRemaining();
+//    }
 
     @Override
     public String toString() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommand.java
@@ -26,7 +26,7 @@ public class IncrementCommand extends AbstractTextCommand {
     private String key;
     private int value;
     private boolean noreply;
-    private ByteBuffer response;
+    private byte[] response;
 
     public IncrementCommand(TextCommandConstants.TextCommandType type, String key, int value, boolean noReply) {
         super(type);
@@ -36,12 +36,17 @@ public class IncrementCommand extends AbstractTextCommand {
     }
 
     @Override
-    public boolean writeTo(ByteBuffer dst) {
-        while (dst.hasRemaining() && response.hasRemaining()) {
-            dst.put(response.get());
-        }
-        return !response.hasRemaining();
+    public byte[] toBytes() {
+        return response;
     }
+//
+//    @Override
+//    public boolean writeTo(ByteBuffer dst) {
+//        while (dst.hasRemaining() && response.hasRemaining()) {
+//            dst.put(response.get());
+//        }
+//        return !response.hasRemaining();
+//    }
 
     @Override
     public boolean readFrom(ByteBuffer src) {
@@ -62,6 +67,6 @@ public class IncrementCommand extends AbstractTextCommand {
     }
 
     public void setResponse(byte[] value) {
-        this.response = ByteBuffer.wrap(value);
+        this.response = value;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommand.java
@@ -74,15 +74,20 @@ public class SetCommand extends AbstractTextCommand {
     }
 
     @Override
-    public boolean writeTo(ByteBuffer dst) {
-        if (response == null) {
-            response = ByteBuffer.wrap(TextCommandConstants.STORED);
-        }
-        while (dst.hasRemaining() && response.hasRemaining()) {
-            dst.put(response.get());
-        }
-        return !response.hasRemaining();
+    public byte[] toBytes() {
+        return TextCommandConstants.STORED;
     }
+//
+//    @Override
+//    public boolean writeTo(ByteBuffer dst) {
+//        if (response == null) {
+//            response = ByteBuffer.wrap(TextCommandConstants.STORED);
+//        }
+//        while (dst.hasRemaining() && response.hasRemaining()) {
+//            dst.put(response.get());
+//        }
+//        return !response.hasRemaining();
+//    }
 
     @Override
     public boolean shouldReply() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommand.java
@@ -22,7 +22,7 @@ import com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType;
 import java.nio.ByteBuffer;
 
 public class SimpleCommand extends AbstractTextCommand {
-    private ByteBuffer response;
+    private byte[] response;
 
     public SimpleCommand(TextCommandType type) {
         super(type);
@@ -32,16 +32,22 @@ public class SimpleCommand extends AbstractTextCommand {
         return true;
     }
 
-    public void setResponse(byte[] value) {
-        this.response = ByteBuffer.wrap(value);
+    public void setResponse(byte[] response) {
+        this.response = response;
     }
 
-    public boolean writeTo(ByteBuffer dst) {
-        while (dst.hasRemaining() && response.hasRemaining()) {
-            dst.put(response.get());
-        }
-        return !response.hasRemaining();
+    @Override
+    public byte[] toBytes() {
+        return response;
     }
+
+    //
+//    public boolean writeTo(ByteBuffer dst) {
+//        while (dst.hasRemaining() && response.hasRemaining()) {
+//            dst.put(response.get());
+//        }
+//        return !response.hasRemaining();
+//    }
 
     @Override
     public String toString() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/StatsCommand.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.ascii.TextCommandConstants;
 
 import java.nio.ByteBuffer;
 
-import static com.hazelcast.nio.IOUtil.copyToHeapBuffer;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
 public class StatsCommand extends AbstractTextCommand {
@@ -96,13 +95,18 @@ public class StatsCommand extends AbstractTextCommand {
     }
 
     @Override
-    public boolean writeTo(ByteBuffer dst) {
-        if (response == null) {
-            response = ByteBuffer.allocate(0);
-        }
-        copyToHeapBuffer(response, dst);
-        return !response.hasRemaining();
+    public byte[] toBytes() {
+        return new byte[0];
     }
+//
+//    @Override
+//    public boolean writeTo(ByteBuffer dst) {
+//        if (response == null) {
+//            response = ByteBuffer.allocate(0);
+//        }
+//        copyToHeapBuffer(response, dst);
+//        return !response.hasRemaining();
+//    }
 
     @Override
     public String toString() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommand.java
@@ -36,15 +36,20 @@ public class TouchCommand extends AbstractTextCommand {
     }
 
     @Override
-    public boolean writeTo(ByteBuffer dst) {
-        if (response == null) {
-            response = ByteBuffer.wrap(TextCommandConstants.STORED);
-        }
-        while (dst.hasRemaining() && response.hasRemaining()) {
-            dst.put(response.get());
-        }
-        return !response.hasRemaining();
+    public byte[] toBytes() {
+        return TextCommandConstants.STORED;
     }
+//
+//    @Override
+//    public boolean writeTo(ByteBuffer dst) {
+//        if (response == null) {
+//            response = ByteBuffer.wrap(TextCommandConstants.STORED);
+//        }
+//        while (dst.hasRemaining() && response.hasRemaining()) {
+//            dst.put(response.get());
+//        }
+//        return !response.hasRemaining();
+//    }
 
     @Override
     public boolean readFrom(ByteBuffer src) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/VersionCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/VersionCommand.java
@@ -30,11 +30,16 @@ public class VersionCommand extends AbstractTextCommand {
     protected VersionCommand(TextCommandConstants.TextCommandType type) {
         super(type);
     }
+//
+//    @Override
+//    public boolean writeTo(ByteBuffer dst) {
+//        dst.put(VERSION);
+//        return true;
+//    }
 
     @Override
-    public boolean writeTo(ByteBuffer dst) {
-        dst.put(VERSION);
-        return true;
+    public byte[] toBytes() {
+        return VERSION;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -22,7 +22,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.ByteBuffer;
 
-import static com.hazelcast.nio.IOUtil.copyToHeapBuffer;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
 @SuppressFBWarnings({"EI_EXPOSE_REP", "MS_MUTABLE_ARRAY", "MS_PKGPROTECT"})
@@ -121,10 +120,20 @@ public abstract class HttpCommand extends AbstractTextCommand {
     }
 
     @Override
-    public boolean writeTo(ByteBuffer dst) {
-        copyToHeapBuffer(response, dst);
-        return !response.hasRemaining();
+    public byte[] toBytes() {
+        return response.array();
     }
+
+    @Override
+    public boolean readFrom(ByteBuffer src) {
+        return false;
+    }
+//
+//    @Override
+//    public boolean writeTo(ByteBuffer dst) {
+//        copyToHeapBuffer(response, dst);
+//        return !response.hasRemaining();
+//    }
 
     @Override
     public String toString() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -130,11 +130,6 @@ public abstract class AbstractSerializationService implements InternalSerializat
     }
 
     @Override
-    public byte[] toBytes(int padding, Object obj) {
-        return toBytes(padding, obj, globalPartitioningStrategy);
-    }
-
-    @Override
     public byte[] toBytes(Object obj, PartitioningStrategy strategy) {
         return toBytes(0, obj, strategy);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -130,6 +130,11 @@ public abstract class AbstractSerializationService implements InternalSerializat
     }
 
     @Override
+    public byte[] toBytes(int padding, Object obj) {
+        return toBytes(padding, obj, globalPartitioningStrategy);
+    }
+
+    @Override
     public byte[] toBytes(Object obj, PartitioningStrategy strategy) {
         return toBytes(0, obj, strategy);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -415,6 +415,16 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
     }
 
     @Override
+    public byte[] toByteArray(int padding) {
+        if (buffer == null || pos == 0) {
+            return new byte[padding];
+        }
+        final byte[] newBuffer = new byte[padding + pos];
+        System.arraycopy(buffer, 0, newBuffer, padding, pos);
+        return newBuffer;
+    }
+
+    @Override
     public void clear() {
         pos = 0;
         if (buffer != null && buffer.length > initialSize * 8) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -415,16 +415,6 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
     }
 
     @Override
-    public byte[] toByteArray(int padding) {
-        if (buffer == null || pos == 0) {
-            return new byte[padding];
-        }
-        final byte[] newBuffer = new byte[padding + pos];
-        System.arraycopy(buffer, 0, newBuffer, padding, pos);
-        return newBuffer;
-    }
-
-    @Override
     public void clear() {
         pos = 0;
         if (buffer != null && buffer.length > initialSize * 8) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -134,6 +134,11 @@ final class EmptyObjectDataOutput implements ObjectDataOutput {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public byte[] toByteArray(int padding) {
+        throw new UnsupportedOperationException();
+    }
+
     public void close() throws IOException {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -134,11 +134,6 @@ final class EmptyObjectDataOutput implements ObjectDataOutput {
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public byte[] toByteArray(int padding) {
-        throw new UnsupportedOperationException();
-    }
-
     public void close() throws IOException {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -268,11 +268,6 @@ public class ObjectDataOutputStream extends OutputStream implements ObjectDataOu
     }
 
     @Override
-    public byte[] toByteArray(int padding) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void flush() throws IOException {
         dataOut.flush();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -268,6 +268,11 @@ public class ObjectDataOutputStream extends OutputStream implements ObjectDataOu
     }
 
     @Override
+    public byte[] toByteArray(int padding) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void flush() throws IOException {
         dataOut.flush();
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/Connection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Connection.java
@@ -115,10 +115,11 @@ public interface Connection {
      * does not need to be a synchronous call.
      *
      * @param frame the frame to write.
+     * @param  urgent if the frame has priority or not.
      * @return false if the frame was not accepted to be written, e.g. because the Connection was not alive.
      * @throws NullPointerException if frame is null.
      */
-    boolean write(OutboundFrame frame);
+    boolean write(byte[] frame, boolean urgent);
 
     /**
      * Closes this connection.

--- a/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ConnectionManager.java
@@ -95,7 +95,7 @@ public interface ConnectionManager extends ConnectionListenable {
      * to be received since the Packet perhaps is stuck in some buffer. It just means that it is buffered somewhere.
      * @throws NullPointerException if packet is null.
      */
-    boolean transmit(Packet packet, Connection connection);
+    boolean transmit(byte[] packet, boolean urgent, Connection connection);
 
     /**
      * Transmits a packet to a certain address.
@@ -109,7 +109,7 @@ public interface ConnectionManager extends ConnectionListenable {
      * @throws NullPointerException if packet or target is null.
      * @see #transmit(com.hazelcast.nio.Packet, com.hazelcast.nio.Connection)
      */
-    boolean transmit(Packet packet, Address target);
+    boolean transmit(byte[] packet, boolean urgent, Address target);
 
     /**
      * Starts ConnectionManager, initializes its resources, starts threads, etc. After start, ConnectionManager

--- a/hazelcast/src/main/java/com/hazelcast/nio/PacketUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/PacketUtil.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+
+import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
+import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
+import static com.hazelcast.nio.Bits.readInt;
+import static com.hazelcast.nio.Bits.readShort;
+import static com.hazelcast.nio.Bits.writeInt;
+import static com.hazelcast.nio.Bits.writeShort;
+
+public final class PacketUtil {
+
+    private static final int OFFSET_VERSION = 0;
+    private static final int OFFSET_FLAGS = OFFSET_VERSION + 1;
+    private static final int OFFSET_PARTITION_ID = OFFSET_FLAGS + SHORT_SIZE_IN_BYTES;
+    private static final int OFFSET_SIZE = OFFSET_PARTITION_ID + INT_SIZE_IN_BYTES;
+    private static final int OFFSET_PAYLOAD = OFFSET_SIZE + INT_SIZE_IN_BYTES;
+
+    private PacketUtil() {
+    }
+
+    public static Packet toPacket(byte[] bytes) {
+        byte[] payload = new byte[bytes.length - OFFSET_PAYLOAD];
+        System.arraycopy(bytes, OFFSET_PAYLOAD, payload, 0, payload.length);
+
+        short flags = readShort(bytes, OFFSET_FLAGS, true);
+        int partitionId = readInt(bytes, OFFSET_PARTITION_ID, true);
+        return new Packet(payload, partitionId)
+                .setAllFlags(flags);
+    }
+
+    public static byte[] getPayload(byte[] packet) {
+        byte[] payload = new byte[packet.length - OFFSET_PAYLOAD];
+        System.arraycopy(packet, OFFSET_PAYLOAD, payload, 0, payload.length);
+        return payload;
+    }
+
+    public static byte[] fromPacket(Packet packet) {
+        byte[] payload = packet.toByteArray();
+        byte[] bytes = new byte[OFFSET_PAYLOAD + payload.length];
+        System.arraycopy(payload, 0, bytes, OFFSET_PAYLOAD, payload.length);
+
+        // version
+        bytes[OFFSET_VERSION] = Packet.VERSION;
+        //flags
+        writeShort(bytes, OFFSET_FLAGS, packet.getFlags(), true);
+        //partition-id
+        writeInt(bytes, OFFSET_PARTITION_ID, packet.getPartitionId(), true);
+        //size
+        writeInt(bytes, OFFSET_SIZE, payload.length, true);
+
+        return bytes;
+    }
+
+    public static byte[] toBytePacket(InternalSerializationService serializationService,
+                                      Object payload,
+                                      int flags,
+                                      int partitionId) {
+        byte[] bytes = serializationService.toBytes(OFFSET_PAYLOAD, payload);
+        // version
+        bytes[OFFSET_VERSION] = Packet.VERSION;
+        //flags
+        writeShort(bytes, OFFSET_FLAGS, (short) flags, true);
+        //partition-id
+        writeInt(bytes, OFFSET_PARTITION_ID, partitionId, true);
+        //size
+        writeInt(bytes, OFFSET_SIZE, bytes.length - OFFSET_PAYLOAD, true);
+
+        return bytes;
+    }
+
+    public static short getFlags(byte[] packet) {
+        return readShort(packet, OFFSET_FLAGS, true);
+    }
+
+    public static int getSize(byte[] packet) {
+        return readInt(packet, OFFSET_SIZE, true);
+    }
+
+    public static int getPartition(byte[] packet) {
+        return readInt(packet, OFFSET_PARTITION_ID, true);
+    }
+
+
+    /**
+     * Checks if a flag is set.
+     *
+     * @param flag the flag to check
+     * @return true if the flag is set, false otherwise.
+     */
+    public static boolean isFlagSet(byte[] packet, int flag) {
+        return (getFlags(packet) & flag) != 0;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextWriteHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextWriteHandler.java
@@ -38,10 +38,10 @@ public class TextWriteHandler implements WriteHandler<TextCommand> {
     public void enqueue(TextCommand response) {
         long requestId = response.getRequestId();
         if (requestId == -1) {
-            connection.write(response);
+            connection.write(response.toBytes(), false);
         } else {
             if (currentRequestId == requestId) {
-                connection.write(response);
+                connection.write(response.toBytes(), false);
                 currentRequestId++;
                 processWaitingResponses();
             } else {
@@ -53,7 +53,7 @@ public class TextWriteHandler implements WriteHandler<TextCommand> {
     private void processWaitingResponses() {
         TextCommand response = responses.remove(currentRequestId);
         while (response != null) {
-            connection.write(response);
+            connection.write(response.toBytes(), false);
             currentRequestId++;
             response = responses.remove(currentRequestId);
         }
@@ -61,6 +61,7 @@ public class TextWriteHandler implements WriteHandler<TextCommand> {
 
     @Override
     public boolean onWrite(TextCommand textCommand, ByteBuffer dst) throws Exception {
-        return textCommand.writeTo(dst);
+        //return textCommand.writeTo(dst);
+        throw new UnsupportedOperationException();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketWriter.java
@@ -57,8 +57,9 @@ public interface SocketWriter {
      * No guarantees are made that the frame is going to be written or received by the other side.
      *
      * @param frame the Frame to write.
+     * @param urgent if the frame has priority
      */
-    void write(OutboundFrame frame);
+    void write(byte[] frame, boolean urgent);
 
     /**
      * Gets the {@link WriteHandler} that belongs to this SocketWriter.

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ConnectionType;
-import com.hazelcast.nio.OutboundFrame;
 
 import java.io.EOFException;
 import java.net.InetAddress;
@@ -210,14 +209,14 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
     }
 
     @Override
-    public boolean write(OutboundFrame frame) {
+    public boolean write(byte[] frame, boolean urgent) {
         if (!alive.get()) {
             if (logger.isFinestEnabled()) {
                 logger.finest("Connection is closed, won't write packet -> " + frame);
             }
             return false;
         }
-        socketWriter.write(frame);
+        socketWriter.write(frame, urgent);
         return true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
@@ -74,7 +74,11 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
 
     @Override
     public void write(byte[] bytes, boolean urgent) {
-        throw new UnsupportedOperationException();
+        if (urgent) {
+            urgentWriteQueue.add(bytes);
+        } else {
+            writeQueue.add(bytes);
+        }
     }
 
     @Probe(name = "writeQueuePendingBytes")

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/spinning/SpinningSocketWriter.java
@@ -20,7 +20,6 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.OutboundFrame;
-import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.tcp.IOOutOfMemoryHandler;
 import com.hazelcast.nio.tcp.SocketConnection;
 import com.hazelcast.nio.tcp.SocketWriter;
@@ -46,11 +45,11 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
 
     @SuppressWarnings("checkstyle:visibilitymodifier")
     @Probe(name = "writeQueueSize")
-    public final Queue<OutboundFrame> writeQueue = new ConcurrentLinkedQueue<OutboundFrame>();
+    public final Queue writeQueue = new ConcurrentLinkedQueue();
 
     @SuppressWarnings("checkstyle:visibilitymodifier")
     @Probe(name = "priorityWriteQueueSize")
-    public final Queue<OutboundFrame> urgentWriteQueue = new ConcurrentLinkedQueue<OutboundFrame>();
+    public final Queue urgentWriteQueue = new ConcurrentLinkedQueue();
 
     private final SocketWriterInitializer initializer;
     private ByteBuffer outputBuffer;
@@ -62,7 +61,8 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
     private final SwCounter priorityFramesWritten = newSwCounter();
     private volatile long lastWriteTime;
     private WriteHandler writeHandler;
-    private volatile OutboundFrame currentFrame;
+    private volatile byte[] currentFrame;
+    private int position;
 
     public SpinningSocketWriter(SocketConnection connection,
                                 ILogger logger,
@@ -73,12 +73,8 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
     }
 
     @Override
-    public void write(OutboundFrame frame) {
-        if (frame.isUrgent()) {
-            urgentWriteQueue.add(frame);
-        } else {
-            writeQueue.add(frame);
-        }
+    public void write(byte[] bytes, boolean urgent) {
+        throw new UnsupportedOperationException();
     }
 
     @Probe(name = "writeQueuePendingBytes")
@@ -101,11 +97,11 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
         return urgentWriteQueue.size() + writeQueue.size();
     }
 
-    private long bytesPending(Queue<OutboundFrame> writeQueue) {
+    private long bytesPending(Queue<Object> writeQueue) {
         long bytesPending = 0;
-        for (OutboundFrame frame : writeQueue) {
-            if (frame instanceof Packet) {
-                bytesPending += ((Packet) frame).packetSize();
+        for (Object frame : writeQueue) {
+            if (frame instanceof byte[]) {
+                bytesPending += ((byte[]) frame).length;
             }
         }
         return bytesPending;
@@ -153,10 +149,10 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
         this.outputBuffer = outputBuffer;
     }
 
-    private OutboundFrame poll() {
+    private byte[] poll() {
         for (; ; ) {
             boolean urgent = true;
-            OutboundFrame frame = urgentWriteQueue.poll();
+            Object frame = urgentWriteQueue.poll();
 
             if (frame == null) {
                 urgent = false;
@@ -179,7 +175,7 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
                 normalFramesWritten.inc();
             }
 
-            return frame;
+            return (byte[]) frame;
         }
     }
 
@@ -189,7 +185,7 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
         urgentWriteQueue.clear();
 
         ShutdownTask shutdownTask = new ShutdownTask();
-        write(new TaskFrame(shutdownTask));
+        // write(new TaskFrame(shutdownTask));
         shutdownTask.awaitCompletion();
     }
 
@@ -245,14 +241,35 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
                 }
             }
 
-            // Lets write the currentFrame to the outputBuffer.
-            if (!writeHandler.onWrite(currentFrame, outputBuffer)) {
-                // We are done for this round because not all data of the current frame fits in the outputBuffer
+            // the number of bytes that can be written to the bb.
+            int bytesWritable = outputBuffer.remaining();
+
+            // the number of bytes that need to be written.
+            int bytesNeeded = currentFrame.length - position;
+
+            int bytesWrite;
+            boolean done;
+            if (bytesWritable >= bytesNeeded) {
+                // All bytes for the value are available.
+                bytesWrite = bytesNeeded;
+                done = true;
+            } else {
+                // Not all bytes for the value are available. So lets write as much as is available.
+                bytesWrite = bytesWritable;
+                done = false;
+            }
+
+            outputBuffer.put(currentFrame, position, bytesWrite);
+            position += bytesWrite;
+
+            if (!done) {
                 return;
             }
 
+
             // The current frame has been written completely. So lets null it and lets try to write another frame.
             currentFrame = null;
+            position = 0;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -59,6 +59,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
+import static com.hazelcast.nio.Packet.FLAG_EVENT;
+import static com.hazelcast.nio.PacketUtil.toBytePacket;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
@@ -398,10 +400,9 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
                 ignore(ignored);
             }
         } else {
-            Packet packet = new Packet(serializationService.toBytes(eventEnvelope), orderKey);
-            packet.setFlag(Packet.FLAG_EVENT);
+            byte[] packet = toBytePacket(serializationService, eventEnvelope, FLAG_EVENT, -1);
 
-            if (!nodeEngine.getNode().getConnectionManager().transmit(packet, subscriber)) {
+            if (!nodeEngine.getNode().getConnectionManager().transmit(packet, false, subscriber)) {
                 if (nodeEngine.isRunning()) {
                     logFailure("Failed to send event packet to: %s , connection might not alive.", subscriber);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -55,6 +55,7 @@ import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_CONTROL;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
+import static com.hazelcast.nio.PacketUtil.toBytePacket;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -477,9 +478,8 @@ class InvocationMonitor implements PacketHandler, MetricsProvider {
             if (address.equals(thisAddress)) {
                 scheduler.execute(new ProcessOperationHeartbeatsTask(callIds));
             } else {
-                Packet packet = new Packet(serializationService.toBytes(callIds))
-                        .setAllFlags(FLAG_OP | FLAG_OP_CONTROL | FLAG_URGENT);
-                nodeEngine.getNode().getConnectionManager().transmit(packet, address);
+                byte[] packet = toBytePacket(serializationService, callIds, FLAG_OP | FLAG_OP_CONTROL | FLAG_URGENT, -1);
+                nodeEngine.getNode().getConnectionManager().transmit(packet, true, address);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/Main.java
+++ b/hazelcast/src/test/java/com/hazelcast/Main.java
@@ -1,0 +1,32 @@
+package com.hazelcast;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Created by alarmnummer on 10/22/16.
+ */
+public class Main extends HazelcastTestSupport{
+
+    @Test
+    public void test(){
+        setLoggingLog4j();
+
+        System.out.println("====================== hz1 ==========================");
+        HazelcastInstance hz1 = Hazelcast.newHazelcastInstance();
+
+        System.out.println("====================== hz2 ==========================");
+        HazelcastInstance hz2 = Hazelcast.newHazelcastInstance();
+
+        System.out.println("starting");
+
+        for(int k=0;k<10000;k++){
+            hz1.getAtomicLong("k").get();
+        }
+
+        System.out.println("done");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/AbstractOutOfMemoryHandlerTest.java
@@ -91,12 +91,12 @@ public abstract class AbstractOutOfMemoryHandlerTest extends HazelcastTestSuppor
         }
 
         @Override
-        public boolean transmit(Packet packet, Connection connection) {
+        public boolean transmit(byte[] packet, boolean urgent, Connection connection) {
             return false;
         }
 
         @Override
-        public boolean transmit(Packet packet, Address target) {
+        public boolean transmit(byte[] packet, boolean urgent, Address target) {
             return false;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -82,6 +82,18 @@ public class AbstractSerializationServiceTest {
         assertEquals(original.value, found.value);
     }
 
+    @Test
+    public void testPortable() {
+        ExternalizableValue original = new ExternalizableValue(100);
+
+        Data data = abstractSerializationService.toData(original);
+        ExternalizableValue found = abstractSerializationService.toObject(data);
+
+        assertNotNull(found);
+        assertEquals(original.value, found.value);
+    }
+
+
     static class ExternalizableValue implements Externalizable {
         int value;
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/PacketUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/PacketUtilTest.java
@@ -1,0 +1,59 @@
+package com.hazelcast.nio;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import org.junit.Test;
+
+import static com.hazelcast.nio.PacketUtil.isFlagSet;
+import static com.hazelcast.nio.PacketUtil.toBytePacket;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PacketUtilTest {
+
+    private InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+    public static final String PAYLOAD = "foobar";
+
+    @Test
+    public void testToPacket() {
+        Packet packet = new Packet(serializationService.toBytes(PAYLOAD))
+                .setFlag(Packet.FLAG_BIND);
+
+        Packet found = PacketUtil.toPacket(PacketUtil.fromPacket(packet));
+        assertEquals(packet, found);
+    }
+
+    @Test
+    public void toPacket2() {
+        Packet packet = new Packet(serializationService.toBytes(PAYLOAD))
+                .setFlag(Packet.FLAG_BIND);
+
+
+        byte[] bytes = toBytePacket(serializationService, PAYLOAD, Packet.FLAG_BIND, 0);
+        assertEquals(packet.toByteArray().length, PacketUtil.getSize(bytes));
+    }
+
+    @Test
+    public void testIsFlagSet() {
+
+        byte[] bytes = toBytePacket(serializationService, PAYLOAD, Packet.FLAG_OP, 0);
+
+        assertTrue(isFlagSet(bytes, Packet.FLAG_OP));
+        assertFalse(isFlagSet(bytes, Packet.FLAG_BIND));
+    }
+
+    @Test
+    public void testGetPartition_withPartitionId() {
+        byte[] bytes = toBytePacket(serializationService, PAYLOAD, Packet.FLAG_OP, 10);
+        assertEquals(10, PacketUtil.getPartition(bytes));
+    }
+
+    @Test
+    public void testGetPartition_withoutPartitionId() {
+        String payload = "foobar";
+
+        byte[] bytes = toBytePacket(serializationService, payload, Packet.FLAG_OP, -1);
+        assertEquals(-1, PacketUtil.getPartition(bytes));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/DroppingConnection.java
@@ -53,7 +53,7 @@ class DroppingConnection implements Connection {
     }
 
     @Override
-    public boolean write(OutboundFrame frame) {
+    public boolean write(byte[] frame, boolean urgent) {
         return true;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
@@ -78,24 +78,24 @@ public class FirewallingMockConnectionManager extends MockConnectionManager {
         this.packetFilter = packetFilter;
     }
 
-    private boolean isAllowed(Packet packet, Address target) {
+    private boolean isAllowed(byte[] packet, boolean urgent, Address target) {
         boolean allowed = true;
         PacketFilter filter = packetFilter;
         if (filter != null) {
-            allowed = filter.allow(packet, target);
+            allowed = filter.allow(packet, urgent, target);
         }
         return allowed;
     }
 
     @Override
-    public boolean transmit(Packet packet, Connection connection) {
+    public boolean transmit(byte[] packet, boolean urgent, Connection connection) {
         return connection != null
-                && isAllowed(packet, connection.getEndPoint())
-                && super.transmit(packet, connection);
+                && isAllowed(packet, urgent, connection.getEndPoint())
+                && super.transmit(packet, urgent, connection);
     }
 
     @Override
-    public boolean transmit(Packet packet, Address target) {
-        return isAllowed(packet, target) && super.transmit(packet, target);
+    public boolean transmit(byte[] packet, boolean urgent, Address target) {
+        return isAllowed(packet, urgent, target) && super.transmit(packet, urgent, target);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
@@ -25,6 +25,6 @@ import com.hazelcast.nio.Packet;
  */
 public interface PacketFilter {
 
-    boolean allow(Packet packet, Address endpoint);
+    boolean allow(byte[] packet, boolean urgent, Address endpoint);
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BaseTest.java
@@ -1,6 +1,7 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.nio.Packet;
+import com.hazelcast.nio.PacketUtil;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.test.AssertTask;
 import org.junit.Before;
@@ -12,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.hazelcast.nio.PacketUtil.toBytePacket;
 import static java.lang.System.currentTimeMillis;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -45,9 +47,9 @@ public abstract class TcpIpConnection_BaseTest extends TcpIpConnection_AbstractT
     public void write_whenNonUrgent() {
         TcpIpConnection c = connect(connManagerA, addressB);
 
-        Packet packet = new Packet(serializationService.toBytes("foo"));
+        final byte[] packet = toBytePacket(serializationService, "foo", 0, -1);
 
-        boolean result = c.write(packet);
+        boolean result = c.write(packet, false);
 
         assertTrue(result);
         assertTrueEventually(new AssertTask() {
@@ -58,17 +60,16 @@ public abstract class TcpIpConnection_BaseTest extends TcpIpConnection_AbstractT
         });
 
         Packet found = packetsB.get(0);
-        assertEquals(packet, found);
+        assertEquals(PacketUtil.toPacket(packet), found);
     }
 
     @Test
     public void write_whenUrgent() {
         TcpIpConnection c = connect(connManagerA, addressB);
 
-        Packet packet = new Packet(serializationService.toBytes("foo"));
-        packet.setFlag(Packet.FLAG_URGENT);
+        final byte[] packet = toBytePacket(serializationService, "foo", Packet.FLAG_URGENT, -1);
 
-        boolean result = c.write(packet);
+        boolean result = c.write(packet, true);
 
         assertTrue(result);
         assertTrueEventually(new AssertTask() {
@@ -79,7 +80,7 @@ public abstract class TcpIpConnection_BaseTest extends TcpIpConnection_AbstractT
         });
 
         Packet found = packetsB.get(0);
-        assertEquals(packet, found);
+        assertEquals(PacketUtil.toPacket(packet), found);
     }
 
     @Test
@@ -90,9 +91,9 @@ public abstract class TcpIpConnection_BaseTest extends TcpIpConnection_AbstractT
         // we need this so we can determine the lastWriteTime got updated
         sleepSeconds(LAST_READ_WRITE_SLEEP_SECONDS);
 
-        Packet packet = new Packet(serializationService.toBytes("foo"));
+        final byte[] packet = toBytePacket(serializationService, "foo", 0, -1);
 
-        connAB.write(packet);
+        connAB.write(packet, false);
 
         // wait for the packet to get written.
         assertTrueEventually(new AssertTask() {
@@ -135,9 +136,9 @@ public abstract class TcpIpConnection_BaseTest extends TcpIpConnection_AbstractT
         // we need this so we can determine the lastReadTime got updated
         sleepSeconds(LAST_READ_WRITE_SLEEP_SECONDS);
 
-        Packet packet = new Packet(serializationService.toBytes("foo"));
+        final byte[] packet = toBytePacket(serializationService, "foo", 0, -1);
 
-        connAB.write(packet);
+        connAB.write(packet, false);
 
         // wait for the packet to get read.
         assertTrueEventually(new AssertTask() {
@@ -174,9 +175,9 @@ public abstract class TcpIpConnection_BaseTest extends TcpIpConnection_AbstractT
         TcpIpConnection c = connect(connManagerA, addressB);
         c.close(null, null);
 
-        Packet packet = new Packet(serializationService.toBytes("foo"));
+        final byte[] packet = toBytePacket(serializationService, "foo", 0, -1);
 
-        boolean result = c.write(packet);
+        boolean result = c.write(packet, false);
 
         assertFalse(result);
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionType;
 import com.hazelcast.nio.OutboundFrame;
 import com.hazelcast.nio.Packet;
+import com.hazelcast.nio.PacketUtil;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -63,7 +64,8 @@ public class MockConnection implements Connection {
         return remoteEndpoint;
     }
 
-    public boolean write(OutboundFrame frame) {
+    @Override
+    public boolean write(byte[] frame, boolean urgent) {
         if (!live) {
             return false;
         }
@@ -72,8 +74,10 @@ public class MockConnection implements Connection {
             return false;
         }
 
-        Packet packet = (Packet) frame;
+        //Packet newPacket = PacketUtil.toPacket(frame);
+        Packet packet = PacketUtil.toPacket(frame);
         Packet newPacket = readFromPacket(packet);
+        newPacket.setConn(localConnection);
         nodeEngine.getPacketDispatcher().dispatch(newPacket);
         return true;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -209,26 +209,26 @@ public class MockConnectionManager implements ConnectionManager {
     }
 
     @Override
-    public boolean transmit(Packet packet, Connection connection) {
-        return (connection != null && connection.write(packet));
+    public boolean transmit(byte[] packet, boolean priority, Connection connection) {
+        return (connection != null && connection.write(packet, priority));
     }
 
     /**
      * Retries sending packet maximum 5 times until connection to target becomes available.
      */
     @Override
-    public boolean transmit(Packet packet, Address target) {
-        return send(packet, target, null);
+    public boolean transmit(byte[] packet, boolean priority, Address target) {
+        return send(packet,priority,  target, null);
     }
 
-    private boolean send(Packet packet, Address target, SendTask sendTask) {
+    private boolean send(byte[] packet, boolean priority, Address target, SendTask sendTask) {
         Connection connection = getConnection(target);
         if (connection != null) {
-            return transmit(packet, connection);
+            return transmit(packet, priority, connection);
         }
 
         if (sendTask == null) {
-            sendTask = new SendTask(packet, target);
+            sendTask = new SendTask(packet, priority, target);
         }
 
         int retries = sendTask.retries;
@@ -243,12 +243,14 @@ public class MockConnectionManager implements ConnectionManager {
 
     private final class SendTask implements Runnable {
 
-        private final Packet packet;
+        private final byte[] packet;
         private final Address target;
+        private final boolean priority;
 
         private volatile int retries;
 
-        private SendTask(Packet packet, Address target) {
+        private SendTask(byte[] packet, boolean priority, Address target) {
+            this.priority = priority;
             this.packet = packet;
             this.target = target;
         }
@@ -260,7 +262,7 @@ public class MockConnectionManager implements ConnectionManager {
             if (logger.isFinestEnabled()) {
                 logger.finest("Retrying[" + retries + "] packet send operation to: " + target);
             }
-            send(packet, target, this);
+            send(packet, priority, target, this);
         }
     }
 }


### PR DESCRIPTION
Using a byte array instead of a Packet.

This saves 2 allocations per remote call (1 for the operation, 1 for the allocation).
It saves 1 allocation per event
