### PR TITLE
#9163 - OSGi Activator: allow disabling JSR-223 script engine scanning

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiService.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/HazelcastOSGiService.java
@@ -43,6 +43,11 @@ public interface HazelcastOSGiService {
     String HAZELCAST_OSGI_GROUPING_DISABLED = "hazelcast.osgi.grouping.disabled";
 
     /**
+     * System property for disabling the JSR-223 script engine scan by the Hazelcast OSGI service.
+     */
+    String HAZELCAST_OSGI_JSR223_DISABLED = "hazelcast.osgi.jsr223.disabled";
+
+    /**
      * Gets the id of service.
      *
      * @return the id of service

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/Activator.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/Activator.java
@@ -18,6 +18,8 @@ package com.hazelcast.osgi.impl;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.osgi.HazelcastOSGiService;
+
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
@@ -76,6 +78,9 @@ public class Activator
     }
 
     static boolean isJavaxScriptingAvailable() {
+        if (Boolean.getBoolean(HazelcastOSGiService.HAZELCAST_OSGI_JSR223_DISABLED)) {
+            return false;
+        }
         try {
             Class.forName("javax.script.ScriptEngineManager");
             return true;


### PR DESCRIPTION
#9163 - OSGi Activator: allow disabling JSR-223 script engine scanning in all bundles if the system property "hazelcast.osgi.jsr223.disabled" is set to true
Details: https://github.com/hazelcast/hazelcast/issues/9163