### PR TITLE
Cleanup of NearCacheContext creation on Hazelcast clients

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/ClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/ClientExtension.java
@@ -44,7 +44,7 @@ public interface ClientExtension {
      * Creates a {@link InternalSerializationService} instance to be used by this client.
      *
      * @param version serialization version to be created. Values less than 1 will be ignored and max supported version
-     * will be used
+     *                will be used
      * @return the created {@link InternalSerializationService} instance
      */
     InternalSerializationService createSerializationService(byte version);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -192,11 +192,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         NearCacheConfig nearCacheConfig = clientContext.getClientConfig().getNearCacheConfig(name);
         if (nearCacheConfig != null) {
             cacheOnUpdate = nearCacheConfig.getLocalUpdatePolicy() == NearCacheConfig.LocalUpdatePolicy.CACHE;
-            NearCacheContext nearCacheContext = new NearCacheContext(
-                    clientContext.getSerializationService(),
-                    clientContext.getExecutionService(),
-                    nearCacheManager
-            );
+            NearCacheContext nearCacheContext = clientContext.getNearCacheContext();
             nearCache = nearCacheManager.getOrCreateNearCache(nameWithPrefix, nearCacheConfig, nearCacheContext);
             registerInvalidationListener();
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
@@ -133,9 +133,6 @@ public class DefaultClientExtension implements ClientExtension {
 
     @Override
     public NearCacheManager createNearCacheManager() {
-        // If there is a specific behaviour for client,
-        // there maybe a custom "NearCacheManager" implementation such as "ClientNearCacheManager".
-        // Currently "DefaultNearCacheManager" is enough.
         return new DefaultNearCacheManager();
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl;
 
+import com.hazelcast.cache.impl.nearcache.NearCacheContext;
 import com.hazelcast.cache.impl.nearcache.NearCacheManager;
 import com.hazelcast.cardinality.impl.CardinalityEstimatorService;
 import com.hazelcast.client.ClientExtension;
@@ -171,6 +172,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final ClientListenerServiceImpl listenerService;
     private final ClientTransactionManagerService transactionManager;
     private final NearCacheManager nearCacheManager;
+    private final NearCacheContext nearCacheContext;
     private final ProxyManager proxyManager;
     private final ConcurrentMap<String, Object> userContext;
     private final LoadBalancer loadBalancer;
@@ -222,6 +224,8 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         listenerService = initListenerService();
         userContext = new ConcurrentHashMap<String, Object>();
         nearCacheManager = clientExtension.createNearCacheManager();
+        nearCacheContext = new NearCacheContext(serializationService, executionService, nearCacheManager,
+                config.getClassLoader());
 
         diagnostics = initDiagnostics(config);
 
@@ -660,6 +664,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public NearCacheManager getNearCacheManager() {
         return nearCacheManager;
+    }
+
+    public NearCacheContext getNearCacheContext() {
+        return nearCacheContext;
     }
 
     public ThreadGroup getThreadGroup() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -406,9 +406,7 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
             if (nearCacheConfig == null) {
                 return;
             }
-            NearCacheContext nearCacheContext = new NearCacheContext(
-                    context.getSerializationService(),
-                    context.getExecutionService());
+            NearCacheContext nearCacheContext = context.getNearCacheContext();
 
             nearCache = context.getNearCacheManager().getOrCreateNearCache(name, nearCacheConfig, nearCacheContext);
             if (nearCache.isInvalidatedOnChange()) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.proxy;
 
 import com.hazelcast.cache.impl.nearcache.NearCache;
-import com.hazelcast.cache.impl.nearcache.NearCacheContext;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddNearCacheEntryListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.MapGetAllCodec;
@@ -86,12 +85,8 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
         NearCacheConfig nearCacheConfig = context.getClientConfig().getNearCacheConfig(name);
 
-        NearCacheContext nearCacheContext = new NearCacheContext(
-                context.getSerializationService(),
-                context.getExecutionService());
-
         NearCache<Data, Object> clientNearCache = context.getNearCacheManager()
-                .getOrCreateNearCache(name, nearCacheConfig, nearCacheContext);
+                .getOrCreateNearCache(name, nearCacheConfig, context.getNearCacheContext());
 
         int partitionCount = context.getPartitionService().getPartitionCount();
         nearCache = wrapAsStaleReadPreventerNearCache(clientNearCache, partitionCount);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.spi;
 
+import com.hazelcast.cache.impl.nearcache.NearCacheContext;
 import com.hazelcast.cache.impl.nearcache.NearCacheManager;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
@@ -34,7 +35,7 @@ public final class ClientContext {
     private final ClientInvocationService invocationService;
     private final ClientExecutionService executionService;
     private final ClientListenerService listenerService;
-    private final NearCacheManager nearCacheManager;
+    private final NearCacheContext nearCacheContext;
     private final ClientTransactionManagerService transactionManager;
     private final ProxyManager proxyManager;
     private final ClientConfig clientConfig;
@@ -47,7 +48,7 @@ public final class ClientContext {
         this.invocationService = client.getInvocationService();
         this.executionService = client.getClientExecutionService();
         this.listenerService = client.getListenerService();
-        this.nearCacheManager = client.getNearCacheManager();
+        this.nearCacheContext = client.getNearCacheContext();
         this.proxyManager = proxyManager;
         this.clientConfig = client.getClientConfig();
         this.transactionManager = client.getTransactionManager();
@@ -87,7 +88,11 @@ public final class ClientContext {
     }
 
     public NearCacheManager getNearCacheManager() {
-        return nearCacheManager;
+        return nearCacheContext.getNearCacheManager();
+    }
+
+    public NearCacheContext getNearCacheContext() {
+        return nearCacheContext;
     }
 
     public LoggingService getLoggingService() {


### PR DESCRIPTION
* cached `NearCacheContext` for Hazelcast clients in `HazelcastClientInstanceImpl`
* used cached `NearCacheContext` in `AbstractClientInternalCacheProxy`, `ClientReplicatedMapProxy` and `NearCachedClientMapProxy`
* replaced `NearCacheManager` with `NearCacheContext` in `ClientContext`

This aligns the behavior on Hazelcast clients with Hazelcast members, which use the same `NearCacheContext` instance from the `NearCacheProvider` for all Near Caches. This also ensures that the `ClassLoader` from the `ClientConfig` is passed into the `NearCacheContext` in all usage scenarios.