### PR TITLE
Add toString into PriorityPartitionSpecificRunnable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -523,5 +523,10 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         public int getPartitionId() {
             return task.getPartitionId();
         }
+
+        @Override
+        public String toString() {
+            return "PriorityPartitionSpecificRunnable:{ " + task + "}";
+        }
     }
 }


### PR DESCRIPTION
This is useful for troubleshooting as otherwise slow operation detector
can see just `com.hazelcast.client.impl.ClientEngineImpl$PriorityPartitionSpecificRunnable`