### PR TITLE
Padding option for InternalSerializationService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -35,7 +35,11 @@ public interface InternalSerializationService extends SerializationService, Disp
 
     byte[] toBytes(Object obj);
 
+    byte[] toBytes(int padding, Object obj);
+
     byte[] toBytes(Object obj, PartitioningStrategy strategy);
+
+    byte[] toBytes(int padding, Object obj, PartitioningStrategy strategy);
 
     void writeObject(ObjectDataOutput out, Object obj);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -121,11 +121,21 @@ public abstract class AbstractSerializationService implements InternalSerializat
 
     @Override
     public byte[] toBytes(Object obj) {
-        return toBytes(obj, globalPartitioningStrategy);
+        return toBytes(0, obj, globalPartitioningStrategy);
+    }
+
+    @Override
+    public byte[] toBytes(int padding, Object obj) {
+        return toBytes(padding, obj, globalPartitioningStrategy);
     }
 
     @Override
     public byte[] toBytes(Object obj, PartitioningStrategy strategy) {
+        return toBytes(0, obj, strategy);
+    }
+
+    @Override
+    public byte[] toBytes(int padding, Object obj, PartitioningStrategy strategy) {
         checkNotNull(obj);
 
         BufferPool pool = bufferPoolThreadLocal.get();
@@ -138,7 +148,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
             out.writeInt(serializer.getTypeId(), ByteOrder.BIG_ENDIAN);
 
             serializer.write(out, obj);
-            return out.toByteArray();
+            return out.toByteArray(padding);
         } catch (Throwable e) {
             throw handleSerializeException(obj, e);
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -400,11 +400,17 @@ class ByteArrayObjectDataOutput extends OutputStream implements BufferObjectData
 
     @Override
     public byte toByteArray()[] {
+        return toByteArray(0);
+    }
+
+    @Override
+    public byte[] toByteArray(int padding) {
         if (buffer == null || pos == 0) {
-            return new byte[0];
+            return new byte[padding];
         }
-        final byte[] newBuffer = new byte[pos];
-        System.arraycopy(buffer, 0, newBuffer, 0, pos);
+
+        final byte[] newBuffer = new byte[padding + pos];
+        System.arraycopy(buffer, 0, newBuffer, padding, pos);
         return newBuffer;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -126,6 +126,11 @@ final class EmptyObjectDataOutput implements ObjectDataOutput {
 
     @Override
     public byte[] toByteArray() {
+        return toByteArray(0);
+    }
+
+    @Override
+    public byte[] toByteArray(int padding) {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -29,6 +29,7 @@ import java.nio.ByteOrder;
 
 import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 
+@SuppressWarnings("checkstyle:methodcount")
 public class ObjectDataOutputStream extends OutputStream implements ObjectDataOutput, Closeable {
 
     private final InternalSerializationService serializationService;
@@ -258,6 +259,11 @@ public class ObjectDataOutputStream extends OutputStream implements ObjectDataOu
 
     @Override
     public byte[] toByteArray() {
+       return toByteArray(0);
+    }
+
+    @Override
+    public byte[] toByteArray(int padding) {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -99,6 +99,12 @@ public interface ObjectDataOutput extends DataOutput {
     byte[] toByteArray();
 
     /**
+     * @param padding padding bytes at the beginning of the byte-array.
+     * @return copy of internal byte array
+     */
+    byte[] toByteArray(int padding);
+
+    /**
      * @return ByteOrder BIG_ENDIAN or LITTLE_ENDIAN
      */
     ByteOrder getByteOrder();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -45,8 +45,30 @@ public class AbstractSerializationServiceTest {
     @Before
     public void setup() {
         DefaultSerializationServiceBuilder defaultSerializationServiceBuilder = new DefaultSerializationServiceBuilder();
-        abstractSerializationService = (AbstractSerializationService) defaultSerializationServiceBuilder
+        abstractSerializationService = defaultSerializationServiceBuilder
                 .setVersion(InternalSerializationService.VERSION_1).build();
+    }
+
+    @Test
+    public void toBytes_withPadding() {
+        String payload = "somepayload";
+        int padding = 10;
+
+        byte[] unpadded = abstractSerializationService.toBytes(payload);
+        byte[] padded = abstractSerializationService.toBytes(10, payload);
+
+        // make sure the size is expected
+        assertEquals(unpadded.length + padding, padded.length);
+
+        // check if the header is zero'ed and doesn't contains anything unexpected
+        for (int k = 0; k < padding; k++) {
+            assertEquals(0, padded[k]);
+        }
+
+        // check if the actual content is the same
+        for (int k = 0; k < unpadded.length; k++) {
+            assertEquals(unpadded[k], padded[k + padding]);
+        }
     }
 
     @Test


### PR DESCRIPTION
The padding option can be used to reserve extra bytes in front of the actual payload. This
space can be used for putting e.g. header information.

This functionality is required to get rid of all kinds of data wrappers like Response/Packet. Instead of creating these wrapper objects with their own fields, a byte-array can be reserved with sufficient space so the Response/Packet information can be written in front of the actual payload.