### PR TITLE
The client may not invalidate near caches on cluster disconnection - putToCacheAndGetInvalidationEventWhenNodeShutdown test randomly fails

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -225,6 +225,7 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
                     @Override
                     public void run() {
                         try {
+                            client.getNearCacheManager().clearAllNearCaches();
                             connectToCluster();
                         } catch (Exception e) {
                             logger.warning("Could not re-connect to cluster shutting down the client", e);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientNearCacheTestSupport.java
@@ -338,14 +338,7 @@ public abstract class ClientNearCacheTestSupport extends HazelcastTestSupport {
             nearCacheTestContext2.cache.remove(entry.getKey());
         }
 
-        // we don't shutdown the instance because in case of shutdown even though events are published to event queue,
-        // they may not be processed in the event queue due to shutdown event queue executor or may not be sent
-        // to client endpoint due to IO handler shutdown
-
-        // for not to making test fragile, we just simulate shutting down by sending its event through `LifeCycleService`,
-        // so the node should flush invalidation events before shutdown
-        ((LifecycleServiceImpl) instanceToShutdown.getLifecycleService())
-                .fireLifecycleEvent(LifecycleEvent.LifecycleState.SHUTTING_DOWN);
+        instanceToShutdown.shutdown();
 
         // verify that records in the Near Cache of client-1 are invalidated eventually when instance shutdown
         for (Map.Entry<String, String> entry : keyAndValues.entrySet()) {


### PR DESCRIPTION
Fix for issue https://github.com/hazelcast/hazelcast/issues/9172

Invalidates the near caches when the client is disconnected from the cluster to avoid the usage of stale near cache data.