### PR TITLE
OSS changes for Hot Restart IP address restriction removal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -30,6 +30,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.memory.DefaultMemoryStats;
 import com.hazelcast.memory.MemoryStats;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;
@@ -49,6 +50,7 @@ import com.hazelcast.spi.impl.servicemanager.ServiceManager;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.UuidUtil;
 import com.hazelcast.wan.WanReplicationService;
 import com.hazelcast.wan.impl.WanReplicationServiceImpl;
 
@@ -242,5 +244,10 @@ public class DefaultNodeExtension implements NodeExtension {
     public boolean triggerForceStart() {
         logger.warning("Force start is available when hot restart is active!");
         return false;
+    }
+
+    @Override
+    public String createMemberUuid(Address address) {
+        return UuidUtil.createMemberUuid(address);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -230,6 +230,10 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
+    public void onPartitionStateChange() {
+    }
+
+    @Override
     public boolean registerListener(Object listener) {
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -87,7 +87,6 @@ import static com.hazelcast.spi.properties.GroupProperty.GRACEFUL_SHUTDOWN_MAX_W
 import static com.hazelcast.spi.properties.GroupProperty.LOGGING_TYPE;
 import static com.hazelcast.spi.properties.GroupProperty.MAX_JOIN_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_ENABLED;
-import static com.hazelcast.util.UuidUtil.createMemberUuid;
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:visibilitymodifier", "checkstyle:classdataabstractioncoupling",
         "checkstyle:classfanoutcomplexity"})
@@ -167,14 +166,15 @@ public class Node {
         final ServerSocketChannel serverSocketChannel = addressPicker.getServerSocketChannel();
         try {
             address = addressPicker.getPublicAddress();
+            nodeExtension = nodeContext.createNodeExtension(this);
+
             final Map<String, Object> memberAttributes = findMemberAttributes(config.getMemberAttributeConfig().asReadOnly());
-            localMember = new MemberImpl(address, true, createMemberUuid(address),
+            localMember = new MemberImpl(address, true, nodeExtension.createMemberUuid(address),
                     hazelcastInstance, memberAttributes, liteMember);
             loggingService.setThisMember(localMember);
             logger = loggingService.getLogger(Node.class.getName());
             hazelcastThreadGroup = new HazelcastThreadGroup(hazelcastInstance.getName(), logger, configClassLoader);
 
-            this.nodeExtension = createNodeExtension(nodeContext);
             nodeExtension.printNodeInfo();
             nodeExtension.beforeStart();
 
@@ -284,10 +284,6 @@ public class Node {
                 logger.warning(error, t);
             }
         }
-    }
-
-    protected NodeExtension createNodeExtension(NodeContext nodeContext) {
-        return nodeContext.createNodeExtension(this);
     }
 
     public ManagementCenterService getManagementCenterService() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -181,6 +181,11 @@ public interface NodeExtension {
     void onClusterStateChange(ClusterState newState, boolean isTransient);
 
     /**
+     * Called when partition state (partition assignments, version etc) changes
+     */
+    void onPartitionStateChange();
+
+    /**
      * Registers given register if it's a known type.
      * @param listener listener instance
      * @return true if listener is registered, false otherwise

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -19,6 +19,7 @@ package com.hazelcast.instance;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.memory.MemoryStats;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.internal.networking.ReadHandler;
@@ -199,4 +200,11 @@ public interface NodeExtension {
      * @return true if hot restart is enabled and this node knows the master
      */
     boolean triggerForceStart();
+
+    /**
+     * Creates a UUID for local member
+     * @param address address of local member
+     * @return new uuid
+     */
+    String createMemberUuid(Address address);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -420,7 +420,8 @@ public class ClusterHeartbeatManager {
         }
         Collection<MemberImpl> members = clusterService.getMemberImpls();
         MemberInfoUpdateOperation op = new MemberInfoUpdateOperation(
-                createMemberInfoList(members), clusterClock.getClusterTime(), false);
+                createMemberInfoList(members), clusterClock.getClusterTime(), null, false);
+
         for (MemberImpl member : members) {
             if (member.localMember()) {
                 continue;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -211,7 +211,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         }
         Collection<MemberImpl> members = getMemberImpls();
         MemberInfoUpdateOperation op = new MemberInfoUpdateOperation(
-                createMemberInfoList(members), clusterClock.getClusterTime(), false);
+                createMemberInfoList(members), clusterClock.getClusterTime(), null, false);
         nodeEngine.getOperationService().send(op, target);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberMap.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableCollection;
+
+/**
+ * A special, immutable {@link MemberImpl} map type,
+ * that allows querying members using address or uuid.
+ */
+final class MemberMap {
+
+    private final Map<Address, MemberImpl> addressToMemberMap;
+    private final Map<String, MemberImpl> uuidToMemberMap;
+    private final Set<MemberImpl> members;
+
+    private MemberMap(Map<Address, MemberImpl> addressMap, Map<String, MemberImpl> uuidMap) {
+        assert new HashSet<MemberImpl>(addressMap.values()).equals(new HashSet<MemberImpl>(uuidMap.values()))
+                : "Maps are different! AddressMap: " + addressMap + ", UuidMap: " + uuidMap;
+
+        this.addressToMemberMap = addressMap;
+        this.uuidToMemberMap = uuidMap;
+        this.members = Collections.unmodifiableSet(new LinkedHashSet<MemberImpl>(addressToMemberMap.values()));
+    }
+
+    /**
+     * Creates an empty {@code MemberMap}.
+     * @return empty {@code MemberMap}
+     */
+    static MemberMap empty() {
+        return new MemberMap(Collections.<Address, MemberImpl>emptyMap(), Collections.<String, MemberImpl>emptyMap());
+    }
+
+    /**
+     * Creates a singleton {@code MemberMap} including only specified member.
+     * @param member sole member in map
+     * @return singleton {@code MemberMap}
+     */
+    static MemberMap singleton(MemberImpl member) {
+        return new MemberMap(singletonMap(member.getAddress(), member), singletonMap(member.getUuid(), member));
+    }
+
+    /**
+     * Creates a new {@code MemberMap} including given members.
+     * @param members members
+     * @return a new {@code MemberMap}
+     */
+    static MemberMap createNew(MemberImpl... members) {
+        Map<Address, MemberImpl> addressMap = new LinkedHashMap<Address, MemberImpl>();
+        Map<String, MemberImpl> uuidMap = new LinkedHashMap<String, MemberImpl>();
+
+        for (MemberImpl member : members) {
+            putMember(addressMap, uuidMap, member);
+        }
+
+        return new MemberMap(addressMap, uuidMap);
+    }
+
+    /**
+     * Creates clone of source {@code MemberMap}, excluding given members.
+     * If source is empty, same map instance will be returned. If excluded members are empty or not present in
+     * source, a new map will be created containing the same members with source.
+     * @param source source map
+     * @param excludeMembers members to exclude
+     * @return clone map
+     */
+    static MemberMap cloneExcluding(MemberMap source, MemberImpl... excludeMembers) {
+        if (source.size() == 0) {
+            return source;
+        }
+
+        Map<Address, MemberImpl> addressMap = new LinkedHashMap<Address, MemberImpl>(source.addressToMemberMap);
+        Map<String, MemberImpl> uuidMap = new LinkedHashMap<String, MemberImpl>(source.uuidToMemberMap);
+
+        for (MemberImpl member : excludeMembers) {
+            MemberImpl removed = addressMap.remove(member.getAddress());
+            if (removed != null) {
+                uuidMap.remove(removed.getUuid());
+            }
+
+            removed = uuidMap.remove(member.getUuid());
+            if (removed != null) {
+                addressMap.remove(removed.getAddress());
+            }
+        }
+
+        return new MemberMap(addressMap, uuidMap);
+    }
+
+    /**
+     * Creates clone of source {@code MemberMap} additionally including new members.
+     * @param source source map
+     * @param newMembers new members to add
+     * @return clone map
+     */
+    static MemberMap cloneAdding(MemberMap source, MemberImpl... newMembers) {
+        Map<Address, MemberImpl> addressMap = new LinkedHashMap<Address, MemberImpl>(source.addressToMemberMap);
+        Map<String, MemberImpl> uuidMap = new LinkedHashMap<String, MemberImpl>(source.uuidToMemberMap);
+
+        for (MemberImpl member : newMembers) {
+            putMember(addressMap, uuidMap, member);
+        }
+
+        return new MemberMap(addressMap, uuidMap);
+    }
+
+    private static void putMember(Map<Address, MemberImpl> addressMap,
+            Map<String, MemberImpl> uuidMap, MemberImpl member) {
+
+        MemberImpl current = addressMap.put(member.getAddress(), member);
+        if (current != null) {
+            throw new IllegalArgumentException("Replacing existing member with address: " + member);
+        }
+
+        current = uuidMap.put(member.getUuid(), member);
+        if (current != null) {
+            throw new IllegalArgumentException("Replacing existing member with uuid: " + member);
+        }
+    }
+
+    MemberImpl getMember(Address address) {
+        return addressToMemberMap.get(address);
+    }
+
+    MemberImpl getMember(String uuid) {
+        return uuidToMemberMap.get(uuid);
+    }
+
+    boolean contains(Address address) {
+        return addressToMemberMap.containsKey(address);
+    }
+
+    boolean contains(String uuid) {
+        return uuidToMemberMap.containsKey(uuid);
+    }
+
+    Set<MemberImpl> getMembers() {
+        return members;
+    }
+
+    Collection<Address> getAddresses() {
+        return unmodifiableCollection(addressToMemberMap.keySet());
+    }
+
+    int size() {
+        return members.size();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -85,4 +85,6 @@ public interface InternalPartitionService extends IPartitionService {
     void updatePartitionReplicaVersions(int partitionId, long[] replicaVersions, int replicaIndex);
 
     long[] incrementPartitionReplicaVersions(int partitionId, int totalBackupCount);
+
+    PartitionTableView createPartitionTableView();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionTableView.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionTableView.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.hazelcast.internal.partition.InternalPartition.MAX_REPLICA_COUNT;
+
+/**
+ * An immutable/readonly view of partition table.
+ * View consists of partition replica assignments and global partition state version.
+ * <p>
+ * {@link #getAddresses(int)} returns clone of internal addresses array.
+ */
+public class PartitionTableView {
+
+    private final Address[][] addresses;
+    private final int version;
+
+    public PartitionTableView(Address[][] addresses, int version) {
+        this.addresses = addresses;
+        this.version = version;
+    }
+
+    public PartitionTableView(InternalPartition[] partitions, int version) {
+        Address[][] a = new Address[partitions.length][MAX_REPLICA_COUNT];
+        for (InternalPartition partition : partitions) {
+            int partitionId = partition.getPartitionId();
+            for (int replica = 0; replica < MAX_REPLICA_COUNT; replica++) {
+                a[partitionId][replica] = partition.getReplicaAddress(replica);
+            }
+        }
+
+        this.addresses = a;
+        this.version = version;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public Address getAddress(int partitionId, int replicaIndex) {
+        return addresses[partitionId][replicaIndex];
+    }
+
+    public int getLength() {
+        return addresses.length;
+    }
+
+    public Address[] getAddresses(int partitionId) {
+        Address[] a = addresses[partitionId];
+        return Arrays.copyOf(a, a.length);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PartitionTableView that = (PartitionTableView) o;
+        return version == that.version && Arrays.deepEquals(addresses, that.addresses);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.deepHashCode(addresses);
+        result = 31 * result + version;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PartitionTable{" + "addresses=" + Arrays.deepToString(addresses) + ", version=" + version + '}';
+    }
+
+    public static void writeData(PartitionTableView table, ObjectDataOutput out) throws IOException {
+        Address[][] addresses = table.addresses;
+        out.writeInt(addresses.length);
+        for (Address[] a : addresses) {
+            for (int j = 0; j < MAX_REPLICA_COUNT; j++) {
+                Address address = a[j];
+                boolean addressExists = address != null;
+                out.writeBoolean(addressExists);
+                if (addressExists) {
+                    address.writeData(out);
+                }
+            }
+        }
+
+        out.writeInt(table.version);
+    }
+
+    public static PartitionTableView readData(ObjectDataInput in) throws IOException {
+        int len = in.readInt();
+        Address[][] addresses = new Address[len][MAX_REPLICA_COUNT];
+        for (int i = 0; i < len; i++) {
+            for (int j = 0; j < MAX_REPLICA_COUNT; j++) {
+                boolean exists = in.readBoolean();
+                if (exists) {
+                    Address address = new Address();
+                    addresses[i][j] = address;
+                    address.readData(in);
+                }
+            }
+        }
+
+        int version = in.readInt();
+        return new PartitionTableView(addresses, version);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
@@ -41,7 +41,7 @@ public class InternalPartitionImpl implements InternalPartition {
         this.thisAddress = thisAddress;
     }
 
-    InternalPartitionImpl(int partitionId, PartitionListener listener, Address thisAddress,
+    public InternalPartitionImpl(int partitionId, PartitionListener listener, Address thisAddress,
             Address[] addresses) {
         this(partitionId, listener, thisAddress);
         this.addresses = addresses;
@@ -168,6 +168,25 @@ public class InternalPartitionImpl implements InternalPartition {
 
         for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
             if (address.equals(addresses[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    int replaceAddress(Address oldAddress, Address newAddress) {
+        Address[] currentAddresses = addresses;
+        for (int i = 0; i < MAX_REPLICA_COUNT; i++) {
+            Address address = currentAddresses[i];
+            if (address == null) {
+                break;
+            }
+
+            if (address.equals(oldAddress)) {
+                Address[] newAddresses = Arrays.copyOf(currentAddresses, MAX_REPLICA_COUNT);
+                newAddresses[i] = newAddress;
+                addresses = newAddresses;
+                callPartitionListener(i, oldAddress, newAddress);
                 return i;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -1066,6 +1066,15 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
        }
     }
 
+    public void replaceAddress(Address oldAddress, Address newAddress) {
+        lock.lock();
+        try {
+            partitionStateManager.replaceAddress(oldAddress, newAddress);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     @Override
     public PartitionTableView createPartitionTableView() {
         lock.lock();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -660,6 +660,9 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
         updateAllPartitions(partitionTable);
         partitionStateManager.setVersion(partitionState.getVersion());
+        if (!partitionStateManager.setInitialized()) {
+            node.getNodeExtension().onPartitionStateChange();
+        }
 
         migrationManager.retainCompletedMigrations(completedMigrations);
     }
@@ -1166,6 +1169,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                     applyNewState(newState, thisAddress);
                 } else if (partitionStateManager.isInitialized()) {
                     partitionStateManager.incrementVersion();
+                    node.getNodeExtension().onPartitionStateChange();
+
                     for (MigrationInfo migrationInfo : allCompletedMigrations) {
                         if (migrationManager.addCompletedMigration(migrationInfo)) {
                             if (logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -923,6 +923,7 @@ public class MigrationManager {
                 scheduleActiveMigrationFinalization(migrationInfo);
                 int delta = PARTITION_STATE_VERSION_INCREMENT_DELTA_ON_MIGRATION_FAILURE;
                 partitionService.getPartitionStateManager().incrementVersion(delta);
+                node.getNodeExtension().onPartitionStateChange();
                 if (partitionService.syncPartitionRuntimeState()) {
                     evictCompletedMigrations(migrationInfo);
                 }
@@ -979,6 +980,7 @@ public class MigrationManager {
 
                 addCompletedMigration(migrationInfo);
                 scheduleActiveMigrationFinalization(migrationInfo);
+                node.getNodeExtension().onPartitionStateChange();
                 if (partitionService.syncPartitionRuntimeState()) {
                     evictCompletedMigrations(migrationInfo);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -316,6 +316,24 @@ public class PartitionStateManager {
         }
     }
 
+    int replaceAddress(Address oldAddress, Address newAddress) {
+        if (!initialized) {
+            return 0;
+        }
+        int count = 0;
+        for (InternalPartitionImpl partition : partitions) {
+            if (partition.replaceAddress(oldAddress, newAddress) > -1) {
+                count++;
+            }
+        }
+        if (count > 0) {
+            node.getNodeExtension().onPartitionStateChange();
+            logger.info("Replaced " + oldAddress + " with " + newAddress + " in partition table in "
+                    + count + " partitions.");
+        }
+        return count;
+    }
+
     PartitionTableView getPartitionTable() {
         if (!initialized) {
             return new PartitionTableView(new Address[partitions.length][InternalPartition.MAX_REPLICA_COUNT], 0);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -149,7 +149,7 @@ public class PartitionStateManager {
             Address[] replicas = newState[partitionId];
             partition.setReplicaAddresses(replicas);
         }
-        initialized = true;
+        setInitialized();
         return true;
     }
 
@@ -169,8 +169,10 @@ public class PartitionStateManager {
             }
             partition.setInitialReplicaAddresses(replicas);
         }
-        initialized = foundReplica;
         stateVersion.set(partitionTable.getVersion());
+        if (foundReplica) {
+            setInitialized();
+        }
     }
 
     void updateMemberGroupsSize() {
@@ -293,8 +295,13 @@ public class PartitionStateManager {
         stateVersion.incrementAndGet();
     }
 
-    void setInitialized() {
-        initialized = true;
+    boolean setInitialized() {
+        if (!initialized) {
+            initialized = true;
+            node.getNodeExtension().onPartitionStateChange();
+            return true;
+        }
+        return false;
     }
 
     public boolean isInitialized() {

--- a/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
@@ -21,6 +21,7 @@ import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -56,7 +57,7 @@ public final class ExceptionUtil {
             return t;
         }
 
-        if (t instanceof ExecutionException) {
+        if (t instanceof ExecutionException || t instanceof InvocationTargetException) {
             final Throwable cause = t.getCause();
             if (cause != null) {
                 return peel(cause, allowedType);

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheClearTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheClearTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cache.impl.client.CacheSingleInvalidationMessage;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.instance.Node;
@@ -62,8 +61,10 @@ public class CacheClearTest extends CacheTestSupport {
 
     @Override
     protected void onSetup() {
-        Config config = createConfig();
-        hazelcastInstances = factory.newInstances(config, INSTANCE_COUNT);
+        hazelcastInstances = new HazelcastInstance[INSTANCE_COUNT];
+        for (int i = 0; i < hazelcastInstances.length; i++) {
+            hazelcastInstances[i] = factory.newHazelcastInstance(createConfig());
+        }
         warmUpPartitions(hazelcastInstances);
         waitAllForSafeState(hazelcastInstances);
         hazelcastInstance = hazelcastInstances[0];

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
@@ -6,7 +6,6 @@ import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cache.impl.client.CacheSingleInvalidationMessage;
 import com.hazelcast.cache.impl.operation.CacheDestroyOperation;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -44,10 +43,9 @@ public class CacheDestroyTest extends CacheTestSupport {
 
     @Override
     protected void onSetup() {
-        Config config = createConfig();
         hazelcastInstances = new HazelcastInstance[INSTANCE_COUNT];
-        for (int i = 0; i < INSTANCE_COUNT; i++) {
-            hazelcastInstances[i] = factory.newHazelcastInstance(config);
+        for (int i = 0; i < hazelcastInstances.length; i++) {
+            hazelcastInstances[i] = factory.newHazelcastInstance(createConfig());
         }
         warmUpPartitions(hazelcastInstances);
         waitAllForSafeState(hazelcastInstances);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberMapTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Set;
+
+import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MemberMapTest {
+
+    @Test
+    public void createEmpty() throws Exception {
+        MemberMap map = MemberMap.empty();
+        assertTrue(map.getMembers().isEmpty());
+        assertTrue(map.getAddresses().isEmpty());
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    public void createSingleton() throws Exception {
+        MemberImpl member = newMember(5000);
+        MemberMap map = MemberMap.singleton(member);
+        assertEquals(1, map.getMembers().size());
+        assertEquals(1, map.getAddresses().size());
+        assertEquals(1, map.size());
+        assertTrue(map.contains(member.getAddress()));
+        assertTrue(map.contains(member.getUuid()));
+        assertThat(member, sameInstance(map.getMember(member.getAddress())));
+        assertThat(member, sameInstance(map.getMember(member.getUuid())));
+
+        assertMemberSet(map);
+    }
+
+    private void assertMemberSet(MemberMap map) {
+        for (MemberImpl m : map.getMembers()) {
+            assertTrue(map.contains(m.getUuid()));
+            assertTrue(map.contains(m.getAddress()));
+            assertEquals(m, map.getMember(m.getAddress()));
+            assertEquals(m, map.getMember(m.getUuid()));
+        }
+    }
+
+    @Test
+    public void createNew() throws Exception {
+        MemberImpl[] members = new MemberImpl[5];
+        for (int i = 0; i < members.length; i++) {
+            members[i] = newMember(5000 + i);
+        }
+
+        MemberMap map = MemberMap.createNew(members);
+        assertEquals(members.length, map.getMembers().size());
+        assertEquals(members.length, map.getAddresses().size());
+        assertEquals(members.length, map.size());
+
+        for (MemberImpl member : members) {
+            assertTrue(map.contains(member.getAddress()));
+            assertTrue(map.contains(member.getUuid()));
+            assertThat(member, sameInstance(map.getMember(member.getAddress())));
+            assertThat(member, sameInstance(map.getMember(member.getUuid())));
+        }
+
+        assertMemberSet(map);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void create_failsWithDuplicateAddress() throws Exception {
+        MemberImpl member1 = newMember(5000);
+        MemberImpl member2 = newMember(5000);
+        MemberMap.createNew(member1, member2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void create_failsWithDuplicateUuid() throws Exception {
+        MemberImpl member1 = newMember(5000);
+        MemberImpl member2 = new MemberImpl(newAddress(5001), false, member1.getUuid(), null);
+        MemberMap.createNew(member1, member2);
+    }
+
+    @Test
+    public void cloneExcluding() throws Exception {
+        MemberImpl[] members = new MemberImpl[6];
+        for (int i = 0; i < members.length; i++) {
+            members[i] = newMember(5000 + i);
+        }
+
+        MemberImpl exclude0 = members[0];
+        MemberImpl exclude1 = new MemberImpl(newAddress(6000), false, members[1].getUuid(), null);
+        MemberImpl exclude2 = new MemberImpl(members[2].getAddress(), false, newUnsecureUuidString(), null);
+
+        MemberMap map = MemberMap.cloneExcluding(MemberMap.createNew(members), exclude0, exclude1, exclude2);
+
+        int numOfExcludedMembers = 3;
+        assertEquals(members.length - numOfExcludedMembers, map.getMembers().size());
+        assertEquals(members.length - numOfExcludedMembers, map.getAddresses().size());
+        assertEquals(members.length - numOfExcludedMembers, map.size());
+
+        for (int i = 0; i < numOfExcludedMembers; i++) {
+            MemberImpl member = members[i];
+            assertFalse(map.contains(member.getAddress()));
+            assertFalse(map.contains(member.getUuid()));
+            assertNull(map.getMember(member.getAddress()));
+            assertNull(map.getMember(member.getUuid()));
+        }
+
+        for (int i = numOfExcludedMembers; i < members.length; i++) {
+            MemberImpl member = members[i];
+            assertTrue(map.contains(member.getAddress()));
+            assertTrue(map.contains(member.getUuid()));
+            assertThat(member, sameInstance(map.getMember(member.getAddress())));
+            assertThat(member, sameInstance(map.getMember(member.getUuid())));
+        }
+
+        assertMemberSet(map);
+    }
+
+    @Test
+    public void cloneExcluding_emptyMap() throws Exception {
+        MemberMap empty = MemberMap.empty();
+        MemberMap map = MemberMap.cloneExcluding(empty, newMember(5000));
+
+        assertEquals(0, map.size());
+        assertThat(empty, sameInstance(map));
+    }
+
+
+    @Test
+    public void cloneAdding() throws Exception {
+        MemberImpl[] members = new MemberImpl[5];
+        for (int i = 0; i < members.length; i++) {
+            members[i] = newMember(5000 + i);
+        }
+
+        MemberMap map = MemberMap.cloneAdding(MemberMap.createNew(members[0], members[1], members[2]),
+                members[3], members[4]);
+        assertEquals(members.length, map.getMembers().size());
+        assertEquals(members.length, map.getAddresses().size());
+        assertEquals(members.length, map.size());
+
+        for (MemberImpl member : members) {
+            assertTrue(map.contains(member.getAddress()));
+            assertTrue(map.contains(member.getUuid()));
+            assertThat(member, sameInstance(map.getMember(member.getAddress())));
+            assertThat(member, sameInstance(map.getMember(member.getUuid())));
+        }
+
+        assertMemberSet(map);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cloneAdding_failsWithDuplicateAddress() throws Exception {
+        MemberImpl[] members = new MemberImpl[3];
+        for (int i = 0; i < members.length; i++) {
+            members[i] = newMember(5000 + i);
+        }
+
+        MemberImpl member = newMember(5000);
+        MemberMap.cloneAdding(MemberMap.createNew(members), member);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void cloneAdding_failsWithDuplicateUuid() throws Exception {
+        MemberImpl[] members = new MemberImpl[3];
+        for (int i = 0; i < members.length; i++) {
+            members[i] = newMember(5000 + i);
+        }
+
+        MemberImpl member = new MemberImpl(newAddress(6000), false, members[1].getUuid(), null);
+        MemberMap.cloneAdding(MemberMap.createNew(members), member);
+    }
+
+    @Test
+    public void getMembers_ordered() throws Exception {
+        MemberImpl[] members = new MemberImpl[10];
+        for (int i = 0; i < members.length; i++) {
+            members[i] = newMember(5000 + i);
+        }
+
+        MemberMap map = MemberMap.createNew(members);
+        Set<MemberImpl> memberSet = map.getMembers();
+
+        int k = 0;
+        for (MemberImpl member : memberSet) {
+            assertSame(members[k++], member);
+        }
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getMembers_unmodifiable() throws Exception {
+        MemberImpl[] members = new MemberImpl[5];
+        for (int i = 0; i < members.length; i++) {
+            members[i] = newMember(5000 + i);
+        }
+
+        MemberMap map = MemberMap.createNew(members);
+
+        map.getMembers().add(newMember(9000));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getAddresses_unmodifiable() throws Exception {
+        MemberImpl[] members = new MemberImpl[5];
+        for (int i = 0; i < members.length; i++) {
+            members[i] = newMember(5000 + i);
+        }
+
+        MemberMap map = MemberMap.createNew(members);
+
+        map.getAddresses().add(newAddress(9000));
+    }
+
+    private MemberImpl newMember(int port) throws UnknownHostException {
+        return new MemberImpl(newAddress(port), false, newUnsecureUuidString(), null);
+    }
+
+    private Address newAddress(int port) throws UnknownHostException {
+        return new Address(InetAddress.getLocalHost(), port);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionTableViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionTableViewTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition;
+
+import com.hazelcast.internal.partition.impl.InternalPartitionImpl;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.BufferObjectDataInput;
+import com.hazelcast.nio.BufferObjectDataOutput;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.RandomPicker;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static com.hazelcast.internal.partition.InternalPartition.MAX_REPLICA_COUNT;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PartitionTableViewTest {
+
+    @Test
+    public void test_getVersion() throws Exception {
+        int version = RandomPicker.getInt(1000);
+        PartitionTableView table = new PartitionTableView(new Address[10][MAX_REPLICA_COUNT], version);
+        assertEquals(version, table.getVersion());
+    }
+
+    @Test
+    public void test_getLength() throws Exception {
+        int len = RandomPicker.getInt(100);
+        PartitionTableView table = new PartitionTableView(new Address[len][MAX_REPLICA_COUNT], 0);
+        assertEquals(len, table.getLength());
+    }
+
+    @Test
+    public void test_getAddress() throws Exception {
+        Address[][] addresses = createRandomAddresses();
+        PartitionTableView table = new PartitionTableView(addresses, 0);
+
+        assertEquals(addresses.length, table.getLength());
+        for (int i = 0; i < addresses.length; i++) {
+            for (int j = 0; j < MAX_REPLICA_COUNT; j++) {
+                assertEquals(addresses[i][j], table.getAddress(i, j));
+            }
+        }
+    }
+
+    @Test
+    public void test_getAddresses() throws Exception {
+        Address[][] addresses = createRandomAddresses();
+        PartitionTableView table = new PartitionTableView(addresses, 0);
+
+        assertEquals(addresses.length, table.getLength());
+        for (int i = 0; i < addresses.length; i++) {
+            Address[] replicas = table.getAddresses(i);
+            assertNotSame(addresses[i], replicas);
+            assertArrayEquals(addresses[i], replicas);
+        }
+    }
+
+    @Test
+    public void test_getAddresses_withNullAddress() throws Exception {
+        Address[][] addresses = new Address[100][MAX_REPLICA_COUNT];
+        PartitionTableView table = new PartitionTableView(addresses, 0);
+
+        assertEquals(addresses.length, table.getLength());
+        for (int i = 0; i < addresses.length; i++) {
+            Address[] replicas = table.getAddresses(i);
+            assertNotSame(addresses[i], replicas);
+            assertArrayEquals(addresses[i], replicas);
+        }
+    }
+
+    @Test
+    public void test_createUsingInternalPartitions() throws Exception {
+        Address[][] addresses = createRandomAddresses();
+        InternalPartition[] partitions = new InternalPartition[addresses.length];
+        for (int i = 0; i < partitions.length; i++) {
+            partitions[i] = new InternalPartitionImpl(i, null, null, addresses[i]);
+        }
+
+        PartitionTableView table = new PartitionTableView(partitions, 0);
+        assertEquals(partitions.length, table.getLength());
+
+        for (int i = 0; i < addresses.length; i++) {
+            for (int j = 0; j < InternalPartition.MAX_REPLICA_COUNT; j++) {
+                assertEquals(partitions[i].getReplicaAddress(j), table.getAddress(i, j));
+            }
+        }
+    }
+
+    @Test
+    public void test_writeAndReadData() throws Exception {
+        InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+
+        PartitionTableView table1 = createRandomPartitionTable();
+        BufferObjectDataOutput out = serializationService.createObjectDataOutput();
+        PartitionTableView.writeData(table1, out);
+
+        BufferObjectDataInput in = serializationService.createObjectDataInput(out.toByteArray());
+        PartitionTableView table2 = PartitionTableView.readData(in);
+
+        assertEquals(table1, table2);
+        assertEquals(table1.hashCode(), table2.hashCode());
+    }
+
+    @Test
+    public void testIdentical() throws Exception {
+        PartitionTableView table = createRandomPartitionTable();
+        assertEquals(table, table);
+    }
+
+    @Test
+    public void testEquals() throws Exception {
+        PartitionTableView table1 = createRandomPartitionTable();
+        PartitionTableView table2 = new PartitionTableView(extractPartitionTableAddresses(table1), table1.getVersion());
+
+        assertEquals(table1, table2);
+        assertEquals(table1.hashCode(), table2.hashCode());
+    }
+
+    @Test
+    public void testEquals_whenVersionIsDifferent() throws Exception {
+        PartitionTableView table1 = createRandomPartitionTable();
+        PartitionTableView table2 = new PartitionTableView(extractPartitionTableAddresses(table1), table1.getVersion() + 1);
+
+        assertNotEquals(table1, table2);
+    }
+
+    @Test
+    public void testEquals_whenSingleAddressIsDifferent() throws Exception {
+        PartitionTableView table1 = createRandomPartitionTable();
+        Address[][] addresses = extractPartitionTableAddresses(table1);
+        Address address = addresses[addresses.length - 1][MAX_REPLICA_COUNT - 1];
+        addresses[addresses.length - 1][MAX_REPLICA_COUNT - 1] = new Address(address.getInetAddress(), address.getPort() + 1);
+        PartitionTableView table2 = new PartitionTableView(addresses, table1.getVersion());
+
+        assertNotEquals(table1, table2);
+    }
+
+    private static PartitionTableView createRandomPartitionTable() throws UnknownHostException {
+        Address[][] addresses = createRandomAddresses();
+        return new PartitionTableView(addresses, RandomPicker.getInt(1000));
+    }
+
+    private static Address[][] createRandomAddresses() throws UnknownHostException {
+        InetAddress localAddress = InetAddress.getLocalHost();
+        Address[][] addresses = new Address[100][MAX_REPLICA_COUNT];
+        for (int i = 0; i < addresses.length; i++) {
+            for (int j = 0; j < MAX_REPLICA_COUNT; j++) {
+                addresses[i][j] = new Address("10.10." + i + "." + RandomPicker.getInt(256), localAddress, 5000 + j);
+            }
+        }
+        return addresses;
+    }
+
+    private static Address[][] extractPartitionTableAddresses(PartitionTableView table) {
+        Address[][] addresses = new Address[table.getLength()][];
+        for (int i = 0; i < addresses.length; i++) {
+            addresses[i] = table.getAddresses(i);
+        }
+        return addresses;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImplTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.internal.partition.PartitionListener;
+import com.hazelcast.internal.partition.PartitionTableView;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -92,7 +93,7 @@ public class InternalPartitionServiceImplTest extends HazelcastTestSupport {
             addresses[i][0] = thisAddress;
         }
 
-        partitionService.setInitialState(addresses, partitionCount);
+        partitionService.setInitialState(new PartitionTableView(addresses, partitionCount));
         for (int i = 0; i < partitionCount; i++) {
             assertTrue(partitionService.isPartitionOwner(i));
         }
@@ -106,8 +107,8 @@ public class InternalPartitionServiceImplTest extends HazelcastTestSupport {
             addresses[i][0] = thisAddress;
         }
 
-        partitionService.setInitialState(addresses, 0);
-        partitionService.setInitialState(addresses, 0);
+        partitionService.setInitialState(new PartitionTableView(addresses, 0));
+        partitionService.setInitialState(new PartitionTableView(addresses, 0));
     }
 
     @Test
@@ -120,7 +121,7 @@ public class InternalPartitionServiceImplTest extends HazelcastTestSupport {
         TestPartitionListener listener = new TestPartitionListener();
         partitionService.addPartitionListener(listener);
 
-        partitionService.setInitialState(addresses, 0);
+        partitionService.setInitialState(new PartitionTableView(addresses, 0));
         assertEquals(0, listener.eventCount);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
@@ -59,7 +59,6 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
-import static org.junit.internal.matchers.ThrowableCauseMatcher.hasCause;
 
 /**
  * Tests that verifies the behavior of the DefaultPortableReader.
@@ -117,7 +116,7 @@ public class DefaultPortableReaderSpecTest extends HazelcastTestSupport {
         Object resultToMatch = expectedResult;
         if (expectedResult instanceof Class) {
             // expected exception case
-            expected.expectCause(hasCause(isA((Class) expectedResult)));
+            expected.expect(isA((Class) expectedResult));
         } else if (expectedResult instanceof List) {
             // just convenience -> if result is a list if will be compared to an array, so it has to be converted
             resultToMatch = ((List) resultToMatch).toArray();

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -104,23 +104,10 @@ public class TestHazelcastInstanceFactory {
         String instanceName = config != null ? config.getInstanceName() : null;
         if (mockNetwork) {
             config = initOrCreateConfig(config);
-            NodeContext nodeContext = registry.createNodeContext(pickAddress());
+            NodeContext nodeContext = registry.createNodeContext(nextAddress());
             return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
         }
         return HazelcastInstanceFactory.newHazelcastInstance(config);
-    }
-
-    private Address pickAddress() {
-        int id = nodeIndex.getAndIncrement();
-
-        Address currentAddress = addressMap.get(id);
-        if (currentAddress != null) {
-            return currentAddress;
-        }
-
-        Address newAddress = createAddress("127.0.0.1", PORTS.incrementAndGet());
-        addressMap.put(id, newAddress);
-        return newAddress;
     }
 
     /**
@@ -146,6 +133,19 @@ public class TestHazelcastInstanceFactory {
             return HazelcastInstanceFactory.newHazelcastInstance(config, instanceName, nodeContext);
         }
         throw new UnsupportedOperationException("Explicit address is only available for mock network setup!");
+    }
+
+    public Address nextAddress() {
+        int id = nodeIndex.getAndIncrement();
+
+        Address currentAddress = addressMap.get(id);
+        if (currentAddress != null) {
+            return currentAddress;
+        }
+
+        Address newAddress = createAddress("127.0.0.1", PORTS.incrementAndGet());
+        addressMap.put(id, newAddress);
+        return newAddress;
     }
 
     public HazelcastInstance[] newInstances() {

--- a/hazelcast/src/test/resources/log4j.properties
+++ b/hazelcast/src/test/resources/log4j.properties
@@ -25,6 +25,7 @@ log4j.logger.com.hazelcast.cluster=debug
 log4j.logger.com.hazelcast.internal.cluster=debug
 log4j.logger.com.hazelcast.internal.partition=debug
 log4j.logger.com.hazelcast.spi.hotrestart=info
+log4j.logger.com.hazelcast.spi.hotrestart.cluster=debug
 log4j.logger.com.hazelcast.test.mocknetwork=debug
 
 log4j.rootLogger=info, stdout


### PR DESCRIPTION
Changes in join mechanism and partition service required to remove IP address restriction in Hot Restart.

See design doc for details:

https://hazelcast.atlassian.net/wiki/display/EN/Copy+HRS+Data+from+a+Source+to+a+Target+Cluster+Design

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/1101
