### PR TITLE
Fixed Near Cache usage in TransactionalMapProxySupport

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
@@ -21,13 +21,11 @@ import com.hazelcast.cache.impl.nearcache.NearCacheContext;
 import com.hazelcast.cache.impl.nearcache.NearCacheManager;
 import com.hazelcast.cache.impl.nearcache.impl.DefaultNearCacheManager;
 import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapManagedService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.invalidation.BatchInvalidator;
 import com.hazelcast.map.impl.nearcache.invalidation.NearCacheInvalidator;
 import com.hazelcast.map.impl.nearcache.invalidation.NonStopInvalidator;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
@@ -104,15 +102,6 @@ public class NearCacheProvider {
 
         String uuid = nodeEngine.getLocalMember().getUuid();
         nearCacheInvalidator.destroy(mapName, uuid);
-    }
-
-    public Object getFromNearCache(String mapName, Data key) {
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        if (!mapContainer.hasInvalidationListener()) {
-            return null;
-        }
-        NearCache<Data, Object> nearCache = getOrCreateNearCache(mapName);
-        return nearCache.get(key);
     }
 
     public NearCacheInvalidator getNearCacheInvalidator() {


### PR DESCRIPTION
Added proper support for the Near Cache to `getInternal()` and put fetched values into the Near Cache (including stale read prevention).

When extending my unified Near Cache tests to the `TransactionalMap` I realised that the proxy is missing some functionality in the `get()` code path. Actually this is the only code path with uses the Near Cache at all, but nevertheless it should support all Near Cache features. So I copied the logic from the `IMap` proxy.

I think good reviewers would be @ahmetmircik, @vbekiaris or @gurbuzali.