### PR TITLE
Warn user when on localhost but loopback mode disabled.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -96,7 +96,15 @@ public final class MulticastService implements Runnable {
                 } else if (multicastConfig.isLoopbackModeEnabled()) {
                     multicastSocket.setLoopbackMode(true);
                     multicastSocket.setInterface(bindAddress.getInetAddress());
+                } else {
+                    // If LoopBack is not enabled but its the selected interface from the given
+                    // bind address, then we rely on Default Network Interface.
+                    logger.warning("Hazelcast is bind to " + bindAddress.getHost() + " and loop-back mode is disabled in the configuration. "
+                            + "This could cause multicast auto-discovery issues and render it unable to work. "
+                            + "Check you network connectivity, try to enable the loopback mode and/or "
+                            + "force -Djava.net.preferIPv4Stack=true on your JVM.");
                 }
+
             } catch (Exception e) {
                 logger.warning(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -99,12 +99,11 @@ public final class MulticastService implements Runnable {
                 } else {
                     // If LoopBack is not enabled but its the selected interface from the given
                     // bind address, then we rely on Default Network Interface.
-                    logger.warning("Hazelcast is bind to " + bindAddress.getHost() + " and loop-back mode is disabled in the configuration. "
-                            + "This could cause multicast auto-discovery issues and render it unable to work. "
+                    logger.warning("Hazelcast is bind to " + bindAddress.getHost() + " and loop-back mode is disabled in "
+                            + "the configuration. This could cause multicast auto-discovery issues and render it unable to work. "
                             + "Check you network connectivity, try to enable the loopback mode and/or "
                             + "force -Djava.net.preferIPv4Stack=true on your JVM.");
                 }
-
             } catch (Exception e) {
                 logger.warning(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -99,7 +99,7 @@ public final class MulticastService implements Runnable {
                 } else {
                     // If LoopBack is not enabled but its the selected interface from the given
                     // bind address, then we rely on Default Network Interface.
-                    logger.warning("Hazelcast is bind to " + bindAddress.getHost() + " and loop-back mode is disabled in "
+                    logger.warning("Hazelcast is bound to " + bindAddress.getHost() + " and loop-back mode is disabled in "
                             + "the configuration. This could cause multicast auto-discovery issues and render it unable to work. "
                             + "Check you network connectivity, try to enable the loopback mode and/or "
                             + "force -Djava.net.preferIPv4Stack=true on your JVM.");


### PR DESCRIPTION
Attempt to warn the end user, for potential auto-discovery issues as described in #9081, when the bind address is on the loopback interface, but loopback mode is disabled.

This is just a best effort attempt to early catch potential issues with mostly dev environments when not internet connected. As seen in #9081 even when on loopback mode, it could fail later when attempting to send a datagram.
