### PR TITLE
Adds option to reset StoreLatencyPlugin statistics

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/AbstractDiagnosticsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/AbstractDiagnosticsPluginTest.java
@@ -21,6 +21,10 @@ public class AbstractDiagnosticsPluginTest extends HazelcastTestSupport {
         logWriter.init(new PrintWriter(out));
     }
 
+    protected void reset(){
+        out.reset();
+    }
+
     protected String getContent() {
         return out.toString();
     }
@@ -32,6 +36,6 @@ public class AbstractDiagnosticsPluginTest extends HazelcastTestSupport {
 
     protected void assertNotContains(String expected) {
         String message = getContent();
-        assertFalse("'" + message + "' doesn't contains '" + expected + "'", message.contains(expected));
+        assertFalse("'" + message + "' does contains '" + expected + "'", message.contains(expected));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginResetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginResetTest.java
@@ -1,0 +1,53 @@
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Properties;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class StoreLatencyPluginResetTest extends AbstractDiagnosticsPluginTest {
+
+    @Test
+    public void test() throws InterruptedException {
+        Properties props = new Properties();
+        props.put(StoreLatencyPlugin.PERIOD_SECONDS.getName(), "1");
+        props.put(StoreLatencyPlugin.RESET_PERIOD_SECONDS.getName(), "2");
+
+        HazelcastProperties properties = new HazelcastProperties(props);
+        StoreLatencyPlugin plugin = new StoreLatencyPlugin(Logger.getLogger(StoreLatencyPlugin.class), properties);
+
+        StoreLatencyPlugin.LatencyProbe probe = plugin.newProbe("foo", "queue", "somemethod");
+
+        probe.recordValue(MICROSECONDS.toNanos(1));
+        probe.recordValue(MICROSECONDS.toNanos(2));
+        probe.recordValue(MICROSECONDS.toNanos(5));
+
+        // run for the first time.
+        plugin.run(logWriter);
+        assertContains("max(us)=5");
+
+        // reset the logWriter so we don't get previous run content.
+        reset();
+        // run for the second time;
+        plugin.run(logWriter);
+        // now it should still contain the old statistics
+        assertContains("max(us)=5");
+
+        // reset the logWriter so we don't get previous run content.
+        reset();
+        // run for the third time; now the stats should be gone
+        plugin.run(logWriter);
+        // now it should not contain the old statistics
+        assertNotContains("max(us)=5");
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/StoreLatencyPluginTest.java
@@ -26,7 +26,9 @@ public class StoreLatencyPluginTest extends AbstractDiagnosticsPluginTest {
 
     @Before
     public void setup() {
-        HazelcastProperties properties = new HazelcastProperties(new Properties());
+        Properties p = new Properties();
+        p.put(StoreLatencyPlugin.PERIOD_SECONDS, "1");
+        HazelcastProperties properties = new HazelcastProperties(p);
         plugin = new StoreLatencyPlugin(Logger.getLogger(StoreLatencyPlugin.class), properties);
     }
 
@@ -50,7 +52,7 @@ public class StoreLatencyPluginTest extends AbstractDiagnosticsPluginTest {
         probe.recordValue(MICROSECONDS.toNanos(1000));
         probe.recordValue(MICROSECONDS.toNanos(4));
 
-        assertEquals(1000, probe.maxMicros);
+        assertEquals(1000, probe.stats.maxMicros);
     }
 
     @Test
@@ -60,7 +62,7 @@ public class StoreLatencyPluginTest extends AbstractDiagnosticsPluginTest {
         probe.recordValue(MICROSECONDS.toNanos(10));
         probe.recordValue(MICROSECONDS.toNanos(10));
 
-        assertEquals(3, probe.count);
+        assertEquals(3, probe.stats.count);
     }
 
     @Test
@@ -70,7 +72,7 @@ public class StoreLatencyPluginTest extends AbstractDiagnosticsPluginTest {
         probe.recordValue(MICROSECONDS.toNanos(20));
         probe.recordValue(MICROSECONDS.toNanos(30));
 
-        assertEquals(60, probe.totalMicros);
+        assertEquals(60, probe.stats.totalMicros);
     }
 
     @Test


### PR DESCRIPTION
An automatic reset option was added to the latency plugin that resets the statistics. 

There is no sliding window implementation; the current implementation is suboptimal but requested by Alparslan to give them some feedback what happened in a given time window. 

Due to the implementation it can happen that the reset period is 5 minutes and at 4:59 a very latency is measured of e..g 15 minutes.. then this 15 minutes is rendered once... and then it is gone. This is a known limitation of this approach since there is no sliding window.
