### PR TITLE
Minor InvocationRegistry cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -48,6 +48,9 @@ import static com.hazelcast.spi.OperationAccessor.setCallId;
  * the PartitionInvocation and TargetInvocation can be folded into Invocation.
  */
 public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider {
+    private static final int CORE_SIZE_CHECK = 8;
+    private static final int CORE_SIZE_FACTOR = 4;
+    private static final int CONCURRENCY_LEVEL = 16;
 
     private static final int INITIAL_CAPACITY = 1000;
     private static final float LOAD_FACTOR = 0.75f;
@@ -60,9 +63,14 @@ public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider
 
     private volatile boolean alive = true;
 
-    public InvocationRegistry(ILogger logger, CallIdSequence callIdSequence, int concurrencyLevel) {
+    public InvocationRegistry(ILogger logger, CallIdSequence callIdSequence) {
         this.logger = logger;
         this.callIdSequence = callIdSequence;
+
+        int coreSize = Runtime.getRuntime().availableProcessors();
+        boolean reallyMultiCore = coreSize >= CORE_SIZE_CHECK;
+        int concurrencyLevel = reallyMultiCore ? coreSize * CORE_SIZE_FACTOR : CONCURRENCY_LEVEL;
+
         this.invocations = new ConcurrentHashMap<Long, Invocation>(INITIAL_CAPACITY, LOAD_FACTOR, concurrencyLevel);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -99,9 +99,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 public final class OperationServiceImpl implements InternalOperationService, MetricsProvider, LiveOperationsTracker {
 
-    private static final int CORE_SIZE_CHECK = 8;
-    private static final int CORE_SIZE_FACTOR = 4;
-    private static final int CONCURRENCY_LEVEL = 16;
     private static final int ASYNC_QUEUE_CAPACITY = 100000;
     private static final long TERMINATION_TIMEOUT_MILLIS = SECONDS.toMillis(10);
 
@@ -154,16 +151,11 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         this.backpressureRegulator = new BackpressureRegulator(
                 node.getProperties(), node.getLogger(BackpressureRegulator.class));
 
-        int coreSize = Runtime.getRuntime().availableProcessors();
-        boolean reallyMultiCore = coreSize >= CORE_SIZE_CHECK;
-        int concurrencyLevel = reallyMultiCore ? coreSize * CORE_SIZE_FACTOR : CONCURRENCY_LEVEL;
-
         this.outboundResponseHandler = new OutboundResponseHandler(
                 thisAddress, serializationService, node, node.getLogger(OutboundResponseHandler.class));
 
         this.invocationRegistry = new InvocationRegistry(
-                node.getLogger(OperationServiceImpl.class),
-                backpressureRegulator.newCallIdSequence(), concurrencyLevel);
+                node.getLogger(OperationServiceImpl.class), backpressureRegulator.newCallIdSequence());
 
         this.invocationMonitor = new InvocationMonitor(
                 nodeEngine, thisAddress, node.getHazelcastThreadGroup(), node.getProperties(), invocationRegistry,


### PR DESCRIPTION
The calculation of the concurrency level is now moved into the InvocationRegistry. It
is no longer a concern of the OperationServiceImpl. 

This makes the OperationServiceImpl a bit cleaner since it doesn't need to know about implementation details of the InvocationRegistry.

I believe this is an called an improved cohesion since letting the operationservice take care of a calculation that isn't its primary concern is causing low cohesion. And by moving it to the InvocationRegistry it increased cohesion since the OperationServiceImpl doesn't do something it doesn't care about; and it is moved to a place where it is important.
