### PR TITLE
Backup cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -607,10 +607,16 @@ class ByteArrayObjectDataInput extends InputStream implements BufferObjectDataIn
     }
 
     @Override
+    public <T> T readDataAsObject() throws IOException {
+        // a future optimization would be to skip the construction of the Data object.
+        Data data = readData();
+        return data == null ? null : (T) service.toObject(data);
+    }
+
+    @Override
     public final Data readData() throws IOException {
         byte[] bytes = readByteArray();
-        Data data = bytes == null ? null : new HeapData(bytes);
-        return data;
+        return bytes == null ? null : new HeapData(bytes);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -334,6 +334,13 @@ public class ObjectDataInputStream extends InputStream implements ObjectDataInpu
         return serializationService.readObject(this);
     }
 
+    // a future optimization would be to skip the construction of the Data object.
+    @Override
+    public <T> T readDataAsObject() throws IOException {
+        Data data = readData();
+        return data == null ? null : (T) serializationService.toObject(data);
+    }
+
     @Override
     public Object readObject(Class aClass) throws IOException {
         return serializationService.readObject(this, aClass);
@@ -342,8 +349,7 @@ public class ObjectDataInputStream extends InputStream implements ObjectDataInpu
     @Override
     public Data readData() throws IOException {
         byte[] bytes = readByteArray();
-        Data data = bytes != null ? new HeapData(bytes) : null;
-        return data;
+        return bytes == null ? null : new HeapData(bytes);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -89,6 +89,20 @@ public interface ObjectDataInput extends DataInput {
     <T> T readObject() throws IOException;
 
     /**
+     * Reads to stored Data as an object instead of a Data instance.
+     *
+     * The reason this method exists is that in some cases 'Data' is stored on serialization, but on deserialization the
+     * actual object instance is needed. Getting access to the Data is easy by calling the {@link #readData()} method. But
+     * deserializing the Data to an object instance is impossible because there is no reference to the
+     * {@link com.hazelcast.spi.serialization.SerializationService}.
+     *
+     * @param <T>
+     * @return the read Object
+     * @throws IOException if it reaches end of file before finish reading
+     */
+    <T> T readDataAsObject() throws IOException;
+
+    /**
      * @param <T> type of the object in array to be read
      * @param aClass The type of the class to use when reading
      * @return object array read

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputIntegrationTest.java
@@ -1,0 +1,64 @@
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ByteArrayObjectDataInputIntegrationTest {
+    private final InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+
+    @Test
+    public void testNotNull() throws Exception {
+        readDataAsObject("foo");
+    }
+
+    @Test
+    public void testNull() throws Exception {
+        readDataAsObject(null);
+    }
+
+    public void readDataAsObject(Object value) throws Exception {
+        Data data = serializationService.toData(value);
+        MyObject myObject = new MyObject(data);
+        Data myObjectData = serializationService.toData(myObject);
+        MyObject myObjectDeserialized = serializationService.toObject(myObjectData);
+
+        assertEquals(value, myObjectDeserialized.o);
+    }
+
+    private static class MyObject implements DataSerializable {
+        private Data data;
+        private Object o;
+
+        public MyObject() {
+        }
+
+        public MyObject(Data data) {
+            this.data = data;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeData(data);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            o = in.readDataAsObject();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputTest.java
@@ -25,8 +25,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * ByteArrayObjectDataInput Tester.


### PR DESCRIPTION
The main change is that the Backup will immediately deserialize the backup Operation in the deserialize
method. There is no intermediate Data required.

This is done by adding an extra method to the ObjectDataInput.readDataAsObject.

Also the need to publish the actual BackupOperation in the Backup isn't needed any longer (publishing
was needed for diagnostics purposes).
