### PR TITLE
TcpIpConnectionManager shutdown scheduler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -531,6 +531,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
         shutdownAcceptorThread();
         closeServerSocket();
         stop();
+        scheduler.shutdownNow();
         connectionListeners.clear();
     }
 


### PR DESCRIPTION
The internal scheduler was not shutdown on stop. Fix #9187
