### PR TITLE
Improved probes for events.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -366,7 +366,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         final ClientNetworkConfig networkConfig = config.getNetworkConfig();
         if (networkConfig.isSmartRouting()) {
             return new ClientSmartListenerService(this, eventThreadCount, eventQueueCapacity);
-
         } else {
             return new ClientNonSmartListenerService(this, eventThreadCount, eventQueueCapacity);
         }
@@ -401,6 +400,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
                 new MetricsPlugin(loggingService.getLogger(MetricsPlugin.class), metricsRegistry, properties));
         diagnostics.register(
                 new SystemLogPlugin(properties, connectionManager, this, loggingService.getLogger(SystemLogPlugin.class)));
+
+        metricsRegistry.collectMetrics(listenerService);
+
     }
 
     public MetricsRegistryImpl getMetricsRegistry() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -58,6 +58,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.util.FutureUtil.ExceptionHandler;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
@@ -162,10 +163,15 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
         return eventQueueCapacity;
     }
 
-    @Probe(name = "eventQueueSize")
+    @Probe(name = "eventQueueSize", level = MANDATORY)
     @Override
     public int getEventQueueSize() {
         return eventExecutor.getWorkQueueSize();
+    }
+
+    @Probe(level = MANDATORY)
+    private long eventsProcessed() {
+        return eventExecutor.processedCount();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceSegment.java
@@ -50,6 +50,10 @@ public class EventServiceSegment<S> {
         this.service = service;
     }
 
+    private int listenerCount() {
+        return registrationIdMap.size();
+    }
+
     private void pingNotifiableEventListener(String topic, Registration registration, boolean register) {
         Object listener = registration.getListener();
         if (!(listener instanceof NotifiableEventListener)) {


### PR DESCRIPTION
Added probes on the client
- number of listeners
- number of pending events
- number of processed events

On the server added:
- number of pending events
- number of processed events

This deals partially with ticket #9130. User wants to see number
of pending events using JMX, but this would require a lot of effort
since client has no JMX. Luckily client does have diagnostics, so
it is easy to make use of that.
