### PR TITLE
IO service simplification

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -20,10 +20,10 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.IOOutOfMemoryHandler;
 import com.hazelcast.nio.tcp.ReadHandler;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
@@ -41,7 +41,9 @@ public interface IOService {
 
     boolean isActive();
 
-    ILogger getLogger(String name);
+    HazelcastThreadGroup getHazelcastThreadGroup();
+
+    LoggingService getLoggingService();
 
     IOOutOfMemoryHandler getIoOutOfMemoryHandler();
 
@@ -64,10 +66,6 @@ public interface IOService {
     boolean isRestEnabled();
 
     void removeEndpoint(Address endpoint);
-
-    String getThreadPrefix();
-
-    ThreadGroup getThreadGroup();
 
     void onSuccessfulConnection(Address address);
 
@@ -129,10 +127,6 @@ public interface IOService {
     EventService getEventService();
 
     Collection<Integer> getOutboundPorts();
-
-    Data toData(Object obj);
-
-    Object toObject(Data data);
 
     InternalSerializationService getSerializationService();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -28,8 +28,7 @@ import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.IOOutOfMemoryHandler;
 import com.hazelcast.nio.tcp.ReadHandler;
 import com.hazelcast.nio.tcp.SocketChannelWrapperFactory;
@@ -59,13 +58,18 @@ public class NodeIOService implements IOService {
     }
 
     @Override
-    public boolean isActive() {
-        return node.getState() != NodeState.SHUT_DOWN;
+    public HazelcastThreadGroup getHazelcastThreadGroup() {
+        return nodeEngine.getHazelcastThreadGroup();
     }
 
     @Override
-    public ILogger getLogger(String name) {
-        return node.getLogger(name);
+    public LoggingService getLoggingService() {
+        return nodeEngine.getLoggingService();
+    }
+
+    @Override
+    public boolean isActive() {
+        return node.getState() != NodeState.SHUT_DOWN;
     }
 
     @Override
@@ -127,18 +131,6 @@ public class NodeIOService implements IOService {
     @Override
     public boolean isRestEnabled() {
         return node.getProperties().getBoolean(GroupProperty.REST_ENABLED);
-    }
-
-    @Override
-    public String getThreadPrefix() {
-        HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
-        return threadGroup.getThreadPoolNamePrefix("IO");
-    }
-
-    @Override
-    public ThreadGroup getThreadGroup() {
-        HazelcastThreadGroup threadGroup = node.getHazelcastThreadGroup();
-        return threadGroup.getInternalThreadGroup();
     }
 
     @Override
@@ -286,16 +278,6 @@ public class NodeIOService implements IOService {
     @Override
     public EventService getEventService() {
         return nodeEngine.getEventService();
-    }
-
-    @Override
-    public Data toData(Object obj) {
-        return nodeEngine.toData(obj);
-    }
-
-    @Override
-    public Object toObject(Data data) {
-        return nodeEngine.toObject(data);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
@@ -104,7 +104,7 @@ public class TextReadHandler implements ReadHandler {
         this.connection = connection;
         this.memcacheEnabled = ioService.isMemcacheEnabled();
         this.restEnabled = ioService.isRestEnabled();
-        this.logger = ioService.getLogger(this.getClass().getName());
+        this.logger = ioService.getLoggingService().getLogger(getClass());
     }
 
     public void sendResponse(TextCommand command) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/InitConnectionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/InitConnectionTask.java
@@ -53,7 +53,7 @@ public class InitConnectionTask implements Runnable {
         this.connectionManager = connectionManager;
         this.ioService = connectionManager.getIoService();
         this.address = address;
-        this.logger = ioService.getLogger(this.getClass().getName());
+        this.logger = ioService.getLoggingService().getLogger(getClass());
         this.silent = silent;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketAcceptorThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketAcceptorThread.java
@@ -74,7 +74,7 @@ public class SocketAcceptorThread extends Thread {
         this.serverSocketChannel = serverSocketChannel;
         this.connectionManager = connectionManager;
         this.ioService = connectionManager.getIoService();
-        this.logger = ioService.getLogger(this.getClass().getName());
+        this.logger = ioService.getLoggingService().getLogger(getClass());
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ConnectionType;
+import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.OutboundFrame;
 
 import java.io.EOFException;
@@ -61,6 +62,8 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
 
     private final int connectionId;
 
+    private final IOService ioService;
+
     private Address endPoint;
 
     private TcpIpConnectionMonitor monitor;
@@ -76,8 +79,9 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
                            SocketChannelWrapper socketChannel,
                            IOThreadingModel ioThreadingModel) {
         this.connectionId = connectionId;
-        this.logger = connectionManager.getIoService().getLogger(TcpIpConnection.class.getName());
         this.connectionManager = connectionManager;
+        this.ioService = connectionManager.getIoService();
+        this.logger = ioService.getLoggingService().getLogger(TcpIpConnection.class);
         this.socketChannel = socketChannel;
         this.socketWriter = ioThreadingModel.newSocketWriter(this);
         this.socketReader = ioThreadingModel.newSocketReader(this);
@@ -261,7 +265,7 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
         }
 
         connectionManager.onClose(this);
-        connectionManager.getIoService().onDisconnect(endPoint, cause);
+        ioService.onDisconnect(endPoint, cause);
         if (cause != null && monitor != null) {
             monitor.onError(cause);
         }
@@ -277,7 +281,7 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
             message += "Socket explicitly closed";
         }
 
-        if (connectionManager.getIoService().isActive()) {
+        if (ioService.isActive()) {
             if (closeCause == null || closeCause instanceof EOFException) {
                 logger.info(message);
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -479,8 +479,8 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
         }
 
         acceptorThread = new SocketAcceptorThread(
-                ioService.getThreadGroup(),
-                ioService.getThreadPrefix() + "Acceptor",
+                ioService.getHazelcastThreadGroup().getInternalThreadGroup(),
+                ioService.getHazelcastThreadGroup().getThreadPoolNamePrefix("IO") + "Acceptor",
                 serverSocketChannel,
                 this);
         acceptorThread.start();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionMonitor.java
@@ -37,7 +37,7 @@ public class TcpIpConnectionMonitor {
         this.ioService = connectionManager.getIoService();
         this.minInterval = ioService.getConnectionMonitorInterval();
         this.maxFaults = ioService.getConnectionMonitorMaxFaults();
-        this.logger = ioService.getLogger(getClass().getName());
+        this.logger = ioService.getLoggingService().getLogger(getClass());
     }
 
     public Address getEndPoint() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
+import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.ClusterService;
@@ -48,6 +49,7 @@ import com.hazelcast.internal.metrics.metricsets.ThreadMetricSet;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
@@ -191,6 +193,14 @@ public class NodeEngineImpl implements NodeEngine {
             PacketHandler packetHandler = (PacketHandler) node.getConnectionManager();
             packetHandler.handle(packet);
         }
+    }
+
+    public LoggingService getLoggingService() {
+        return loggingService;
+    }
+
+    public HazelcastThreadGroup getHazelcastThreadGroup() {
+        return node.getHazelcastThreadGroup();
     }
 
     public MetricsRegistry getMetricsRegistry() {

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -10,6 +10,7 @@ import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -29,6 +30,8 @@ import java.nio.channels.ServerSocketChannel;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static com.hazelcast.logging.Logger.getLogger;
 
 public class MockIOService implements IOService {
 
@@ -64,8 +67,13 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public ILogger getLogger(String name) {
-        return loggingService.getLogger(name);
+    public HazelcastThreadGroup getHazelcastThreadGroup() {
+        return hazelcastThreadGroup;
+    }
+
+    @Override
+    public LoggingService getLoggingService() {
+        return loggingService;
     }
 
     @Override
@@ -84,7 +92,6 @@ public class MockIOService implements IOService {
 
     @Override
     public void onFatalError(Exception e) {
-
     }
 
     @Override
@@ -104,7 +111,6 @@ public class MockIOService implements IOService {
 
     @Override
     public void handleClientMessage(ClientMessage cm, Connection connection) {
-
     }
 
     @Override
@@ -124,27 +130,14 @@ public class MockIOService implements IOService {
 
     @Override
     public void removeEndpoint(Address endpoint) {
-
-    }
-
-    @Override
-    public String getThreadPrefix() {
-        return hazelcastThreadGroup.getThreadPoolNamePrefix("IO");
-    }
-
-    @Override
-    public ThreadGroup getThreadGroup() {
-        return hazelcastThreadGroup.getInternalThreadGroup();
     }
 
     @Override
     public void onSuccessfulConnection(Address address) {
-
     }
 
     @Override
     public void onFailedConnection(Address address) {
-
     }
 
     @Override
@@ -236,7 +229,6 @@ public class MockIOService implements IOService {
 
     @Override
     public void onDisconnect(Address endpoint, Throwable cause) {
-
     }
 
     @Override
@@ -302,7 +294,6 @@ public class MockIOService implements IOService {
 
             @Override
             public void deregisterAllListeners(String serviceName, String topic) {
-
             }
 
             @Override
@@ -322,22 +313,18 @@ public class MockIOService implements IOService {
 
             @Override
             public void publishEvent(String serviceName, String topic, Object event, int orderKey) {
-
             }
 
             @Override
             public void publishEvent(String serviceName, EventRegistration registration, Object event, int orderKey) {
-
             }
 
             @Override
             public void publishEvent(String serviceName, Collection<EventRegistration> registrations, Object event, int orderKey) {
-
             }
 
             @Override
             public void publishRemoteEvent(String serviceName, Collection<EventRegistration> registrations, Object event, int orderKey) {
-
             }
 
             @Override
@@ -350,16 +337,6 @@ public class MockIOService implements IOService {
     @Override
     public Collection<Integer> getOutboundPorts() {
         return Collections.emptyList();
-    }
-
-    @Override
-    public Data toData(Object obj) {
-        return serializationService.toData(obj);
-    }
-
-    @Override
-    public Object toObject(Data data) {
-        return serializationService.toObject(data);
     }
 
     @Override
@@ -380,7 +357,7 @@ public class MockIOService implements IOService {
     @Override
     public ReadHandler createReadHandler(final TcpIpConnection connection) {
         return new MemberReadHandler(connection, new PacketDispatcher() {
-            private ILogger logger = getLogger("MockIOService");
+            private ILogger logger = loggingService.getLogger("MockIOService");
 
             @Override
             public void dispatch(Packet packet) {

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -60,7 +60,7 @@ public class MockConnectionManager implements ConnectionManager {
         this.ioService = ioService;
         this.registry = registry;
         this.node = node;
-        this.logger = ioService.getLogger(MockConnectionManager.class.getName());
+        this.logger = ioService.getLoggingService().getLogger(MockConnectionManager.class);
     }
 
     @Override


### PR DESCRIPTION
Removed IOService.getLogger, replaced by getLoggingService
Removed IOService.getThreadPrefix/getThreadGroup, replaced by getHazelcastThreadGoup
Removed IOService.toData/toObject. Not used

No Enterprise change needed.