### PR TITLE
Implement join and UUID changes related to the partial-start feature

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEngine.java
@@ -57,6 +57,8 @@ public interface ClientEngine {
 
     Address getThisAddress();
 
+    String getThisUuid();
+
     MemberImpl getLocalMember();
 
     SecurityContext getSecurityContext();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -221,6 +221,11 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     }
 
     @Override
+    public String getThisUuid() {
+        return node.getThisUuid();
+    }
+
+    @Override
     public MemberImpl getLocalMember() {
         return node.getLocalMember();
     }
@@ -375,7 +380,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
                     return;
                 }
 
-                String localMemberUuid = node.getLocalMember().getUuid();
+                String localMemberUuid = node.getThisUuid();
                 String ownerUuid = endpoint.getPrincipal().getOwnerUuid();
                 if (localMemberUuid.equals(ownerUuid)) {
                     callDisconnectionOperation(endpoint);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -73,7 +73,7 @@ public class ClientHeartbeatMonitor implements Runnable {
 
     @Override
     public void run() {
-        final String memberUuid = clientEngine.getLocalMember().getUuid();
+        final String memberUuid = clientEngine.getThisUuid();
         for (ClientEndpoint ce : clientEndpointManager.getEndpoints()) {
             ClientEndpointImpl clientEndpoint = (ClientEndpointImpl) ce;
             monitor(memberUuid, clientEndpoint);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -156,7 +156,7 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractCallableM
     private ClientMessage handleAuthenticated() {
         if (isOwnerConnection()) {
             final String uuid = getUuid();
-            final String localMemberUUID = clientEngine.getLocalMember().getUuid();
+            final String localMemberUUID = clientEngine.getThisUuid();
 
             principal = new ClientPrincipal(uuid, localMemberUUID);
             reAuthLocal();

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartClusterDataRecoveryPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartClusterDataRecoveryPolicy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Specifies the policy that will be respected during hot restart cluster start
+ */
+public enum HotRestartClusterDataRecoveryPolicy {
+
+    /**
+     * Starts the cluster only when all expected nodes are present and correct. Otherwise, it fails.
+     */
+    FULL_RECOVERY_ONLY,
+
+    /**
+     * Starts the cluster with the members which have most up-to-date partition table and successfully restored their data.
+     * All other members will leave the cluster and force-start themselves.
+     * If no member restores its data successfully, cluster start fails.
+     */
+    PARTIAL_RECOVERY_MOST_RECENT,
+
+    /**
+     * Starts the cluster with the largest group of members which have the same partition table version
+     * and successfully restored their data. All other members will leave the cluster and force-start themselves.
+     * If no member restores its data successfully, cluster start fails.
+     */
+    PARTIAL_RECOVERY_MOST_COMPLETE
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
@@ -58,6 +58,8 @@ public class HotRestartPersistenceConfig {
     private int parallelism = DEFAULT_PARALLELISM;
     private int validationTimeoutSeconds = DEFAULT_VALIDATION_TIMEOUT;
     private int dataLoadTimeoutSeconds = DEFAULT_DATA_LOAD_TIMEOUT;
+    private HotRestartClusterDataRecoveryPolicy clusterDataRecoveryPolicy
+            = HotRestartClusterDataRecoveryPolicy.FULL_RECOVERY_ONLY;
 
     /**
      * Returns whether hot restart enabled on this member.
@@ -75,6 +77,28 @@ public class HotRestartPersistenceConfig {
      */
     public HotRestartPersistenceConfig setEnabled(boolean enabled) {
         this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Returns the policy to be used when the cluster is started
+     *
+     * @return the policy to be used when the cluster is started
+     */
+    public HotRestartClusterDataRecoveryPolicy getClusterDataRecoveryPolicy() {
+        return clusterDataRecoveryPolicy;
+    }
+
+    /**
+     * Sets the policy to be used when the cluster is started
+     *
+     * @param clusterDataRecoveryPolicy the policy to be used when the cluster is started
+     *
+     * @return HotRestartConfig
+     */
+    public HotRestartPersistenceConfig setClusterDataRecoveryPolicy(HotRestartClusterDataRecoveryPolicy
+                                                                            clusterDataRecoveryPolicy) {
+        this.clusterDataRecoveryPolicy = clusterDataRecoveryPolicy;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -57,6 +57,7 @@ import com.hazelcast.wan.impl.WanReplicationServiceImpl;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.hazelcast.map.impl.MapServiceConstructor.getDefaultMapServiceConstructor;
 
@@ -247,7 +248,27 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
+    public boolean triggerPartialStart() {
+        logger.warning("Partial start is available when hot restart is active!");
+        return false;
+    }
+
+    @Override
     public String createMemberUuid(Address address) {
         return UuidUtil.createMemberUuid(address);
+    }
+
+    @Override
+    public boolean isMemberExcluded(Address memberAddress, String memberUuid) {
+        return false;
+    }
+
+    @Override
+    public Set<String> getExcludedMemberUuids() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void handleExcludedMemberUuids(Address sender, Set<String> excludedMemberUuids) {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -318,7 +318,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
 
     @Override
     public Member getLocalEndpoint() {
-        return node.clusterService.getLocalMember();
+        return node.getLocalMember();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -17,6 +17,7 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.memory.MemoryStats;
 import com.hazelcast.nio.Address;
@@ -30,6 +31,7 @@ import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * NodeExtension is a <tt>Node</tt> extension mechanism to be able to plug different implementations of
@@ -197,9 +199,18 @@ public interface NodeExtension {
      * Forces node to start by skipping hot-restart completely and removing all hot-restart data
      * even if node is still on validation phase or loading hot-restart data.
      *
-     * @return true if hot restart is enabled and this node knows the master
+     * @return true if force start is triggered successfully. force start cannot be triggered if hot restart is disabled or
+     * the master is not known yet
      */
     boolean triggerForceStart();
+
+    /**
+     * Triggers partial start if the cluster cannot be started with full recovery and
+     * {@link HotRestartPersistenceConfig#clusterDataRecoveryPolicy} is set accordingly.
+     *
+     * @return true if partial start is triggered.
+     */
+    boolean triggerPartialStart();
 
     /**
      * Creates a UUID for local member
@@ -207,4 +218,29 @@ public interface NodeExtension {
      * @return new uuid
      */
     String createMemberUuid(Address address);
+
+    /**
+     * Checks if the given member has been excluded during the cluster start or not.
+     * If returns true, it means that the given member is not allowed to join to the cluster.
+     *
+     * @param memberAddress address of the member to check
+     * @param memberUuid uuid of the member to check
+     * @return true if the member has been excluded on cluster start.
+     */
+    boolean isMemberExcluded(Address memberAddress, String memberUuid);
+
+    /**
+     * Returns uuids of the members that have been excluded during the cluster start.
+     *
+     * @return uuids of the members that have been excluded during the cluster start
+     */
+    Set<String> getExcludedMemberUuids();
+
+    /**
+     * Handles the uuid set of excluded members only if this member is also excluded, and triggers the member force start process.
+     *
+     * @param sender the member that has sent the excluded members set
+     * @param excludedMemberUuids uuids of the members that have been excluded during the cluster start
+     */
+    void handleExcludedMemberUuids(Address sender, Set<String> excludedMemberUuids);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -158,7 +158,7 @@ public class MulticastJoiner extends AbstractJoiner {
     }
 
     void onReceivedJoinRequest(JoinRequest joinRequest) {
-        if (joinRequest.getUuid().compareTo(node.localMember.getUuid()) < 0) {
+        if (joinRequest.getUuid().compareTo(node.getThisUuid()) < 0) {
             maxTryCount.incrementAndGet();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -72,7 +72,7 @@ public class NodeMulticastListener implements MulticastListener {
 
         if (node.isMaster()) {
             JoinMessage response = new JoinMessage(Packet.VERSION, node.getBuildInfo().getBuildNumber(),
-                    node.getThisAddress(), node.localMember.getUuid(), node.isLiteMember(), node.createConfigCheck());
+                    node.getThisAddress(), node.getThisUuid(), node.isLiteMember(), node.createConfigCheck());
             node.multicastService.send(response);
         } else if (isMasterNode(joinMessage.getAddress()) && !checkMasterUuid(joinMessage.getUuid())) {
             String message = "New join request has been received from current master. "

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -305,10 +305,12 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         try {
             ClusterState clusterState = node.getClusterService().getClusterState();
             if (clusterState == ClusterState.FROZEN || clusterState == ClusterState.PASSIVE) {
+                logger.fine(address + " can join since cluster state is " + clusterState);
                 return true;
             }
 
             if (partitionStateManager.isPresentInPartitionTable(address)) {
+                logger.fine(address + " is in partition table");
                 return false;
             }
 
@@ -317,6 +319,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                 final MigrationManager.MigrateTask migrateTask = (MigrationManager.MigrateTask) activeTask;
                 final MigrationInfo migrationInfo = migrateTask.migrationInfo;
                 if (address.equals(migrationInfo.getSource()) || address.equals(migrationInfo.getDestination())) {
+                    logger.fine(address + " cannot join since " + migrationInfo);
                     return false;
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -291,7 +291,7 @@ public class PartitionStateManager {
         }
     }
 
-    void incrementVersion() {
+    public void incrementVersion() {
         stateVersion.incrementAndGet();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -158,7 +158,7 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
 
     private void verifyGoodMaster(NodeEngine nodeEngine) {
         Address masterAddress = nodeEngine.getMasterAddress();
-        if (!masterAddress.equals(migrationInfo.getMaster())) {
+        if (!migrationInfo.getMaster().equals(masterAddress)) {
             throw new RetryableHazelcastException("Migration initiator is not master node! => " + toString());
         }
         if (!masterAddress.equals(getCallerAddress())) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -200,6 +200,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         this.serializationService = nodeEngine.getSerializationService();
         this.thisAddress = nodeEngine.getClusterService().getThisAddress();
         this.statisticsEnabled = mapConfig.isStatisticsEnabled();
+        // it is safe to cache local member uuid here because cluster start must be already completed
         this.localMemberUuid = mapServiceContext.getNodeEngine().getLocalMember().getUuid();
 
         this.putAllBatchSize = properties.getInteger(MAP_PUT_ALL_BATCH_SIZE);

--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -147,7 +147,7 @@ public final class PhoneHome {
         Long clusterUpTime = clusterService.getClusterClock().getClusterUpTime();
         PhoneHomeParameterCreator parameterCreator = new PhoneHomeParameterCreator();
         parameterCreator.addParam("version", version);
-        parameterCreator.addParam("m", hazelcastNode.getLocalMember().getUuid());
+        parameterCreator.addParam("m", hazelcastNode.getThisUuid());
         parameterCreator.addParam("e", Boolean.toString(isEnterprise));
         parameterCreator.addParam("l", MD5Util.toMD5String(hazelcastNode.getConfig().getLicenseKey()));
         parameterCreator.addParam("p", downloadId);

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerStressTest.java
@@ -40,6 +40,10 @@ public class PartitionLostListenerStressTest
         public synchronized List<PartitionLostEvent> getEvents() {
             return new ArrayList<PartitionLostEvent>(lostPartitions);
         }
+
+        public synchronized void clear() {
+            lostPartitions.clear();
+        }
     }
 
     @Parameterized.Parameters(name = "numberOfNodesToCrash:{0},withData:{1},nodeLeaveType:{2},shouldExpectPartitionLostEvents:{3}")

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -503,7 +503,7 @@ public abstract class HazelcastTestSupport {
         }
     }
 
-    protected static String generateKeyForPartition(HazelcastInstance instance, int partitionId) {
+    public static String generateKeyForPartition(HazelcastInstance instance, int partitionId) {
         Cluster cluster = instance.getCluster();
         checkPartitionCountGreaterOrEqualMemberCount(instance);
 
@@ -626,6 +626,14 @@ public abstract class HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             public void run() {
                assertAllInSafeState(instances);
+            }
+        }, timeoutInSeconds);
+    }
+
+    public static void waitAllForSafeState(final HazelcastInstance[] nodes, int timeoutInSeconds) {
+        assertTrueEventually(new AssertTask() {
+            public void run() {
+                assertAllInSafeState(asList(nodes));
             }
         }, timeoutInSeconds);
     }


### PR DESCRIPTION
* If Node A receives a join request from Node B, it accepts it only when both of these nodes are not excluded.
   - If Node B is excluded, it will fail with a BeforeJoinFailureOperation.
   - If Node A is excluded, it will silently ignore join request of Node B.

* Allow a node to change its UUID before the node start is completed. Therefore, Node.localMember reference is not final anymore. Still, It is cache-able after NodeExtension.isStartCompleted() returns true.
