### PR TITLE
Fix partition replica version handling when backups are reordered

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -239,15 +239,21 @@ public class PartitionReplicaManager {
     void updatePartitionReplicaVersions(int partitionId, long[] versions, int replicaIndex) {
         PartitionReplicaVersions partitionVersion = replicaVersions[partitionId];
         if (!partitionVersion.update(versions, replicaIndex)) {
-            // this partition backup is behind the owner.
+            // this partition backup is behind the owner or dirty.
             triggerPartitionReplicaSync(partitionId, replicaIndex, 0L);
         }
     }
 
     // called in operation threads
-    boolean isPartitionReplicaVersionStale(int partitionId, long[] versions, int replicaIndex) {
+    public boolean isPartitionReplicaVersionStale(int partitionId, long[] versions, int replicaIndex) {
         PartitionReplicaVersions partitionVersion = replicaVersions[partitionId];
         return partitionVersion.isStale(versions, replicaIndex);
+    }
+
+    // called in operation threads
+    public boolean isPartitionReplicaVersionDirty(int partitionId) {
+        PartitionReplicaVersions partitionVersion = replicaVersions[partitionId];
+        return partitionVersion.isDirty();
     }
 
     // called in operation threads

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/CheckReplicaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/CheckReplicaVersion.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.ReplicaErrorLogger;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.internal.partition.impl.PartitionReplicaManager;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -49,15 +50,16 @@ public final class CheckReplicaVersion extends AbstractPartitionOperation
         InternalPartitionServiceImpl partitionService = getService();
         int partitionId = getPartitionId();
         int replicaIndex = getReplicaIndex();
-        long[] currentVersions = partitionService.getPartitionReplicaVersions(partitionId);
+        PartitionReplicaManager replicaManager = partitionService.getReplicaManager();
+        long[] currentVersions = replicaManager.getPartitionReplicaVersions(partitionId);
         long currentVersion = currentVersions[replicaIndex - 1];
 
-        if (currentVersion == version) {
-            response = true;
-        } else {
+        if (replicaManager.isPartitionReplicaVersionDirty(partitionId) || currentVersion != version) {
             logBackupVersionMismatch(currentVersion);
-            partitionService.getReplicaManager().triggerPartitionReplicaSync(partitionId, replicaIndex, 0L);
+            replicaManager.triggerPartitionReplicaSync(partitionId, replicaIndex, 0L);
             response = false;
+        } else {
+            response = true;
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
@@ -31,6 +31,7 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.test.TestPartitionUtils.PartitionReplicaVersionsView;
 import org.junit.Before;
 import org.junit.runners.Parameterized;
 
@@ -43,11 +44,13 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.test.TestPartitionUtils.getPartitionReplicaVersionsView;
 import static com.hazelcast.test.TestPartitionUtils.getReplicaVersions;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -159,10 +162,18 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
     }
 
     void assertSizeAndDataEventually() {
-        assertTrueEventually(new AssertSizeAndDataTask());
+        assertSizeAndDataEventually(false);
+    }
+
+    void assertSizeAndDataEventually(boolean allowDirty) {
+        assertTrueEventually(new AssertSizeAndDataTask(allowDirty));
     }
 
     void assertSizeAndData() throws InterruptedException {
+        assertSizeAndData(false);
+    }
+
+    private void assertSizeAndData(boolean allowDirty) throws InterruptedException {
         Collection<HazelcastInstance> instances = factory.getAllHazelcastInstances();
         final int actualBackupCount = Math.min(backupCount, instances.size() - 1);
         final int expectedSize = partitionCount * (actualBackupCount + 1);
@@ -184,7 +195,7 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
             assertNoMissingData(service, partitions, thisAddress);
 
             // check values
-            assertPartitionVersionsAndBackupValues(actualBackupCount, service, node, partitions);
+            assertPartitionVersionsAndBackupValues(actualBackupCount, service, node, partitions, allowDirty);
 
             assertMigrationEvents(service, thisAddress);
         }
@@ -213,7 +224,7 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
     }
 
     private void assertPartitionVersionsAndBackupValues(int actualBackupCount, TestMigrationAwareService service,
-            Node node, InternalPartition[] partitions) throws InterruptedException {
+            Node node, InternalPartition[] partitions, boolean allowDirty) throws InterruptedException {
         Address thisAddress = node.getThisAddress();
 
         for (InternalPartition partition : partitions) {
@@ -231,7 +242,8 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
                     Node backupNode = getNode(backupInstance);
                     assertNotNull(backupNode);
 
-                    long[] backupReplicaVersions = getReplicaVersions(backupNode, partitionId);
+                    PartitionReplicaVersionsView backupReplicaVersionsView = getPartitionReplicaVersionsView(backupNode, partitionId);
+                    long[] backupReplicaVersions = backupReplicaVersionsView.getVersions();
                     assertNotNull("Versions null on " + backupNode.address + ", partitionId: " + partitionId, backupReplicaVersions);
 
                     for (int i = replica - 1; i < actualBackupCount; i++) {
@@ -239,6 +251,11 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
                                         + ", Partition: " + partition + ", Replica: " + (i + 1) + " owner versions: "
                                         + Arrays.toString(replicaVersions) + " backup versions: " + Arrays.toString(backupReplicaVersions),
                                 replicaVersions[i], backupReplicaVersions[i]);
+                    }
+
+                    if (!allowDirty) {
+                        assertFalse("Backup replica is dirty! Owner: " + thisAddress + ", Backup: " + address
+                                        + ", Partition: " + partition, backupReplicaVersionsView.isDirty());
                     }
 
                     TestMigrationAwareService backupService = getService(backupInstance);
@@ -296,9 +313,15 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
     }
 
     private class AssertSizeAndDataTask extends AssertTask {
+        private final boolean allowDirty;
+
+        AssertSizeAndDataTask(boolean allowDirty) {
+            this.allowDirty = allowDirty;
+        }
+
         @Override
         public void run() throws Exception {
-            assertSizeAndData();
+            assertSizeAndData(allowDirty);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
@@ -27,12 +27,19 @@ import com.hazelcast.test.mocknetwork.TestNodeRegistry;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public class FirewallingMockConnectionManager extends MockConnectionManager {
 
     private final Set<Address> blockedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
+    private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
 
-    private volatile PacketFilter packetFilter;
+    private volatile PacketFilter droppingPacketFilter;
+    private volatile PacketFilter delayingPacketFilter;
 
     public FirewallingMockConnectionManager(IOService ioService, Node node, TestNodeRegistry registry) {
         super(ioService, node, registry);
@@ -74,28 +81,92 @@ public class FirewallingMockConnectionManager extends MockConnectionManager {
         }
     }
 
-    public void setPacketFilter(PacketFilter packetFilter) {
-        this.packetFilter = packetFilter;
+    public void setDroppingPacketFilter(PacketFilter droppingPacketFilter) {
+        this.droppingPacketFilter = droppingPacketFilter;
+    }
+
+    public void setDelayingPacketFilter(PacketFilter delayingPacketFilter) {
+        this.delayingPacketFilter = delayingPacketFilter;
     }
 
     private boolean isAllowed(Packet packet, Address target) {
         boolean allowed = true;
-        PacketFilter filter = packetFilter;
+        PacketFilter filter = droppingPacketFilter;
         if (filter != null) {
             allowed = filter.allow(packet, target);
         }
         return allowed;
     }
 
+    private boolean isDelayed(Packet packet, Address target) {
+        boolean delayed = false;
+        PacketFilter filter = delayingPacketFilter;
+        if (filter != null) {
+            delayed = !filter.allow(packet, target);
+        }
+        return delayed;
+    }
+
     @Override
     public boolean transmit(Packet packet, Connection connection) {
-        return connection != null
-                && isAllowed(packet, connection.getEndPoint())
-                && super.transmit(packet, connection);
+        if (connection != null) {
+            if (!isAllowed(packet, connection.getEndPoint())) {
+                return false;
+            }
+            if (isDelayed(packet, connection.getEndPoint())) {
+                scheduledExecutor.schedule(new DelayedPacketTask(packet, connection), randomDelay(), NANOSECONDS);
+                return true;
+            }
+        }
+        return super.transmit(packet, connection);
     }
 
     @Override
     public boolean transmit(Packet packet, Address target) {
-        return isAllowed(packet, target) && super.transmit(packet, target);
+        if (!isAllowed(packet, target)) {
+            return false;
+        }
+        if (isDelayed(packet, target)) {
+            scheduledExecutor.schedule(new DelayedPacketTask(packet, target), randomDelay(), NANOSECONDS);
+            return true;
+        }
+        return super.transmit(packet, target);
+    }
+
+    private static long randomDelay() {
+        return (long) (TimeUnit.SECONDS.toNanos(1) * Math.random());
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        scheduledExecutor.shutdown();
+    }
+
+    private class DelayedPacketTask implements Runnable {
+        Packet packet;
+        Connection connection;
+        Address target;
+
+        DelayedPacketTask(Packet packet, Connection connection) {
+            assert connection != null;
+            this.packet = packet;
+            this.connection = connection;
+        }
+
+        DelayedPacketTask(Packet packet, Address target) {
+            assert target != null;
+            this.packet = packet;
+            this.target = target;
+        }
+
+        @Override
+        public void run() {
+            if (connection != null) {
+                FirewallingMockConnectionManager.super.transmit(packet, connection);
+            } else {
+                FirewallingMockConnectionManager.super.transmit(packet, target);
+            }
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
@@ -21,10 +21,18 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
 
 /**
- * A filter used by mock network system to allow or drop {@code Packet}s
+ * A filter used by mock network system to allow, drop or delay {@code Packet}s
  */
 public interface PacketFilter {
 
+    /**
+     * Filters a packet inspecting its content and/or endpoint and decides
+     * whether this packet should be filtered.
+     *
+     * @param packet packet
+     * @param endpoint target endpoint which packet is sent to
+     * @return returns true if packet should pass through intact, false otherwise
+     */
     boolean allow(Packet packet, Address endpoint);
 
 }


### PR DESCRIPTION
When backups are reordered and a backup with a version greater than `(localVersion + 1)`
is received, backup is applied but partition replica versions are not updated. After that point, until replica is repaired, succeeding stale backups cannot be detected
anymore. This breaks monotonicity of backups.

Now, partition replica versions are always updated when `(newVersion > localVersion)` but
partition is marked as dirty if `(newVersion > localVersion + 1)`. Anti-entropy system will take
this dirty flag into account too.