### PR TITLE
[BACKPORT] Fix partition replica version handling when backups are reordered

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -239,15 +239,21 @@ public class PartitionReplicaManager {
     void updatePartitionReplicaVersions(int partitionId, long[] versions, int replicaIndex) {
         PartitionReplicaVersions partitionVersion = replicaVersions[partitionId];
         if (!partitionVersion.update(versions, replicaIndex)) {
-            // this partition backup is behind the owner.
+            // this partition backup is behind the owner or dirty.
             triggerPartitionReplicaSync(partitionId, replicaIndex, 0L);
         }
     }
 
     // called in operation threads
-    boolean isPartitionReplicaVersionStale(int partitionId, long[] versions, int replicaIndex) {
+    public boolean isPartitionReplicaVersionStale(int partitionId, long[] versions, int replicaIndex) {
         PartitionReplicaVersions partitionVersion = replicaVersions[partitionId];
         return partitionVersion.isStale(versions, replicaIndex);
+    }
+
+    // called in operation threads
+    public boolean isPartitionReplicaVersionDirty(int partitionId) {
+        PartitionReplicaVersions partitionVersion = replicaVersions[partitionId];
+        return partitionVersion.isDirty();
     }
 
     // called in operation threads

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/DirtyBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/DirtyBackupTest.java
@@ -41,50 +41,55 @@ import java.util.Collection;
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class AntiEntropyCorrectnessTest extends PartitionCorrectnessTestSupport {
-
-    private static final float BACKUP_BLOCK_RATIO = 0.65f;
+public class DirtyBackupTest extends PartitionCorrectnessTestSupport {
 
     @Parameterized.Parameters(name = "backups:{0},nodes:{1}")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
                 {1, 2},
-                {1, InternalPartition.MAX_REPLICA_COUNT},
                 {2, 3},
-                {2, InternalPartition.MAX_REPLICA_COUNT},
-                {3, 4},
-                {3, InternalPartition.MAX_REPLICA_COUNT}
+                {3, 4}
         });
     }
 
     @Test
-    public void testPartitionData() throws InterruptedException {
-        HazelcastInstance[] instances = factory.newInstances(getConfig(true, true), nodeCount);
+    public void testPartitionData_withoutAntiEntropy() throws InterruptedException {
+        startInstancesAndFillPartitions(false);
+        assertSizeAndDataEventually(true);
+    }
+
+    @Test
+    public void testPartitionData_withAntiEntropy() throws InterruptedException {
+        startInstancesAndFillPartitions(true);
+        assertSizeAndDataEventually(false);
+    }
+
+    private void startInstancesAndFillPartitions(boolean antiEntropyEnabled) {
+        backupCount = 1;
+        nodeCount = 3;
+
+        HazelcastInstance[] instances = factory.newInstances(getConfig(true, antiEntropyEnabled), nodeCount);
         for (HazelcastInstance instance : instances) {
-            setBackupPacketDropFilter(instance, BACKUP_BLOCK_RATIO);
+            setBackupPacketReorderFilter(instance);
         }
         warmUpPartitions(instances);
 
         for (HazelcastInstance instance : instances) {
             fillData(instance);
         }
-
-        assertSizeAndDataEventually();
     }
 
-    public static void setBackupPacketDropFilter(HazelcastInstance instance, float blockRatio) {
+    private static void setBackupPacketReorderFilter(HazelcastInstance instance) {
         Node node = getNode(instance);
         FirewallingMockConnectionManager cm = (FirewallingMockConnectionManager) node.getConnectionManager();
-        cm.setDroppingPacketFilter(new BackupPacketDropFilter(node.getSerializationService(), blockRatio));
+        cm.setDelayingPacketFilter(new BackupPacketReorderFilter(node.getSerializationService()));
     }
 
-    private static class BackupPacketDropFilter implements PacketFilter {
+    private static class BackupPacketReorderFilter implements PacketFilter {
         final InternalSerializationService serializationService;
-        final float blockRatio;
 
-        BackupPacketDropFilter(InternalSerializationService serializationService, float blockRatio) {
+        BackupPacketReorderFilter(InternalSerializationService serializationService) {
             this.serializationService = serializationService;
-            this.blockRatio = blockRatio;
         }
 
         @Override
@@ -100,7 +105,7 @@ public class AntiEntropyCorrectnessTest extends PartitionCorrectnessTestSupport 
                     int factory = input.readInt();
                     int type = input.readInt();
                     boolean isBackup = factory == SpiDataSerializerHook.F_ID && type == SpiDataSerializerHook.BACKUP;
-                    return !isBackup || Math.random() > blockRatio;
+                    return !isBackup;
                 }
             } catch (IOException e) {
                 throw new HazelcastException(e);

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingMockConnectionManager.java
@@ -27,12 +27,19 @@ import com.hazelcast.test.mocknetwork.TestNodeRegistry;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public class FirewallingMockConnectionManager extends MockConnectionManager {
 
     private final Set<Address> blockedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
+    private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
 
-    private volatile PacketFilter packetFilter;
+    private volatile PacketFilter droppingPacketFilter;
+    private volatile PacketFilter delayingPacketFilter;
 
     public FirewallingMockConnectionManager(IOService ioService, Node node, TestNodeRegistry registry) {
         super(ioService, node, registry);
@@ -74,28 +81,92 @@ public class FirewallingMockConnectionManager extends MockConnectionManager {
         }
     }
 
-    public void setPacketFilter(PacketFilter packetFilter) {
-        this.packetFilter = packetFilter;
+    public void setDroppingPacketFilter(PacketFilter droppingPacketFilter) {
+        this.droppingPacketFilter = droppingPacketFilter;
+    }
+
+    public void setDelayingPacketFilter(PacketFilter delayingPacketFilter) {
+        this.delayingPacketFilter = delayingPacketFilter;
     }
 
     private boolean isAllowed(Packet packet, Address target) {
         boolean allowed = true;
-        PacketFilter filter = packetFilter;
+        PacketFilter filter = droppingPacketFilter;
         if (filter != null) {
             allowed = filter.allow(packet, target);
         }
         return allowed;
     }
 
+    private boolean isDelayed(Packet packet, Address target) {
+        boolean delayed = false;
+        PacketFilter filter = delayingPacketFilter;
+        if (filter != null) {
+            delayed = !filter.allow(packet, target);
+        }
+        return delayed;
+    }
+
     @Override
     public boolean transmit(Packet packet, Connection connection) {
-        return connection != null
-                && isAllowed(packet, connection.getEndPoint())
-                && super.transmit(packet, connection);
+        if (connection != null) {
+            if (!isAllowed(packet, connection.getEndPoint())) {
+                return false;
+            }
+            if (isDelayed(packet, connection.getEndPoint())) {
+                scheduledExecutor.schedule(new DelayedPacketTask(packet, connection), randomDelay(), NANOSECONDS);
+                return true;
+            }
+        }
+        return super.transmit(packet, connection);
     }
 
     @Override
     public boolean transmit(Packet packet, Address target) {
-        return isAllowed(packet, target) && super.transmit(packet, target);
+        if (!isAllowed(packet, target)) {
+            return false;
+        }
+        if (isDelayed(packet, target)) {
+            scheduledExecutor.schedule(new DelayedPacketTask(packet, target), randomDelay(), NANOSECONDS);
+            return true;
+        }
+        return super.transmit(packet, target);
+    }
+
+    private static long randomDelay() {
+        return (long) (TimeUnit.SECONDS.toNanos(1) * Math.random());
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        scheduledExecutor.shutdown();
+    }
+
+    private class DelayedPacketTask implements Runnable {
+        Packet packet;
+        Connection connection;
+        Address target;
+
+        DelayedPacketTask(Packet packet, Connection connection) {
+            assert connection != null;
+            this.packet = packet;
+            this.connection = connection;
+        }
+
+        DelayedPacketTask(Packet packet, Address target) {
+            assert target != null;
+            this.packet = packet;
+            this.target = target;
+        }
+
+        @Override
+        public void run() {
+            if (connection != null) {
+                FirewallingMockConnectionManager.super.transmit(packet, connection);
+            } else {
+                FirewallingMockConnectionManager.super.transmit(packet, target);
+            }
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
@@ -21,10 +21,18 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
 
 /**
- * A filter used by mock network system to allow or drop {@code Packet}s
+ * A filter used by mock network system to allow, drop or delay {@code Packet}s
  */
 public interface PacketFilter {
 
+    /**
+     * Filters a packet inspecting its content and/or endpoint and decides
+     * whether this packet should be filtered.
+     *
+     * @param packet packet
+     * @param endpoint target endpoint which packet is sent to
+     * @return returns true if packet should pass through intact, false otherwise
+     */
     boolean allow(Packet packet, Address endpoint);
 
 }


### PR DESCRIPTION
When backups are reordered and a backup with a version greater than `(localVersion + 1)`
is received, backup is applied but partition replica versions are not updated. After that point, until replica is repaired, succeeding stale backups cannot be detected
anymore. This breaks monotonicity of backups.

Now, partition replica versions are always updated when `(newVersion > localVersion)` but
partition is marked as dirty if `(newVersion > localVersion + 1)`. Anti-entropy system will take
this dirty flag into account too.

Backport of https://github.com/hazelcast/hazelcast/pull/9205