### PR TITLE
Add buildNumber in MemberImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -28,10 +28,12 @@ import static com.hazelcast.nio.IOUtil.closeResource;
  */
 public final class BuildInfoProvider {
 
+    public static final BuildInfo BUILD_INFO = parseBuildInfo();
+
     private BuildInfoProvider() {
     }
 
-    public static BuildInfo getBuildInfo() {
+    private static BuildInfo parseBuildInfo() {
         final InputStream inRuntimeProperties =
                 BuildInfoProvider.class.getClassLoader().getResourceAsStream("hazelcast-runtime.properties");
         Properties runtimeProperties = new Properties();
@@ -68,4 +70,7 @@ public final class BuildInfoProvider {
         return new BuildInfo(version, build, revision, buildNumber, enterprise, serialVersion);
     }
 
+    public static BuildInfo getBuildInfo() {
+        return BUILD_INFO;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -42,8 +42,12 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
     private boolean localMember;
     private volatile HazelcastInstanceImpl instance;
     private volatile ILogger logger;
+    // the build number of this member, as reported by its {@code BuildInfo#getBuildNumber()} method
+    // added in 3.7.3 for compatibility fixes, this field is not serialized/deserialized over the wire
+    private int buildNumber;
 
     public MemberImpl() {
+        buildNumber = BuildInfoProvider.BUILD_INFO.getBuildNumber();
     }
 
     public MemberImpl(Address address, boolean localMember) {
@@ -63,11 +67,21 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
         super(address, uuid, attributes, liteMember);
         this.localMember = localMember;
         this.instance = instance;
+        buildNumber = BuildInfoProvider.BUILD_INFO.getBuildNumber();
+    }
+
+    public MemberImpl(Address address, boolean localMember, String uuid, HazelcastInstanceImpl instance,
+                      Map<String, Object> attributes, boolean liteMember, int buildNumber) {
+        super(address, uuid, attributes, liteMember);
+        this.localMember = localMember;
+        this.instance = instance;
+        this.buildNumber = buildNumber;
     }
 
     public MemberImpl(MemberImpl member) {
         super(member);
         this.localMember = member.localMember;
+        this.buildNumber = member.buildNumber;
     }
 
     @Override
@@ -183,6 +197,10 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
             MemberAttributeChangedOperation operation = new MemberAttributeChangedOperation(REMOVE, key, null);
             invokeOnAllMembers(operation);
         }
+    }
+
+    public int getBuildNumber() {
+        return buildNumber;
     }
 
     private void isLocalMember() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -33,6 +33,7 @@ public class MemberInfo implements DataSerializable {
     private String uuid;
     private boolean liteMember;
     private Map<String, Object> attributes;
+    private int buildNumber;
 
     public MemberInfo() {
     }
@@ -52,9 +53,18 @@ public class MemberInfo implements DataSerializable {
                 ? Collections.<String, Object>emptyMap() : new HashMap<String, Object>(attributes);
         this.liteMember = liteMember;
     }
+    public MemberInfo(Address address, String uuid, Map<String, Object> attributes, boolean liteMember, int buildNumber) {
+        this.address = address;
+        this.uuid = uuid;
+        this.attributes = attributes == null || attributes.isEmpty()
+                ? Collections.<String, Object>emptyMap() : new HashMap<String, Object>(attributes);
+        this.liteMember = liteMember;
+        this.buildNumber = buildNumber;
+    }
 
     public MemberInfo(MemberImpl member) {
         this(member.getAddress(), member.getUuid(), member.getAttributes(), member.isLiteMember());
+        this.buildNumber = member.getBuildNumber();
     }
 
     public Address getAddress() {
@@ -71,6 +81,10 @@ public class MemberInfo implements DataSerializable {
 
     public boolean isLiteMember() {
         return liteMember;
+    }
+
+    public int getBuildNumber() {
+        return buildNumber;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -667,7 +667,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         Address address = memberInfo.getAddress();
         address.setScopeId(ipV6ScopeId);
         return new MemberImpl(address, thisAddress.equals(address), memberInfo.getUuid(),
-                (HazelcastInstanceImpl) nodeEngine.getHazelcastInstance(), memberInfo.getAttributes(), memberInfo.isLiteMember());
+                (HazelcastInstanceImpl) nodeEngine.getHazelcastInstance(), memberInfo.getAttributes(), memberInfo.isLiteMember(),
+                memberInfo.getBuildNumber());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -60,7 +60,7 @@ public class JoinRequest extends JoinMessage implements DataSerializable {
     }
 
     public MemberInfo toMemberInfo() {
-        return new MemberInfo(address, uuid, attributes, liteMember);
+        return new MemberInfo(address, uuid, attributes, liteMember, buildNumber);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
@@ -244,5 +244,6 @@ public class MemberImplTest extends HazelcastTestSupport {
         assertEquals("127.0.0.1", member.getInetAddress().getHostAddress());
         assertTrue(member.getFactoryId() > -1);
         assertTrue(member.getId() > -1);
+        assertEquals(BuildInfoProvider.getBuildInfo().getBuildNumber(), member.getBuildNumber());
     }
 }


### PR DESCRIPTION
- Introduces `MemberImpl.getBuildNumber`, populated from joining members' join requests.
- `BuildInfoProvider.getBuildInfo` does not parse runtime properties on each invocation, instead returns a cached static `BuildInfo` object.

reasoning: `buildNumber` was already sent over the wire in `JoinMessage` & `JoinRequest`, however the information was not available in `MemberImpl` objects returned by `Cluster.getMembers`.