### PR TITLE
This PR fixes #8846 - Fixing nested queries on VersionPortables with different versions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldDefinitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FieldDefinitionImpl.java
@@ -28,6 +28,7 @@ public class FieldDefinitionImpl implements FieldDefinition {
     int factoryId;
     int version;
 
+
     public FieldDefinitionImpl(int index, String fieldName, FieldType type, int version) {
         this(index, fieldName, type, 0, 0, version);
     }


### PR DESCRIPTION
This fixes: https://github.com/hazelcast/hazelcast/issues/8846

Fix: Added a Version attribute to the FieldDefinition class