### PR TITLE
getEventExecutor API missing error

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -92,6 +92,10 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
         ClientExecutionServiceImpl.shutdownExecutor("registrationExecutor", registrationExecutor, logger);
     }
 
+    public StripedExecutor getEventExecutor() {
+        return eventExecutor;
+    }
+
     public void start() {
     }
 


### PR DESCRIPTION
Restoring getEventExecutor which is required by enterprise.