### PR TITLE
EntryProcessor sample for non-java client tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedEntryProcessor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hazelcast.client.test;
+
+import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Entry processor to test non java clients.
+ * This class is for Non-java clients. Please do not remove or modify.
+ */
+public class IdentifiedEntryProcessor extends AbstractEntryProcessor<String, String> implements IdentifiedDataSerializable {
+
+    static final int CLASS_ID = 1;
+
+    private String value;
+
+    public IdentifiedEntryProcessor() {
+    }
+
+    @Override
+    public int getFactoryId() {
+        return IdentifiedFactory.FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CLASS_ID;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(value);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        value = in.readUTF();
+    }
+
+    @Override
+    public Object process(Map.Entry<String, String> entry) {
+        entry.setValue(value);
+        return value;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hazelcast.client.test;
+
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+/**
+ * This class is for Non-java clients. Please do not remove or modify.
+ */
+public class IdentifiedFactory implements DataSerializableFactory {
+    public static final int FACTORY_ID = 66;
+
+    @Override
+    public IdentifiedDataSerializable create(int typeId) {
+        if(typeId == IdentifiedEntryProcessor.CLASS_ID) {
+                return new IdentifiedEntryProcessor();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
A simple IdentifiedDataserializable EntryProcessor and its factory for non java clients to test EntryProcessor.