### PR TITLE
Move concurrent queues from HotRestart module

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -26,6 +26,9 @@
     <suppress checks="Javadoc(Method|Type|Variable)" files="com/hazelcast/internal/"/>
     <suppress checks="Javadoc(Method|Type|Variable)" files="com/hazelcast/util/executor/"/>
 
+    <!-- Concurrent queue composed of many parts for padding that avoids false sharing -->
+    <suppress checks="OuterTypeNumber" files="AbstractConcurrentArrayQueue\.java"/>
+
     <!-- SerializerHook -->
     <suppress checks="MethodCount|MethodLength|ReturnCount|AnonInnerLength" files="SerializerHook\.java$"/>
     <suppress checks="CyclomaticComplexityCheck|ClassFanOutComplexityCheck|ClassDataAbstractionCoupling"

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.cache.impl.AbstractHazelcastCacheManager;
 import com.hazelcast.cache.impl.ICacheInternal;
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.nearcache.NearCacheManager;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.config.CacheConfig;
@@ -170,5 +171,14 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
 
     @Override
     protected void onShuttingDown() {
+    }
+
+    /**
+     * Gets the related {@link NearCacheManager} with the underlying client instance.
+     *
+     * @return the related {@link NearCacheManager} with the underlying client instance
+     */
+    public NearCacheManager getNearCacheManager() {
+        return client.getNearCacheManager();
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -31,7 +31,7 @@ import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeLevel;
-import com.hazelcast.internal.util.collection.MPSCQueue;
+import com.hazelcast.internal.util.concurrent.MPSCQueue;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.properties.HazelcastProperty;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueue.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
+
+import com.hazelcast.util.QuickMath;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/** Pad out a cacheline to the left of producer fields to prevent false sharing. */
+@SuppressFBWarnings(value = "UuF", justification = "Fields used for padding are unused programatically")
+class AbstractConcurrentArrayQueuePadding1 {
+    @SuppressWarnings({"unused", "checkstyle:multiplevariabledeclarations"})
+    protected long p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15;
+}
+
+/** Values for the producer that are expected to be padded. */
+class AbstractConcurrentArrayQueueProducer extends AbstractConcurrentArrayQueuePadding1 {
+    protected static final AtomicLongFieldUpdater<AbstractConcurrentArrayQueueProducer> TAIL =
+            AtomicLongFieldUpdater.newUpdater(AbstractConcurrentArrayQueueProducer.class, "tail");
+    protected static final AtomicLongFieldUpdater<AbstractConcurrentArrayQueueProducer> SHARED_HEAD_CACHE =
+            AtomicLongFieldUpdater.newUpdater(AbstractConcurrentArrayQueueProducer.class, "sharedHeadCache");
+
+    protected volatile long tail;
+    protected long headCache;
+    protected volatile long sharedHeadCache;
+}
+
+/** Pad out a cacheline between the producer and consumer fields to prevent false sharing. */
+@SuppressFBWarnings(value = "UuF", justification = "Fields used for padding are unused programatically")
+class AbstractConcurrentArrayQueuePadding2 extends AbstractConcurrentArrayQueueProducer {
+    @SuppressWarnings({"unused", "checkstyle:multiplevariabledeclarations"})
+    protected long p16, p17, p18, p19, p20, p21, p22, p23, p24, p25, p26, p27, p28, p29, p30;
+}
+
+/** Values for the consumer that are expected to be padded. */
+class AbstractConcurrentArrayQueueConsumer extends AbstractConcurrentArrayQueuePadding2 {
+    protected static final AtomicLongFieldUpdater<AbstractConcurrentArrayQueueConsumer> HEAD =
+            AtomicLongFieldUpdater.newUpdater(AbstractConcurrentArrayQueueConsumer.class, "head");
+
+    protected volatile long head;
+}
+
+/** Pad out a cacheline to the right of consumer fields to prevent false sharing. */
+@SuppressFBWarnings(value = "UuF", justification = "Fields used for padding are unused programatically")
+class AbstractConcurrentArrayQueuePadding3 extends AbstractConcurrentArrayQueueConsumer {
+    @SuppressWarnings({"unused", "checkstyle:multiplevariabledeclarations"})
+    protected long p31, p32, p33, p34, p35, p36, p37, p38, p39, p40, p41, p42, p43, p44, p45;
+}
+
+/**
+ * Abstract base class for concurrent array queues.
+ * @param <E> type of elements in the queue.
+ */
+abstract class AbstractConcurrentArrayQueue<E>
+extends AbstractConcurrentArrayQueuePadding3
+implements QueuedPipe<E> {
+
+    protected final int capacity;
+    protected final AtomicReferenceArray<E> buffer;
+
+    @SuppressWarnings("unchecked")
+    protected AbstractConcurrentArrayQueue(int requestedCapacity) {
+        capacity = QuickMath.nextPowerOfTwo(requestedCapacity);
+        buffer = new AtomicReferenceArray(capacity);
+    }
+
+    @Override
+    public long addedCount() {
+        return tail;
+    }
+
+    @Override
+    public long removedCount() {
+        return head;
+    }
+
+    @Override
+    public int capacity() {
+        return capacity;
+    }
+
+    @Override
+    public int remainingCapacity() {
+        return capacity() - size();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public E peek() {
+        return buffer.get(seqToArrayIndex(head, capacity - 1));
+    }
+
+    @Override
+    public boolean add(E e) {
+        if (offer(e)) {
+            return true;
+        }
+        throw new IllegalStateException("Queue is full");
+    }
+
+    @Override
+    public E remove() {
+        final E e = poll();
+        if (e == null) {
+            throw new NoSuchElementException("Queue is empty");
+        }
+        return e;
+    }
+
+    @Override
+    public E element() {
+        final E e = peek();
+        if (e == null) {
+            throw new NoSuchElementException("Queue is empty");
+        }
+        return e;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return peek() == null;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        if (o == null) {
+            return false;
+        }
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        long mask = capacity - 1;
+        for (long i = head, limit = tail; i < limit; i++) {
+            final Object e = buffer.get(seqToArrayIndex(i, mask));
+            if (o.equals(e)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object[] toArray() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        for (final Object o : c) {
+            if (!contains(o)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        for (E e : c) {
+            add(e);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        Object value;
+        do {
+            value = poll();
+        } while (value != null);
+    }
+
+    @Override
+    public int size() {
+        long currentHeadBefore;
+        long currentTail;
+        long currentHeadAfter = head;
+        do {
+            currentHeadBefore = currentHeadAfter;
+            currentTail = tail;
+            currentHeadAfter = head;
+        } while (currentHeadAfter != currentHeadBefore);
+        return (int) (currentTail - currentHeadAfter);
+    }
+
+    protected static int seqToArrayIndex(long sequence, long mask) {
+        return (int) (sequence & mask);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyor.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
+
+import com.hazelcast.util.concurrent.BackoffIdleStrategy;
+import com.hazelcast.util.concurrent.IdleStrategy;
+
+import java.util.Collection;
+import java.util.Queue;
+
+import static java.lang.Thread.currentThread;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.locks.LockSupport.unpark;
+
+/**
+ * A many-to-one conveyor of interthread messages. Allows a setup where communication from N submitter threads
+ * to 1 drainer thread happens over N one-to-one concurrent queues. Queues are numbered from 0 to N-1 and the
+ * queue at index 0 is the <i>default</i> queue. There are some convenience methods which assume the usage of
+ * the default queue.
+ * <p/>
+ * Allows the drainer thread to signal completion and failure to the submitters and make their blocking
+ * {@code submit()} calls fail with an exception. This mechanism supports building an implementation which
+ * is both starvation-safe and uses bounded queues with blocking queue submission.
+ * <p/>
+ * There is a further option for the drainer to apply immediate backpressure to the submitter by invoking
+ * {@link #backpressureOn()}. This will make the {@code submit()} invocations block after having
+ * successfully submitted their item, until the drainer calls {@link #backpressureOff()} or fails.
+ * This mechanism allows the drainer to apply backpressure and keep draining the queue, thus letting
+ * all submitters progress until after submitting their item. Such an arrangement eliminates a class
+ * of deadlock patterns where the submitter blocks to submit the item that would have made the drainer
+ * remove backpressure.
+ * <p/>
+ * Does not manage drainer threads. There should be only one drainer thread at a time.
+ * <p/>
+ * <h3>Usage example</h3>
+ * <pre>{@code
+ * // 1. Set up the concurrent conveyor
+ *
+ * final int queueCapacity = 128;
+ * final Runnable doneItem = new Runnable() { public void run() {} };
+ * final QueuedPipe<Runnable>[] qs = new QueuedPipe[2];
+ * qs[0] = new OneToOneConcurrentArrayQueue<Runnable>(queueCapacity);
+ * qs[1] = new OneToOneConcurrentArrayQueue<Runnable>(queueCapacity);
+ * final ConcurrentConveyor<Runnable> conveyor = concurrentConveyor(doneItem, qs);
+ *
+ * // 2. Set up the drainer thread
+ *
+ * final Thread drainer = new Thread(new Runnable() {
+ *     private int submitterGoneCount;
+ *
+ *     @Override
+ *     public void run() {
+ *         conveyor.drainerArrived();
+ *         try {
+ *             final List<Runnable> batch = new ArrayList<Runnable>(queueCapacity);
+ *             while (submitterGoneCount < conveyor.queueCount()) {
+ *                 for (int i = 0; i < conveyor.queueCount(); i++) {
+ *                     batch.clear();
+ *                     conveyor.drainTo(i, batch);
+ *                     // process(batch) should increment submitterGoneCount
+ *                     // each time it encounters the conveyor.submitterGoneItem()
+ *                     process(batch);
+ *                 }
+ *             }
+ *             conveyor.drainerDone();
+ *         } catch (Throwable t) {
+ *             conveyor.drainerFailed(t);
+ *         }
+ *     }
+ * });
+ * drainer.start();
+ *
+ * // 3. Set up the submitter threads
+ *
+ * for (final int submitterIndex : new int[] { 0, 1, 2, 3 }) {
+ *     new Thread(new Runnable() {
+ *         @Override
+ *         public void run() {
+ *             final QueuedPipe<Runnable> q = conveyor.queue(submitterIndex);
+ *             try {
+ *                 while (!askedToStop) {
+ *                     conveyor.submit(q, new Item());
+ *                 }
+ *             } finally {
+ *                 try {
+ *                     conveyor.submit(q, conveyor.submitterGoneItem());
+ *                 } catch (ConcurrentConveyorException e) {
+ *                     // logger.warning() || rethrow || ...
+ *                 }
+ *             }
+ *         }
+ *     }).start();
+ * }
+ * }</pre>
+ */
+@SuppressWarnings("checkstyle:interfaceistype")
+public class ConcurrentConveyor<E> {
+    /**
+     * How many times to busy-spin while waiting to submit to the work queue.
+     */
+    public static final int SUBMIT_SPIN_COUNT = 1000;
+    /**
+     * How many times to yield while waiting to submit to the work queue.
+     */
+    public static final int SUBMIT_YIELD_COUNT = 200;
+    /**
+     * Max park microseconds while waiting to submit to the work queue.
+     */
+    public static final long SUBMIT_MAX_PARK_MICROS = 200;
+    /**
+     * Idling strategy used by the {@code submit()} methods.
+     */
+    public static final IdleStrategy SUBMIT_IDLER = new BackoffIdleStrategy(
+            SUBMIT_SPIN_COUNT, SUBMIT_YIELD_COUNT, 1, MICROSECONDS.toNanos(SUBMIT_MAX_PARK_MICROS));
+
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+    private static final Throwable REGULAR_DEPARTURE = regularDeparture();
+    private final QueuedPipe<E>[] queues;
+    private final E submitterGoneItem;
+
+    private volatile boolean backpressure;
+    private volatile Thread drainer;
+    private volatile Throwable drainerDepartureCause;
+
+    ConcurrentConveyor(E submitterGoneItem, QueuedPipe<E>... queues) {
+        if (queues.length == 0) {
+            throw new IllegalArgumentException("No concurrent queues supplied");
+        }
+        this.submitterGoneItem = submitterGoneItem;
+        this.queues = queues;
+    }
+
+    /**
+     * Creates a new concurrent conveyor.
+     *
+     * @param submitterGoneItem the object that a submitter thread can use to signal it's done submitting
+     * @param queues            the concurrent queues the conveyor will manage
+     */
+    public static <E1> ConcurrentConveyor<E1> concurrentConveyor(
+            E1 submitterGoneItem, QueuedPipe<E1>... queues
+    ) {
+        return new ConcurrentConveyor<E1>(submitterGoneItem, queues);
+    }
+
+    /**
+     * @return the last item that the submitter thread submits to the conveyor
+     */
+    public final E submitterGoneItem() {
+        return submitterGoneItem;
+    }
+
+    /**
+     * Returns the size of the array holding the concurrent queues. Initially (when the conveyor is
+     * constructed) each array slot should point to a distinct concurrent queue; therefore the size
+     * of the array matches the number of queues. Some array slots may be nulled out later by calling
+     * {@link #removeQueue(int)}, but this method will keep reporting the same number. The intended
+     * use case for this method is giving the upper bound for a loop that iterates over all queues.
+     * Since queue indices never change, this number must stay the same.
+     */
+    public final int queueCount() {
+        return queues.length;
+    }
+
+    /**
+     * @return the concurrent queue at the given index
+     */
+    public final QueuedPipe<E> queue(int index) {
+        return queues[index];
+    }
+
+    public final boolean removeQueue(int index) {
+        final boolean didRemove = queues[index] != null;
+        queues[index] = null;
+        return didRemove;
+    }
+
+    /**
+     * Offers an item to the queue at the given index.
+     *
+     * @return whether the item was accepted by the queue
+     */
+    public final boolean offer(int queueIndex, E item) {
+        return offer(queues[queueIndex], item);
+    }
+
+    /**
+     * Offers an item to the given queue. No check is performed that the queue actually belongs
+     * to this conveyor.
+     *
+     * @return whether the item was accepted by the queue
+     * @throws ConcurrentConveyorException if the draining thread has already left
+     */
+    public final boolean offer(Queue<E> queue, E item) throws ConcurrentConveyorException {
+        if (queue.offer(item)) {
+            return true;
+        } else {
+            checkDrainerGone();
+            unparkDrainer();
+            return false;
+        }
+    }
+
+    /**
+     * Blocks until successfully inserting the given item to the given queue. No check is performed that
+     * the queue actually belongs to this conveyor. If the {@code #backpressure} flag is raised on this conveyor
+     * at the time the item has been submitted, further blocks until the flag is lowered.
+     *
+     * @throws ConcurrentConveyorException if the current thread is interrupted or the draining thread has already left
+     */
+    public final void submit(Queue<E> queue, E item) throws ConcurrentConveyorException {
+        for (long idleCount = 0; !queue.offer(item); idleCount++) {
+            SUBMIT_IDLER.idle(idleCount);
+            checkDrainerGone();
+            unparkDrainer();
+            checkInterrupted();
+        }
+        for (long idleCount = 0; backpressure; idleCount++) {
+            SUBMIT_IDLER.idle(idleCount);
+            checkInterrupted();
+        }
+    }
+
+    /**
+     * Drains a batch of items from the default queue into the supplied collection.
+     *
+     * @return the number of items drained
+     */
+    public final int drainTo(Collection<? super E> drain) {
+        return drain(queues[0], drain, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Drains a batch of items from the queue at the supplied index into the supplied collection.
+     *
+     * @return the number of items drained
+     */
+    public final int drainTo(int queueIndex, Collection<? super E> drain) {
+        return drain(queues[queueIndex], drain, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Drains no more than {@code limit} items from the default queue into the supplied collection.
+     *
+     * @return the number of items drained
+     */
+    public final int drainTo(Collection<? super E> drain, int limit) {
+        return drain(queues[0], drain, limit);
+    }
+
+    /**
+     * Drains no more than {@code limit} items from the queue at the supplied index into the supplied collection.
+     *
+     * @return the number of items drained
+     */
+    public final int drainTo(int queueIndex, Collection<? super E> drain, int limit) {
+        return drain(queues[queueIndex], drain, limit);
+    }
+
+    /**
+     * Called by the drainer thread to signal that it has started draining the queue.
+     */
+    public final void drainerArrived() {
+        drainerDepartureCause = null;
+        drainer = currentThread();
+    }
+
+    /**
+     * Called by the drainer thread to signal that it has failed and will drain no more items from the queue.
+     *
+     * @param t the drainer's failure
+     */
+    public final void drainerFailed(Throwable t) {
+        if (t == null) {
+            throw new NullPointerException("ConcurrentConveyor.drainerFailed(null)");
+        }
+        drainer = null;
+        drainerDepartureCause = t;
+    }
+
+
+    /**
+     * Called by the drainer thread to signal that it is done draining the queue.
+     */
+    public final void drainerDone() {
+        drainer = null;
+        drainerDepartureCause = REGULAR_DEPARTURE;
+    }
+
+    /**
+     * @return whether the drainer thread has left
+     */
+    public final boolean isDrainerGone() {
+        return drainerDepartureCause != null;
+    }
+
+    /**
+     * Checks whether the drainer thread has left and throws an exception if it has. If the drainer thread
+     * has failed, its failure will be the cause of the exception thrown.
+     */
+    public final void checkDrainerGone() {
+        final Throwable cause = drainerDepartureCause;
+        if (cause == REGULAR_DEPARTURE) {
+            throw new ConcurrentConveyorException("Queue drainer has already left");
+        }
+        propagateDrainerFailure(cause);
+    }
+
+    /**
+     * Blocks until the drainer thread leaves.
+     */
+    public final void awaitDrainerGone() {
+        for (long i = 0; !isDrainerGone(); i++) {
+            SUBMIT_IDLER.idle(i);
+        }
+        propagateDrainerFailure(drainerDepartureCause);
+    }
+
+    /**
+     * Raises the {@code backpressure} flag, which will make the caller of {@code submit} to block until
+     * the flag is lowered.
+     */
+    public final void backpressureOn() {
+        backpressure = true;
+    }
+
+    /**
+     * Lowers the {@code backpressure} flag.
+     */
+    public final void backpressureOff() {
+        backpressure = false;
+    }
+
+    private int drain(QueuedPipe<E> q, Collection<? super E> drain, int limit) {
+        return q.drainTo(drain, limit);
+    }
+
+    private void unparkDrainer() {
+        final Thread drainer = this.drainer;
+        if (drainer != null) {
+            unpark(drainer);
+        }
+    }
+
+    private void propagateDrainerFailure(Throwable cause) {
+        if (cause != null && cause != REGULAR_DEPARTURE) {
+            throw new ConcurrentConveyorException("Queue drainer failed", cause);
+        }
+    }
+
+    private static void checkInterrupted() throws ConcurrentConveyorException {
+        if (currentThread().isInterrupted()) {
+            throw new ConcurrentConveyorException("Thread interrupted");
+        }
+    }
+
+    private static ConcurrentConveyorException regularDeparture() {
+        final ConcurrentConveyorException e = new ConcurrentConveyorException("Regular departure");
+        e.setStackTrace(new StackTraceElement[0]);
+        return e;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
+
+/**
+ * Exception thrown by the {@link ConcurrentConveyor}.
+ */
+public class ConcurrentConveyorException extends RuntimeException {
+    public ConcurrentConveyorException(String message) {
+        super(message);
+    }
+
+    public ConcurrentConveyorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorSingleQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorSingleQueue.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
+
+/**
+ * Specialization of {@link ConcurrentConveyor} to a single queue.
+ */
+@SuppressWarnings("checkstyle:interfaceistype")
+public final class ConcurrentConveyorSingleQueue<E> extends ConcurrentConveyor<E> {
+    private final QueuedPipe<E> queue;
+
+    private ConcurrentConveyorSingleQueue(E submitterGoneItem, QueuedPipe<E> queue) {
+        super(submitterGoneItem, queue);
+        this.queue = queue;
+    }
+
+    /**
+     * Creates a new concurrent conveyor with a single queue.
+     *
+     * @param submitterGoneItem the object that a submitter thread can use to signal it's done submitting
+     * @param queue             the concurrent queue the conveyor will manage
+     */
+    public static <E1> ConcurrentConveyorSingleQueue<E1> concurrentConveyorSingleQueue(
+            E1 submitterGoneItem, QueuedPipe<E1> queue
+    ) {
+        return new ConcurrentConveyorSingleQueue<E1>(submitterGoneItem, queue);
+    }
+
+    /**
+     * Offers an item to the queue.
+     *
+     * @return whether the item was accepted by the queue
+     * @throws ConcurrentConveyorException if the draining thread has already left
+     */
+    public boolean offer(E item) throws ConcurrentConveyorException {
+        return offer(queue, item);
+    }
+
+    /**
+     * Submits an item to the queue.
+     *
+     * @throws ConcurrentConveyorException if the current thread is interrupted or the draining thread has already left
+     */
+    public void submit(E item) throws ConcurrentConveyorException {
+        submit(queue, item);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/MPSCQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/MPSCQueue.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.internal.util.collection;
+package com.hazelcast.internal.util.concurrent;
 
 import com.hazelcast.util.concurrent.IdleStrategy;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueue.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.internal.util.concurrent;
 
 import com.hazelcast.util.function.Consumer;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueue.java
@@ -1,0 +1,102 @@
+package com.hazelcast.internal.util.concurrent;
+
+import com.hazelcast.util.function.Consumer;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ * Many producers to single consumer concurrent queue backed by an array. Adapted from the Agrona project.
+ *
+ * @param <E> type of the elements stored in the queue.
+ */
+public class ManyToOneConcurrentArrayQueue<E> extends AbstractConcurrentArrayQueue<E> {
+
+    public ManyToOneConcurrentArrayQueue(int requestedCapacity) {
+        super(requestedCapacity);
+    }
+
+    @Override
+    public boolean offer(E e) {
+        assert e != null : "attempt to offer a null element";
+
+        final int capacity = this.capacity;
+
+        long acquiredHead = sharedHeadCache;
+        long bufferLimit = acquiredHead + capacity;
+        long acquiredTail;
+        do {
+            acquiredTail = tail;
+            if (acquiredTail >= bufferLimit) {
+                acquiredHead = head;
+                bufferLimit = acquiredHead + capacity;
+                if (acquiredTail >= bufferLimit) {
+                    return false;
+                }
+                SHARED_HEAD_CACHE.lazySet(this, acquiredHead);
+            }
+        } while (!TAIL.compareAndSet(this, acquiredTail, acquiredTail + 1));
+        buffer.lazySet(seqToArrayIndex(acquiredTail, capacity - 1), e);
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public E poll() {
+        final long head = this.head;
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final int arrayIndex = seqToArrayIndex(head, capacity - 1);
+        final E item = buffer.get(arrayIndex);
+        if (item != null) {
+            buffer.lazySet(arrayIndex, null);
+            HEAD.lazySet(this, head + 1);
+        }
+        return item;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public int drain(Consumer<E> elementHandler) {
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long mask = capacity - 1;
+        final long acquiredHead = head;
+        final long limit = acquiredHead + mask + 1;
+
+        long nextSequence = acquiredHead;
+        while (nextSequence < limit) {
+            final int arrayIndex = seqToArrayIndex(nextSequence, mask);
+            final E item = buffer.get(arrayIndex);
+            if (item == null) {
+                break;
+            }
+            buffer.lazySet(arrayIndex, null);
+            nextSequence++;
+            HEAD.lazySet(this, nextSequence);
+            elementHandler.accept(item);
+        }
+        return (int) (nextSequence - acquiredHead);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public int drainTo(Collection<? super E> target, int limit) {
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long mask = capacity - 1;
+
+        long nextSequence = head;
+        int count = 0;
+        while (count < limit) {
+            final int arrayIndex = seqToArrayIndex(nextSequence, mask);
+            final E item = buffer.get(arrayIndex);
+            if (item == null) {
+                break;
+            }
+            buffer.lazySet(arrayIndex, null);
+            nextSequence++;
+            HEAD.lazySet(this, nextSequence);
+            count++;
+            target.add(item);
+        }
+        return count;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/OneToOneConcurrentArrayQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/OneToOneConcurrentArrayQueue.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
+
+import com.hazelcast.util.function.Consumer;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ * Single producer to single consumer concurrent queue backed by an array. Adapted from the Agrona project.
+ *
+ * @param <E> type of the elements stored in the queue.
+ */
+public class OneToOneConcurrentArrayQueue<E> extends AbstractConcurrentArrayQueue<E> {
+
+    public OneToOneConcurrentArrayQueue(final int requestedCapacity) {
+        super(requestedCapacity);
+    }
+
+    @Override
+    public boolean offer(final E e) {
+        assert e != null : "Attempted to offer null to a concurrent array queue";
+
+        final int capacity = this.capacity;
+        final long currentTail = tail;
+
+        long acquiredHead = headCache;
+        long bufferLimit = acquiredHead + capacity;
+        if (currentTail >= bufferLimit) {
+            acquiredHead = head;
+            bufferLimit = acquiredHead + capacity;
+            if (currentTail >= bufferLimit) {
+                return false;
+            }
+            headCache = acquiredHead;
+        }
+        final int arrayIndex = seqToArrayIndex(currentTail, capacity - 1);
+        buffer.lazySet(arrayIndex, e);
+        TAIL.lazySet(this, currentTail + 1);
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public E poll() {
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long currentHead = head;
+        final int arrayIndex = seqToArrayIndex(currentHead, capacity - 1);
+        final E e = buffer.get(arrayIndex);
+        if (e != null) {
+            buffer.lazySet(arrayIndex, null);
+            HEAD.lazySet(this, currentHead + 1);
+        }
+        return e;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public int drain(Consumer<E> elementHandler) {
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long mask = this.capacity - 1;
+        final long acquiredHead = head;
+        final long limit = acquiredHead + mask + 1;
+
+        long nextSequence = acquiredHead;
+        while (nextSequence < limit) {
+            final int arrayIndex = seqToArrayIndex(nextSequence, mask);
+            final E item = buffer.get(arrayIndex);
+            if (item == null) {
+                break;
+            }
+            buffer.lazySet(arrayIndex, null);
+            nextSequence++;
+            HEAD.lazySet(this, nextSequence);
+            elementHandler.accept(item);
+        }
+        return (int) (nextSequence - acquiredHead);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public int drainTo(final Collection<? super E> target, final int limit) {
+        if (limit <= 0) {
+            return 0;
+        }
+        final AtomicReferenceArray<E> buffer = this.buffer;
+        final long mask = capacity - 1;
+
+        long nextSequence = head;
+        int count = 0;
+        while (count < limit) {
+            final int arrayIndex = seqToArrayIndex(nextSequence, mask);
+            final E item = buffer.get(arrayIndex);
+            if (item == null) {
+                break;
+            }
+            buffer.lazySet(arrayIndex, null);
+            nextSequence++;
+            HEAD.lazySet(this, nextSequence);
+            count++;
+            target.add(item);
+        }
+        return count;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/Pipe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/Pipe.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
+
+import com.hazelcast.util.function.Consumer;
+
+import java.util.Collection;
+
+/**
+ * A container for items processed in sequence.
+ *
+ * @param <E> type of elements in the pipe.
+ */
+public interface Pipe<E> {
+    /**
+     * The number of items added to this container since creation.
+     *
+     * @return the number of items added.
+     */
+    long addedCount();
+
+    /**
+     * The number of items removed from this container since creation.
+     *
+     * @return the number of items removed.
+     */
+    long removedCount();
+
+    /**
+     * The maximum capacity of this container to hold items.
+     *
+     * @return the capacity of the container.
+     */
+    int capacity();
+
+    /**
+     * Get the remaining capacity for elements in the container given the current size.
+     *
+     * @return remaining capacity of the container
+     */
+    int remainingCapacity();
+
+    /**
+     * Invoke a {@link Consumer} callback on each elements to drain the collection of elements until it is empty.
+     *
+     * If possible, implementations should use smart batching to best handle burst traffic.
+     *
+     * @param elementHandler to callback for processing elements
+     * @return the number of elements drained
+     */
+    int drain(Consumer<E> elementHandler);
+
+    /**
+     * Drain available elements into the provided {@link Collection} up to a provided maximum limit of elements.
+     *
+     * If possible, implementations should use smart batching to best handle burst traffic.
+     *
+     * @param target in to which elements are drained.
+     * @param limit  of the maximum number of elements to drain.
+     * @return the number of elements actually drained.
+     */
+    int drainTo(Collection<? super E> target, int limit);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/QueuedPipe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/QueuedPipe.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
+
+import java.util.Queue;
+
+/**
+ * Composed interface for concurrent queues and sequenced containers.
+ *
+ * @param <E> type of the elements stored in the {@link Queue}.
+ */
+public interface QueuedPipe<E> extends Queue<E>, Pipe<E> {
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Concurrent queues etc.
+ */
+package com.hazelcast.internal.util.concurrent;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -21,7 +21,7 @@ import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
-import com.hazelcast.internal.util.collection.MPSCQueue;
+import com.hazelcast.internal.util.concurrent.MPSCQueue;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
@@ -20,7 +20,7 @@ import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
-import com.hazelcast.internal.util.collection.MPSCQueue;
+import com.hazelcast.internal.util.concurrent.MPSCQueue;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.impl.PacketHandler;

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueueTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
+
+import com.hazelcast.test.RequireAssertEnabled;
+import com.hazelcast.util.function.Consumer;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractConcurrentArrayQueueTest {
+
+    // must be a power of two to work
+    static final int CAPACITY = 1 << 2;
+
+    AbstractConcurrentArrayQueue<Integer> queue;
+
+    private List<Integer> emptyList = emptyList();
+
+    @Test
+    public void testIsEmpty_whenEmpty() {
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    public void testIsEmpty_whenNotEmpty() {
+        queue.offer(1);
+
+        assertFalse(queue.isEmpty());
+    }
+
+    @Test
+    public void testContains_whenContains() {
+        queue.offer(23);
+
+        assertTrue(queue.contains(23));
+    }
+
+    @Test
+    public void testContains_whenNotContains() {
+        assertFalse(queue.contains(42));
+    }
+
+    @Test
+    public void testContains_whenNull() {
+        assertFalse(queue.contains(null));
+    }
+
+    @Test
+    public void testContainsAll_whenContainsAll() {
+        queue.offer(1);
+        queue.offer(23);
+        queue.offer(42);
+        queue.offer(95);
+
+        assertTrue(queue.containsAll(asList(23, 42)));
+    }
+
+    @Test
+    public void testContainsAll_whenNotContainsAll() {
+        queue.offer(1);
+        queue.offer(95);
+
+        assertFalse(queue.containsAll(asList(23, 42)));
+    }
+
+    @Test
+    public void testAddAll() {
+        queue.addAll(asList(23, 42));
+
+        assertEquals(2, queue.size());
+        assertTrue(queue.contains(23));
+        assertTrue(queue.contains(42));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAddAll_whenOverCapacity_thenThrowException() {
+        queue.addAll(asList(1, 2, 3, 4, 5, 6));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemoveAll() {
+        queue.removeAll(emptyList);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRetainAll() {
+        queue.retainAll(emptyList);
+    }
+
+    @Test
+    public void testOffer() {
+        assertTrue(queue.offer(1));
+    }
+
+    @Test
+    public void testOffer_whenQueueIsFull_thenReject() {
+        for (int i = 0; i < CAPACITY; i++) {
+            queue.offer(i);
+        }
+
+        assertFalse(queue.offer(23));
+    }
+
+    @Test
+    public void testOffer_whenArrayQueueWasCompletelyFilled_thenUpdateHeadCache() {
+        for (int i = 0; i < CAPACITY; i++) {
+            queue.offer(i);
+        }
+        queue.poll();
+
+        assertTrue(queue.offer(23));
+    }
+
+    @RequireAssertEnabled
+    @Test(expected = AssertionError.class)
+    public void testOffer_whenNull_thenAssert() {
+        queue.offer(null);
+    }
+
+    @Test
+    public void testPoll() {
+        queue.offer(23);
+        queue.offer(42);
+
+        int result1 = queue.poll();
+        int result2 = queue.poll();
+
+        assertEquals(23, result1);
+        assertEquals(42, result2);
+    }
+
+    @Test
+    public void testDrain() {
+        for (int i = 0; i < CAPACITY; i++) {
+            queue.offer(i);
+        }
+
+        queue.drain(new Consumer<Integer>() {
+            @Override
+            public void accept(Integer integer) {
+                assertNotNull(integer);
+            }
+        });
+    }
+
+    @Test
+    public void testDrainTo() {
+        testDrainTo(3, 3);
+    }
+
+    @Test
+    public void testDrainTo_whenLimitIsLargerThanQueue_thenDrainAllElements() {
+        testDrainTo(CAPACITY + 1, CAPACITY);
+    }
+
+    @Test
+    public void testDrainTo_whenLimitIsZero_thenDoNothing() {
+        testDrainTo(0, 0);
+    }
+
+    @Test
+    public void testDrainTo_whenLimitIsNegative_thenDoNothing() {
+        testDrainTo(-1, 0);
+    }
+
+    private void testDrainTo(int limit, int expected) {
+        List<Integer> result = new ArrayList<Integer>();
+        for (int i = 0; i < CAPACITY; i++) {
+            queue.offer(i);
+        }
+
+        queue.drainTo(result, limit);
+
+        assertEquals(expected, result.size());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorTest.java
@@ -1,0 +1,304 @@
+package com.hazelcast.internal.util.concurrent;
+
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.internal.util.concurrent.ConcurrentConveyor.concurrentConveyor;
+import static java.lang.Thread.currentThread;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.locks.LockSupport.parkNanos;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.rules.ExpectedException.none;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConcurrentConveyorTest {
+
+    @Rule
+    public ExpectedException excRule = none();
+
+    private final int queueCapacity = 2;
+    private final int queueCount = 2;
+    private final Item item1 = new Item();
+    private final Item item2 = new Item();
+    private final List<Item> batch = new ArrayList<Item>(queueCapacity);
+
+    private OneToOneConcurrentArrayQueue<Item> defaultQ;
+    private final Item doneItem = new Item();
+    private ConcurrentConveyor<Item> conveyor;
+
+    @Before
+    public void before() {
+        final QueuedPipe<Item>[] qs = new QueuedPipe[queueCount];
+        defaultQ = new OneToOneConcurrentArrayQueue<Item>(queueCapacity);
+        qs[0] = defaultQ;
+        qs[1] = new OneToOneConcurrentArrayQueue<Item>(queueCapacity);
+        conveyor = concurrentConveyor(doneItem, qs);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void mustPassSomeQueues() {
+        concurrentConveyor(doneItem);
+    }
+
+    @Test
+    public void submitterGoneItem() {
+        assertSame(doneItem, conveyor.submitterGoneItem());
+    }
+
+    @Test
+    public void queueCount() {
+        assertEquals(queueCount, conveyor.queueCount());
+    }
+
+    @Test
+    public void getQueueAtIndex() {
+        assertSame(defaultQ, conveyor.queue(0));
+    }
+
+    @Test
+    public void when_offerToQueueZero_then_poll() {
+        // When
+        final boolean didOffer = conveyor.offer(0, item1);
+
+        // Then
+        assertTrue(didOffer);
+        assertSame(item1, defaultQ.poll());
+    }
+
+    @Test
+    public void when_offerToGivenQueue_then_poll() {
+        // When
+        final boolean didOffer = conveyor.offer(defaultQ, item1);
+
+        // Then
+        assertTrue(didOffer);
+        assertSame(item1, defaultQ.poll());
+    }
+
+    @Test
+    public void when_submitToGivenQueue_then_poll() {
+        // When
+        conveyor.submit(defaultQ, item1);
+
+        // Then
+        assertSame(item1, defaultQ.poll());
+    }
+
+    @Test
+    public void when_drainToList_then_listPopulated() {
+        // Given
+        conveyor.offer(0, item1);
+        conveyor.offer(0, item2);
+
+        // When
+        conveyor.drainTo(batch);
+
+        // Then
+        assertEquals(asList(item1, item2), batch);
+    }
+
+    @Test
+    public void when_drainQueue1ToList_then_listPopulated() {
+        // Given
+        conveyor.offer(1, item1);
+        conveyor.offer(1, item2);
+
+        // When
+        conveyor.drainTo(1, batch);
+
+        // Then
+        assertEquals(asList(item1, item2), batch);
+    }
+
+    @Test
+    public void when_drainQueue1ToListLimited_then_listHasLimitedItems() {
+        // Given
+        conveyor.offer(1, item1);
+        conveyor.offer(1, item2);
+
+        // When
+        conveyor.drainTo(1, batch, 1);
+
+        // Then
+        assertEquals(singletonList(item1), batch);
+    }
+
+    @Test
+    public void when_drainToListLimited_then_listHasLimitItems() {
+        // Given
+        conveyor.offer(0, item1);
+        conveyor.offer(0, item2);
+
+        // When
+        conveyor.drainTo(batch, 1);
+
+        // Then
+        assertEquals(singletonList(item1), batch);
+    }
+
+    @Test
+    public void when_drainerDone_then_offerToFullQueueFails() {
+        // Given
+        assertTrue(conveyor.offer(1, item1));
+        assertTrue(conveyor.offer(1, item2));
+
+        // When
+        conveyor.drainerDone();
+
+        // Then
+        excRule.expect(ConcurrentConveyorException.class);
+        conveyor.offer(1, item1);
+    }
+
+    @Test
+    public void when_drainerDone_then_submitToFullQueueFails() {
+        // Given
+        assertTrue(conveyor.offer(defaultQ, item1));
+        assertTrue(conveyor.offer(defaultQ, item2));
+
+        // When
+        conveyor.drainerDone();
+
+        // Then
+        excRule.expect(ConcurrentConveyorException.class);
+        conveyor.submit(defaultQ, item1);
+    }
+
+    @Test
+    public void when_interrupted_then_submitToFullQueueFails() {
+        // Given
+        conveyor.drainerArrived();
+        assertTrue(conveyor.offer(defaultQ, item1));
+        assertTrue(conveyor.offer(defaultQ, item2));
+
+        // When
+        currentThread().interrupt();
+
+        // Then
+        excRule.expect(ConcurrentConveyorException.class);
+        conveyor.submit(defaultQ, item1);
+    }
+
+    @Test
+    public void when_drainerLeavesThenArrives_then_offerDoesntFail() {
+        // Given
+        assertTrue(conveyor.offer(defaultQ, item1));
+        assertTrue(conveyor.offer(defaultQ, item2));
+        conveyor.drainerDone();
+
+        // When
+        conveyor.drainerArrived();
+
+        // Then
+        conveyor.offer(defaultQ, item1);
+    }
+
+    @Test
+    public void when_drainerFails_then_offerFailsWithItsFailureAsCause() {
+        // Given
+        assertTrue(conveyor.offer(1, item1));
+        assertTrue(conveyor.offer(1, item2));
+
+        // When
+        final Exception drainerFailure = new Exception("test failure");
+        conveyor.drainerFailed(drainerFailure);
+
+        // Then
+        try {
+            conveyor.offer(1, item1);
+            fail("Expected exception not thrown");
+        } catch (ConcurrentConveyorException e) {
+            assertSame(drainerFailure, e.getCause());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void when_callDrainerFailedWithNull_then_throwNPE() {
+        conveyor.drainerFailed(null);
+    }
+
+    @Test
+    public void when_drainerDone_then_isDrainerGoneReturnsTrue() {
+        // When
+        conveyor.drainerDone();
+
+        // Then
+        assertTrue(conveyor.isDrainerGone());
+    }
+
+    @Test
+    public void when_drainerFailed_then_isDrainerGoneReturnsTrue() {
+        // When
+        conveyor.drainerFailed(new Exception("test failure"));
+
+        // Then
+        assertTrue(conveyor.isDrainerGone());
+    }
+
+    @Test
+    public void when_backpressureOn_then_submitBlocks() throws InterruptedException {
+        // Given
+        final AtomicBoolean flag = new AtomicBoolean();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        new Thread() { public void run() {
+            // When
+            conveyor.backpressureOn();
+            latch.countDown();
+            parkNanos(MILLISECONDS.toNanos(10));
+
+            // Then
+            assertFalse(flag.get());
+            conveyor.backpressureOff();
+        }}.start();
+
+        latch.await();
+        conveyor.submit(defaultQ, item1);
+        flag.set(true);
+    }
+
+    @Test
+    public void awaitDrainerGone_blocksUntilDrainerGone() throws InterruptedException {
+        // Given
+        final AtomicBoolean flag = new AtomicBoolean();
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        new Thread() { public void run() {
+            // When
+            conveyor.drainerArrived();
+            latch.countDown();
+            parkNanos(MILLISECONDS.toNanos(10));
+
+            // Then
+            assertFalse(flag.get());
+            conveyor.drainerDone();
+        }}.start();
+
+        latch.await();
+        conveyor.awaitDrainerGone();
+        flag.set(true);
+    }
+
+    private static class Item {
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/MPSCQueueStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/MPSCQueueStressTest.java
@@ -1,4 +1,20 @@
-package com.hazelcast.internal.util.collection;
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/MPSCQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/MPSCQueueTest.java
@@ -1,4 +1,20 @@
-package com.hazelcast.internal.util.collection;
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.concurrent;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/ManyToOneConcurrentArrayQueueTest.java
@@ -1,0 +1,18 @@
+package com.hazelcast.internal.util.concurrent;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ManyToOneConcurrentArrayQueueTest extends AbstractConcurrentArrayQueueTest {
+
+    @Before
+    public void setUp() {
+        queue = new ManyToOneConcurrentArrayQueue<Integer>(CAPACITY);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/OneToOneConcurrentArrayQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/OneToOneConcurrentArrayQueueTest.java
@@ -1,0 +1,18 @@
+package com.hazelcast.internal.util.concurrent;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OneToOneConcurrentArrayQueueTest extends AbstractConcurrentArrayQueueTest {
+
+    @Before
+    public void setUp()  {
+        queue = new OneToOneConcurrentArrayQueue<Integer>(CAPACITY);
+    }
+}


### PR DESCRIPTION
The concurrent array queues are now used in Jet as well.

Also:

1. Move `MPSCQueue` to the same `...concurrent` package
2. Restore the deleted method `getNearCache`, which is used from Simulator code.

Followup PR on EE: https://github.com/hazelcast/hazelcast-enterprise/pull/1117