### PR TITLE
Partitions should remain unavailable until services commit/rollback

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/CheckReplicaVersionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/CheckReplicaVersionTask.java
@@ -57,6 +57,11 @@ final class CheckReplicaVersionTask implements PartitionSpecificRunnable, Urgent
         int partitionId = getPartitionId();
         int replicaIndex = this.replicaIndex;
         InternalPartition partition = partitionService.getPartition(partitionId);
+        if (partition.isMigrating()) {
+            notifyCallback(false);
+            return;
+        }
+
         Address target = partition.getReplicaAddress(replicaIndex);
         if (target == null) {
             notifyCallback(false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
@@ -220,6 +220,7 @@ public class PartitionReplicaStateChecker {
         }
     }
 
+    @SuppressWarnings("checkstyle:npathcomplexity")
     private int invokeReplicaSyncOperations(int maxBackupCount, Semaphore semaphore, AtomicBoolean result) {
         Address thisAddress = node.getThisAddress();
         ExecutionCallback<Object> callback = new ReplicaSyncResponseCallback(result, semaphore);
@@ -239,8 +240,15 @@ public class PartitionReplicaStateChecker {
             if (!thisAddress.equals(owner)) {
                 continue;
             }
-
             ownedCount++;
+
+            if (maxBackupCount == 0) {
+                if (partition.isMigrating()) {
+                    result.set(false);
+                }
+                continue;
+            }
+
             for (int index = 1; index <= maxBackupCount; index++) {
                 Address replicaAddress = partition.getReplicaAddress(index);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -69,6 +69,9 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
             rollbackDestination();
         }
 
+        InternalPartitionServiceImpl partitionService = getService();
+        partitionService.getMigrationManager().removeActiveMigration(getPartitionId());
+
         if (success) {
             nodeEngine.onPartitionMigrate(migrationInfo);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.impl.InternalMigrationListener.MigrationParticipant;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
-import com.hazelcast.internal.partition.impl.MigrationManager;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExceptionAction;
@@ -74,15 +73,10 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
         InternalPartition partition = getPartition();
         verifySource(nodeEngine.getThisAddress(), partition);
 
+        setActiveMigration();
+
         if (!migrationInfo.startProcessing()) {
             getLogger().warning("Migration is cancelled -> " + migrationInfo);
-            setFailed();
-            return;
-        }
-
-        InternalPartitionServiceImpl partitionService = getService();
-        MigrationManager migrationManager = partitionService.getMigrationManager();
-        if (!migrationManager.addActiveMigration(migrationInfo)) {
             setFailed();
             return;
         }
@@ -90,6 +84,7 @@ public final class MigrationRequestOperation extends BaseMigrationOperation {
         try {
             executeBeforeMigrations();
             Collection<Operation> tasks = prepareMigrationOperations();
+            InternalPartitionServiceImpl partitionService = getService();
             long[] replicaVersions = partitionService.getPartitionReplicaVersions(migrationInfo.getPartitionId());
             invokeMigrationOperation(destination, replicaVersions, tasks);
             returnResponse = false;

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationAwareServiceEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationAwareServiceEventTest.java
@@ -19,10 +19,14 @@ package com.hazelcast.internal.partition;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -35,9 +39,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Properties;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -79,6 +87,120 @@ public class MigrationAwareServiceEventTest extends HazelcastTestSupport {
 
         factory.newHazelcastInstance(config);
         assertTrueEventually(assertTask);
+    }
+
+    @Test
+    public void partitionIsMigratingFlag_shouldBeSet_until_serviceCommitRollback_isCompleted() throws Exception {
+        FailingOperationResponseHandler responseHandler = new FailingOperationResponseHandler();
+        HazelcastInstance hz = factory.newHazelcastInstance(newConfig(responseHandler));
+        warmUpPartitions(hz);
+
+        HazelcastInstance[] instances = new HazelcastInstance[2];
+        for (int i = 0; i < instances.length; i++) {
+            instances[i] = factory.newHazelcastInstance(newConfig(responseHandler));
+        }
+        waitAllForSafeState(instances);
+        for (HazelcastInstance instance : instances) {
+            instance.getLifecycleService().terminate();
+        }
+        waitAllForSafeState(hz);
+
+        Queue<Object> responses = responseHandler.responses;
+        assertTrue("Unexpected responses: " + responses, responses.isEmpty());
+    }
+
+    private Config newConfig(FailingOperationResponseHandler responseHandler) {
+        Config config = new Config();
+        config.getServicesConfig().addServiceConfig(
+                new ServiceConfig().setEnabled(true).setImplementation(new MigrationCommitRollbackTestingService(responseHandler))
+                        .setName(MigrationCommitRollbackTestingService.NAME));
+        return config;
+    }
+
+    private static class FailingOperationResponseHandler implements OperationResponseHandler {
+        private final Queue<Object> responses = new ConcurrentLinkedQueue<Object>();
+
+        @Override
+        public void sendResponse(Operation op, Object response) {
+            if (!(response instanceof RetryableHazelcastException)) {
+                responses.add(response);
+                System.err.println("Unexpected response " + response + " from " + op);
+            }
+        }
+    }
+
+    private static class MigrationCommitRollbackTestingService implements MigrationAwareService, ManagedService {
+        private static final String NAME = MigrationCommitRollbackTestingService.class.getSimpleName();
+        private final FailingOperationResponseHandler responseHandler;
+        private volatile NodeEngine nodeEngine;
+
+        MigrationCommitRollbackTestingService(FailingOperationResponseHandler responseHandler) {
+            this.responseHandler = responseHandler;
+        }
+
+        @Override
+        public void init(NodeEngine nodeEngine, Properties properties) {
+            this.nodeEngine = nodeEngine;
+        }
+
+        @Override
+        public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
+            return null;
+        }
+
+        @Override
+        public void beforeMigration(PartitionMigrationEvent event) {
+        }
+
+        @Override
+        public void commitMigration(PartitionMigrationEvent event) {
+            executePartitionOperation(event);
+        }
+
+        private void executePartitionOperation(PartitionMigrationEvent event) {
+            if (event.getNewReplicaIndex() != 0 && event.getCurrentReplicaIndex() != 0) {
+                return;
+            }
+
+            DummyPartitionAwareOperation op = new DummyPartitionAwareOperation(event);
+            op.setPartitionId(event.getPartitionId()).setReplicaIndex(event.getNewReplicaIndex());
+            op.setOperationResponseHandler(responseHandler);
+            nodeEngine.getOperationService().run(op);
+        }
+
+        @Override
+        public void rollbackMigration(PartitionMigrationEvent event) {
+            executePartitionOperation(event);
+        }
+
+        @Override
+        public void reset() {
+        }
+
+        @Override
+        public void shutdown(boolean terminate) {
+        }
+    }
+
+    private static class DummyPartitionAwareOperation extends Operation {
+        private final PartitionMigrationEvent event;
+        DummyPartitionAwareOperation(PartitionMigrationEvent event) {
+            this.event = event;
+        }
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        public Object getResponse() {
+            return Boolean.TRUE;
+        }
+
+        @Override
+        public String toString() {
+            return "TestPartitionAwareOperation{" + "event=" + event + '}';
+        }
     }
 
     private static class MigrationEventCounterService implements MigrationAwareService {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
@@ -15,6 +15,7 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -26,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class})
+@Category({QuickTest.class, ParallelTest.class})
 public class StaleReadDuringMigrationTest extends HazelcastTestSupport {
 
     @Test


### PR DESCRIPTION
Partitions should be unavailable/inaccessible until `MigrationAwareService`s
complete commit/rollback during migration and/or promotion.
Each partition has an `isMigrating` flag which is set before migration starts
and cleared after migration completes. When a partition is marked as migrating,
partition operations will be rejected immediately.

This fix provides safety by guaranteeing an operation which is submitted after
migration starts, won't be executed before MigrationAwareService commit/rollback returns.

This is a partial fix for issue https://github.com/hazelcast/hazelcast/issues/8385.
There's no ordering for observers outside of partition operation threads.