### PR TITLE
Removed TxnLockAndGetOperation.toString timeout

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -96,7 +96,6 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
     protected void toString(StringBuilder sb) {
         super.toString(sb);
 
-        sb.append(", timeout=").append(getWaitTimeout());
         sb.append(", thread=").append(getThreadId());
     }
 


### PR DESCRIPTION
The wait timeout is already added to the Operation.toString; so it is
already included. No need for duplication.