### PR TITLE
Adds cluster version and node-cluster version validation.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.Cluster;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.version.Version;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -71,6 +72,11 @@ public class ClientClusterProxy implements Cluster {
 
     @Override
     public void changeClusterState(ClusterState newState) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Version getClusterVersion() {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -42,6 +42,7 @@ import com.hazelcast.topic.TopicOverloadPolicy;
 import com.hazelcast.topic.impl.reliable.ReliableMessageListenerAdapter;
 import com.hazelcast.topic.impl.reliable.ReliableTopicMessage;
 import com.hazelcast.util.UuidUtil;
+import com.hazelcast.version.Version;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -259,7 +260,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
         private Message<E> toMessage(ReliableTopicMessage m) {
             Member member = null;
             if (m.getPublisherAddress() != null) {
-                member = new com.hazelcast.client.impl.MemberImpl(m.getPublisherAddress());
+                member = new com.hazelcast.client.impl.MemberImpl(m.getPublisherAddress(), Version.UNKNOWN);
             }
             E payload = serializationService.toObject(m.getPayload());
             return new Message<E>(name, payload, m.getPublishTime(), member);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.version.Version;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Map;
@@ -37,16 +38,20 @@ public final class MemberImpl extends AbstractMember implements Member {
     public MemberImpl() {
     }
 
-    public MemberImpl(Address address) {
-        super(address);
+    public MemberImpl(Address address, Version version) {
+        super(address, version);
     }
 
-    public MemberImpl(Address address, String uuid) {
-        super(address, uuid);
+    public MemberImpl(Address address, Version version, String uuid) {
+        super(address, version, uuid);
     }
 
     public MemberImpl(Address address, String uuid, Map<String, Object> attributes, boolean liteMember) {
-        super(address, uuid, attributes, liteMember);
+        super(address, Version.UNKNOWN, uuid, attributes, liteMember);
+    }
+
+    public MemberImpl(Address address, Version version, String uuid, Map<String, Object> attributes, boolean liteMember) {
+        super(address, version, uuid, attributes, liteMember);
     }
 
     public MemberImpl(AbstractMember member) {

--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.version.Version;
 
 import java.util.Set;
 
@@ -167,6 +168,29 @@ public interface Cluster {
      * @since 3.6
      */
     void changeClusterState(ClusterState newState, TransactionOptions transactionOptions);
+
+    /**
+     * The cluster version indicates the operating version of the cluster. It is separate from each node's codebase version,
+     * as it may be acceptable for a node to operate at a different compatibility version than its codebase version. This method
+     * may return {@code null} if invoked after the ClusterService is constructed and before the node forms a cluster, either
+     * by joining existing members or becoming master of its standalone cluster if it is the first node on the cluster.
+     * Importantly, this is the time during which a lifecycle event with state
+     * {@link com.hazelcast.core.LifecycleEvent.LifecycleState#STARTING} is triggered.
+     *
+     * For example, consider a cluster comprised of nodes running on {@code hazelcast-3.8.jar}. Each node's codebase version
+     * is 3.8.0 and on startup the cluster version is also 3.8.0. After a while, another node joins, running on
+     * {@code hazelcast-3.9.jar}; this node's codebase version is 3.9.0. If deemed compatible, it is allowed to join the cluster.
+     * At this point, the cluster version is still 3.8.0, the 3.9.0 member should be able to adapt its behaviour to be compatible
+     * with other the 3.8.0 members. Once all 3.8.0 members have been shutdown and replaced by other members on codebase
+     * version 3.9.0, still the cluster version will be 3.8.0. At this point, it is possible to update the cluster version to
+     * 3.9.0, since all cluster members will be compatible with the new cluster version. Once cluster version
+     * is updated to 3.9.0, further communication among members will take place in 3.9.0 and all new features and functionality
+     * of version 3.9.0 will be available.
+     *
+     * @return the version at which this cluster operates.
+     * @since 3.8
+     */
+    Version getClusterVersion();
 
     /**
      * Changes state of the cluster to the {@link ClusterState#PASSIVE} transactionally,

--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -18,6 +18,7 @@ package com.hazelcast.core;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.version.Version;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
@@ -257,5 +258,16 @@ public interface Member extends DataSerializable, Endpoint {
      * @since 3.2
      */
     void removeAttribute(String key);
+
+    /**
+     * Returns the Hazelcast codebase version of this member; this may or may not be different from the version reported by
+     * {@link Cluster#getClusterVersion()}, for example when a node with a different codebase version is added to an
+     * existing cluster. See the documentation for {@link Cluster#getClusterVersion()} for a more thorough discussion
+     * of {@code Cluster} and {@code Member} / {@code Node} version.
+     *
+     * @return the {@link Version} of this member.
+     * @since 3.8
+     */
+    Version getVersion();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
@@ -19,6 +19,7 @@ package com.hazelcast.core;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.exception.RetryableException;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -57,13 +58,14 @@ public class MemberLeftException extends ExecutionException implements Retryable
         out.defaultWriteObject();
 
         Address address = member.getAddress();
-        String host  = address.getHost();
+        String host = address.getHost();
         int port = address.getPort();
 
         out.writeUTF(member.getUuid());
         out.writeUTF(host);
         out.writeInt(port);
         out.writeBoolean(member.isLiteMember());
+        out.writeObject(member.getVersion());
     }
 
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -73,7 +75,8 @@ public class MemberLeftException extends ExecutionException implements Retryable
         String host = in.readUTF();
         int port = in.readInt();
         boolean liteMember = in.readBoolean();
+        Version version = (Version) in.readObject();
 
-        member = new MemberImpl(new Address(host, port), false, uuid, null, null, liteMember);
+        member = new MemberImpl(new Address(host, port), version, false, uuid, null, null, liteMember);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.instance;
 
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.util.EmptyStatement;
 
 import java.io.InputStream;
@@ -28,9 +30,29 @@ import static com.hazelcast.nio.IOUtil.closeResource;
  */
 public final class BuildInfoProvider {
 
+    /**
+     * Use this in production code to obtain the BuildInfo already parsed when this class was first loaded.
+     * Its properties will not change at runtime.
+     */
+    public static final BuildInfo BUILD_INFO;
+
+    private static final ILogger LOGGER;
+
+    static {
+        LOGGER = Logger.getLogger(BuildInfoProvider.class);
+        BUILD_INFO = getBuildInfo();
+    }
+
     private BuildInfoProvider() {
     }
 
+    /**
+     * Parses {@code hazelcast-runtime.properties} for {@code BuildInfo}; also checks for overrides in System.properties.
+     * Use this method to obtain and cache a {@code BuildInfo} object or from test code that needs to re-parse properties
+     * on each invocation.
+     *
+     * @return the parsed BuildInfo
+     */
     public static BuildInfo getBuildInfo() {
         final InputStream inRuntimeProperties =
                 BuildInfoProvider.class.getClassLoader().getResourceAsStream("hazelcast-runtime.properties");
@@ -62,6 +84,13 @@ public final class BuildInfoProvider {
             build = String.valueOf(hazelcastBuild);
         }
         int buildNumber = Integer.parseInt(build);
+
+        // override version with a system property
+        String overridingVersion = System.getProperty("hazelcast.version");
+        if (overridingVersion != null) {
+            LOGGER.info("Overriding hazelcast version with system property value " + overridingVersion);
+            version = overridingVersion;
+        }
 
         String sv = runtimeProperties.getProperty("hazelcast.serialization.version");
         byte serialVersion = Byte.parseByte(sv);

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -21,9 +21,16 @@ import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SerializationConfig;
+import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.internal.cluster.ClusterStateListener;
+import com.hazelcast.internal.cluster.ClusterVersionListener;
+import com.hazelcast.internal.cluster.impl.JoinMessage;
+import com.hazelcast.internal.cluster.impl.VersionMismatchException;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
+import com.hazelcast.internal.networking.ReadHandler;
+import com.hazelcast.internal.networking.SocketChannelWrapperFactory;
+import com.hazelcast.internal.networking.WriteHandler;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.SerializationServiceBuilder;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
@@ -38,10 +45,7 @@ import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.nio.tcp.DefaultSocketChannelWrapperFactory;
 import com.hazelcast.nio.tcp.MemberReadHandler;
 import com.hazelcast.nio.tcp.MemberWriteHandler;
-import com.hazelcast.internal.networking.ReadHandler;
-import com.hazelcast.internal.networking.SocketChannelWrapperFactory;
 import com.hazelcast.nio.tcp.TcpIpConnection;
-import com.hazelcast.internal.networking.WriteHandler;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.NodeEngine;
@@ -51,7 +55,9 @@ import com.hazelcast.spi.impl.servicemanager.ServiceManager;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.Preconditions;
 import com.hazelcast.util.UuidUtil;
+import com.hazelcast.version.Version;
 import com.hazelcast.wan.WanReplicationService;
 import com.hazelcast.wan.impl.WanReplicationServiceImpl;
 
@@ -59,16 +65,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.hazelcast.map.impl.MapServiceConstructor.getDefaultMapServiceConstructor;
+import static com.hazelcast.version.Version.MAJOR_MINOR_VERSION_COMPARATOR;
 
 @PrivateApi
-@SuppressWarnings({"checkstyle:methodcount"})
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
 public class DefaultNodeExtension implements NodeExtension {
 
     protected final Node node;
     protected final ILogger logger;
     protected final ILogger systemLogger;
+    protected final List<ClusterVersionListener> clusterVersionListeners = new CopyOnWriteArrayList<ClusterVersionListener>();
 
     private final MemoryStats memoryStats = new DefaultMemoryStats();
 
@@ -221,13 +230,17 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
-    public void validateJoinRequest() {
+    public void validateJoinRequest(JoinMessage joinMessage) {
+        // check joining member's major.minor version is same as current cluster version's major.minor numbers
+        if (MAJOR_MINOR_VERSION_COMPARATOR.compare(joinMessage.getVersion(), node.getClusterService().getClusterVersion()) != 0) {
+            throw new VersionMismatchException("Joining node's version " + joinMessage.getVersion() + " is not compatible with "
+                    + node.getVersion());
+        }
     }
 
     @Override
     public void onClusterStateChange(ClusterState newState, boolean isTransient) {
-        NodeEngineImpl nodeEngine = node.getNodeEngine();
-        ServiceManager serviceManager = nodeEngine.getServiceManager();
+        ServiceManager serviceManager = node.getNodeEngine().getServiceManager();
         List<ClusterStateListener> listeners = serviceManager.getServices(ClusterStateListener.class);
         for (ClusterStateListener listener : listeners) {
             listener.onClusterStateChange(newState);
@@ -239,7 +252,37 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
+    public void onClusterVersionChange(Version newVersion) {
+        systemLogger.info("Cluster version changed to " + newVersion);
+        ServiceManager serviceManager = node.getNodeEngine().getServiceManager();
+        List<ClusterVersionListener> listeners = serviceManager.getServices(ClusterVersionListener.class);
+        for (ClusterVersionListener listener : listeners) {
+            listener.onClusterVersionChange(newVersion);
+        }
+        // also trigger cluster version change on explicitly registered listeners
+        for (ClusterVersionListener listener : clusterVersionListeners) {
+            listener.onClusterVersionChange(newVersion);
+        }
+    }
+
+    @Override
+    public boolean isNodeVersionCompatibleWith(Version clusterVersion) {
+        Preconditions.checkNotNull(clusterVersion);
+        return MAJOR_MINOR_VERSION_COMPARATOR.compare(node.getVersion(), clusterVersion) == 0;
+    }
+
+    @Override
     public boolean registerListener(Object listener) {
+        if (listener instanceof HazelcastInstanceAware) {
+            ((HazelcastInstanceAware) listener).setHazelcastInstance(node.hazelcastInstance);
+        }
+        if (listener instanceof ClusterVersionListener) {
+            ClusterVersionListener clusterVersionListener = (ClusterVersionListener) listener;
+            clusterVersionListeners.add(clusterVersionListener);
+            // on registration, invoke once the listening method so version is properly initialized on the listener
+            clusterVersionListener.onClusterVersionChange(getClusterOrNodeVersion());
+            return true;
+        }
         return false;
     }
 
@@ -258,6 +301,18 @@ public class DefaultNodeExtension implements NodeExtension {
     @Override
     public String createMemberUuid(Address address) {
         return UuidUtil.createMemberUuid(address);
+    }
+
+    // obtain cluster version, if already initialized (not null)
+    // otherwise, if overridden with GroupProperty#INIT_CLUSTER_VERSION, use this one
+    // otherwise, if not overridden, use current node's codebase version
+    private Version getClusterOrNodeVersion() {
+        if (node.getClusterService() != null && node.getClusterService().getClusterVersion() != null) {
+            return node.getClusterService().getClusterVersion();
+        } else {
+            String overriddenClusterVersion = node.getProperties().getString(GroupProperty.INIT_CLUSTER_VERSION);
+            return (overriddenClusterVersion != null) ? Version.of(overriddenClusterVersion) : node.getVersion();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.instance;
 
+import com.hazelcast.cardinality.CardinalityEstimator;
 import com.hazelcast.cardinality.impl.CardinalityEstimatorService;
 import com.hazelcast.client.impl.ClientServiceProxy;
 import com.hazelcast.collection.impl.list.ListService;
@@ -28,7 +29,6 @@ import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.config.Config;
-import com.hazelcast.cardinality.CardinalityEstimator;
 import com.hazelcast.core.ClientService;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.DistributedObject;
@@ -133,7 +133,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
 
             node.start();
             if (!node.isRunning()) {
-                throw new IllegalStateException("Node failed to start!");
+                    throw new IllegalStateException("Node failed to start!");
             }
 
             managementService = new ManagementService(this);

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -29,6 +29,7 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.version.Version;
 
 import java.util.Map;
 
@@ -46,21 +47,21 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
     public MemberImpl() {
     }
 
-    public MemberImpl(Address address, boolean localMember) {
-        this(address, localMember, null, null);
+    public MemberImpl(Address address, Version version, boolean localMember) {
+        this(address, version, localMember, null, null);
     }
 
-    public MemberImpl(Address address, boolean localMember, boolean liteMember) {
-        this(address, localMember, null, null, null, liteMember);
+    public MemberImpl(Address address, Version version, boolean localMember, boolean liteMember) {
+        this(address, version, localMember, null, null, null, liteMember);
     }
 
-    public MemberImpl(Address address, boolean localMember, String uuid, HazelcastInstanceImpl instance) {
-        this(address, localMember, uuid, instance, null, false);
+    public MemberImpl(Address address, Version version, boolean localMember, String uuid, HazelcastInstanceImpl instance) {
+        this(address, version, localMember, uuid, instance, null, false);
     }
 
-    public MemberImpl(Address address, boolean localMember, String uuid, HazelcastInstanceImpl instance,
+    public MemberImpl(Address address, Version version, boolean localMember, String uuid, HazelcastInstanceImpl instance,
                       Map<String, Object> attributes, boolean liteMember) {
-        super(address, uuid, attributes, liteMember);
+        super(address, version, uuid, attributes, liteMember);
         this.localMember = localMember;
         this.instance = instance;
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -18,18 +18,22 @@ package com.hazelcast.instance;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.HotRestartPersistenceConfig;
+import com.hazelcast.internal.cluster.impl.JoinMessage;
+import com.hazelcast.internal.cluster.impl.JoinRequest;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
+import com.hazelcast.internal.networking.ReadHandler;
+import com.hazelcast.internal.networking.SocketChannelWrapperFactory;
+import com.hazelcast.internal.networking.WriteHandler;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.memory.MemoryStats;
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;
-import com.hazelcast.internal.networking.ReadHandler;
-import com.hazelcast.internal.networking.SocketChannelWrapperFactory;
 import com.hazelcast.nio.tcp.TcpIpConnection;
-import com.hazelcast.internal.networking.WriteHandler;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.annotation.PrivateApi;
+import com.hazelcast.version.Version;
 
 import java.util.Map;
 import java.util.Set;
@@ -39,6 +43,7 @@ import java.util.Set;
  * some modules, like; <tt>SerializationService</tt>, <tt>SocketChannelWrapperFactory</tt> etc.
  */
 @PrivateApi
+@SuppressWarnings({"checkstyle:methodcount"})
 public interface NodeExtension {
 
     /**
@@ -166,14 +171,12 @@ public interface NodeExtension {
     MemoryStats getMemoryStats();
 
      /**
-     * Called before a new node is joining to cluster,
-     * executed if node is the master node before join event.
-     * {@link com.hazelcast.internal.cluster.impl.ClusterJoinManager} calls this method,
-     * when handleJoinRequest method is called. By this way, we can check the logic we want
-     * by implementing this method. Implementation should throw required exception, with a valid
-     * message which explains rejection reason.
-     */
-    void validateJoinRequest();
+      * Executed on the master node before allowing a new member to join from
+      * {@link com.hazelcast.internal.cluster.impl.ClusterJoinManager#handleJoinRequest(JoinRequest, Connection)}.
+      * Implementation should check if the {@code JoinMessage} should be allowed to proceed, otherwise throw an exception
+      * with a message explaining rejection reason.
+      */
+    void validateJoinRequest(JoinMessage joinMessage);
 
     /**
      * Called when cluster state is changed
@@ -190,7 +193,21 @@ public interface NodeExtension {
     void onPartitionStateChange();
 
     /**
-     * Registers given register if it's a known type.
+     * Called after cluster version is changed.
+     *
+     * @param newVersion the new version at which the cluster operates.
+     */
+    void onClusterVersionChange(Version newVersion);
+
+    /**
+     * Check if this node's codebase version is compatible with given cluster version.
+     * @param clusterVersion the cluster version to check against
+     * @return {@code true} if compatible, otherwise false.
+     */
+    boolean isNodeVersionCompatibleWith(Version clusterVersion);
+
+    /**
+     * Registers given listener if it's a known type.
      * @param listener listener instance
      * @return true if listener is registered, false otherwise
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.internal.cluster;
 
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberSelector;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.CoreService;
+import com.hazelcast.transaction.TransactionOptions;
+import com.hazelcast.version.Version;
 
 import java.util.Collection;
 
@@ -123,4 +126,56 @@ public interface ClusterService extends CoreService, Cluster {
      */
     String getClusterId();
 
+    /**
+     * Changes the cluster version transactionally. Internally this method uses the same transaction infrastructure as
+     * {@link #changeClusterState(ClusterState)} and the transaction defaults are the same in this case as well
+     * ({@code TWO_PHASE} transaction with durability 1 by default).
+     * <p/>
+     * If the requested cluster version is same as the current one, nothing happens.
+     * <p/>
+     * If a node of the cluster is not compatible with the given cluster {@code version}, as implemented by
+     * {@link com.hazelcast.instance.NodeExtension#isNodeVersionCompatibleWith(Version)}, then a
+     * {@link com.hazelcast.internal.cluster.impl.VersionMismatchException} is thrown.
+     * <p/>
+     * If an invalid version transition is requested, for example changing to a different major version, an
+     * {@link IllegalArgumentException} is thrown.
+     * <p/>
+     * If a membership change occurs in the cluster during locking phase, a new member joins or
+     * an existing member leaves, then this method will fail with an {@code IllegalStateException}.
+     * <p/>
+     * Likewise, once locking phase is completed successfully, {@link Cluster#getClusterState()}
+     * will report being {@link ClusterState#IN_TRANSITION}, disallowing membership changes until the new cluster version is
+     * committed.
+     *
+     * @param version new version of the cluster
+     * @since 3.8
+     */
+    void changeClusterVersion(Version version);
+
+    /**
+     * Changes the cluster version transactionally, with the transaction options provided. Internally this method uses the same
+     * transaction infrastructure as {@link #changeClusterState(ClusterState, TransactionOptions)}. The transaction
+     * options must specify a {@code TWO_PHASE} transaction.
+     * <p/>
+     * If the requested cluster version is same as the current one, nothing happens.
+     * <p/>
+     * If a node of the cluster is not compatible with the given cluster {@code version}, as implemented by
+     * {@link com.hazelcast.instance.NodeExtension#isNodeVersionCompatibleWith(Version)}, then a
+     * {@link com.hazelcast.internal.cluster.impl.VersionMismatchException} is thrown.
+     * <p/>
+     * If an invalid version transition is requested, for example changing to a different major version, an
+     * {@link IllegalArgumentException} is thrown.
+     * <p/>
+     * If a membership change occurs in the cluster during locking phase, a new member joins or
+     * an existing member leaves, then this method will fail with an {@code IllegalStateException}.
+     * <p/>
+     * Likewise, once locking phase is completed successfully, {@link Cluster#getClusterState()}
+     * will report being {@link ClusterState#IN_TRANSITION}, disallowing membership changes until the new cluster version is
+     * committed.
+     *
+     * @param version new version of the cluster
+     * @param options options by which to execute the transaction
+     * @since 3.8
+     */
+    void changeClusterVersion(Version version, TransactionOptions options);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterVersionListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterVersionListener.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster;
+
+import com.hazelcast.core.Cluster;
+import com.hazelcast.version.Version;
+
+/**
+ * Listeners interested in acting upon cluster version update should implement this interface.
+ * Services registered with the Hazelcast {@link com.hazelcast.spi.impl.servicemanager.ServiceManager} which implement this
+ * interface do not have have to register themselves, as their {@link #onClusterVersionChange(Version)} method will be invoked
+ * automatically.
+ *
+ * Other listeners have to register themselves with {@link com.hazelcast.instance.NodeExtension#registerListener(Object)}.
+ * Upon registration, the listener's {@link #onClusterVersionChange(Version)} method will be invoked once with the current value
+ * of the cluster version.
+ *
+ * @see Cluster#getClusterVersion()
+ * @see ClusterService#changeClusterVersion(Version)
+ * @since 3.8
+ */
+public interface ClusterVersionListener {
+
+    /**
+     * Invoked on registered listeners after the new cluster version has been applied. Listeners are executed synchronously
+     * immediately after {@code ClusterStateManager#version} has been updated and while the cluster service lock
+     * {@code ClusterServiceImpl#lock} is still locked, as part of the commit phase of the transaction changing
+     * the cluster version. Unhandled exceptions from listeners implementation will break the new version commit and a slow
+     * implementation will stall the system and may cause a transaction timeout.
+     * If new cluster version is {@code null} and property
+     * {@link com.hazelcast.spi.properties.GroupProperty#INIT_CLUSTER_VERSION} is set, the version set by this property
+     * will be provided as argument to the listener. If neither are set, running node's codebase version will be used.
+     *
+     * @param newVersion the new version
+     */
+    void onClusterVersionChange(Version newVersion);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -33,33 +34,35 @@ public class MemberInfo implements IdentifiedDataSerializable {
     private Address address;
     private String uuid;
     private boolean liteMember;
+    private Version version;
     private Map<String, Object> attributes;
 
     public MemberInfo() {
     }
 
-    public MemberInfo(Address address) {
-        this.address = address;
+    public MemberInfo(Address address, String uuid, Map<String, Object> attributes, Version version) {
+        this(address, uuid, attributes, false, version);
     }
 
-    public MemberInfo(Address address, String uuid, Map<String, Object> attributes) {
-        this(address, uuid, attributes, false);
-    }
-
-    public MemberInfo(Address address, String uuid, Map<String, Object> attributes, boolean liteMember) {
+    public MemberInfo(Address address, String uuid, Map<String, Object> attributes, boolean liteMember, Version version) {
         this.address = address;
         this.uuid = uuid;
         this.attributes = attributes == null || attributes.isEmpty()
                 ? Collections.<String, Object>emptyMap() : new HashMap<String, Object>(attributes);
         this.liteMember = liteMember;
+        this.version = version;
     }
 
     public MemberInfo(MemberImpl member) {
-        this(member.getAddress(), member.getUuid(), member.getAttributes(), member.isLiteMember());
+        this(member.getAddress(), member.getUuid(), member.getAttributes(), member.isLiteMember(), member.getVersion());
     }
 
     public Address getAddress() {
         return address;
+    }
+
+    public Version getVersion() {
+        return version;
     }
 
     public String getUuid() {
@@ -91,6 +94,7 @@ public class MemberInfo implements IdentifiedDataSerializable {
             Object value = in.readObject();
             attributes.put(key, value);
         }
+        version = in.readObject();
     }
 
     @Override
@@ -109,6 +113,7 @@ public class MemberInfo implements IdentifiedDataSerializable {
                 out.writeObject(entry.getValue());
             }
         }
+        out.writeObject(version);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -48,6 +48,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.util.ConstructorFunction;
+import com.hazelcast.version.Version;
 
 public final class ClusterDataSerializerHook implements DataSerializerHook {
 
@@ -86,8 +87,10 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public static final int JOIN_MESSAGE = 29;
     public static final int JOIN_REQUEST = 30;
     public static final int MIGRATION_INFO = 31;
+    public static final int VERSION = 32;
+    public static final int CLUSTER_STATE_CHANGE = 33;
 
-    private static final int LEN = MIGRATION_INFO + 1;
+    private static final int LEN = CLUSTER_STATE_CHANGE + 1;
 
     @Override
     public int getFactoryId() {
@@ -256,6 +259,16 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
         constructors[MIGRATION_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new MigrationInfo();
+            }
+        };
+        constructors[VERSION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new Version();
+            }
+        };
+        constructors[CLUSTER_STATE_CHANGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new ClusterStateChange();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -59,6 +59,7 @@ import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.executor.ExecutorType;
+import com.hazelcast.version.Version;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.ArrayList;
@@ -728,7 +729,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     private MemberImpl createMember(MemberInfo memberInfo, String ipV6ScopeId) {
         Address address = memberInfo.getAddress();
         address.setScopeId(ipV6ScopeId);
-        return new MemberImpl(address, thisAddress.equals(address), memberInfo.getUuid(),
+        return new MemberImpl(address, memberInfo.getVersion(), thisAddress.equals(address), memberInfo.getUuid(),
                 (HazelcastInstanceImpl) nodeEngine.getHazelcastInstance(), memberInfo.getAttributes(), memberInfo.isLiteMember());
     }
 
@@ -896,7 +897,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     private void changeClusterState(ClusterState newState, boolean isTransient) {
         int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
-        clusterStateManager.changeClusterState(newState, getMembers(), partitionStateVersion, isTransient);
+        clusterStateManager.changeClusterState(ClusterStateChange.from(newState), getMembers(), partitionStateVersion,
+                isTransient);
     }
 
     @Override
@@ -906,7 +908,26 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     private void changeClusterState(ClusterState newState, TransactionOptions options, boolean isTransient) {
         int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
-        clusterStateManager.changeClusterState(newState, getMembers(), options, partitionStateVersion, isTransient);
+        clusterStateManager.changeClusterState(ClusterStateChange.from(newState), getMembers(), options, partitionStateVersion,
+                isTransient);
+    }
+
+    @Override
+    public Version getClusterVersion() {
+        return clusterStateManager.getClusterVersion();
+    }
+
+    @Override
+    public void changeClusterVersion(Version version) {
+        int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
+        clusterStateManager.changeClusterState(ClusterStateChange.from(version), getMembers(), partitionStateVersion, false);
+    }
+
+    @Override
+    public void changeClusterVersion(Version version, TransactionOptions options) {
+        int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
+        clusterStateManager.changeClusterState(ClusterStateChange.from(version), getMembers(), options, partitionStateVersion,
+                false);
     }
 
     void addMembersRemovedInNotActiveState(Collection<MemberImpl> members) {
@@ -964,11 +985,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         hazelcastInstance.getLifecycleService().shutdown();
     }
 
-    public void initialClusterState(ClusterState clusterState) {
+    public void initialClusterState(ClusterState clusterState, Version version) {
         if (node.joined()) {
             throw new IllegalStateException("Cannot set initial state after node joined! -> " + clusterState);
         }
-        clusterStateManager.initialClusterState(clusterState);
+        clusterStateManager.initialClusterState(clusterState, version);
     }
 
     public ClusterStateManager getClusterStateManager() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateChange.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateChange.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * Wrapper object indicating a change in the cluster state - it may be cluster state change or cluster version change.
+ */
+public class ClusterStateChange<T> implements IdentifiedDataSerializable {
+
+    private Class<T> type;
+    private T newState;
+
+    public ClusterStateChange() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public ClusterStateChange(T newState) {
+        this.type = (Class<T>) newState.getClass();
+        this.newState = newState;
+    }
+
+    public Class<T> getType() {
+        return type;
+    }
+
+    public T getNewState() {
+        return newState;
+    }
+
+    public <T> boolean isOfType(Class<T> type) {
+        return this.type.equals(type);
+    }
+
+    public void validate() {
+        if (type == null || newState == null) {
+            throw new IllegalArgumentException("Invalid null state");
+        }
+
+        if (isOfType(ClusterState.class)) {
+            if (newState == ClusterState.IN_TRANSITION) {
+                throw new IllegalArgumentException("IN_TRANSITION is an internal state!");
+            }
+        }
+    }
+
+    public static <T> ClusterStateChange<T> from(T object) {
+        return new ClusterStateChange<T>(object);
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(type);
+        out.writeObject(newState);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        type = in.readObject();
+        newState = in.readObject();
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterStateChange{"
+                + "type=" + type
+                + ", newState=" + newState
+                + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClusterDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.CLUSTER_STATE_CHANGE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClusterStateChange<?> that = (ClusterStateChange<?>) o;
+
+        if (!type.equals(that.type)) {
+            return false;
+        }
+        return newState.equals(that.newState);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + newState.hashCode();
+        return result;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -37,26 +37,26 @@ import java.io.IOException;
  */
 public class ClusterStateTransactionLogRecord implements TargetAwareTransactionLogRecord {
 
-    private ClusterState newState;
-    private Address initiator;
-    private Address target;
-    private String txnId;
-    private long leaseTime;
-    private int partitionStateVersion;
-    private boolean isTransient;
+    ClusterStateChange stateChange;
+    Address initiator;
+    Address target;
+    String txnId;
+    long leaseTime;
+    int partitionStateVersion;
+    boolean isTransient;
 
     public ClusterStateTransactionLogRecord() {
     }
 
-    public ClusterStateTransactionLogRecord(ClusterState newState, Address initiator, Address target,
+    public ClusterStateTransactionLogRecord(ClusterStateChange stateChange, Address initiator, Address target,
             String txnId, long leaseTime, int partitionStateVersion, boolean isTransient) {
-        Preconditions.checkNotNull(newState);
+        Preconditions.checkNotNull(stateChange);
         Preconditions.checkNotNull(initiator);
         Preconditions.checkNotNull(target);
         Preconditions.checkNotNull(txnId);
         Preconditions.checkPositive(leaseTime, "Lease time should be positive!");
 
-        this.newState = newState;
+        this.stateChange = stateChange;
         this.initiator = initiator;
         this.target = target;
         this.txnId = txnId;
@@ -72,12 +72,12 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
 
     @Override
     public Operation newPrepareOperation() {
-        return new LockClusterStateOperation(newState, initiator, txnId, leaseTime, partitionStateVersion);
+        return new LockClusterStateOperation(stateChange, initiator, txnId, leaseTime, partitionStateVersion);
     }
 
     @Override
     public Operation newCommitOperation() {
-        return new ChangeClusterStateOperation(newState, initiator, txnId, isTransient);
+        return new ChangeClusterStateOperation(stateChange, initiator, txnId, isTransient);
     }
 
     @Override
@@ -92,9 +92,9 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(newState.toString());
-        initiator.writeData(out);
-        target.writeData(out);
+        out.writeObject(stateChange);
+        out.writeObject(initiator);
+        out.writeObject(target);
         out.writeUTF(txnId);
         out.writeLong(leaseTime);
         out.writeInt(partitionStateVersion);
@@ -103,12 +103,9 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        String stateName = in.readUTF();
-        newState = ClusterState.valueOf(stateName);
-        initiator = new Address();
-        initiator.readData(in);
-        target = new Address();
-        target.readData(in);
+        stateChange = in.readObject();
+        initiator = in.readObject();
+        target = in.readObject();
         txnId = in.readUTF();
         leaseTime = in.readLong();
         partitionStateVersion = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessage.java
@@ -20,16 +20,23 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
+// Used as request and response in join protocol
 public class JoinMessage implements IdentifiedDataSerializable {
 
     protected byte packetVersion;
     protected int buildNumber;
+    /**
+     * this is populated with the codebase version of the node trying to join the cluster
+     * (ie {@link com.hazelcast.instance.Node#getVersion()}).
+     */
+    protected Version version;
     protected Address address;
     protected String uuid;
     protected boolean liteMember;
@@ -40,15 +47,16 @@ public class JoinMessage implements IdentifiedDataSerializable {
     public JoinMessage() {
     }
 
-    public JoinMessage(byte packetVersion, int buildNumber, Address address,
+    public JoinMessage(byte packetVersion, int buildNumber, Version version, Address address,
                        String uuid, boolean liteMember, ConfigCheck configCheck) {
-        this(packetVersion, buildNumber, address, uuid, liteMember, configCheck, Collections.<Address>emptySet(), 0);
+        this(packetVersion, buildNumber, version, address, uuid, liteMember, configCheck, Collections.<Address>emptySet(), 0);
     }
 
-    public JoinMessage(byte packetVersion, int buildNumber, Address address, String uuid, boolean liteMember,
+    public JoinMessage(byte packetVersion, int buildNumber, Version version, Address address, String uuid, boolean liteMember,
                        ConfigCheck configCheck, Collection<Address> memberAddresses, int dataMemberCount) {
         this.packetVersion = packetVersion;
         this.buildNumber = buildNumber;
+        this.version = version;
         this.address = address;
         this.uuid = uuid;
         this.liteMember = liteMember;
@@ -63,6 +71,10 @@ public class JoinMessage implements IdentifiedDataSerializable {
 
     public int getBuildNumber() {
         return buildNumber;
+    }
+
+    public Version getVersion() {
+        return version;
     }
 
     public Address getAddress() {
@@ -97,6 +109,7 @@ public class JoinMessage implements IdentifiedDataSerializable {
     public void readData(ObjectDataInput in) throws IOException {
         packetVersion = in.readByte();
         buildNumber = in.readInt();
+        version = in.readObject();
         address = new Address();
         address.readData(in);
         uuid = in.readUTF();
@@ -118,6 +131,7 @@ public class JoinMessage implements IdentifiedDataSerializable {
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeByte(packetVersion);
         out.writeInt(buildNumber);
+        out.writeObject(version);
         address.writeData(out);
         out.writeUTF(uuid);
         configCheck.writeData(out);
@@ -138,6 +152,7 @@ public class JoinMessage implements IdentifiedDataSerializable {
         return "JoinMessage{"
                 + "packetVersion=" + packetVersion
                 + ", buildNumber=" + buildNumber
+                + ", version=" + version
                 + ", address=" + address
                 + ", uuid='" + uuid + '\''
                 + ", liteMember=" + liteMember

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.security.Credentials;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -41,9 +42,10 @@ public class JoinRequest extends JoinMessage {
     public JoinRequest() {
     }
 
-    public JoinRequest(byte packetVersion, int buildNumber, Address address, String uuid, boolean liteMember, ConfigCheck config,
-                       Credentials credentials, Map<String, Object> attributes, Set<String> excludedMemberUuids) {
-        super(packetVersion, buildNumber, address, uuid, liteMember, config);
+    public JoinRequest(byte packetVersion, int buildNumber, Version version, Address address, String uuid, boolean liteMember,
+                       ConfigCheck config, Credentials credentials, Map<String, Object> attributes,
+                       Set<String> excludedMemberUuids) {
+        super(packetVersion, buildNumber, version, address, uuid, liteMember, config);
         this.credentials = credentials;
         this.attributes = attributes;
         if (excludedMemberUuids != null) {
@@ -72,7 +74,7 @@ public class JoinRequest extends JoinMessage {
     }
 
     public MemberInfo toMemberInfo() {
-        return new MemberInfo(address, uuid, attributes, liteMember);
+        return new MemberInfo(address, uuid, attributes, liteMember, version);
     }
 
     @Override
@@ -120,6 +122,7 @@ public class JoinRequest extends JoinMessage {
         return "JoinRequest{"
                 + "packetVersion=" + packetVersion
                 + ", buildNumber=" + buildNumber
+                + ", version=" + version
                 + ", address=" + address
                 + ", uuid='" + uuid + "'"
                 + ", liteMember=" + liteMember

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -71,7 +71,7 @@ public class NodeMulticastListener implements MulticastListener {
         }
 
         if (node.isMaster()) {
-            JoinMessage response = new JoinMessage(Packet.VERSION, node.getBuildInfo().getBuildNumber(),
+            JoinMessage response = new JoinMessage(Packet.VERSION, node.getBuildInfo().getBuildNumber(), node.getVersion(),
                     node.getThisAddress(), node.getThisUuid(), node.isLiteMember(), node.createConfigCheck());
             node.multicastService.send(response);
         } else if (isMasterNode(joinMessage.getAddress()) && !checkMasterUuid(joinMessage.getUuid())) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/VersionMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/VersionMismatchException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * Indicates that the version of a joining member is not compatible with the cluster version.
+ */
+public class VersionMismatchException extends HazelcastException {
+    public VersionMismatchException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ChangeClusterStateOperation.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.ClusterStateChange;
 import com.hazelcast.internal.cluster.impl.ClusterStateManager;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -30,23 +30,21 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.transaction.TransactionException;
-import com.hazelcast.util.EmptyStatement;
 
 import java.io.IOException;
 
 public class ChangeClusterStateOperation extends Operation implements AllowedDuringPassiveState, IdentifiedDataSerializable {
 
-    private ClusterState newState;
+    private ClusterStateChange stateChange;
     private Address initiator;
     private String txnId;
-    private String stateName;
     private boolean isTransient;
 
     public ChangeClusterStateOperation() {
     }
 
-    public ChangeClusterStateOperation(ClusterState newState, Address initiator, String txnId, boolean isTransient) {
-        this.newState = newState;
+    public ChangeClusterStateOperation(ClusterStateChange stateChange, Address initiator, String txnId, boolean isTransient) {
+        this.stateChange = stateChange;
         this.initiator = initiator;
         this.txnId = txnId;
         this.isTransient = isTransient;
@@ -54,18 +52,19 @@ public class ChangeClusterStateOperation extends Operation implements AllowedDur
 
     @Override
     public void beforeRun() throws Exception {
-        if (newState == null) {
-            throw new IllegalArgumentException("Unknown cluster state: " + stateName);
+        if (stateChange == null) {
+            throw new IllegalArgumentException("Invalid null cluster state");
         }
+        stateChange.validate();
     }
 
     @Override
     public void run() throws Exception {
         ClusterServiceImpl service = getService();
         ClusterStateManager clusterStateManager = service.getClusterStateManager();
-        getLogger().info("Changing cluster state state to " + newState + ", Initiator: " + initiator
+        getLogger().info("Changing cluster state state to " + stateChange + ", Initiator: " + initiator
                 + " transient: " + isTransient);
-        clusterStateManager.commitClusterState(newState, initiator, txnId, isTransient);
+        clusterStateManager.commitClusterState(stateChange, initiator, txnId, isTransient);
     }
 
     @Override
@@ -98,7 +97,7 @@ public class ChangeClusterStateOperation extends Operation implements AllowedDur
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(newState.toString());
+        out.writeObject(stateChange);
         initiator.writeData(out);
         out.writeUTF(txnId);
         out.writeBoolean(isTransient);
@@ -107,12 +106,7 @@ public class ChangeClusterStateOperation extends Operation implements AllowedDur
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        stateName = in.readUTF();
-        try {
-            newState = ClusterState.valueOf(stateName);
-        } catch (IllegalArgumentException ignored) {
-            EmptyStatement.ignore(ignored);
-        }
+        stateChange = in.readObject();
         initiator = new Address();
         initiator.readData(in);
         txnId = in.readUTF();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
@@ -31,6 +31,7 @@ import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -48,28 +49,31 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
     private String clusterId;
     private long clusterStartTime;
     private ClusterState clusterState;
+    private Version clusterVersion;
 
     public FinalizeJoinOperation() {
     }
 
     public FinalizeJoinOperation(Collection<MemberInfo> members, PostJoinOperation postJoinOp, long masterTime,
-                                 String clusterId, long clusterStartTime, ClusterState clusterState,
+                                 String clusterId, long clusterStartTime, ClusterState clusterState, Version clusterVersion,
                                  PartitionRuntimeState partitionRuntimeState) {
         super(members, masterTime, partitionRuntimeState, true);
         this.postJoinOp = postJoinOp;
         this.clusterId = clusterId;
         this.clusterStartTime = clusterStartTime;
         this.clusterState = clusterState;
+        this.clusterVersion = clusterVersion;
     }
 
     public FinalizeJoinOperation(Collection<MemberInfo> members, PostJoinOperation postJoinOp, long masterTime,
-                                 String clusterId, long clusterStartTime, ClusterState clusterState,
+                                 String clusterId, long clusterStartTime, ClusterState clusterState, Version clusterVersion,
                                  PartitionRuntimeState partitionRuntimeState, boolean sendResponse) {
         super(members, masterTime, partitionRuntimeState, sendResponse);
         this.postJoinOp = postJoinOp;
         this.clusterId = clusterId;
         this.clusterStartTime = clusterStartTime;
         this.clusterState = clusterState;
+        this.clusterVersion = clusterVersion;
     }
 
     @Override
@@ -101,7 +105,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
     }
 
     private void initClusterStates(ClusterServiceImpl clusterService) {
-        clusterService.initialClusterState(clusterState);
+        clusterService.initialClusterState(clusterState, clusterVersion);
         clusterService.setClusterId(clusterId);
         ClusterClockImpl clusterClock = clusterService.getClusterClock();
         clusterClock.setClusterStartTime(clusterStartTime);
@@ -156,6 +160,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         out.writeUTF(clusterId);
         out.writeLong(clusterStartTime);
         out.writeUTF(clusterState.toString());
+        out.writeObject(clusterVersion);
     }
 
     @Override
@@ -170,6 +175,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         clusterStartTime = in.readLong();
         String stateName = in.readUTF();
         clusterState = ClusterState.valueOf(stateName);
+        clusterVersion = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinCheckOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinCheckOperation.java
@@ -61,7 +61,13 @@ public class JoinCheckOperation extends AbstractJoinOperation {
             ILogger logger = getLogger();
             try {
                 if (service.getClusterJoinManager().validateJoinMessage(request)) {
-                    response = node.createSplitBrainJoinMessage();
+                    try {
+                        // also validate other node's version is able to join our cluster
+                        node.getNodeExtension().validateJoinRequest(request);
+                        response = node.createSplitBrainJoinMessage();
+                    } catch (Exception e) {
+                        logger.info("Join check from " + getCallerAddress() + " failed validation: " + e.getMessage());
+                    }
                 }
                 if (logger.isFineEnabled()) {
                     logger.fine("Returning " + response + " to " + getCallerAddress());

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SetMasterOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SetMasterOperation.java
@@ -38,7 +38,7 @@ public class SetMasterOperation extends AbstractClusterOperation {
     @Override
     public void run() {
         ClusterServiceImpl clusterService = getService();
-        clusterService.getClusterJoinManager().handleMaster(masterAddress, getCallerAddress());
+        clusterService.getClusterJoinManager().setMaster(masterAddress, getCallerAddress());
     }
 
     public Address getMasterAddress() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -77,7 +77,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
     private final PortableContextImpl portableContext;
     private final PortableSerializer portableSerializer;
 
-    SerializationServiceV1(InputOutputFactory inputOutputFactory, byte version, int portableVersion, ClassLoader classLoader,
+     SerializationServiceV1(InputOutputFactory inputOutputFactory, byte version, int portableVersion, ClassLoader classLoader,
             Map<Integer, ? extends DataSerializableFactory> dataSerializableFactories,
             Map<Integer, ? extends PortableFactory> portableFactories, ManagedContext managedContext,
             PartitioningStrategy globalPartitionStrategy, int initialOutputBufferSize, BufferPoolFactory bufferPoolFactory,

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublishingService.java
@@ -124,7 +124,7 @@ public class MapEventPublishingService implements EventPublishingService<Object,
     private Member getMember(EventData eventData) {
         Member member = nodeEngine.getClusterService().getMember(eventData.getCaller());
         if (member == null) {
-            member = new MemberImpl(eventData.getCaller(), false);
+            member = new MemberImpl(eventData.getCaller(), nodeEngine.getVersion(), false);
         }
         return member;
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEventPublishingService.java
@@ -160,7 +160,7 @@ public class ReplicatedMapEventPublishingService implements EventPublishingServi
     private Member getMember(EventData eventData) {
         Member member = replicatedMapService.getNodeEngine().getClusterService().getMember(eventData.getCaller());
         if (member == null) {
-            member = new MemberImpl(eventData.getCaller(), false);
+            member = new MemberImpl(eventData.getCaller(), nodeEngine.getVersion(), false);
         }
         return member;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/NodeEngine.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.cluster.ClusterService;
@@ -28,6 +29,7 @@ import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.TransactionManagerService;
+import com.hazelcast.version.Version;
 import com.hazelcast.wan.WanReplicationService;
 
 /**
@@ -273,4 +275,14 @@ public interface NodeEngine {
      * @deprecated since 3.7. Use {@link #getService(String)} instead.
      */
     <T extends SharedService> T getSharedService(String serviceName);
+
+    /**
+     * Returns the codebase version of the node. For example, when running on hazelcast-3.8.jar, this would resolve
+     * to {@code Version.of(3,8,0)}. A node's codebase version may be different than cluster version.
+     *
+     * @return codebase version of the node.
+     * @see Cluster#getClusterVersion()
+     * @since 3.8
+     */
+    Version getVersion();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -80,6 +80,7 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
+import com.hazelcast.version.Version;
 import com.hazelcast.wan.WanReplicationService;
 
 import java.util.Collection;
@@ -397,6 +398,11 @@ public class NodeEngineImpl implements NodeEngine {
     @Override
     public <T extends SharedService> T getSharedService(String serviceName) {
         return serviceManager.getSharedService(serviceName);
+    }
+
+    @Override
+    public Version getVersion() {
+        return node.getVersion();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -626,6 +626,15 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.serialization.version",
             BuildInfoProvider.getBuildInfo().getSerializationVersion());
 
+    /**
+     * Override cluster version to use while node is not yet member of a cluster. The cluster version assumed before joining
+     * a cluster may affect the serialization format of cluster discovery & join operations and its compatibility with members
+     * of a cluster running on different Hazelcast codebase versions. The default is to use the node's codebase version. You may
+     * need to override it for your node to join a cluster running on a previous cluster version.
+     */
+    public static final HazelcastProperty INIT_CLUSTER_VERSION
+            = new HazelcastProperty("hazelcast.init.cluster.version");
+
     private GroupProperty() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicService.java
@@ -126,7 +126,7 @@ public class TopicService implements ManagedService, RemoteService, EventPublish
         ClusterService clusterService = nodeEngine.getClusterService();
         MemberImpl member = clusterService.getMember(topicEvent.publisherAddress);
         if (member == null) {
-            member = new MemberImpl(topicEvent.publisherAddress, false);
+            member = new MemberImpl(topicEvent.publisherAddress, nodeEngine.getVersion(), false);
         }
         Message message = new DataAwareMessage(topicEvent.name, topicEvent.data, topicEvent.publishTime, member
                 , nodeEngine.getSerializationService());

--- a/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.version;
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * Version comparator that disregards patch version, comparing versions on their major & minor versions only.
+ */
+@SuppressWarnings("checkstyle:magicnumber")
+class MajorMinorVersionComparator implements Comparator<Version>, Serializable {
+
+    private static final long serialVersionUID = 364570099633468810L;
+
+    @Override
+    public int compare(Version o1, Version o2) {
+        int thisVersion = (o1.getMajor() << 8 & 0xff00) | (o1.getMinor() & 0xff);
+        int thatVersion = (o2.getMajor() << 8 & 0xff00) | (o2.getMinor() & 0xff);
+        if (thisVersion > thatVersion) {
+            return 1;
+        } else {
+            return thisVersion == thatVersion ? 0 : -1;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/version/Version.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/Version.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.version;
+
+import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Comparator;
+
+/**
+ * Determines Hazelcast version.
+ */
+@SuppressWarnings("checkstyle:magicnumber")
+public final class Version implements IdentifiedDataSerializable, Comparable<Version>, Serializable {
+
+
+    /**
+     * UNKNOWN version
+     */
+    public static final Version UNKNOWN = new Version(0, 0, 0);
+
+    /**
+     * Version comparator that takes into account only major & minor version, disregarding patch version number.
+     */
+    public static final transient Comparator<Version> MAJOR_MINOR_VERSION_COMPARATOR = new MajorMinorVersionComparator();
+
+    private static final String UNKNOWN_VERSION_STRING = "0.0.0";
+    private static final long serialVersionUID = 2603770920931610781L;
+
+    private byte major;
+    private byte minor;
+    private byte patch;
+
+    public Version() {
+    }
+
+    public Version(int major, int minor, int patch) {
+        this.major = (byte) major;
+        this.minor = (byte) minor;
+        this.patch = (byte) patch;
+    }
+
+    public Version(String version) {
+        parse(version);
+    }
+
+    // populate this Version's major, minor, patch from given String
+    private void parse(String version) {
+        String[] tokens = version.split("\\.");
+        this.major = Byte.valueOf(tokens[0]);
+        this.minor = Byte.valueOf(stripPostfix(tokens[1]));
+        if (tokens.length > 2) {
+            this.patch = Byte.valueOf(stripPostfix(tokens[2]));
+        }
+    }
+
+    private static String stripPostfix(String token) {
+        int hyphenIndex = token.indexOf("-");
+        return hyphenIndex >= 0 ? token.substring(0, hyphenIndex) : token;
+    }
+
+    public byte getMajor() {
+        return major;
+    }
+
+    public byte getMinor() {
+        return minor;
+    }
+
+    public byte getPatch() {
+        return patch;
+    }
+
+    public boolean isUnknown() {
+        return this.equals(UNKNOWN);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Version that = (Version) o;
+        if (major != that.major) {
+            return false;
+        }
+        if (minor != that.minor) {
+            return false;
+        }
+        return patch == that.patch;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) major;
+        result = 31 * result + (int) minor;
+        result = 31 * result + (int) patch;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return major + "." + minor + "." + patch;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeByte(major);
+        out.writeByte(minor);
+        out.writeByte(patch);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.major = in.readByte();
+        this.minor = in.readByte();
+        this.patch = in.readByte();
+    }
+
+    public static Version of(int major, int minor, int patch) {
+        if (major == 0 && minor == 0 && patch == 0) {
+            return Version.UNKNOWN;
+        } else {
+            return new Version(major, minor, patch);
+        }
+    }
+
+    public static Version of(String version) {
+        if (version == null || version.startsWith(UNKNOWN_VERSION_STRING)) {
+            return Version.UNKNOWN;
+        } else {
+            return new Version(version);
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClusterDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.VERSION;
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:booleanexpressioncomplexity")
+    public int compareTo(Version otherVersion) {
+        // pack major-minor-patch to 3 least significant bytes of integer, then compare the integers
+        // even though major, minor & patch are not expected to be negative, masking makes sure we avoid sign extension
+        int thisVersion = (major << 16 & 0xff0000) | ((minor << 8) & 0xff00) | (patch & 0xff);
+        int thatVersion = (otherVersion.major << 16 & 0xff0000) | (otherVersion.minor << 8 & 0xff00)
+                | (otherVersion.patch & 0xff);
+        if (thisVersion > thatVersion) {
+            return 1;
+        } else {
+            return thisVersion == thatVersion ? 0 : -1;
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/version/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains classes to support the versioning API.
+ */
+package com.hazelcast.version;

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheSerializationTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -130,7 +131,7 @@ public class CacheSerializationTest extends HazelcastTestSupport {
     @Test
     public void testCachePartitionEventData() throws UnknownHostException {
         Address address = new Address("127.0.0.1", 5701);
-        Member member = new MemberImpl(address, true, false);
+        Member member = new MemberImpl(address, Version.UNKNOWN, true, false);
         CachePartitionEventData cachePartitionEventData = new CachePartitionEventData("test", 1, member);
         CachePartitionEventData deserialized = service.toObject(cachePartitionEventData);
         assertEquals(cachePartitionEventData, deserialized);

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/MemberImplTest.java
@@ -5,6 +5,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -23,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class MemberImplTest extends HazelcastTestSupport {
 
+    private static final Version VERSION = Version.of("1.3.2");
     private static Address address;
 
     @BeforeClass
@@ -41,7 +43,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withAddress() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
 
         assertBasicMemberImplFields(member);
         assertFalse(member.isLiteMember());
@@ -49,7 +51,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withAddressAndUUid() {
-        MemberImpl member = new MemberImpl(address, "uuid2342");
+        MemberImpl member = new MemberImpl(address, VERSION, "uuid2342");
 
         assertBasicMemberImplFields(member);
         assertEquals("uuid2342", member.getUuid());
@@ -69,7 +71,7 @@ public class MemberImplTest extends HazelcastTestSupport {
         attributes.put("floatKey", Float.MAX_VALUE);
         attributes.put("doubleKey", Double.MAX_VALUE);
 
-        MemberImpl member = new MemberImpl(address, "uuid2342", attributes, true);
+        MemberImpl member = new MemberImpl(address, VERSION, "uuid2342", attributes, true);
 
         assertBasicMemberImplFields(member);
         assertEquals("uuid2342", member.getUuid());
@@ -113,62 +115,62 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withMemberImpl() {
-        MemberImpl member = new MemberImpl(new MemberImpl(address));
+        MemberImpl member = new MemberImpl(new MemberImpl(address, VERSION));
 
         assertBasicMemberImplFields(member);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetStringAttribute() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
         member.setStringAttribute("stringKey", "stringValue");
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetBooleanAttribute() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
         member.setBooleanAttribute("booleanKeyTrue", true);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetByteAttribute() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
         member.setByteAttribute("byteKey", Byte.MAX_VALUE);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetShortAttribute() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
         member.setShortAttribute("shortKey", Short.MAX_VALUE);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetIntAttribute() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
         member.setIntAttribute("intKey", Integer.MAX_VALUE);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetLongAttribute() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
         member.setLongAttribute("longKey", Long.MAX_VALUE);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetFloatAttribute() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
         member.setFloatAttribute("floatKey", Float.MAX_VALUE);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetDoubleAttribute() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
         member.setDoubleAttribute("doubleKey", Double.MAX_VALUE);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testRemoveAttribute() {
-        MemberImpl member = new MemberImpl(address);
+        MemberImpl member = new MemberImpl(address, VERSION);
         member.removeAttribute("removeKey");
     }
 
@@ -178,5 +180,8 @@ public class MemberImplTest extends HazelcastTestSupport {
         assertEquals("127.0.0.1", member.getInetAddress().getHostAddress());
         assertNull(member.getLogger());
         assertFalse(member.localMember());
+        assertEquals(1, member.getVersion().getMajor());
+        assertEquals(3, member.getVersion().getMinor());
+        assertEquals(2, member.getVersion().getPatch());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
@@ -70,6 +70,7 @@ import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 import com.hazelcast.util.AddressUtil;
+import com.hazelcast.version.Version;
 import com.hazelcast.wan.WANReplicationQueueFullException;
 
 import javax.cache.CacheException;
@@ -186,7 +187,7 @@ public class ReferenceObjects {
         }
     }
 
-    public static Member aMember = new MemberImpl(anAddress, aString, Collections.singletonMap(aString, (Object) aString), false);
+    public static Member aMember = new MemberImpl(anAddress, Version.UNKNOWN, aString, Collections.singletonMap(aString, (Object) aString), false);
     public static Collection<Map.Entry<Address, List<Integer>>> aPartitionTable;
 
     static {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cluster;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.impl.VersionMismatchException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.TestClusterUpgradeUtils.assertClusterVersion;
+import static com.hazelcast.test.TestClusterUpgradeUtils.upgradeClusterMembers;
+
+/**
+ * Create a cluster, then change cluster version. This test uses artificial version numbers, to avoid relying on current version.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClusterUpgradeTest extends HazelcastTestSupport {
+
+    static final Version VERSION_2_0_5 = Version.of(2, 0, 5);
+    static final Version VERSION_2_1_0 = Version.of(2, 1, 0);
+    static final Version VERSION_2_1_1 = Version.of(2, 1, 1);
+    static final Version VERSION_2_2_0 = Version.of(2, 2, 0);
+    static final Version VERSION_3_0_0 = Version.of(3, 0, 0);
+
+    static final int CLUSTER_MEMBERS_COUNT = 3;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(10);
+    private HazelcastInstance[] clusterMembers;
+    private ClusterService clusterService;
+
+    @Before
+    public void setup() {
+        System.setProperty("hazelcast.version", VERSION_2_1_0.toString());
+        clusterMembers = new HazelcastInstance[CLUSTER_MEMBERS_COUNT];
+        for (int i=0; i < CLUSTER_MEMBERS_COUNT; i++) {
+            clusterMembers[i] = factory.newHazelcastInstance(getConfig());
+        }
+        clusterService = (ClusterService) clusterMembers[0].getCluster();
+    }
+
+    @Test
+    public void test_upgradePatchVersion() {
+        upgradeCluster(VERSION_2_1_1);
+        clusterService.changeClusterVersion(VERSION_2_1_1);
+        assertClusterVersion(clusterMembers, VERSION_2_1_1);
+    }
+
+    @Test
+    public void test_upgradeMinorVersion_notAllowed() {
+        expectedException.expect(IllegalStateException.class);
+        upgradeCluster(VERSION_2_2_0);
+    }
+
+    @Test
+    public void test_upgradeMajorVersion_notAllowed() {
+        expectedException.expect(IllegalStateException.class);
+        upgradeCluster(VERSION_3_0_0);
+    }
+
+    @Test
+    public void test_addNodeOfLesserThanClusterVersion_notAllowed() {
+        System.setProperty("hazelcast.version", VERSION_2_0_5.toString());
+        expectedException.expect(IllegalStateException.class);
+        factory.newHazelcastInstance(getConfig());
+    }
+
+    @Test
+    public void test_changeClusterVersion_allowedForPatchVersions() {
+        clusterService.changeClusterVersion(VERSION_2_1_1);
+    }
+
+    @Test
+    public void test_changeClusterVersion_disallowedForMinorVersions() {
+        expectedException.expect(VersionMismatchException.class);
+        clusterService.changeClusterVersion(VERSION_2_0_5);
+    }
+
+    void upgradeCluster(Version version) {
+        upgradeClusterMembers(factory, clusterMembers, version, getConfig());
+        // also update the reference to clusterService to the one from
+        clusterService = (ClusterService) clusterMembers[0].getCluster();
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("hazelcast.version");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
@@ -166,9 +166,9 @@ public class MemberListTest {
 
         // Simulates node2 getting an out of order member list. That causes node2 to think it's the master.
         List<MemberInfo> members = new ArrayList<MemberInfo>();
-        members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections.<String, Object>emptyMap()));
-        members.add(new MemberInfo(m3.getAddress(), m3.getUuid(), Collections.<String, Object>emptyMap()));
-        members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections.<String, Object>emptyMap()));
+        members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
+        members.add(new MemberInfo(m3.getAddress(), m3.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
+        members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
         n2.clusterService.updateMembers(members);
         n2.setMasterAddress(m2.getAddress());
 
@@ -210,8 +210,8 @@ public class MemberListTest {
         final Node n2 = TestUtil.getNode(h2);
         // Simulates node2 getting an out of order member list. That causes node2 to think it's the master.
         List<MemberInfo> members = new ArrayList<MemberInfo>();
-        members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections.<String, Object>emptyMap()));
-        members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections.<String, Object>emptyMap()));
+        members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
+        members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
         n2.clusterService.updateMembers(members);
 
         // Give the cluster some time to figure things out. The merge and heartbeat code should have kicked in by this point

--- a/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
@@ -93,6 +93,14 @@ public class BuildInfoProviderTest {
         assertEquals(109900, BuildInfo.calculateVersion("10.99-RC1"));
     }
 
+    @Test
+    public void testOverrideBuildVersion() {
+        System.setProperty("hazelcast.version", "99.99.99");
+        BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
+        assertEquals("99.99.99", buildInfo.getVersion());
+        System.clearProperty("hazelcast.version");
+    }
+
     @After
     public void cleanup() {
         System.clearProperty("hazelcast.build");

--- a/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
@@ -1,0 +1,218 @@
+package com.hazelcast.instance;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.internal.cluster.ClusterVersionListener;
+import com.hazelcast.internal.cluster.impl.ClusterStateManager;
+import com.hazelcast.internal.cluster.impl.JoinRequest;
+import com.hazelcast.internal.cluster.impl.VersionMismatchException;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.UuidUtil;
+import com.hazelcast.version.Version;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+import java.net.UnknownHostException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.instance.BuildInfoProvider.BUILD_INFO;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test DefaultNodeExtension behavior
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DefaultNodeExtensionTest extends HazelcastTestSupport {
+
+    protected HazelcastInstance hazelcastInstance;
+    protected Node node;
+    protected NodeExtension nodeExtension;
+
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+
+    @Before
+    public void setup() throws Exception {
+        hazelcastInstance = createHazelcastInstance();
+        nodeExtension = getNode(hazelcastInstance).getNodeExtension();
+        node = getNode(hazelcastInstance);
+    }
+
+    @Test
+    public void test_nodeVersionCompatibleWith_otherPatchVersion() {
+        Version currentVersion = getNode(hazelcastInstance).getVersion();
+        Version patchPlusOne = new Version(currentVersion.getMajor(), currentVersion.getMinor(), currentVersion.getPatch() + 1);
+        assertTrue(nodeExtension.isNodeVersionCompatibleWith(patchPlusOne));
+    }
+
+    @Test
+    public void test_nodeVersionNotCompatibleWith_otherMinorVersion() {
+        Version currentVersion = getNode(hazelcastInstance).getVersion();
+        Version minorMinusOne = new Version(currentVersion.getMajor(), currentVersion.getMinor() - 1, currentVersion.getPatch());
+        assertFalse(nodeExtension.isNodeVersionCompatibleWith(minorMinusOne));
+    }
+
+    @Test
+    public void test_nodeVersionCompatibleWith_otherMajorVersion() {
+        Version currentVersion = getNode(hazelcastInstance).getVersion();
+        Version majorPlusOne = new Version(currentVersion.getMajor() + 1, currentVersion.getMinor(), currentVersion.getPatch());
+        assertFalse(nodeExtension.isNodeVersionCompatibleWith(majorPlusOne));
+    }
+
+    @Test
+    public void test_joinRequestAllowed_whenSameVersion()
+            throws UnknownHostException {
+        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BUILD_INFO.getBuildNumber(), node.getVersion(),
+                new Address("127.0.0.1", 9999), UuidUtil.newUnsecureUuidString(), false, null, null, null, null);
+        nodeExtension.validateJoinRequest(joinRequest);
+    }
+
+    @Test
+    public void test_joinRequestAllowed_whenOtherPatchVersion()
+            throws UnknownHostException {
+        Version otherPatchVersion = Version
+                .of(node.getVersion().getMajor(), node.getVersion().getMinor(), node.getVersion().getPatch() + 1);
+        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BUILD_INFO.getBuildNumber(), otherPatchVersion,
+                new Address("127.0.0.1", 9999), UuidUtil.newUnsecureUuidString(), false, null, null, null, null);
+        nodeExtension.validateJoinRequest(joinRequest);
+    }
+
+    @Test
+    public void test_joinRequestFails_whenOtherMinorVersion()
+            throws UnknownHostException {
+        Version otherPatchVersion = Version
+                .of(node.getVersion().getMajor(), node.getVersion().getMinor() + 1, node.getVersion().getPatch());
+        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BUILD_INFO.getBuildNumber(), otherPatchVersion,
+                new Address("127.0.0.1", 9999), UuidUtil.newUnsecureUuidString(), false, null, null, null, null);
+        expected.expect(VersionMismatchException.class);
+        nodeExtension.validateJoinRequest(joinRequest);
+    }
+
+    @Test
+    public void test_joinRequestFails_whenOtherMajorVersion()
+            throws UnknownHostException {
+        Version otherPatchVersion = Version
+                .of(node.getVersion().getMajor() + 1, node.getVersion().getMinor(), node.getVersion().getPatch());
+        JoinRequest joinRequest = new JoinRequest(Packet.VERSION, BUILD_INFO.getBuildNumber(), otherPatchVersion,
+                new Address("127.0.0.1", 9999), UuidUtil.newUnsecureUuidString(), false, null, null, null, null);
+        expected.expect(VersionMismatchException.class);
+        nodeExtension.validateJoinRequest(joinRequest);
+    }
+
+    @Test
+    public void test_clusterVersionListener_invokedOnRegistration()
+            throws UnknownHostException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        ClusterVersionListener listener = new ClusterVersionListener() {
+            @Override
+            public void onClusterVersionChange(Version newVersion) {
+                latch.countDown();
+            }
+        };
+        assertTrue(nodeExtension.registerListener(listener));
+        assertOpenEventually(latch);
+    }
+
+    @Test
+    public void test_listenerNotRegistered_whenUnknownType()
+            throws UnknownHostException {
+        assertFalse(nodeExtension.registerListener(new Object()));
+    }
+
+    @Test
+    public void test_listenerHazelcastInstanceInjected_whenHazelcastInstanceAware() {
+        HazelcastInstanceAwareVersionListener listener = new HazelcastInstanceAwareVersionListener();
+        assertTrue(nodeExtension.registerListener(listener));
+        assertEquals(hazelcastInstance, listener.getInstance());
+    }
+
+    @Test
+    public void test_clusterVersionListener_invokedWithNodeCodebaseVersion_whenClusterVersionIsNull()
+            throws UnknownHostException, NoSuchFieldException, IllegalAccessException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicBoolean failed = new AtomicBoolean(false);
+        ClusterVersionListener listener = new ClusterVersionListener() {
+            @Override
+            public void onClusterVersionChange(Version newVersion) {
+                if (!newVersion.equals(node.getVersion())) {
+                    failed.set(true);
+                }
+                latch.countDown();
+            }
+        };
+        nullifyClusterVersionAndVerifyListener(latch, failed, listener);
+    }
+
+    @Test
+    public void test_clusterVersionListener_invokedWithOverriddenPropertyValue_whenClusterVersionIsNull()
+            throws UnknownHostException, NoSuchFieldException, IllegalAccessException {
+        // override initial cluster version
+        System.setProperty(GroupProperty.INIT_CLUSTER_VERSION.getName(), "2.1.7");
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicBoolean failed = new AtomicBoolean(false);
+        ClusterVersionListener listener = new ClusterVersionListener() {
+            @Override
+            public void onClusterVersionChange(Version newVersion) {
+                if (!newVersion.equals(Version.of("2.1.7"))) {
+                    failed.set(true);
+                }
+                latch.countDown();
+            }
+        };
+        nullifyClusterVersionAndVerifyListener(latch, failed, listener);
+        System.clearProperty(GroupProperty.INIT_CLUSTER_VERSION.getName());
+    }
+
+    private void nullifyClusterVersionAndVerifyListener(CountDownLatch latch, AtomicBoolean failed,
+                                                        ClusterVersionListener listener)
+            throws NoSuchFieldException, IllegalAccessException {
+        // directly set clusterVersion field's value to null
+        Field setClusterVersionMethod = ClusterStateManager.class.getDeclaredField("clusterVersion");
+        setClusterVersionMethod.setAccessible(true);
+        setClusterVersionMethod.set(node.getClusterService().getClusterStateManager(), null);
+        // register listener and assert it's successful
+        assertTrue(nodeExtension.registerListener(listener));
+        // listener was executed
+        assertOpenEventually(latch);
+        // clusterVersion field's value was actually null
+        assertNull(node.getClusterService().getClusterStateManager().getClusterVersion());
+        // listener received node's codebase version as new cluster version
+        assertFalse(failed.get());
+    }
+
+    public static class HazelcastInstanceAwareVersionListener implements ClusterVersionListener, HazelcastInstanceAware {
+
+        private HazelcastInstance instance;
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            instance = hazelcastInstance;
+        }
+
+        @Override
+        public void onClusterVersionChange(Version newVersion) {
+
+        }
+
+        public HazelcastInstance getInstance() {
+            return instance;
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
@@ -6,6 +6,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withLocalMember_isTrue() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
 
         assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
@@ -49,7 +50,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withLocalMember_isFalse() {
-        MemberImpl member = new MemberImpl(address, false);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), false);
 
         assertBasicMemberImplFields(member);
         assertFalse(member.localMember());
@@ -57,7 +58,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withLiteMember_isTrue() {
-        MemberImpl member = new MemberImpl(address, true, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true, true);
 
         assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
@@ -66,7 +67,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withLiteMember_isFalse() {
-        MemberImpl member = new MemberImpl(address, true, false);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true, false);
 
         assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
@@ -75,7 +76,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withHazelcastInstance() throws Exception {
-        MemberImpl member = new MemberImpl(address, true, "uuid2342", hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true, "uuid2342", hazelcastInstance);
 
         assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
@@ -88,7 +89,7 @@ public class MemberImplTest extends HazelcastTestSupport {
         attributes.put("key1", "value");
         attributes.put("key2", 12345);
 
-        MemberImpl member = new MemberImpl(address, true, "uuid2342", hazelcastInstance, attributes, false);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true, "uuid2342", hazelcastInstance, attributes, false);
 
         assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
@@ -100,7 +101,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withMemberImpl() {
-        MemberImpl member = new MemberImpl(new MemberImpl(address, true));
+        MemberImpl member = new MemberImpl(new MemberImpl(address, Version.of("3.8.0"), true));
 
         assertBasicMemberImplFields(member);
         assertTrue(member.localMember());
@@ -108,7 +109,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testSetHazelcastInstance() throws Exception {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getLogger());
 
         member.setHazelcastInstance(hazelcastInstance);
@@ -118,7 +119,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testStringAttribute() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getStringAttribute("stringKey"));
 
         member.setStringAttribute("stringKey", "stringValue");
@@ -127,7 +128,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testBooleanAttribute() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getBooleanAttribute("booleanKeyTrue"));
         assertNull(member.getBooleanAttribute("booleanKeyFalse"));
 
@@ -140,7 +141,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testByteAttribute() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getByteAttribute("byteKey"));
 
         Byte value = Byte.MAX_VALUE;
@@ -150,7 +151,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testShortAttribute() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getShortAttribute("shortKey"));
 
         Short value = Short.MAX_VALUE;
@@ -160,7 +161,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testIntAttribute() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getIntAttribute("intKey"));
 
         Integer value = Integer.MAX_VALUE;
@@ -170,7 +171,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testLongAttribute() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getLongAttribute("longKey"));
 
         Long value = Long.MAX_VALUE;
@@ -180,7 +181,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testFloatAttribute() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getFloatAttribute("floatKey"));
 
         Float value = Float.MAX_VALUE;
@@ -190,7 +191,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testDoubleAttribute() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getDoubleAttribute("doubleKey"));
 
         Double value = Double.MAX_VALUE;
@@ -200,7 +201,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testRemoveAttribute() {
-        MemberImpl member = new MemberImpl(address, true);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true);
         assertNull(member.getStringAttribute("removeKey"));
 
         member.setStringAttribute("removeKey", "removeValue");
@@ -212,7 +213,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testRemoveAttribute_withHazelcastInstance() {
-        MemberImpl member = new MemberImpl(address, true, "uuid", hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true, "uuid", hazelcastInstance);
 
         member.removeAttribute("removeKeyWithInstance");
         assertNull(member.getStringAttribute("removeKeyWithInstance"));
@@ -220,7 +221,7 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testSetAttribute_withHazelcastInstance() {
-        MemberImpl member = new MemberImpl(address, true, "uuid", hazelcastInstance);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), true, "uuid", hazelcastInstance);
 
         member.setStringAttribute("setKeyWithInstance", "setValueWithInstance");
         assertEquals("setValueWithInstance", member.getStringAttribute("setKeyWithInstance"));
@@ -228,13 +229,13 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testRemoveAttribute_onRemoteMember() {
-        MemberImpl member = new MemberImpl(address, false);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), false);
         member.removeAttribute("remoteMemberRemove");
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testSetAttribute_onRemoteMember() {
-        MemberImpl member = new MemberImpl(address, false);
+        MemberImpl member = new MemberImpl(address, Version.of("3.8.0"), false);
         member.setStringAttribute("remoteMemberSet", "wontWork");
     }
 
@@ -244,5 +245,9 @@ public class MemberImplTest extends HazelcastTestSupport {
         assertEquals("127.0.0.1", member.getInetAddress().getHostAddress());
         assertTrue(member.getFactoryId() > -1);
         assertTrue(member.getId() > -1);
+        assertNotNull(member.getVersion());
+        assertEquals(3, member.getVersion().getMajor());
+        assertEquals(8, member.getVersion().getMinor());
+        assertEquals(0, member.getVersion().getPatch());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -30,16 +31,18 @@ public class SimpleMemberImpl implements Member {
     private String uuid;
     private InetSocketAddress address;
     private boolean liteMember;
+    private Version version;
 
     @SuppressWarnings("unused")
     public SimpleMemberImpl() {
     }
 
-    public SimpleMemberImpl(String uuid, InetSocketAddress address) {
-        this(uuid, address, false);
+    public SimpleMemberImpl(Version version, String uuid, InetSocketAddress address) {
+        this(version, uuid, address, false);
     }
 
-    public SimpleMemberImpl(String uuid, InetSocketAddress address, boolean liteMember) {
+    public SimpleMemberImpl(Version version, String uuid, InetSocketAddress address, boolean liteMember) {
+        this.version = version;
         this.uuid = uuid;
         this.address = address;
         this.liteMember = liteMember;
@@ -157,7 +160,13 @@ public class SimpleMemberImpl implements Member {
     }
 
     @Override
+    public Version getVersion() {
+        return null;
+    }
+
+    @Override
     public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(version);
         out.writeUTF(uuid);
         out.writeObject(address);
         out.writeBoolean(liteMember);
@@ -165,6 +174,7 @@ public class SimpleMemberImpl implements Member {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
+        version = in.readObject();
         uuid = in.readUTF();
         address = in.readObject();
         liteMember = in.readBoolean();

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
@@ -6,11 +6,13 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.version.Version;
 import com.hazelcast.wan.WanReplicationService;
 
 import java.net.UnknownHostException;
 import java.nio.channels.ServerSocketChannel;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,6 +45,8 @@ public class TestNodeContext implements NodeContext {
         when(nodeExtension.createService(ICacheService.class)).thenReturn(mock(ICacheService.class));
         when(nodeExtension.createService(WanReplicationService.class)).thenReturn(mock(WanReplicationService.class));
         when(nodeExtension.createSerializationService()).thenReturn(new DefaultSerializationServiceBuilder().build());
+        when(nodeExtension.isStartCompleted()).thenReturn(true);
+        when(nodeExtension.isNodeVersionCompatibleWith(any(Version.class))).thenReturn(true);
         return nodeExtension;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -136,7 +136,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
         long timeoutInMillis = TimeUnit.SECONDS.toMillis(60);
         ClusterStateManager clusterStateManager = node.clusterService.getClusterStateManager();
-        clusterStateManager.lockClusterState(ClusterState.FROZEN, node.getThisAddress(), "fakeTxn", timeoutInMillis, partitionStateVersion);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(ClusterState.FROZEN), node.getThisAddress(), "fakeTxn", timeoutInMillis, partitionStateVersion);
     }
 
     @Test
@@ -638,13 +638,15 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
     private void changeClusterState(HazelcastInstance instance, ClusterState newState, Collection<Member> members) {
         int partitionStateVersion = getNode(instance).getPartitionService().getPartitionStateVersion();
         ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(instance);
-        clusterService.getClusterStateManager().changeClusterState(newState, members, partitionStateVersion, false);
+        clusterService.getClusterStateManager().changeClusterState(ClusterStateChange.from(newState), members,
+                partitionStateVersion, false);
     }
 
     private void changeClusterState(HazelcastInstance instance, ClusterState newState, int partitionStateVersion) {
         ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(instance);
         Set<Member> members = clusterService.getMembers();
-        clusterService.getClusterStateManager().changeClusterState(newState, members, partitionStateVersion, false);
+        clusterService.getClusterStateManager().changeClusterState(ClusterStateChange.from(newState), members,
+                partitionStateVersion, false);
     }
 
     private static TransactionManagerServiceImpl spyTransactionManagerService(HazelcastInstance hz) throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
@@ -1,0 +1,106 @@
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.internal.cluster.MemberInfo;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.hazelcast.instance.BuildInfoProvider.BUILD_INFO;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClusterDataSerializationTest {
+
+    private static final SerializationService SERIALIZATION_SERVICE = new DefaultSerializationServiceBuilder().build();
+    private static final ClusterStateChange<Version> VERSION_CLUSTER_STATE_CHANGE = ClusterStateChange.from(Version.of(
+            BUILD_INFO.getVersion()));
+    private static final ClusterStateChange<ClusterState> CLUSTER_STATE_CHANGE = ClusterStateChange.from(ClusterState.FROZEN);
+
+
+    @Test
+    public void testSerializationOf_clusterStateChange_fromVersion() {
+        Data serialized = SERIALIZATION_SERVICE.toData(VERSION_CLUSTER_STATE_CHANGE);
+        ClusterStateChange deserialized = SERIALIZATION_SERVICE.toObject(serialized);
+        assertEquals(VERSION_CLUSTER_STATE_CHANGE, deserialized);
+    }
+
+    @Test
+    public void testSerializationOf_clusterStateChange_fromClusterState() {
+        Data serialized = SERIALIZATION_SERVICE.toData(CLUSTER_STATE_CHANGE);
+        ClusterStateChange deserialized = SERIALIZATION_SERVICE.toObject(serialized);
+        assertEquals(CLUSTER_STATE_CHANGE, deserialized);
+    }
+
+    @Test
+    public void testSerializationOf_clusterStateChangeTxnLogRecord_whenVersionChange() throws UnknownHostException {
+        ClusterStateTransactionLogRecord txnLogRecord = new ClusterStateTransactionLogRecord(VERSION_CLUSTER_STATE_CHANGE,
+                new Address("127.0.0.1", 5071), new Address("127.0.0.1", 5702), UUID.randomUUID().toString(), 120, 130, false);
+
+        Data serialized = SERIALIZATION_SERVICE.toData(txnLogRecord);
+
+        ClusterStateTransactionLogRecord deserialized = SERIALIZATION_SERVICE.toObject(serialized);
+        assertEquals(txnLogRecord.stateChange, deserialized.stateChange);
+        assertEquals(txnLogRecord.initiator, deserialized.initiator);
+        assertEquals(txnLogRecord.target, deserialized.target);
+        assertEquals(txnLogRecord.txnId, deserialized.txnId);
+        assertEquals(txnLogRecord.leaseTime, deserialized.leaseTime);
+        assertEquals(txnLogRecord.isTransient, deserialized.isTransient);
+        assertEquals(txnLogRecord.partitionStateVersion, deserialized.partitionStateVersion);
+    }
+
+    @Test
+    public void testSerializationOf_clusterStateChangeTxnLogRecord_whenStateChange() throws UnknownHostException {
+        ClusterStateTransactionLogRecord txnLogRecord = new ClusterStateTransactionLogRecord(CLUSTER_STATE_CHANGE,
+                new Address("127.0.0.1", 5071), new Address("127.0.0.1", 5702), UUID.randomUUID().toString(), 120, 130, false);
+
+        Data serialized = SERIALIZATION_SERVICE.toData(txnLogRecord);
+
+        ClusterStateTransactionLogRecord deserialized = SERIALIZATION_SERVICE.toObject(serialized);
+        assertEquals(txnLogRecord.stateChange, deserialized.stateChange);
+        assertEquals(txnLogRecord.initiator, deserialized.initiator);
+        assertEquals(txnLogRecord.target, deserialized.target);
+        assertEquals(txnLogRecord.txnId, deserialized.txnId);
+        assertEquals(txnLogRecord.leaseTime, deserialized.leaseTime);
+        assertEquals(txnLogRecord.isTransient, deserialized.isTransient);
+        assertEquals(txnLogRecord.partitionStateVersion, deserialized.partitionStateVersion);
+    }
+
+    @Test
+    public void testSerializationOf_memberInfo() throws UnknownHostException {
+        // member attributes, test an integer, a String and an IdentifiedDataSerializable as values
+        Map<String, Object> attributes = new HashMap<String, Object>();
+        attributes.put("a", 2);
+        attributes.put("b", "b");
+        attributes.put("c", new Address("127.0.0.1", 5999));
+        MemberInfo memberInfo = new MemberInfo(new Address("127.0.0.1", 5071), UUID.randomUUID().toString(), attributes,
+                false, Version.of(BUILD_INFO.getVersion()));
+
+        Data serialized = SERIALIZATION_SERVICE.toData(memberInfo);
+
+        MemberInfo deserialized = SERIALIZATION_SERVICE.toObject(serialized);
+        assertEquals(deserialized.getAddress(), memberInfo.getAddress());
+        assertEquals(deserialized.getVersion(), memberInfo.getVersion());
+        assertEquals(deserialized.getUuid(), memberInfo.getUuid());
+        assertEquals(deserialized.getAttributes().get("a"), memberInfo.getAttributes().get("a"));
+        assertEquals(deserialized.getAttributes().get("b"), memberInfo.getAttributes().get("b"));
+        assertEquals(deserialized.getAttributes().get("c"), memberInfo.getAttributes().get("c"));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl;
 
-import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.partition.InternalPartitionService;
@@ -28,10 +28,12 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.util.Clock;
+import com.hazelcast.version.Version;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -57,6 +59,7 @@ public class ClusterStateManagerTest {
 
     private static final String TXN = "txn";
     private static final String ANOTHER_TXN = "another-txn";
+    private static final Version CURRENT_NODE_VERSION = Version.of(BuildInfoProvider.getBuildInfo().getVersion());
 
     private final Node node = mock(Node.class);
     private final InternalPartitionService partitionService = mock(InternalPartitionService.class);
@@ -69,11 +72,13 @@ public class ClusterStateManagerTest {
     public void setup() {
         NodeExtension nodeExtension = mock(NodeExtension.class);
         when(nodeExtension.isStartCompleted()).thenReturn(true);
+        when(nodeExtension.isNodeVersionCompatibleWith(Matchers.any(Version.class))).thenReturn(true);
 
         when(node.getPartitionService()).thenReturn(partitionService);
         when(node.getClusterService()).thenReturn(clusterService);
         when(node.getNodeExtension()).thenReturn(nodeExtension);
         when(node.getLogger(ClusterStateManager.class)).thenReturn(mock(ILogger.class));
+        when(node.getVersion()).thenReturn(CURRENT_NODE_VERSION);
 
         clusterStateManager = new ClusterStateManager(node, lock);
     }
@@ -85,28 +90,32 @@ public class ClusterStateManagerTest {
 
     @Test
     public void test_initialClusterState_ACTIVE() {
-        clusterStateManager.initialClusterState(ACTIVE);
+        clusterStateManager.initialClusterState(ACTIVE, CURRENT_NODE_VERSION);
         assertEquals(ACTIVE, clusterStateManager.getState());
+        assertEquals(CURRENT_NODE_VERSION, clusterStateManager.getClusterVersion());
     }
 
     @Test
     public void test_initialClusterState_FROZEN() {
-        clusterStateManager.initialClusterState(FROZEN);
+        clusterStateManager.initialClusterState(FROZEN, CURRENT_NODE_VERSION);
         assertEquals(FROZEN, clusterStateManager.getState());
+        assertEquals(CURRENT_NODE_VERSION, clusterStateManager.getClusterVersion());
     }
 
     @Test
     public void test_initialClusterState_PASSIVE() {
-        clusterStateManager.initialClusterState(PASSIVE);
+        clusterStateManager.initialClusterState(PASSIVE, CURRENT_NODE_VERSION);
         assertEquals(PASSIVE, clusterStateManager.getState());
+        assertEquals(CURRENT_NODE_VERSION, clusterStateManager.getClusterVersion());
     }
 
     @Test
     public void test_initialClusterState_rejected() {
-        clusterStateManager.initialClusterState(FROZEN);
+        clusterStateManager.initialClusterState(FROZEN, CURRENT_NODE_VERSION);
+        clusterStateManager.initialClusterState(ACTIVE, CURRENT_NODE_VERSION);
 
-        clusterStateManager.initialClusterState(ACTIVE);
         assertEquals(FROZEN, clusterStateManager.getState());
+        assertEquals(CURRENT_NODE_VERSION, clusterStateManager.getClusterVersion());
     }
 
     @Test(expected = NullPointerException.class)
@@ -117,26 +126,25 @@ public class ClusterStateManagerTest {
 
     @Test(expected = NullPointerException.class)
     public void test_lockClusterState_nullInitiator() throws Exception {
-        clusterStateManager.lockClusterState(FROZEN, null, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), null, TXN, 1000, 0);
     }
 
     @Test(expected = NullPointerException.class)
     public void test_lockClusterState_nullTransactionId() throws Exception {
         Address initiator = newAddress();
-        clusterStateManager.lockClusterState(FROZEN, initiator, null, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, null, 1000, 0);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_lockClusterState_nonPositiveLeaseTime() throws Exception {
         Address initiator = newAddress();
-        clusterStateManager.lockClusterState(FROZEN, initiator, TXN, -1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, -1000, 0);
     }
 
     @Test
     public void test_lockClusterState_success() throws Exception {
         Address initiator = newAddress();
-        final ClusterState newState = FROZEN;
-        clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 1000, 0);
 
         assertLockedBy(initiator);
     }
@@ -144,7 +152,7 @@ public class ClusterStateManagerTest {
     @Test(expected = TransactionException.class)
     public void test_lockClusterState_fail() throws Exception {
         Address initiator = newAddress();
-        final ClusterState newState = FROZEN;
+        final ClusterStateChange newState = ClusterStateChange.from(FROZEN);
         clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
 
         clusterStateManager.lockClusterState(newState, initiator, ANOTHER_TXN, 1000, 0);
@@ -155,17 +163,16 @@ public class ClusterStateManagerTest {
         when(partitionService.hasOnGoingMigrationLocal()).thenReturn(true);
 
         Address initiator = newAddress();
-        final ClusterState newState = FROZEN;
-        clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 1000, 0);
     }
 
     @Test(expected = IllegalStateException.class)
     public void test_lockClusterState_forActiveState_whenHasOnGoingMigration() throws Exception {
         when(partitionService.hasOnGoingMigrationLocal()).thenReturn(true);
-        clusterStateManager.initialClusterState(FROZEN);
+        clusterStateManager.initialClusterState(FROZEN, CURRENT_NODE_VERSION);
 
         Address initiator = newAddress();
-        final ClusterState newState = ACTIVE;
+        final ClusterStateChange newState = ClusterStateChange.from(ACTIVE);
         clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
 
         assertLockedBy(initiator);
@@ -174,10 +181,10 @@ public class ClusterStateManagerTest {
     @Test(expected = IllegalStateException.class)
     public void test_lockClusterState_forPassiveState_whenHasOnGoingMigration() throws Exception {
         when(partitionService.hasOnGoingMigrationLocal()).thenReturn(true);
-        clusterStateManager.initialClusterState(FROZEN);
+        clusterStateManager.initialClusterState(FROZEN, CURRENT_NODE_VERSION);
 
         Address initiator = newAddress();
-        final ClusterState newState = PASSIVE;
+        final ClusterStateChange newState = ClusterStateChange.from(PASSIVE);
         clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
 
         assertLockedBy(initiator);
@@ -195,25 +202,25 @@ public class ClusterStateManagerTest {
 
     @Test
     public void test_unlockClusterState_fail_whenLockedByElse() throws Exception {
-        clusterStateManager.lockClusterState(FROZEN, newAddress(), TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, 0);
         assertFalse(clusterStateManager.rollbackClusterState(ANOTHER_TXN));
     }
 
     @Test(expected = IllegalStateException.class)
     public void test_lockClusterState_fail_withDifferentPartitionStateVersions() throws Exception {
-        clusterStateManager.lockClusterState(FROZEN, newAddress(), TXN, 1000, 1);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, 1);
     }
 
     @Test
     public void test_unlockClusterState_success() throws Exception {
-        clusterStateManager.lockClusterState(FROZEN, newAddress(), TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, 0);
         assertTrue(clusterStateManager.rollbackClusterState(TXN));
     }
 
     @Test
     public void test_lockClusterState_getLockExpiryTime() throws Exception {
         final Address initiator = newAddress();
-        clusterStateManager.lockClusterState(FROZEN, initiator, TXN, TimeUnit.DAYS.toMillis(1), 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, TimeUnit.DAYS.toMillis(1), 0);
 
         final ClusterStateLock stateLock = clusterStateManager.getStateLock();
         assertTrue(Clock.currentTimeMillis() + TimeUnit.HOURS.toMillis(12) < stateLock.getLockExpiryTime());
@@ -222,8 +229,8 @@ public class ClusterStateManagerTest {
     @Test
     public void test_lockClusterState_extendLease() throws Exception {
         final Address initiator = newAddress();
-        clusterStateManager.lockClusterState(FROZEN, initiator, TXN, 10000, 0);
-        clusterStateManager.lockClusterState(FROZEN, initiator, TXN, TimeUnit.DAYS.toMillis(1), 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 10000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, TimeUnit.DAYS.toMillis(1), 0);
 
         final ClusterStateLock stateLock = clusterStateManager.getStateLock();
         assertTrue(Clock.currentTimeMillis() + TimeUnit.HOURS.toMillis(12) < stateLock.getLockExpiryTime());
@@ -239,7 +246,7 @@ public class ClusterStateManagerTest {
 
     @Test
     public void test_lockClusterState_expiry() throws Exception {
-        clusterStateManager.lockClusterState(FROZEN, newAddress(), TXN, 1, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1, 0);
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -257,58 +264,58 @@ public class ClusterStateManagerTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_changeLocalClusterState_IN_TRANSITION() throws Exception {
-        clusterStateManager.commitClusterState(IN_TRANSITION, newAddress(), TXN);
+        clusterStateManager.commitClusterState(ClusterStateChange.from(IN_TRANSITION), newAddress(), TXN);
     }
 
     @Test(expected = NullPointerException.class)
     public void test_changeLocalClusterState_nullTransactionId() throws Exception {
-        clusterStateManager.commitClusterState(FROZEN, newAddress(), null);
+        clusterStateManager.commitClusterState(ClusterStateChange.from(FROZEN), newAddress(), null);
     }
 
     @Test(expected = TransactionException.class)
     public void test_changeLocalClusterState_fail_notLocked() throws Exception {
-        clusterStateManager.commitClusterState(FROZEN, newAddress(), TXN);
+        clusterStateManager.commitClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN);
     }
 
     @Test(expected = TransactionException.class)
     public void test_changeLocalClusterState_fail_whenLockedByElse() throws Exception {
         final Address initiator = newAddress();
-        clusterStateManager.lockClusterState(FROZEN, initiator, TXN, 10000, 0);
-        clusterStateManager.commitClusterState(FROZEN, initiator, ANOTHER_TXN);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 10000, 0);
+        clusterStateManager.commitClusterState(ClusterStateChange.from(FROZEN), initiator, ANOTHER_TXN);
     }
 
     @Test
     public void test_changeLocalClusterState_success() throws Exception {
-        final ClusterState newState = FROZEN;
+        final ClusterStateChange newState = ClusterStateChange.from(FROZEN);
         final Address initiator = newAddress();
         clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, 0);
         clusterStateManager.commitClusterState(newState, initiator, TXN);
 
-        assertEquals(newState, clusterStateManager.getState());
+        assertEquals(newState.getNewState(), clusterStateManager.getState());
         final ClusterStateLock stateLock = clusterStateManager.getStateLock();
         assertFalse(stateLock.isLocked());
     }
 
     @Test
     public void changeLocalClusterState_shouldChangeNodeStateToShuttingDown_whenStateBecomes_PASSIVE() throws Exception {
-        final ClusterState newState = PASSIVE;
+        final ClusterStateChange newState = ClusterStateChange.from(PASSIVE);
         final Address initiator = newAddress();
         clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, 0);
         clusterStateManager.commitClusterState(newState, initiator, TXN);
 
-        assertEquals(newState, clusterStateManager.getState());
+        assertEquals(newState.getNewState(), clusterStateManager.getState());
         verify(node, times(1)).changeNodeStateToPassive();
     }
 
     @Test
     public void changeLocalClusterState_shouldRemoveMembersDeadWhileFrozen_whenStateBecomes_ACTIVE() throws Exception {
-        final ClusterState newState = ACTIVE;
+        final ClusterStateChange newState = ClusterStateChange.from(ACTIVE);
         final Address initiator = newAddress();
-        clusterStateManager.initialClusterState(FROZEN);
+        clusterStateManager.initialClusterState(FROZEN, CURRENT_NODE_VERSION);
         clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, 0);
         clusterStateManager.commitClusterState(newState, initiator, TXN);
 
-        assertEquals(newState, clusterStateManager.getState());
+        assertEquals(newState.getNewState(), clusterStateManager.getState());
         verify(clusterService, times(1)).removeMembersDeadWhileClusterIsNotActive();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionChangeTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.cluster.ClusterVersionListener;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Test cluster version transitions
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClusterVersionChangeTest
+        extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private HazelcastInstance instance;
+    private ClusterServiceImpl cluster;
+    private CountDownLatch clusterVersionUpgradeLatch;
+    private Version codebaseVersion;
+
+    @Before
+    public void setup() {
+        instance = createHazelcastInstance();
+        cluster = (ClusterServiceImpl) instance.getCluster();
+        // expecting countdown twice: once upon listener registration, once more on version upgrade
+        clusterVersionUpgradeLatch = new CountDownLatch(2);
+        getNode(instance).getNodeExtension().registerListener(new ClusterVersionChangedListener(clusterVersionUpgradeLatch));
+        codebaseVersion = getNode(instance).getVersion();
+    }
+
+    @Test
+    public void test_clusterVersionUpgradeSucceeds_whenNodePatchVersionPlusOne() {
+        final Version newVersion = new Version(codebaseVersion.getMajor(), codebaseVersion.getMinor(),
+                codebaseVersion.getPatch()+1);
+        cluster.changeClusterVersion(newVersion);
+        assertOpenEventually(clusterVersionUpgradeLatch);
+    }
+
+    @Test
+    public void test_clusterVersionUpgradeFails_whenNodeMajorVersionPlusOne() {
+        Version newVersion = new Version(codebaseVersion.getMajor()+1, codebaseVersion.getMinor(), codebaseVersion.getPatch());
+
+        expectedException.expect(VersionMismatchException.class);
+        cluster.changeClusterVersion(newVersion);
+    }
+
+    @Test
+    public void test_clusterVersionUpgradeFails_whenNodeMinorVersionPlusOne() {
+        Version newVersion = new Version(codebaseVersion.getMajor(), codebaseVersion.getMinor()+1, codebaseVersion.getPatch());
+
+        expectedException.expect(VersionMismatchException.class);
+        cluster.changeClusterVersion(newVersion);
+    }
+
+    public static class ClusterVersionChangedListener implements ClusterVersionListener {
+        private final CountDownLatch latch;
+
+        public ClusterVersionChangedListener(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public void onClusterVersionChange(Version newVersion) {
+            latch.countDown();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterVersionTest.java
@@ -1,0 +1,124 @@
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClusterVersionTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private HazelcastInstance instance;
+    private ClusterServiceImpl cluster;
+    private Version codebaseVersion;
+
+    @Test
+    public void test_clusterVersion_isEventuallySet_whenSingleNodeMulticastJoinerCluster() {
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(true);
+        setupInstance(config);
+        assertEqualsEventually(new Callable<Version>() {
+            @Override
+            public Version call()
+                    throws Exception {
+                return cluster.getClusterVersion();
+            }
+        }, codebaseVersion);
+    }
+
+    @Test
+    public void test_clusterVersion_isEventuallySet_whenNoJoinerConfiguredSingleNode() {
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
+        setupInstance(config);
+        assertEqualsEventually(new Callable<Version>() {
+            @Override
+            public Version call()
+                    throws Exception {
+                return cluster.getClusterVersion();
+            }
+        }, codebaseVersion);
+    }
+
+    @Test
+    public void test_clusterVersion_isEventuallySet_whenTcpJoinerConfiguredSingleNode() {
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
+        setupInstance(config);
+        assertEqualsEventually(new Callable<Version>() {
+            @Override
+            public Version call()
+                    throws Exception {
+                return cluster.getClusterVersion();
+            }
+        }, codebaseVersion);
+    }
+
+    @Test
+    public void test_clusterVersion_isEventuallySetOnJoiningMember_whenMulticastJoinerConfigured() {
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(true);
+        setupInstance(config);
+        HazelcastInstance joiner = Hazelcast.newHazelcastInstance(config);
+        final ClusterServiceImpl joinerCluster = (ClusterServiceImpl) joiner.getCluster();
+
+        assertEqualsEventually(new Callable<Version>() {
+            @Override
+            public Version call()
+                    throws Exception {
+                return joinerCluster.getClusterVersion();
+            }
+        }, codebaseVersion);
+
+        joiner.shutdown();
+    }
+
+    @Test
+    public void test_clusterVersion_isEventuallySetOnJoiningMember_whenTcpJoinerConfigured() {
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
+        setupInstance(config);
+        HazelcastInstance joiner = Hazelcast.newHazelcastInstance(config);
+        final ClusterServiceImpl joinerCluster = (ClusterServiceImpl) joiner.getCluster();
+
+        assertEqualsEventually(new Callable<Version>() {
+            @Override
+            public Version call()
+                    throws Exception {
+                return joinerCluster.getClusterVersion();
+            }
+        }, codebaseVersion);
+
+        joiner.shutdown();
+    }
+
+    private void setupInstance(Config config) {
+        instance = Hazelcast.newHazelcastInstance(config);
+        cluster = (ClusterServiceImpl) instance.getCluster();
+        codebaseVersion = getNode(instance).getVersion();
+    }
+
+    @After
+    public void tearDown() {
+        instance.shutdown();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberMapTest.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.internal.cluster.impl;
 
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -41,6 +43,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class MemberMapTest {
+
+    private static final Version VERSION = Version.of(BuildInfoProvider.BUILD_INFO.getVersion());
 
     @Test
     public void createEmpty() throws Exception {
@@ -106,7 +110,7 @@ public class MemberMapTest {
     @Test(expected = IllegalArgumentException.class)
     public void create_failsWithDuplicateUuid() throws Exception {
         MemberImpl member1 = newMember(5000);
-        MemberImpl member2 = new MemberImpl(newAddress(5001), false, member1.getUuid(), null);
+        MemberImpl member2 = new MemberImpl(newAddress(5001), VERSION, false, member1.getUuid(), null);
         MemberMap.createNew(member1, member2);
     }
 
@@ -118,8 +122,8 @@ public class MemberMapTest {
         }
 
         MemberImpl exclude0 = members[0];
-        MemberImpl exclude1 = new MemberImpl(newAddress(6000), false, members[1].getUuid(), null);
-        MemberImpl exclude2 = new MemberImpl(members[2].getAddress(), false, newUnsecureUuidString(), null);
+        MemberImpl exclude1 = new MemberImpl(newAddress(6000), VERSION, false, members[1].getUuid(), null);
+        MemberImpl exclude2 = new MemberImpl(members[2].getAddress(), VERSION, false, newUnsecureUuidString(), null);
 
         MemberMap map = MemberMap.cloneExcluding(MemberMap.createNew(members), exclude0, exclude1, exclude2);
 
@@ -198,7 +202,7 @@ public class MemberMapTest {
             members[i] = newMember(5000 + i);
         }
 
-        MemberImpl member = new MemberImpl(newAddress(6000), false, members[1].getUuid(), null);
+        MemberImpl member = new MemberImpl(newAddress(6000), VERSION, false, members[1].getUuid(), null);
         MemberMap.cloneAdding(MemberMap.createNew(members), member);
     }
 
@@ -243,7 +247,7 @@ public class MemberMapTest {
     }
 
     private MemberImpl newMember(int port) throws UnknownHostException {
-        return new MemberImpl(newAddress(port), false, newUnsecureUuidString(), null);
+        return new MemberImpl(newAddress(port), VERSION, false, newUnsecureUuidString(), null);
     }
 
     private Address newAddress(int port) throws UnknownHostException {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollectionTest.java
@@ -7,6 +7,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -49,10 +50,10 @@ public class MemberSelectingCollectionTest {
     @Before
     public void before()
             throws Exception {
-        thisMember = new MemberImpl(new Address("localhost", 5701), true, true);
-        liteMember = new MemberImpl(new Address("localhost", 5702), false, true);
-        dataMember = new MemberImpl(new Address("localhost", 5704), false, false);
-        nonExistingMember = new MemberImpl(new Address("localhost", 5705), false, false);
+        thisMember = new MemberImpl(new Address("localhost", 5701), Version.of("3.8.0"), true, true);
+        liteMember = new MemberImpl(new Address("localhost", 5702), Version.of("3.8.0"), false, true);
+        dataMember = new MemberImpl(new Address("localhost", 5704), Version.of("3.8.0"), false, false);
+        nonExistingMember = new MemberImpl(new Address("localhost", 5705), Version.of("3.8.0"), false, false);
 
         members = createMembers();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberSelectingIteratorTest.java
@@ -1,10 +1,12 @@
 package com.hazelcast.internal.cluster.impl;
 
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,10 +40,11 @@ public class MemberSelectingIteratorTest {
     @Before
     public void before()
             throws Exception {
-        thisMember = new MemberImpl(new Address("localhost", 5701), true, true);
-        matchingMember = new MemberImpl(new Address("localhost", 5702), false, true);
-        matchingMember2 = new MemberImpl(new Address("localhost", 5703), false, true);
-        nonMatchingMember = new MemberImpl(new Address("localhost", 5704), false, false);
+        Version version = new Version(BuildInfoProvider.BUILD_INFO.getVersion());
+        thisMember = new MemberImpl(new Address("localhost", 5701), version, true, true);
+        matchingMember = new MemberImpl(new Address("localhost", 5702), version, false, true);
+        matchingMember2 = new MemberImpl(new Address("localhost", 5703), version, false, true);
+        nonMatchingMember = new MemberImpl(new Address("localhost", 5704), version, false, false);
     }
 
     private Set<MemberImpl> createMembers() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
@@ -20,10 +20,10 @@ import static org.junit.Assert.assertEquals;
 @Category(QuickTest.class)
 public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
 
-    private Config config;
-    private TestHazelcastInstanceFactory hzFactory;
-    private HazelcastInstance hz;
-    private SystemLogPlugin plugin;
+    protected Config config;
+    protected TestHazelcastInstanceFactory hzFactory;
+    protected HazelcastInstance hz;
+    protected SystemLogPlugin plugin;
 
     @Before
     public void setup() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.core.Member;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.PartitionStateGenerator;
@@ -35,6 +36,7 @@ import com.hazelcast.partition.membergroup.SingleMemberGroupFactory;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -60,6 +62,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class PartitionStateGeneratorTest {
 
+    private static final Version VERSION = Version.of(BuildInfoProvider.BUILD_INFO.getVersion());
     private static final boolean PRINT_STATE = false;
 
     @Test
@@ -262,7 +265,7 @@ public class PartitionStateGeneratorTest {
             count++;
             port++;
             MemberImpl m = new MemberImpl(new Address(InetAddress.getByAddress(new byte[]{ip[0], ip[1], ip[2], ip[3]})
-                    , port), false);
+                    , port), VERSION, false);
             members.add(m);
             if ((0xff & ip[3]) == 255) {
                 ip[2] = ++ip[2];
@@ -293,7 +296,7 @@ public class PartitionStateGeneratorTest {
                 set.add(owner);
                 MemberGroup group = null;
                 for (MemberGroup g : groups) {
-                    if (g.hasMember(new MemberImpl(owner, true))) {
+                    if (g.hasMember(new MemberImpl(owner, VERSION, true))) {
                         group = g;
                         break;
                     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -39,6 +39,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.UuidUtil;
+import com.hazelcast.version.Version;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -422,7 +423,7 @@ public class SerializationTest
         String host = "127.0.0.1";
         int port = 5000;
 
-        Member member = new MemberImpl(new Address(host, port), false, uuid, null);
+        Member member = new MemberImpl(new Address(host, port), Version.of("3.8.0"), false, uuid, null);
 
         testMemberLeftException(uuid, host, port, member);
     }
@@ -433,7 +434,7 @@ public class SerializationTest
         String host = "127.0.0.1";
         int port = 5000;
 
-        Member member = new SimpleMemberImpl(uuid, new InetSocketAddress(host, port));
+        Member member = new SimpleMemberImpl(Version.of("3.8.0"), uuid, new InetSocketAddress(host, port));
         testMemberLeftException(uuid, host, port, member);
     }
 
@@ -443,7 +444,7 @@ public class SerializationTest
         String host = "127.0.0.1";
         int port = 5000;
 
-        Member member = new MemberImpl(new Address(host, port), false, uuid, null, null, true);
+        Member member = new MemberImpl(new Address(host, port), Version.of("3.8.0"), false, uuid, null, null, true);
 
         testMemberLeftException(uuid, host, port, member);
     }
@@ -454,7 +455,7 @@ public class SerializationTest
         String host = "127.0.0.1";
         int port = 5000;
 
-        Member member = new SimpleMemberImpl(uuid, new InetSocketAddress(host, port), true);
+        Member member = new SimpleMemberImpl(Version.of("3.8.0"), uuid, new InetSocketAddress(host, port), true);
         testMemberLeftException(uuid, host, port, member);
     }
 
@@ -476,6 +477,7 @@ public class SerializationTest
         assertEquals(host, member2.getAddress().getHost());
         assertEquals(port, member2.getAddress().getPort());
         assertEquals(member.isLiteMember(), member2.isLiteMember());
+        assertEquals(member.getVersion(), member2.getVersion());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
@@ -2,11 +2,13 @@ package com.hazelcast.partition.membergroup;
 
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.core.Member;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.partitiongroup.PartitionGroupMetaData;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -21,6 +23,8 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class MemberGroupFactoryTest {
+
+    private static final Version VERSION = Version.of(BuildInfoProvider.BUILD_INFO.getVersion());
 
     @Test
     public void testHostAwareMemberGroupFactoryCreateMemberGroups() throws Exception {
@@ -98,35 +102,35 @@ public class MemberGroupFactoryTest {
     private Collection<Member> createMembers() throws UnknownHostException {
         Collection<Member> members = new HashSet<Member>();
         InetAddress fakeAddress = InetAddress.getLocalHost();
-        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5702), false));
-        members.add(new MemberImpl(new Address("192.168.3.101", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("192.168.3.101", fakeAddress, 5702), false));
-        members.add(new MemberImpl(new Address("172.16.5.11", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("172.16.5.11", fakeAddress, 5702), false));
-        members.add(new MemberImpl(new Address("172.123.0.13", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("172.123.0.13", fakeAddress, 5702), false));
-        members.add(new MemberImpl(new Address("www.hazelcast.com.tr", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("www.hazelcast.com.tr", fakeAddress, 5702), false));
-        members.add(new MemberImpl(new Address("jobs.hazelcast.com", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("jobs.hazelcast.com", fakeAddress, 5702), false));
-        members.add(new MemberImpl(new Address("www.hazelcast.org", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("www.hazelcast.org", fakeAddress, 5702), false));
-        members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5702), false));
+        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5702), VERSION, false));
+        members.add(new MemberImpl(new Address("192.168.3.101", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("192.168.3.101", fakeAddress, 5702), VERSION, false));
+        members.add(new MemberImpl(new Address("172.16.5.11", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("172.16.5.11", fakeAddress, 5702), VERSION, false));
+        members.add(new MemberImpl(new Address("172.123.0.13", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("172.123.0.13", fakeAddress, 5702), VERSION, false));
+        members.add(new MemberImpl(new Address("www.hazelcast.com.tr", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("www.hazelcast.com.tr", fakeAddress, 5702), VERSION, false));
+        members.add(new MemberImpl(new Address("jobs.hazelcast.com", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("jobs.hazelcast.com", fakeAddress, 5702), VERSION, false));
+        members.add(new MemberImpl(new Address("www.hazelcast.org", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("www.hazelcast.org", fakeAddress, 5702), VERSION, false));
+        members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5702), VERSION, false));
         return members;
     }
 
     private Collection<Member> createMembersWithZoneAwareMetadata() throws UnknownHostException {
         Collection<Member> members = new HashSet<Member>();
         InetAddress fakeAddress = InetAddress.getLocalHost();
-        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), true);
+        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
         member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "us-east-1");
 
-        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), true);
+        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
         member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "us-west-1");
 
-        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), true);
+        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
         member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "eu-central-1");
 
         members.add(member1);
@@ -138,13 +142,13 @@ public class MemberGroupFactoryTest {
     private Collection<Member> createMembersWithRackAwareMetadata() throws UnknownHostException {
         Collection<Member> members = new HashSet<Member>();
         InetAddress fakeAddress = InetAddress.getLocalHost();
-        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), true);
+        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
         member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-1");
 
-        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), true);
+        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
         member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-2");
 
-        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), true);
+        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
         member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-3");
 
         members.add(member1);
@@ -156,13 +160,13 @@ public class MemberGroupFactoryTest {
     private Collection<Member> createMembersWithHostAwareMetadata() throws UnknownHostException {
         Collection<Member> members = new HashSet<Member>();
         InetAddress fakeAddress = InetAddress.getLocalHost();
-        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), true);
+        MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
         member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-1");
 
-        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), true);
+        MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
         member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-2");
 
-        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), true);
+        MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
         member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-3");
 
         members.add(member1);
@@ -174,9 +178,9 @@ public class MemberGroupFactoryTest {
     private Collection<Member> createMembersWithNoMetadata() throws UnknownHostException {
         Collection<Member> members = new HashSet<Member>();
         InetAddress fakeAddress = InetAddress.getLocalHost();
-        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5702), false));
-        members.add(new MemberImpl(new Address("192.168.3.101", fakeAddress, 5701), false));
+        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5702), VERSION, false));
+        members.add(new MemberImpl(new Address("192.168.3.101", fakeAddress, 5701), VERSION, false));
         return members;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.config.properties.SimplePropertyDefinition;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.TestUtil;
@@ -53,6 +54,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -87,6 +89,7 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class DiscoverySpiTest extends HazelcastTestSupport {
 
+    private static final Version VERSION = Version.of(BuildInfoProvider.BUILD_INFO.getVersion());
     private static final ILogger LOGGER = Logger.getLogger(DiscoverySpiTest.class);
 
     @Test
@@ -567,10 +570,10 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
     private static Collection<Member> createMembers() throws UnknownHostException {
         Collection<Member> members = new HashSet<Member>();
         InetAddress fakeAddress = InetAddress.getLocalHost();
-        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), true));
-        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5702), false));
-        members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5701), false));
-        members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5702), false));
+        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true));
+        members.add(new MemberImpl(new Address("192.192.0.1", fakeAddress, 5702), VERSION, false));
+        members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5701), VERSION, false));
+        members.add(new MemberImpl(new Address("download.hazelcast.org", fakeAddress, 5702), VERSION, false));
         return members;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/TestClusterUpgradeUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestClusterUpgradeUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.version.Version;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.waitAllForSafeState;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Utilities for cluster upgrade tests: start cluster members at designated version, assert cluster verion etc
+ */
+public class TestClusterUpgradeUtils {
+
+    // return a new HazelcastInstance at given version
+    public static HazelcastInstance newHazelcastInstance(TestHazelcastInstanceFactory factory,
+                                                         Version version,
+                                                         Config config) {
+        try {
+            System.setProperty("hazelcast.version", version.toString());
+            return factory.newHazelcastInstance(config);
+        }
+        finally {
+            System.clearProperty("hazelcast.version");
+        }
+    }
+
+    // shutdown and replace each member in membersToUpgrade with a new HazelcastInstance at given version
+    public static void upgradeClusterMembers(TestHazelcastInstanceFactory factory, final HazelcastInstance[] membersToUpgrade,
+                                             Version version, Config config) {
+        try {
+            System.setProperty("hazelcast.version", version.toString());
+            // upgrade one by one each member of the cluster to the next version
+            for (int i = 0; i < membersToUpgrade.length; i++) {
+                membersToUpgrade[i].shutdown();
+                waitAllForSafeState(membersToUpgrade);
+                // if new node's version is incompatible, then node startup will fail with IllegalStateException
+                membersToUpgrade[i] = factory.newHazelcastInstance(config);
+                waitAllForSafeState(membersToUpgrade);
+                // assert all members are in the cluster
+                assertTrueEventually(new AssertTask() {
+                    @Override
+                    public void run()
+                            throws Exception {
+                        assertEquals(membersToUpgrade.length,
+                                membersToUpgrade[0].getCluster().getMembers().size());
+                    }
+                }, 15);
+            }
+        }
+        finally {
+            System.clearProperty("hazelcast.version");
+        }
+    }
+
+    // assert all members' clusterService reports the given version
+    public static void assertClusterVersion(HazelcastInstance[] clusterMembers, Version version) {
+        for (int i=0; i < clusterMembers.length; i++) {
+            assertEquals(version, clusterMembers[i].getCluster().getClusterVersion());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/version/VersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/VersionTest.java
@@ -1,0 +1,71 @@
+package com.hazelcast.version;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.version.Version.MAJOR_MINOR_VERSION_COMPARATOR;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class VersionTest {
+
+    static final String VERSION_3_8_SNAPSHOT_STRING = "3.8-SNAPSHOT";
+    static final String VERSION_3_8_1_RC1_STRING = "3.8.1-RC1";
+    static final String VERSION_3_8_2_STRING = "3.8.2";
+    static final String VERSION_3_9_0_STRING = "3.9.0";
+
+    static final Version VERSION_3_8 = Version.of(VERSION_3_8_SNAPSHOT_STRING);
+    static final Version VERSION_3_8_1 = Version.of(VERSION_3_8_1_RC1_STRING);
+    static final Version VERSION_3_8_2 = Version.of(VERSION_3_8_2_STRING);
+    static final Version VERSION_3_9 = Version.of(VERSION_3_9_0_STRING);
+
+    @Test
+    public void test_versionOf_whenVersionStringIsSnapshot() {
+        Version expected = Version.of(3, 8, 0);
+        assertEquals(expected, Version.of(VERSION_3_8_SNAPSHOT_STRING));
+    }
+
+    @Test
+    public void test_versionOf_whenVersionStringIsRC() {
+        Version expected = Version.of(3, 8, 1);
+        assertEquals(expected, Version.of(VERSION_3_8_1_RC1_STRING));
+    }
+
+    @Test
+    public void test_versionOf_whenVersionStringIsRelease() {
+        Version expected = Version.of(3, 8, 2);
+        assertEquals(expected, Version.of(VERSION_3_8_2_STRING));
+    }
+
+    @Test
+    public void testCompareTo() {
+        assertTrue(VERSION_3_8.compareTo(VERSION_3_8) == 0);
+        assertTrue(VERSION_3_8.compareTo(VERSION_3_8_1) < 0);
+        assertTrue(VERSION_3_8.compareTo(VERSION_3_8_2) < 0);
+        assertTrue(VERSION_3_8.compareTo(VERSION_3_9) < 0);
+
+        assertTrue(VERSION_3_9.compareTo(VERSION_3_8) > 0);
+        assertTrue(VERSION_3_9.compareTo(VERSION_3_8_1) > 0);
+        assertTrue(VERSION_3_9.compareTo(VERSION_3_8_2) > 0);
+    }
+
+    @Test
+    public void testMajorMinorVersionComparator() {
+        assertEquals(0, MAJOR_MINOR_VERSION_COMPARATOR.compare(VERSION_3_8, VERSION_3_8_1));
+        assertEquals(0, MAJOR_MINOR_VERSION_COMPARATOR.compare(VERSION_3_8, VERSION_3_8_2));
+        assertTrue(MAJOR_MINOR_VERSION_COMPARATOR.compare(VERSION_3_9, VERSION_3_8) > 0);
+        assertTrue(MAJOR_MINOR_VERSION_COMPARATOR.compare(VERSION_3_8, VERSION_3_9) < 0);
+        assertTrue(MAJOR_MINOR_VERSION_COMPARATOR.compare(VERSION_3_9, VERSION_3_8_1) > 0);
+        assertTrue(MAJOR_MINOR_VERSION_COMPARATOR.compare(VERSION_3_8_1, VERSION_3_9) < 0);
+    }
+
+}


### PR DESCRIPTION
Adds the notion of cluster version to `Cluster` and codebase version to `Node`. Main changes:
* Added cluster version & node version
* During node join, node version is validated for compatibility with current cluster version

Requires an EE counterpart.