### PR TITLE
Error in ClientHearbeatMonitor connection.close message

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -86,14 +86,14 @@ public class ClientHeartbeatMonitor implements Runnable {
         }
 
         final Connection connection = clientEndpoint.getConnection();
-        final long lastTimePackageReceived = connection.lastReadTimeMillis();
+        final long lastTimePacketReceived = connection.lastReadTimeMillis();
         final long timeoutInMillis = SECONDS.toMillis(heartbeatTimeoutSeconds);
         final long currentTimeMillis = Clock.currentTimeMillis();
-        if (lastTimePackageReceived + timeoutInMillis < currentTimeMillis) {
+        if (lastTimePacketReceived + timeoutInMillis < currentTimeMillis) {
             if (memberUuid.equals(clientEndpoint.getPrincipal().getOwnerUuid())) {
                 String message = "Client heartbeat is timed out, closing connection to " + connection
-                        + ". Now: " + timeToString(lastTimePackageReceived)
-                        + ". LastTimePacketReceived: " + timeToString(lastTimePackageReceived);
+                        + ". Now: " + timeToString(currentTimeMillis)
+                        + ". LastTimePacketReceived: " + timeToString(lastTimePacketReceived);
                 logger.log(Level.WARNING, message);
                 connection.close(message, null);
             }


### PR DESCRIPTION
The problem was that the lastPacketReceived time was used for now
instead of current time millis.