### PR TITLE
Configures ssl client with 3 threads

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -38,11 +38,17 @@ import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.spi.impl.ConnectionHeartbeatListener;
 import com.hazelcast.client.spi.impl.listener.ClientListenerServiceImpl;
+import com.hazelcast.client.spi.properties.ClientProperty;
+import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.HazelcastThreadGroup;
+import com.hazelcast.internal.networking.IOOutOfMemoryHandler;
+import com.hazelcast.internal.networking.SocketChannelWrapper;
+import com.hazelcast.internal.networking.SocketChannelWrapperFactory;
+import com.hazelcast.internal.networking.nonblocking.NonBlockingIOThreadingModel;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -50,10 +56,6 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.nio.SocketInterceptor;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.internal.networking.IOOutOfMemoryHandler;
-import com.hazelcast.internal.networking.SocketChannelWrapper;
-import com.hazelcast.internal.networking.SocketChannelWrapperFactory;
-import com.hazelcast.internal.networking.nonblocking.NonBlockingIOThreadingModel;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -85,6 +87,8 @@ import static com.hazelcast.spi.properties.GroupProperty.SOCKET_CLIENT_BUFFER_DI
  */
 @SuppressWarnings("checkstyle:classdataabstractioncoupling")
 public class ClientConnectionManagerImpl implements ClientConnectionManager {
+
+    private static final int DEFAULT_SSL_THREAD_COUNT = 3;
 
     protected final AtomicInteger connectionIdGen = new AtomicInteger();
 
@@ -150,16 +154,37 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     protected void initIOThreads(HazelcastClientInstanceImpl client) {
-        boolean directBuffer = client.getProperties().getBoolean(SOCKET_CLIENT_BUFFER_DIRECT);
+        HazelcastProperties properties = client.getProperties();
+        boolean directBuffer = properties.getBoolean(SOCKET_CLIENT_BUFFER_DIRECT);
+
+        SSLConfig sslConfig = client.getClientConfig().getNetworkConfig().getSSLConfig();
+        boolean sslEnabled = sslConfig != null && sslConfig.isEnabled();
+
+        int configuredInputThreads = properties.getInteger(ClientProperty.IO_INPUT_THREAD_COUNT);
+        int configuredOutputThreads = properties.getInteger(ClientProperty.IO_OUTPUT_THREAD_COUNT);
+
+        int inputThreads;
+        if (configuredInputThreads == -1) {
+            inputThreads = sslEnabled ? DEFAULT_SSL_THREAD_COUNT : 1;
+        } else {
+            inputThreads = configuredInputThreads;
+        }
+
+        int outputThreads;
+        if (configuredOutputThreads == -1) {
+            outputThreads = sslEnabled ? DEFAULT_SSL_THREAD_COUNT : 1;
+        } else {
+            outputThreads = configuredOutputThreads;
+        }
 
         ioThreadingModel = new NonBlockingIOThreadingModel(
                 client.getLoggingService(),
                 client.getMetricsRegistry(),
                 new HazelcastThreadGroup(client.getName(), logger, client.getClientConfig().getClassLoader()),
                 outOfMemoryHandler,
-                1,
-                1,
-                0,
+                inputThreads,
+                outputThreads,
+                properties.getInteger(ClientProperty.IO_BALANCER_INTERVAL_SECONDS),
                 new ClientSocketWriterInitializer(getBufferSize(), directBuffer),
                 new ClientSocketReaderInitializer(getBufferSize(), directBuffer));
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
@@ -102,6 +102,37 @@ public final class ClientProperty {
             = new HazelcastProperty("hazelcast.compatibility.3.6.server", false);
 
 
+    /**
+     * Controls the number of socket input threads. Defaults to -1, so the system will determine.
+     *
+     * If SSL is disabled, system will default to 1.
+     * If SSL is enabled, system will default to 3.
+     */
+    public static final HazelcastProperty IO_INPUT_THREAD_COUNT
+            = new HazelcastProperty("hazelcast.client.io.input.thread.count", -1);
+
+    /**
+     * Controls the number of socket output threads. Defaults to -1, so the system will determine.
+     *
+     * If SSL is disabled, system will default to 1.
+     * If SSL is enabled, system will default to 3.
+     */
+    public static final HazelcastProperty IO_OUTPUT_THREAD_COUNT
+            = new HazelcastProperty("hazelcast.client.io.output.thread.count", -1);
+
+    /**
+     * The interval in seconds between {@link com.hazelcast.internal.networking.nonblocking.iobalancer.IOBalancer IOBalancer}
+     * executions. The shorter intervals will catch I/O Imbalance faster, but they will cause higher overhead.
+     * <p/>
+     * Please see the documentation of {@link com.hazelcast.internal.networking.nonblocking.iobalancer.IOBalancer IOBalancer}
+     * for a detailed explanation of the problem.
+     * <p/>
+     * The default is 20 seconds. A value smaller than 1 disables the balancer.
+     */
+    public static final HazelcastProperty IO_BALANCER_INTERVAL_SECONDS
+            = new HazelcastProperty("hazelcast.client.io.balancer.interval.seconds", 20, SECONDS);
+
+
     private ClientProperty() {
     }
 }


### PR DESCRIPTION
By default nothig changes.

The client has now option to explicitely configure number of input threads/output threads. This defaults
to 1 if SSL is not enabled, and 3 if SSL enabled (to allign with server).

The reason why 3+3 threads are used for SSL, is that encryption/decryption of the stream is done on the io threads. And client is lot slower than server when SSL is used.