### PR TITLE
[DO NOT MERGE] Do not track key loading process when calling map.loadAll(keys)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -139,8 +139,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             Future f = recordStoreLoader.loadValues(keys);
             loadingFutures.add(f);
         }
-
-        keyLoader.trackLoading(false, null);
     }
 
     @Override


### PR DESCRIPTION
Reasoning:
`loadAll(keys)` does not use coordinator as each member receives all keys
directly from the caller.

A candidate fix for #9255