### PR TITLE
[BACKPORT] loadAll(keys) has to notify RecordStores about the end of loading

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -51,6 +51,7 @@ import com.hazelcast.map.impl.operation.AwaitMapFlushOperation;
 import com.hazelcast.map.impl.operation.ClearOperation;
 import com.hazelcast.map.impl.operation.EvictAllOperation;
 import com.hazelcast.map.impl.operation.IsEmptyOperationFactory;
+import com.hazelcast.map.impl.operation.LoadStatusOperation;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.map.impl.operation.PartitionCheckIfLoadedOperation;
@@ -78,6 +79,7 @@ import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.BinaryOperationFactory;
+import com.hazelcast.spi.impl.SimpleExecutionCallback;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -493,10 +495,16 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
         Iterable<Entry<Integer, List<Data>>> entries = partitionIdToKeys.entrySet();
 
         for (Entry<Integer, List<Data>> entry : entries) {
-            Integer partitionId = entry.getKey();
+            final Integer partitionId = entry.getKey();
             List<Data> correspondingKeys = entry.getValue();
             Operation operation = createLoadAllOperation(correspondingKeys, replaceExistingValues);
-            operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId);
+            InternalCompletableFuture<Object> future = operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId);
+            future.andThen(new SimpleExecutionCallback<Object>() {
+                @Override
+                public void notify(Object response) {
+                    operationService.invokeOnPartition(SERVICE_NAME, new LoadStatusOperation(name, null), partitionId);
+                }
+            });
         }
 
         try {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.test.TestCollectionUtils.setOfValuesBetween;
 import static com.hazelcast.test.TimeConstants.MINUTE;
 import static java.lang.String.format;
 import static java.util.Collections.singleton;
@@ -75,7 +76,7 @@ public class MapLoaderTest extends HazelcastTestSupport {
 
         map = ownerAndReplicas[3].getMap(name);
         map.loadAll(false);
-        assertEquals(DummyMapLoader.SIZE, map.size());
+        assertEquals(DummyMapLoader.DEFAULT_SIZE, map.size());
     }
 
     private HazelcastInstance[] findOwnerAndReplicas(HazelcastInstance[] instances, String name) {
@@ -196,6 +197,33 @@ public class MapLoaderTest extends HazelcastTestSupport {
         assertEquals(requestedKeys.length, loadedKeysCounter.get());
     }
 
+    @Test
+    public void givenSpecificKeysWereReloaded_whenLoadAllIsCalled_thenAllEntriesAreLoadedFromTheStore() {
+        String name = randomString();
+        int keysInMapStore = 10000;
+
+        Config config = new Config();
+        MapConfig mapConfig = config.getMapConfig(name);
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setEnabled(true);
+        mapStoreConfig.setImplementation(new DummyMapLoader(keysInMapStore));
+        mapStoreConfig.setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER);
+        mapConfig.setMapStoreConfig(mapStoreConfig);
+        TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = instanceFactory.newInstances(config);
+        IMap<Integer, Integer> map = instances[0].getMap(name);
+
+        //load specific keys
+        map.loadAll(setOfValuesBetween(0, keysInMapStore), true);
+
+        //remove everything
+        map.clear();
+
+        //assert loadAll with load all entries provided by the mapLoader
+        map.loadAll(true);
+        assertEquals(keysInMapStore, map.size());
+    }
+
     @Test(timeout = MINUTE)
     @Ignore //https://github.com/hazelcast/hazelcast/issues/5453
     public void testMapCanBeLoaded_whenLoadAllKeysThrowsExceptionFirstTime() throws InterruptedException {
@@ -278,14 +306,18 @@ public class MapLoaderTest extends HazelcastTestSupport {
         });
     }
 
-    private static class DummyMapLoader implements MapLoader<Integer, Integer> {
+    public static class DummyMapLoader implements MapLoader<Integer, Integer> {
 
-        static final int SIZE = 1000;
+        static final int DEFAULT_SIZE = 1000;
 
-        final Map<Integer, Integer> map = new ConcurrentHashMap<Integer, Integer>(SIZE);
+        final Map<Integer, Integer> map = new ConcurrentHashMap<Integer, Integer>(DEFAULT_SIZE);
 
         public DummyMapLoader() {
-            for (int i = 0; i < SIZE; i++) {
+            this(DEFAULT_SIZE);
+        }
+
+        public DummyMapLoader(int size) {
+            for (int i = 0; i < size; i++) {
                 map.put(i, i);
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
@@ -37,4 +37,12 @@ public class TestCollectionUtils {
         List<T> list = Arrays.asList(items);
         return new HashSet<T>(list);
     }
+
+    public static Set<Integer> setOfValuesBetween(int from, int to) {
+        HashSet<Integer> set = new HashSet<Integer>();
+        for (int i = from; i < to; i++) {
+            set.add(i);
+        }
+        return set;
+    }
 }


### PR DESCRIPTION
When a RecordStore process LoadAllOperation it expects to receive
LoadStatusOperation eventually. The LoadStatusOperation indicates
there are no more keys to be loaded. Without this the record store never
change its state into the `LOADED` state -> subsequent loadAll() calls are ignored

A candidate for #9255