### PR TITLE
Lock quorum

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -41,6 +41,7 @@ import com.hazelcast.config.JobTrackerConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.LoginModuleConfig;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.MapAttributeConfig;
@@ -150,6 +151,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private ManagedMap mapConfigManagedMap;
         private ManagedMap cacheConfigManagedMap;
         private ManagedMap queueManagedMap;
+        private ManagedMap lockManagedMap;
         private ManagedMap ringbufferManagedMap;
         private ManagedMap reliableTopicManagedMap;
         private ManagedMap semaphoreManagedMap;
@@ -170,6 +172,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.mapConfigManagedMap = createManagedMap("mapConfigs");
             this.cacheConfigManagedMap = createManagedMap("cacheConfigs");
             this.queueManagedMap = createManagedMap("queueConfigs");
+            this.lockManagedMap = createManagedMap("lockConfigs");
             this.ringbufferManagedMap = createManagedMap("ringbufferConfigs");
             this.reliableTopicManagedMap = createManagedMap("reliableTopicConfigs");
             this.semaphoreManagedMap = createManagedMap("semaphoreConfigs");
@@ -212,6 +215,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleDurableExecutor(node);
                     } else if ("queue".equals(nodeName)) {
                         handleQueue(node);
+                    } else if ("lock".equals(nodeName)) {
+                        handleLock(node);
                     } else if ("ringbuffer".equals(nodeName)) {
                         handleRingbuffer(node);
                     } else if ("reliable-topic".equals(nodeName)) {
@@ -584,6 +589,18 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             final BeanDefinitionBuilder builder = createBeanBuilder(SemaphoreConfig.class);
             fillAttributeValues(node, builder);
             semaphoreManagedMap.put(getAttribute(node, "name"), builder.getBeanDefinition());
+        }
+
+        public void handleLock(Node node) {
+            final BeanDefinitionBuilder lockConfigBuilder = createBeanBuilder(LockConfig.class);
+            fillAttributeValues(node, lockConfigBuilder);
+            for (Node childNode : childElements(node)) {
+                final String nodeName = cleanNodeName(childNode);
+                if ("quorum-ref".equals(nodeName)) {
+                    lockConfigBuilder.addPropertyValue("quorumName", getTextContent(childNode));
+                }
+            }
+            lockManagedMap.put(getAttribute(node, "name"), lockConfigBuilder.getBeanDefinition());
         }
 
         public void handleRingbuffer(Node node) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
@@ -162,6 +162,14 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
+                        <xs:element name="lock" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                            </xs:complexType>
+                        </xs:element>
                         <xs:element name="ringbuffer" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
                                 <xs:sequence>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -33,6 +33,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.config.MapConfig;
@@ -389,7 +390,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
     @Test
     public void testQueueConfig() {
-        QueueConfig testQConfig = config.getQueueConfig("testQ");
+        final QueueConfig testQConfig = config.getQueueConfig("testQ");
         assertNotNull(testQConfig);
         assertEquals("testQ", testQConfig.getName());
         assertEquals(1000, testQConfig.getMaxSize());
@@ -398,12 +399,14 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         ItemListenerConfig listenerConfig = testQConfig.getItemListenerConfigs().get(0);
         assertEquals("com.hazelcast.spring.DummyItemListener", listenerConfig.getClassName());
         assertTrue(listenerConfig.isIncludeValue());
-        QueueConfig qConfig = config.getQueueConfig("q");
+
+        final QueueConfig qConfig = config.getQueueConfig("q");
         assertNotNull(qConfig);
         assertEquals("q", qConfig.getName());
         assertEquals(2500, qConfig.getMaxSize());
         assertFalse(qConfig.isStatisticsEnabled());
         assertEquals(100, qConfig.getEmptyQueueTtl());
+        assertEquals("my-quorum", qConfig.getQuorumName());
 
         final QueueConfig queueWithStore1 = config.getQueueConfig("queueWithStore1");
         assertNotNull(queueWithStore1);
@@ -428,6 +431,14 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         final QueueStoreConfig storeConfig4 = queueWithStore4.getQueueStoreConfig();
         assertNotNull(storeConfig4);
         assertEquals(dummyQueueStoreFactory, storeConfig4.getFactoryImplementation());
+    }
+
+    @Test
+    public void testLockConfig() {
+        final LockConfig lockConfig = config.getLockConfig("lock");
+        assertNotNull(lockConfig);
+        assertEquals("lock", lockConfig.getName());
+        assertEquals("my-quorum", lockConfig.getQuorumName());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -152,10 +152,7 @@
                                  queue-capacity="300"
                                  statistics-enabled="false"
             />
-            <hz:queue name="testQ"
-                      max-size="1000"
-            >
-
+            <hz:queue name="testQ" max-size="1000">
                 <hz:item-listeners>
                     <hz:item-listener class-name="com.hazelcast.spring.DummyItemListener" include-value="true"/>
                 </hz:item-listeners>
@@ -165,7 +162,9 @@
                       backup-count="1"
                       async-backup-count="1"
                       statistics-enabled="false"
-                      empty-queue-ttl="100"/>
+                      empty-queue-ttl="100">
+                <hz:quorum-ref>my-quorum</hz:quorum-ref>
+            </hz:queue>
 
             <hz:queue name="queueWithStore1">
                 <hz:queue-store enabled="true" class-name="com.hazelcast.spring.DummyQueueStore"/>
@@ -179,6 +178,10 @@
             <hz:queue name="queueWithStore4">
                 <hz:queue-store enabled="true" factory-implementation="dummyQueueStoreFactory"/>
             </hz:queue>
+
+            <hz:lock name="lock">
+                <hz:quorum-ref>my-quorum</hz:quorum-ref>
+            </hz:lock>
 
             <hz:ringbuffer name="testRingbuffer"
                            in-memory-format="OBJECT"

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AbstractLockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AbstractLockOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.NamedOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionAwareOperation;
@@ -31,7 +32,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 public abstract class AbstractLockOperation extends Operation
-        implements PartitionAwareOperation, IdentifiedDataSerializable {
+        implements PartitionAwareOperation, IdentifiedDataSerializable, NamedOperation {
 
     public static final int ANY_THREAD = 0;
 
@@ -121,6 +122,11 @@ public abstract class AbstractLockOperation extends Operation
 
     public final Data getKey() {
         return key;
+    }
+
+    @Override
+    public String getName() {
+        return namespace.getObjectName();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitBackupOperation.java
@@ -24,11 +24,12 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 public class AwaitBackupOperation extends AbstractLockOperation
-        implements BackupOperation {
+        implements BackupOperation, MutatingOperation {
 
     private String originalCaller;
     private String conditionId;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/AwaitOperation.java
@@ -26,11 +26,12 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 public class AwaitOperation extends AbstractLockOperation
-        implements BlockingOperation, BackupAwareOperation {
+        implements BlockingOperation, BackupAwareOperation, MutatingOperation {
 
     private String conditionId;
     private boolean expired;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitBackupOperation.java
@@ -23,10 +23,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class BeforeAwaitBackupOperation extends AbstractLockOperation implements BackupOperation {
+public class BeforeAwaitBackupOperation extends AbstractLockOperation implements BackupOperation, MutatingOperation {
 
     private String conditionId;
     private String originalCaller;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BeforeAwaitOperation.java
@@ -26,10 +26,11 @@ import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class BeforeAwaitOperation extends AbstractLockOperation implements Notifier, BackupAwareOperation {
+public class BeforeAwaitOperation extends AbstractLockOperation implements Notifier, BackupAwareOperation, MutatingOperation {
 
     private String conditionId;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetLockCountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetLockCountOperation.java
@@ -20,8 +20,9 @@ import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.ReadonlyOperation;
 
-public class GetLockCountOperation extends AbstractLockOperation {
+public class GetLockCountOperation extends AbstractLockOperation implements ReadonlyOperation {
 
     public GetLockCountOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetRemainingLeaseTimeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/GetRemainingLeaseTimeOperation.java
@@ -20,8 +20,9 @@ import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.ReadonlyOperation;
 
-public class GetRemainingLeaseTimeOperation extends AbstractLockOperation {
+public class GetRemainingLeaseTimeOperation extends AbstractLockOperation implements ReadonlyOperation {
 
     public GetRemainingLeaseTimeOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/IsLockedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/IsLockedOperation.java
@@ -20,8 +20,9 @@ import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.ReadonlyOperation;
 
-public class IsLockedOperation extends AbstractLockOperation {
+public class IsLockedOperation extends AbstractLockOperation implements ReadonlyOperation {
 
     public IsLockedOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockBackupOperation.java
@@ -23,10 +23,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class LockBackupOperation extends AbstractLockOperation implements BackupOperation {
+public class LockBackupOperation extends AbstractLockOperation implements BackupOperation, MutatingOperation {
 
     private String originalCallerUuid;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockOperation.java
@@ -26,8 +26,9 @@ import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.impl.MutatingOperation;
 
-public class LockOperation extends AbstractLockOperation implements BlockingOperation, BackupAwareOperation {
+public class LockOperation extends AbstractLockOperation implements BlockingOperation, BackupAwareOperation, MutatingOperation {
 
     public LockOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalBackupOperation.java
@@ -20,8 +20,9 @@ import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.MutatingOperation;
 
-public class SignalBackupOperation extends BaseSignalOperation implements BackupOperation {
+public class SignalBackupOperation extends BaseSignalOperation implements BackupOperation, MutatingOperation {
 
     public SignalBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/SignalOperation.java
@@ -22,8 +22,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.MutatingOperation;
 
-public class SignalOperation extends BaseSignalOperation implements BackupAwareOperation {
+public class SignalOperation extends BaseSignalOperation implements BackupAwareOperation, MutatingOperation {
 
     public SignalOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockBackupOperation.java
@@ -23,10 +23,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
-public class UnlockBackupOperation extends AbstractLockOperation implements BackupOperation {
+public class UnlockBackupOperation extends AbstractLockOperation implements BackupOperation, MutatingOperation {
 
     private boolean force;
     private String originalCallerUuid;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockOperation.java
@@ -26,12 +26,13 @@ import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.impl.MutatingOperation;
 
 import java.io.IOException;
 
 import static java.lang.Boolean.TRUE;
 
-public class UnlockOperation extends AbstractLockOperation implements Notifier, BackupAwareOperation {
+public class UnlockOperation extends AbstractLockOperation implements Notifier, BackupAwareOperation, MutatingOperation {
 
     private boolean force;
     private boolean shouldNotify;

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -78,6 +78,8 @@ public class Config {
 
     private final Map<String, QueueConfig> queueConfigs = new ConcurrentHashMap<String, QueueConfig>();
 
+    private final Map<String, LockConfig> lockConfigs = new ConcurrentHashMap<String, LockConfig>();
+
     private final Map<String, MultiMapConfig> multiMapConfigs = new ConcurrentHashMap<String, MultiMapConfig>();
 
     private final Map<String, ListConfig> listConfigs = new ConcurrentHashMap<String, ListConfig>();
@@ -381,6 +383,51 @@ public class Config {
         this.queueConfigs.clear();
         this.queueConfigs.putAll(queueConfigs);
         for (Entry<String, QueueConfig> entry : queueConfigs.entrySet()) {
+            entry.getValue().setName(entry.getKey());
+        }
+        return this;
+    }
+
+    public LockConfig findLockConfig(String name) {
+        final String baseName = getBaseName(name);
+        final LockConfig config = lookupByPattern(lockConfigs, baseName);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getLockConfig("default").getAsReadOnly();
+    }
+
+    public LockConfig getLockConfig(String name) {
+        final String baseName = getBaseName(name);
+        LockConfig config = lookupByPattern(lockConfigs, baseName);
+        if (config != null) {
+            return config;
+        }
+        LockConfig defConfig = lockConfigs.get("default");
+        if (defConfig == null) {
+            defConfig = new LockConfig();
+            defConfig.setName("default");
+            addLockConfig(defConfig);
+        }
+        config = new LockConfig(defConfig);
+        config.setName(name);
+        addLockConfig(config);
+        return config;
+    }
+
+    public Config addLockConfig(LockConfig lockConfig) {
+        lockConfigs.put(lockConfig.getName(), lockConfig);
+        return this;
+    }
+
+    public Map<String, LockConfig> getLockConfigs() {
+        return lockConfigs;
+    }
+
+    public Config setLockConfigs(Map<String, LockConfig> lockConfigs) {
+        this.lockConfigs.clear();
+        this.lockConfigs.putAll(lockConfigs);
+        for (Entry<String, LockConfig> entry : lockConfigs.entrySet()) {
             entry.getValue().setName(entry.getKey());
         }
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Contains the configuration for the {@link com.hazelcast.core.ILock}.
+ */
+public class LockConfig {
+
+
+    private String name;
+    private String quorumName;
+
+    public LockConfig() {
+    }
+
+    /**
+     * Creates a {@link LockConfig} with the provided name.
+     *
+     * @param name the name
+     * @throws NullPointerException if name is null
+     */
+    public LockConfig(String name) {
+        this.name = checkNotNull(name, "name can't be null");
+    }
+
+    /**
+     * Clones a {@link LockConfig}
+     *
+     * @param config the lock config to clone
+     * @throws NullPointerException if config is null
+     */
+    public LockConfig(LockConfig config) {
+        checkNotNull(config, "config can't be null");
+        this.name = config.name;
+        this.quorumName = config.quorumName;
+    }
+
+    /**
+     * Creates a new {@link LockConfig} by cloning an existing config and overriding the name.
+     *
+     * @param name   the new name
+     * @param config the config.
+     * @throws NullPointerException if name or config is null.
+     */
+    public LockConfig(String name, LockConfig config) {
+        this(config);
+        this.name = checkNotNull(name, "name can't be null");
+    }
+
+    /**
+     * Sets the name of the lock.
+     *
+     * @param name the name of the lock
+     * @return the updated {@link LockConfig}
+     * @throws IllegalArgumentException if name is null or an empty string.
+     */
+    public LockConfig setName(String name) {
+        this.name = checkHasText(name, "name must contain text");
+        return this;
+    }
+
+    /**
+     * Returns the name of the lock.
+     *
+     * @return the name of the lock.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the quorum name for lock operations.
+     *
+     * @return the quorum name
+     */
+    public String getQuorumName() {
+        return quorumName;
+    }
+
+    /**
+     * Sets the quorum name for lock operations.
+     *
+     * @param quorumName the quorum name
+     * @return the updated lock configuration
+     */
+    public LockConfig setQuorumName(String quorumName) {
+        this.quorumName = quorumName;
+        return this;
+    }
+
+    /**
+     * Creates a readonly copy of this {@link LockConfig}.
+     *
+     * @return the readonly copy.
+     */
+    public LockConfig getAsReadOnly() {
+        return new LockConfigReadonly(this);
+    }
+
+
+    @Override
+    public String toString() {
+        return "LockConfig{"
+                + "name='" + name + '\''
+                + ", quorumName='" + quorumName + '\''
+                + '}';
+    }
+
+    /**
+     * A readonly version of the {@link LockConfig}.
+     */
+    private static class LockConfigReadonly extends LockConfig {
+
+        LockConfigReadonly(LockConfig config) {
+            super(config);
+        }
+
+        @Override
+        public LockConfig setName(String name) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -69,6 +69,7 @@ import static com.hazelcast.config.XmlElements.LICENSE_KEY;
 import static com.hazelcast.config.XmlElements.LIST;
 import static com.hazelcast.config.XmlElements.LISTENERS;
 import static com.hazelcast.config.XmlElements.LITE_MEMBER;
+import static com.hazelcast.config.XmlElements.LOCK;
 import static com.hazelcast.config.XmlElements.MANAGEMENT_CENTER;
 import static com.hazelcast.config.XmlElements.MAP;
 import static com.hazelcast.config.XmlElements.MEMBER_ATTRIBUTES;
@@ -314,6 +315,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleJobTracker(node);
         } else if (SEMAPHORE.isEqual(nodeName)) {
             handleSemaphore(node);
+        } else if (LOCK.isEqual(nodeName)) {
+            handleLock(node);
         } else if (RINGBUFFER.isEqual(nodeName)) {
             handleRingbuffer(node);
         } else if (LISTENERS.isEqual(nodeName)) {
@@ -875,6 +878,20 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 networkConfig.addOutboundPortDefinition(value);
             }
         }
+    }
+
+    private void handleLock(Node node) {
+        final String name = getAttribute(node, "name");
+        final LockConfig lockConfig = new LockConfig();
+        lockConfig.setName(name);
+        for (Node n : childElements(node)) {
+            final String nodeName = cleanNodeName(n);
+            final String value = getTextContent(n).trim();
+            if ("quorum-ref".equals(nodeName)) {
+                lockConfig.setQuorumName(value);
+            }
+        }
+        this.config.addLockConfig(lockConfig);
     }
 
     private void handleQueue(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -39,6 +39,7 @@ enum XmlElements {
     RELIABLE_TOPIC("reliable-topic", true),
     JOB_TRACKER("jobtracker", true),
     SEMAPHORE("semaphore", true),
+    LOCK("lock", true),
     RINGBUFFER("ringbuffer", true),
     LISTENERS("listeners", false),
     SERIALIZATION("serialization", false),

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -52,6 +52,7 @@
                 <xs:element name="reliable-topic" type="reliable-topic" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="jobtracker" type="jobtracker" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="semaphore" type="semaphore" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="lock" type="lock" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="ringbuffer" type="ringbuffer" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="listeners" type="listeners" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
@@ -1172,6 +1173,23 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
+
+    <xs:complexType name="lock">
+        <xs:all>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the lock.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
     <xs:complexType name="ringbuffer-store">
         <xs:all>
             <xs:element ref="factory-or-class-name" minOccurs="0" maxOccurs="1"/>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -486,7 +486,10 @@ https://hazelcast.org/documentation/.
 	- bulk-load:
 		Size of the bulks loaded from QueueStore when the queue is initialized. Its default 
 		value is 250.
--->    
+    * <quorum-ref>:
+        Adds the quorum for this queue which you configure using the <quorum> element. You should set the <quorum-ref>'s value
+        as the <quorum>'s name.
+-->
     <queue name="default">
         <statistics-enabled>true</statistics-enabled>
         <max-size>0</max-size>
@@ -494,18 +497,19 @@ https://hazelcast.org/documentation/.
         <async-backup-count>0</async-backup-count>
         <empty-queue-ttl>-1</empty-queue-ttl>
         <item-listeners>
-        	<item-listener>
-        		com.hazelcast.examples.ItemListener
-        	</item-listener>
+            <item-listener include-value="true">
+                com.hazelcast.examples.ItemListener
+            </item-listener>
         </item-listeners>
         <queue-store>
-  		<class-name>com.hazelcast.QueueStoreImpl</class-name>
-  		<properties>
-    			<property name="binary">false</property>
-    			<property name="memory-limit">1000</property>
-    			<property name="bulk-load">500</property>
-  		</properties>
-	</queue-store>
+            <class-name>com.hazelcast.QueueStoreImpl</class-name>
+            <properties>
+                <property name="binary">false</property>
+                <property name="memory-limit">1000</property>
+                <property name="bulk-load">500</property>
+            </properties>
+        </queue-store>
+        <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
     </queue>
 <!--
     ===== HAZELCAST MAP CONFIGURATION =====
@@ -1267,6 +1271,22 @@ https://hazelcast.org/documentation/.
         <backup-count>1</backup-count>
         <async-backup-count>0</async-backup-count>
     </semaphore>
+
+    <!--
+    ===== HAZELCAST LOCK CONFIGURATION =====
+
+    Configuration element's name is <lock>. It has the required attribute "name" with which you
+    can specify the name of your Lock. This attribute's default value is "default".
+    It has the following sub-elements:
+    * <quorum-ref>:
+        Adds the quorum for this lock which you configure using the <quorum> element. You should set the <quorum-ref>'s value
+        as the <quorum>'s name.
+-->
+
+    <lock name="default">
+        <quorum-ref>quorumRuleWithThreeNodes</quorum-ref>
+    </lock>
+
 <!--
     ===== HAZELCAST RINGBUFFER CONFIGURATION =====
     

--- a/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InvalidConfigurationTest.java
@@ -455,6 +455,7 @@ public class InvalidConfigurationTest {
                 "</network>\n" +
 
                 "<queue name=\"default\">\n" +
+                "<quorum-ref>quorumRuleWithThreeMembers</quorum-ref>"+
                 "<max-size>0</max-size>\n" +
                 "<backup-count>${queue-backup-count}</backup-count>\n" +
                 "<async-backup-count>${queue-async-backup-count}</async-backup-count>\n" +
@@ -519,6 +520,10 @@ public class InvalidConfigurationTest {
                 "<backup-count>${semaphore-backup-count}</backup-count>\n" +
                 "<async-backup-count>${semaphore-async-backup-count}</async-backup-count>\n" +
                 "</semaphore>\n" +
+
+                "<lock name=\"default\">\n" +
+                "<quorum-ref>quorumRuleWithThreeMembers</quorum-ref>\n" +
+                "</lock>" +
 
                 "    <ringbuffer name=\"default\">\n" +
                 "        <capacity>10000</capacity>\n" +

--- a/hazelcast/src/test/java/com/hazelcast/quorum/BaseQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/BaseQuorumListenerTest.java
@@ -1,0 +1,162 @@
+/*
+* Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*  http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+package com.hazelcast.quorum;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.config.QuorumListenerConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.core.Member;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public abstract class BaseQuorumListenerTest extends HazelcastTestSupport {
+
+    @Test
+    public void testQuorumFailureEventFiredWhenNodeCountDropsBelowThreshold() throws Exception {
+        final CountDownLatch quorumNotPresent = new CountDownLatch(1);
+        final String distributedObjectName = randomString();
+        final Config config = addQuorum(new Config(), distributedObjectName, quorumListener(null, quorumNotPresent));
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance();
+        factory.newHazelcastInstance().shutdown();
+        assertOpenEventually(quorumNotPresent, 15);
+    }
+
+    @Test
+    public void testQuorumEventsFiredWhenNodeCountBelowThenAboveThreshold() throws Exception {
+        final CountDownLatch quorumNotPresent = new CountDownLatch(1);
+        final CountDownLatch quorumPresent = new CountDownLatch(1);
+        final String distributedObjectName = randomString();
+        final Config config = addQuorum(new Config(), distributedObjectName, quorumListener(quorumPresent, quorumNotPresent));
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
+        assertOpenEventually(quorumNotPresent, 15);
+
+        factory.newHazelcastInstance(config);
+        assertOpenEventually(quorumPresent);
+    }
+
+    @Test
+    public void testDifferentQuorumsGetCorrectEvents() throws Exception {
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        final CountDownLatch quorumFailureLatch = new CountDownLatch(2);
+        final Config config = new Config();
+        addQuorum(config, "fourNode", quorumListener(null, quorumFailureLatch));
+        addQuorum(config, "threeNode", quorumListener(null, quorumFailureLatch));
+        factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
+        assertOpenEventually(quorumFailureLatch);
+    }
+
+    @Test
+    public void testCustomResolverFiresQuorumFailureEvent() throws Exception {
+        final CountDownLatch quorumNotPresent = new CountDownLatch(1);
+
+        final QuorumListenerConfig listenerConfig = new QuorumListenerConfig(quorumListener(null, quorumNotPresent));
+        final String distributedObjectName = randomString();
+        final String quorumName = randomString();
+        final QuorumConfig quorumConfig = new QuorumConfig()
+                .setName(quorumName)
+                .setEnabled(true)
+                .addListenerConfig(listenerConfig)
+                .setQuorumFunctionImplementation(new QuorumFunction() {
+                    @Override
+                    public boolean apply(Collection<Member> members) {
+                        return false;
+                    }
+                });
+        final Config config = new Config().addQuorumConfig(quorumConfig);
+        addQuorumConfig(config, distributedObjectName, quorumName);
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance();
+        assertOpenEventually(quorumNotPresent, 15);
+
+    }
+
+    @Test
+    public void testQuorumEventProvidesCorrectMemberListSize() throws Exception {
+        final CountDownLatch quorumNotPresent = new CountDownLatch(1);
+        final QuorumListenerConfig listenerConfig = new QuorumListenerConfig(new QuorumListener() {
+            public void onChange(QuorumEvent quorumEvent) {
+                if (!quorumEvent.isPresent()) {
+                    final Collection<Member> currentMembers = quorumEvent.getCurrentMembers();
+                    assertEquals(2, currentMembers.size());
+                    assertEquals(3, quorumEvent.getThreshold());
+                    quorumNotPresent.countDown();
+                }
+            }
+        });
+        final String distributedObjectName = randomString();
+        final String quorumName = randomString();
+        final QuorumConfig quorumConfig = new QuorumConfig(quorumName, true, 3)
+                .addListenerConfig(listenerConfig);
+        final Config config = new Config().addQuorumConfig(quorumConfig);
+        addQuorumConfig(config, distributedObjectName, quorumName);
+
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
+        assertOpenEventually(quorumNotPresent);
+    }
+
+
+    protected Config addQuorum(Config config, String distributedObjectName, QuorumListener listener) {
+        final String quorumName = randomString();
+        final QuorumListenerConfig listenerConfig = new QuorumListenerConfig();
+        listenerConfig.setImplementation(listener);
+        config.addQuorumConfig(new QuorumConfig(quorumName, true, 3).addListenerConfig(listenerConfig));
+        addQuorumConfig(config, distributedObjectName, quorumName);
+        return config;
+    }
+
+    protected QuorumListener quorumListener(final CountDownLatch quorumPresent, final CountDownLatch quorumNotPresent) {
+        return new QuorumListener() {
+            public void onChange(QuorumEvent quorumEvent) {
+                if (quorumEvent.isPresent()) {
+                    if (quorumPresent != null) {
+                        quorumPresent.countDown();
+                    }
+                } else {
+                    if (quorumNotPresent != null) {
+                        quorumNotPresent.countDown();
+                    }
+                }
+            }
+        };
+    }
+
+    protected abstract void addQuorumConfig(Config config, String distributedObjectName, String quorumName);
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -18,6 +18,7 @@ package com.hazelcast.quorum;
 
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QuorumConfig;
@@ -87,6 +88,15 @@ public class PartitionedCluster {
     public PartitionedCluster createFiveMemberCluster(QueueConfig queueConfig, QuorumConfig quorumConfig) {
         final Config config = createClusterConfig()
                 .addQueueConfig(queueConfig)
+                .addQuorumConfig(quorumConfig);
+        createInstances(config);
+        return this;
+    }
+
+
+    public PartitionedCluster createFiveMemberCluster(LockConfig lockConfig, QuorumConfig quorumConfig) {
+        final Config config = createClusterConfig()
+                .addLockConfig(lockConfig)
                 .addQuorumConfig(quorumConfig);
         createInstances(config);
         return this;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/AbstractLockQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/AbstractLockQuorumTest.java
@@ -1,0 +1,101 @@
+package com.hazelcast.quorum.lock;
+
+import com.hazelcast.config.LockConfig;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICondition;
+import com.hazelcast.core.ILock;
+import com.hazelcast.quorum.PartitionedCluster;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.util.EmptyStatement;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
+import static com.hazelcast.test.HazelcastTestSupport.randomString;
+
+public abstract class AbstractLockQuorumTest {
+    protected static PartitionedCluster cluster;
+    private static ILock l1;
+    private static ILock l2;
+    private static ILock l3;
+    static ILock l4;
+    static ILock l5;
+    private static final String LOCK_NAME_PREFIX = "lock";
+    protected static final String LOCK_NAME = LOCK_NAME_PREFIX + randomString();
+    private static final String QUORUM_ID = "threeNodeQuorumRule";
+
+
+    protected static void initializeFiveMemberCluster(QuorumType type, int quorumSize) throws InterruptedException {
+        final QuorumConfig quorumConfig = new QuorumConfig()
+                .setName(QUORUM_ID)
+                .setType(type)
+                .setEnabled(true)
+                .setSize(quorumSize);
+        final LockConfig lockConfig = new LockConfig(LOCK_NAME_PREFIX + "*").setQuorumName(QUORUM_ID);
+        cluster = new PartitionedCluster(new TestHazelcastInstanceFactory());
+        cluster.createFiveMemberCluster(lockConfig, quorumConfig);
+
+        l1 = getLock(cluster.h1);
+        l2 = getLock(cluster.h2);
+        l3 = getLock(cluster.h3);
+        l4 = getLock(cluster.h4);
+        l5 = getLock(cluster.h5);
+    }
+
+    protected static <E> ILock getLock(HazelcastInstance instance) {
+        return instance.getLock(LOCK_NAME);
+    }
+
+    @Test
+    public void testOperationsSuccessfulWhenQuorumSizeMet() throws Exception {
+        l1.lock();
+        l2.getRemainingLeaseTime();
+        l1.unlock();
+
+        l2.lock();
+        l3.forceUnlock();
+
+        l3.lock();
+        l3.isLocked();
+        l3.getLockCount();
+        l2.isLockedByCurrentThread();
+        l3.unlock();
+
+        l1.tryLock();
+        l1.unlock();
+
+        testCondition(l1);
+    }
+
+    void testCondition(ILock lock) throws InterruptedException {
+        final CountDownLatch signalArrived = new CountDownLatch(1);
+        final ICondition cond = lock.newCondition("condition");
+        await(lock, cond, signalArrived);
+
+        TimeUnit.SECONDS.sleep(1);
+        lock.lock();
+        cond.signal();
+        lock.unlock();
+        assertOpenEventually(signalArrived);
+    }
+
+    private void await(final ILock lock, final ICondition cond, final CountDownLatch signalArrived) {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lock();
+                    cond.await();
+                    signalArrived.countDown();
+                    lock.unlock();
+                } catch (InterruptedException e) {
+                    EmptyStatement.ignore(e);
+                }
+            }
+        }).start();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockQuorumListenerTest.java
@@ -14,11 +14,11 @@
 *  limitations under the License.
 */
 
-package com.hazelcast.quorum.queue;
+package com.hazelcast.quorum.lock;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IQueue;
+import com.hazelcast.core.ILock;
 import com.hazelcast.quorum.BaseQuorumListenerTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -31,17 +31,17 @@ import java.util.concurrent.CountDownLatch;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class QueueQuorumListenerTest extends BaseQuorumListenerTest {
+public class LockQuorumListenerTest extends BaseQuorumListenerTest {
 
     @Test
     public void testQuorumFailureEventFiredWhenNodeCountBelowThreshold() throws Exception {
         final CountDownLatch quorumNotPresent = new CountDownLatch(1);
-        final String queueName = randomString();
-        final Config config = addQuorum(new Config(), queueName, quorumListener(null, quorumNotPresent));
+        final String lockName = randomString();
+        final Config config = addQuorum(new Config(), lockName, quorumListener(null, quorumNotPresent));
         final HazelcastInstance instance = createHazelcastInstance(config);
-        final IQueue<Object> q = instance.getQueue(queueName);
+        final ILock q = instance.getLock(lockName);
         try {
-            q.offer(randomString());
+            q.lock();
         } catch (Exception expected) {
             expected.printStackTrace();
         }
@@ -50,6 +50,6 @@ public class QueueQuorumListenerTest extends BaseQuorumListenerTest {
 
     @Override
     protected void addQuorumConfig(Config config, String distributedObjectName, String quorumName) {
-        config.getQueueConfig(distributedObjectName).setQuorumName(quorumName);
+        config.getLockConfig(distributedObjectName).setQuorumName(quorumName);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadQuorumTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.quorum.lock;
+
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class LockReadQuorumTest extends AbstractLockQuorumTest {
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        initializeFiveMemberCluster(QuorumType.READ, 3);
+        cluster.splitFiveMembersThreeAndTwo();
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testMutationOkWhenQuorumSizeNotMet() throws Exception {
+        l4.lock();
+        l5.forceUnlock();
+
+        l5.lock();
+        l5.unlock();
+
+        l4.tryLock();
+        l4.unlock();
+
+        testCondition(l4);
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetRemainingLeaseTimeFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.getRemainingLeaseTime();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testIsLockedFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.isLocked();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testIsLockedByCurrentThreadFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.isLockedByCurrentThread();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetLockCountFailsWhenQuorumSizeNotMet() throws Exception {
+        l5.getLockCount();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockReadWriteQuorumTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.quorum.lock;
+
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class LockReadWriteQuorumTest extends AbstractLockQuorumTest {
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        initializeFiveMemberCluster(QuorumType.READ_WRITE, 3);
+        cluster.splitFiveMembersThreeAndTwo();
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetRemainingLeaseTimeFailWhenQuorumSizeNotMet() throws Exception {
+        l4.getRemainingLeaseTime();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testIsLockedThrowsFailWhenQuorumSizeNotMet() throws Exception {
+        l4.isLocked();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testIsLockedByCurrnetThreadFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.isLockedByCurrentThread();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testGetLockCountFailsWhenQuorumSizeNotMet() throws Exception {
+        l5.getLockCount();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryLockFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.tryLock();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testLockFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.lock();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testForceUnlockFailsWhenQuorumSizeNotMet() throws Exception {
+        l5.forceUnlock();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testUnlockFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.unlock();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAwaitFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.newCondition("condition").await();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testSignalFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.newCondition("condition").signal();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockWriteQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/lock/LockWriteQuorumTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.hazelcast.quorum.lock;
+
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.quorum.QuorumException;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class LockWriteQuorumTest extends AbstractLockQuorumTest {
+    @BeforeClass
+    public static void initialize() throws InterruptedException {
+        initializeFiveMemberCluster(QuorumType.WRITE, 3);
+        cluster.splitFiveMembersThreeAndTwo();
+    }
+
+    @AfterClass
+    public static void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testReadOnlyOkWhenQuorumSizeNotMet() throws Exception {
+        l4.getRemainingLeaseTime();
+        l4.isLocked();
+        l4.isLockedByCurrentThread();
+        l5.getLockCount();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testTryLockFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.tryLock();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testLockFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.lock();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testForceUnlockFailsWhenQuorumSizeNotMet() throws Exception {
+        l5.forceUnlock();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testUnlockFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.unlock();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testAwaitFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.newCondition("condition").await();
+    }
+
+    @Test(expected = QuorumException.class)
+    public void testSignalFailsWhenQuorumSizeNotMet() throws Exception {
+        l4.newCondition("condition").signal();
+    }
+}

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -33,7 +33,7 @@
     4. If a configuration cannot be found, Hazelcast will use the default hazelcast configuration
        ’hazelcast-default.xml’, which is included in the the Hazelcast jar
 -->
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>
@@ -175,6 +175,7 @@
             <item-listener include-value="true">com.hazelcast.examples.ItemListener</item-listener>
         </item-listeners>
 
+        <quorum-ref>quorumRuleWithThreeMembers</quorum-ref>
     </queue>
     <map name="default">
         <!--
@@ -394,6 +395,10 @@
         <async-backup-count>0</async-backup-count>
     </semaphore>
 
+    <lock name="default">
+        <quorum-ref>quorumRuleWithThreeMembers</quorum-ref>
+    </lock>
+
     <ringbuffer name="default">
         <capacity>25311</capacity>
         <backup-count>2</backup-count>
@@ -548,4 +553,9 @@
         <attribute name="attribute.float" type="float">1234.5678</attribute>
     </member-attributes>
 
+
+    <quorum name="quorumRuleWithThreeMembers" enabled="true">
+        <quorum-size>3</quorum-size>
+        <quorum-type>READ_WRITE</quorum-type>
+    </quorum>
 </hazelcast>


### PR DESCRIPTION
Adding quorum to lock actions. We are reusing the existing quorum support which means that this does not guarantee correctness, just best-effort detection of quorum. This will be emphasised in the  documentation and in the TDD.

The lock configuration element/class was added since lock didn't yet have configuration.

Note to keep in mind when reviewing - adding quorum for locks affects locking methods on map and multimap as well.