### PR TITLE
[BACKPORT] Do not change keyLoaderState when loading keys supplied by user

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoader.java
@@ -335,7 +335,7 @@ public class MapKeyLoader {
             int partitionId = e.getKey();
             List<Data> keys = e.getValue();
 
-            MapOperation op = operationProvider.createLoadAllOperation(mapName, keys, replaceExistingValues);
+            MapOperation op = operationProvider.createLoadAllOperation(mapName, keys, replaceExistingValues, false);
 
             InternalCompletableFuture<Object> future = opService.invokeOnPartition(SERVICE_NAME, op, partitionId);
             futures.add(future);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -215,8 +215,9 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createLoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues) {
-        return new LoadAllOperation(name, keys, replaceExistingValues);
+    public MapOperation createLoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues,
+                                               boolean withUserSuppliedKeys) {
+        return new LoadAllOperation(name, keys, replaceExistingValues, withUserSuppliedKeys);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LoadAllOperation.java
@@ -39,15 +39,20 @@ public class LoadAllOperation extends MapOperation implements PartitionAwareOper
     private List<Data> keys;
 
     private boolean replaceExistingValues;
+    private boolean withUserSuppliedKeys;
 
     public LoadAllOperation() {
         keys = Collections.emptyList();
     }
 
-    public LoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues) {
+    public LoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues, boolean withUserSuppliedKeys) {
         super(name);
         this.keys = keys;
         this.replaceExistingValues = replaceExistingValues;
+        this.withUserSuppliedKeys = withUserSuppliedKeys;
+        // the withUserSuppliedKeys field piggy-backs on Operation flags for serialization
+        // as the field was introduced in a patch release
+        setFlag(withUserSuppliedKeys, BITMASK_LOAD_ALL_WITH_USER_SUPPLIED_KEYS);
     }
 
     @Override
@@ -58,7 +63,7 @@ public class LoadAllOperation extends MapOperation implements PartitionAwareOper
             removeExistingKeys(keys);
         }
 
-        recordStore.loadAllFromStore(keys);
+        recordStore.loadAllFromStore(keys, withUserSuppliedKeys);
     }
 
     @Override
@@ -116,6 +121,8 @@ public class LoadAllOperation extends MapOperation implements PartitionAwareOper
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
+        withUserSuppliedKeys = isFlagSet(BITMASK_LOAD_ALL_WITH_USER_SUPPLIED_KEYS);
+
         final int size = in.readInt();
         if (size > 0) {
             keys = new ArrayList<Data>(size);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapLoadAllOperationFactory.java
@@ -48,7 +48,7 @@ public class MapLoadAllOperationFactory implements OperationFactory {
 
     @Override
     public Operation createOperation() {
-        return new LoadAllOperation(name, keys, replaceExistingValues);
+        return new LoadAllOperation(name, keys, replaceExistingValues, true);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -68,7 +68,8 @@ public interface MapOperationProvider {
 
     MapOperation createGetOperation(String name, Data dataKey);
 
-    MapOperation createLoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues);
+    MapOperation createLoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues,
+                                        boolean withUserSuppliedKeys);
 
     MapOperation createPutAllOperation(String name, MapEntries mapEntries);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -128,8 +128,9 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createLoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues) {
-        return getDelegate().createLoadAllOperation(name, keys, replaceExistingValues);
+    public MapOperation createLoadAllOperation(String name, List<Data> keys, boolean replaceExistingValues,
+                                               boolean withUserSuppliedKeys) {
+        return getDelegate().createLoadAllOperation(name, keys, replaceExistingValues, withUserSuppliedKeys);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -518,7 +518,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     }
 
     private Operation createLoadAllOperation(List<Data> keys, boolean replaceExistingValues) {
-        return operationProvider.createLoadAllOperation(name, keys, replaceExistingValues);
+        return operationProvider.createLoadAllOperation(name, keys, replaceExistingValues, true);
     }
 
     protected Data removeInternal(Data key) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -134,13 +134,14 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public void loadAllFromStore(List<Data> keys) {
+    public void loadAllFromStore(List<Data> keys, boolean withUserSuppliedKeys) {
         if (!keys.isEmpty()) {
             Future f = recordStoreLoader.loadValues(keys);
             loadingFutures.add(f);
         }
-
-        keyLoader.trackLoading(false, null);
+        if (!withUserSuppliedKeys) {
+            keyLoader.trackLoading(false, null);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -315,7 +315,7 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
      *
      * @param keys keys to be loaded.
      */
-    void loadAllFromStore(List<Data> keys);
+    void loadAllFromStore(List<Data> keys, boolean withUserSuppliedKeys);
 
     void updateLoadStatus(boolean lastBatch, Throwable exception);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -56,6 +56,13 @@ public abstract class Operation implements DataSerializable {
     static final int BITMASK_PARTITION_ID_32_BIT = 1 << 4;
     static final int BITMASK_CALL_TIMEOUT_64_BIT = 1 << 5;
     static final int BITMASK_SERVICE_NAME_SET = 1 << 6;
+    //CHECKSTYLE:OFF
+    // this belongs to com.hazelcast.map.impl.operation.LoadAllOperation,
+    // but we cannot add a new field into the maintenance branch due backward compatibility.
+    // the flag is defined in this case to indicate this particular bit is already occupied
+    // and cannot be used for other purposes.
+    protected static final int BITMASK_LOAD_ALL_WITH_USER_SUPPLIED_KEYS = 1 << 7;
+    //CHECKSTYLE:ON
 
     // serialized
     private String serviceName;
@@ -369,7 +376,7 @@ public abstract class Operation implements DataSerializable {
         return ne != null ? ne.getLogger(getClass()) : Logger.getLogger(getClass());
     }
 
-    void setFlag(boolean value, int bitmask) {
+    protected void setFlag(boolean value, int bitmask) {
         if (value) {
             flags |= bitmask;
         } else {
@@ -377,7 +384,7 @@ public abstract class Operation implements DataSerializable {
         }
     }
 
-    boolean isFlagSet(int bitmask) {
+    protected boolean isFlagSet(int bitmask) {
         return (flags & bitmask) != 0;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.test.TestCollectionUtils.setOfValuesBetween;
 import static com.hazelcast.test.TimeConstants.MINUTE;
 import static java.lang.String.format;
 import static java.util.Collections.singleton;
@@ -75,7 +76,7 @@ public class MapLoaderTest extends HazelcastTestSupport {
 
         map = ownerAndReplicas[3].getMap(name);
         map.loadAll(false);
-        assertEquals(DummyMapLoader.SIZE, map.size());
+        assertEquals(DummyMapLoader.DEFAULT_SIZE, map.size());
     }
 
     private HazelcastInstance[] findOwnerAndReplicas(HazelcastInstance[] instances, String name) {
@@ -196,6 +197,33 @@ public class MapLoaderTest extends HazelcastTestSupport {
         assertEquals(requestedKeys.length, loadedKeysCounter.get());
     }
 
+    @Test
+    public void givenSpecificKeysWereReloaded_whenLoadAllIsCalled_thenAllEntriesAreLoadedFromTheStore() {
+        String name = randomString();
+        int keysInMapStore = 10000;
+
+        Config config = new Config();
+        MapConfig mapConfig = config.getMapConfig(name);
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setEnabled(true);
+        mapStoreConfig.setImplementation(new DummyMapLoader(keysInMapStore));
+        mapStoreConfig.setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER);
+        mapConfig.setMapStoreConfig(mapStoreConfig);
+        TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = instanceFactory.newInstances(config);
+        IMap<Integer, Integer> map = instances[0].getMap(name);
+
+        //load specific keys
+        map.loadAll(setOfValuesBetween(0, keysInMapStore), true);
+
+        //remove everything
+        map.clear();
+
+        //assert loadAll with load all entries provided by the mapLoader
+        map.loadAll(true);
+        assertEquals(keysInMapStore, map.size());
+    }
+
     @Test(timeout = MINUTE)
     @Ignore //https://github.com/hazelcast/hazelcast/issues/5453
     public void testMapCanBeLoaded_whenLoadAllKeysThrowsExceptionFirstTime() throws InterruptedException {
@@ -278,14 +306,18 @@ public class MapLoaderTest extends HazelcastTestSupport {
         });
     }
 
-    private static class DummyMapLoader implements MapLoader<Integer, Integer> {
+    public static class DummyMapLoader implements MapLoader<Integer, Integer> {
 
-        static final int SIZE = 1000;
+        static final int DEFAULT_SIZE = 1000;
 
-        final Map<Integer, Integer> map = new ConcurrentHashMap<Integer, Integer>(SIZE);
+        final Map<Integer, Integer> map = new ConcurrentHashMap<Integer, Integer>(DEFAULT_SIZE);
 
         public DummyMapLoader() {
-            for (int i = 0; i < SIZE; i++) {
+            this(DEFAULT_SIZE);
+        }
+
+        public DummyMapLoader(int size) {
+            for (int i = 0; i < size; i++) {
                 map.put(i, i);
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestCollectionUtils.java
@@ -37,4 +37,12 @@ public class TestCollectionUtils {
         List<T> list = Arrays.asList(items);
         return new HashSet<T>(list);
     }
+
+    public static Set<Integer> setOfValuesBetween(int from, int to) {
+        HashSet<Integer> set = new HashSet<Integer>();
+        for (int i = from; i < to; i++) {
+            set.add(i);
+        }
+        return set;
+    }
 }


### PR DESCRIPTION
The LoadAllOperation is used in 2 contexts:
1. loadAll() - when all entries are reloaded
2. loadAll(keys) - when reloading of specific keys is requested by user

The first case uses a complex key-loading coordination and state transitions,
while the 2nd case is fairly simple - every member receives a set of keys
directly from the user.

This changeset fix the behaviour in the 2nd case where the
state was changed by accident and this led to a buggy
behaviour.

Fixes #9255 
EE counter-part: https://github.com/hazelcast/hazelcast-enterprise/pull/1134