### PR TITLE
Smart listener may cause NullPointerException

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -414,6 +414,10 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl implem
         }
 
         Address ownerConnectionAddress = clusterService.getOwnerConnectionAddress();
+        if (null == ownerConnectionAddress) {
+            return;
+        }
+
         for (Member member : members) {
             try {
                 getOrConnect(member, ownerConnectionAddress);


### PR DESCRIPTION
Fix for possibility of NullPointerException when opening connections to all members in the cluster. This was reported at https://github.com/hazelcast/hazelcast/pull/8848#pullrequestreview-8634355 .