### PR TITLE
Client protocol name is printed incorrect

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientSocketWriterInitializer.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientSocketWriterInitializer.java
@@ -17,10 +17,12 @@
 package com.hazelcast.client.connection.nio;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.nio.IOUtil;
 import com.hazelcast.internal.networking.SocketWriter;
 import com.hazelcast.internal.networking.SocketWriterInitializer;
 import com.hazelcast.internal.networking.WriteHandler;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.nio.Protocols;
 
 import java.nio.ByteBuffer;
 
@@ -36,6 +38,9 @@ class ClientSocketWriterInitializer implements SocketWriterInitializer<ClientCon
 
     @Override
     public void init(ClientConnection connection, SocketWriter writer, String protocol) {
+        Logger.getLogger(getClass())
+              .info("Initializing ClientSocketWriter WriteHandler with " + Protocols.toUserFriendlyString(protocol));
+
         writer.initOutputBuffer(IOUtil.newByteBuffer(bufferSize, direct));
 
         writer.initWriteHandler(new WriteHandler<ClientMessage>() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/Protocols.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Protocols.java
@@ -41,4 +41,20 @@ public final class Protocols {
 
     private Protocols() {
     }
+
+    public static String toUserFriendlyString(String protocol) {
+        if (CLUSTER.equals(protocol)) {
+            return "Cluster Protocol";
+        }
+
+        if (CLIENT_BINARY_NEW.equals(protocol)) {
+            return "Client Open Binary Protocol";
+        }
+
+        if (TEXT.equals(protocol)) {
+            return "Test Protocol";
+        }
+
+        return "Unknown Protocol";
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketWriterInitializerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketWriterInitializerImpl.java
@@ -21,11 +21,11 @@ import com.hazelcast.internal.networking.SocketWriterInitializer;
 import com.hazelcast.internal.networking.WriteHandler;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.IOService;
+import com.hazelcast.nio.Protocols;
 import com.hazelcast.nio.ascii.TextWriteHandler;
 
 import java.net.SocketException;
 import java.nio.ByteBuffer;
-import java.util.logging.Level;
 
 import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.IOUtil.newByteBuffer;
@@ -43,7 +43,7 @@ public class SocketWriterInitializerImpl implements SocketWriterInitializer<TcpI
 
     @Override
     public void init(TcpIpConnection connection, SocketWriter writer, String protocol) {
-        logger.log(Level.WARNING, "SocketWriter is not set, creating WriteHandler with CLUSTER protocol!");
+        logger.info("Initializing SocketWriter WriteHandler with " + Protocols.toUserFriendlyString(protocol));
 
         initHandler(connection, writer, protocol);
         initOutputBuffer(connection, writer, protocol);


### PR DESCRIPTION
The client protocol is incorrectly printed as Cluster protocol. The log is:

   SocketWriter is not set, creating WriteHandler with CLUSTER protocol

 It is also printed as warning but it may not be a warning, it may just as well be normal case as info to the user. The PR fixes this problem.