### PR TITLE
Infinite repeating warning logs when client is paused: WARNING: Client heartbeat is timed out , closing connection to Connection

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -113,4 +113,10 @@ public interface ClientEndpoint extends Client {
      * @param connection The connection of the endpoint
      */
     void setConnection(Connection connection);
+
+    /**
+     *
+     * @return true if any listeners are registered or transactions exist for the endpoint
+     */
+    boolean resourcesExist();
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -234,6 +234,11 @@ public final class ClientEndpointImpl implements ClientEndpoint {
         removeListenerActions.clear();
     }
 
+    @Override
+    public boolean resourcesExist() {
+        return !removeListenerActions.isEmpty() || !transactionContextMap.isEmpty();
+    }
+
     public void destroy() throws LoginException {
         clearAllListeners();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -27,8 +27,6 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.Clock;
 
-import java.util.logging.Level;
-
 import static com.hazelcast.util.StringUtil.timeToString;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -94,8 +92,12 @@ public class ClientHeartbeatMonitor implements Runnable {
                 String message = "Client heartbeat is timed out, closing connection to " + connection
                         + ". Now: " + timeToString(currentTimeMillis)
                         + ". LastTimePacketReceived: " + timeToString(lastTimePacketReceived);
-                logger.log(Level.WARNING, message);
                 connection.close(message, null);
+                if (clientEndpoint.resourcesExist()) {
+                    return;
+                }
+
+                clientEndpointManager.removeEndpoint(clientEndpoint, true);
             }
         }
     }


### PR DESCRIPTION
When client is connected and the client process is paused e.g. using a debugger, then the server starts printing the warning message every 10 seconds.

You can generate the case with the java server and client like this:

Use StartServer.java but use the following config:
```
        Config config = new Config();
        config.setProperty(GroupProperty.CLIENT_HEARTBEAT_TIMEOUT_SECONDS.getName(), "3");
        HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
```
Also use this as the client:
```
    @Test
    public void testIssue8777() {
        ClientConfig config = new ClientConfig();
        config.setProperty(ClientProperty.HEARTBEAT_INTERVAL.getName(), "1");
        HazelcastInstance client = HazelcastClient.newHazelcastClient(config);
        client.getMap(randomMapName()).addEntryListener(new EntryAddedListener<String, String >() {
            @Override
            public void entryAdded(EntryEvent<String, String> event) {
                System.out.println("Added");
            }
        }, true);
        sleepSeconds(Integer.MAX_VALUE);
    }
```
Pause the client for 3 seconds, see the warning at the server and before the server does the cleanup (at most 10 seconds), just continue the paused client, then after the client reconnects (you can also do this several times) just pause the client forever and you will see the repeated warnings at the server.

The solution: Print the log only when closing the connection which will only print one time. Also, remove the endpoint only if there is no registered listeners or transactions for the endpoint. When there is at least one listener registered, it will stay in the endpoints since when an event is to be delivered to the client which reconnected in 10 seconds before client cleanup is run, we should be able to deliver this event to the client.




