### PR TITLE
Shade/relocate tests jar too

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -212,6 +212,7 @@
                             <finalName>${project.build.finalName}</finalName>
                             <createSourcesJar>true</createSourcesJar>
                             <shadeSourcesContent>true</shadeSourcesContent>
+                            <shadeTestJar>true</shadeTestJar>
                             <artifactSet>
                                 <includes>
                                     <include>com.eclipsesource.minimal-json:minimal-json</include>


### PR DESCRIPTION
com.eclipsesource.minimal-json artifact is shaded our release jar
and `com.eclipsesource.json` package is relocated to
`com.hazelcast.com.eclipsesource.json` to avoid conflicts with user classpath.

But entries in test jar remain untouched, which makes impossible to test
Management Center requests on EE side.

With this change references to `com.eclipsesource.json` in test classes are
relocated as `com.hazelcast.com.eclipsesource.json` too.

See EE PR https://github.com/hazelcast/hazelcast-enterprise/pull/1137