### PR TITLE
Split brain handling: only allow clusters with same major.minor version to merge

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -23,7 +23,7 @@ import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.AbstractJoiner;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
-import com.hazelcast.internal.cluster.impl.JoinMessage;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
 import com.hazelcast.internal.cluster.impl.operations.MasterClaimOperation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -516,7 +516,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             return;
         }
         for (Address address : possibleAddresses) {
-            JoinMessage response = sendSplitBrainJoinMessage(address);
+            SplitBrainJoinMessage response = sendSplitBrainJoinMessage(address);
             if (shouldMerge(response)) {
                 logger.warning(node.getThisAddress() + " is merging [tcp/ip] to " + address);
                 setTargetAddress(address);

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -37,10 +37,10 @@ import com.hazelcast.internal.ascii.TextCommandServiceImpl;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ConfigCheck;
 import com.hazelcast.internal.cluster.impl.DiscoveryJoiner;
-import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.JoinRequest;
 import com.hazelcast.internal.cluster.impl.MulticastJoiner;
 import com.hazelcast.internal.cluster.impl.MulticastService;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.impl.InternalMigrationListener;
@@ -615,10 +615,10 @@ public class Node {
         joined.set(true);
     }
 
-    public JoinMessage createSplitBrainJoinMessage() {
-        return new JoinMessage(Packet.VERSION, buildInfo.getBuildNumber(), version, address, localMember.getUuid(),
+    public SplitBrainJoinMessage createSplitBrainJoinMessage() {
+        return new SplitBrainJoinMessage(Packet.VERSION, buildInfo.getBuildNumber(), version, address, localMember.getUuid(),
                 localMember.isLiteMember(), createConfigCheck(), clusterService.getMemberAddresses(),
-                clusterService.getSize(MemberSelectors.DATA_MEMBER_SELECTOR));
+                clusterService.getSize(MemberSelectors.DATA_MEMBER_SELECTOR), clusterService.getClusterVersion());
     }
 
     public JoinRequest createJoinRequest(boolean withCredentials) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -26,7 +26,6 @@ import com.hazelcast.internal.cluster.impl.operations.ConfigMismatchOperation;
 import com.hazelcast.internal.cluster.impl.operations.FinalizeJoinOperation;
 import com.hazelcast.internal.cluster.impl.operations.GroupMismatchOperation;
 import com.hazelcast.internal.cluster.impl.operations.HeartbeatOperation;
-import com.hazelcast.internal.cluster.impl.operations.JoinCheckOperation;
 import com.hazelcast.internal.cluster.impl.operations.JoinRequestOperation;
 import com.hazelcast.internal.cluster.impl.operations.LockClusterStateOperation;
 import com.hazelcast.internal.cluster.impl.operations.MasterClaimOperation;
@@ -40,6 +39,7 @@ import com.hazelcast.internal.cluster.impl.operations.PostJoinOperation;
 import com.hazelcast.internal.cluster.impl.operations.RollbackClusterStateOperation;
 import com.hazelcast.internal.cluster.impl.operations.SetMasterOperation;
 import com.hazelcast.internal.cluster.impl.operations.ShutdownNodeOperation;
+import com.hazelcast.internal.cluster.impl.operations.SplitBrainMergeValidationOperation;
 import com.hazelcast.internal.cluster.impl.operations.TriggerMemberListPublishOperation;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.serialization.DataSerializerHook;
@@ -68,7 +68,7 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public static final int CHANGE_CLUSTER_STATE = 10;
     public static final int CONFIG_MISMATCH = 11;
     public static final int GROUP_MISMATCH = 12;
-    public static final int JOIN_CHECK = 13;
+    public static final int SPLIT_BRAIN_MERGE_VALIDATION = 13;
     public static final int JOIN_REQUEST_OP = 14;
     public static final int LOCK_CLUSTER_STATE = 15;
     public static final int MASTER_CLAIM = 16;
@@ -89,8 +89,9 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public static final int MIGRATION_INFO = 31;
     public static final int VERSION = 32;
     public static final int CLUSTER_STATE_CHANGE = 33;
+    public static final int SPLIT_BRAIN_JOIN_MESSAGE = 34;
 
-    private static final int LEN = CLUSTER_STATE_CHANGE + 1;
+    private static final int LEN = SPLIT_BRAIN_JOIN_MESSAGE + 1;
 
     @Override
     public int getFactoryId() {
@@ -166,9 +167,9 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
                 return new GroupMismatchOperation();
             }
         };
-        constructors[JOIN_CHECK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+        constructors[SPLIT_BRAIN_MERGE_VALIDATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
-                return new JoinCheckOperation();
+                return new SplitBrainMergeValidationOperation();
             }
         };
         constructors[JOIN_REQUEST_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
@@ -269,6 +270,11 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
         constructors[CLUSTER_STATE_CHANGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new ClusterStateChange();
+            }
+        };
+        constructors[SPLIT_BRAIN_JOIN_MESSAGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new SplitBrainJoinMessage();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -105,11 +105,11 @@ public class MulticastJoiner extends AbstractJoiner {
 
     @Override
     public void searchForOtherClusters() {
-        final BlockingQueue<JoinMessage> q = new LinkedBlockingQueue<JoinMessage>();
+        final BlockingQueue<SplitBrainJoinMessage> q = new LinkedBlockingQueue<SplitBrainJoinMessage>();
         MulticastListener listener = new MulticastListener() {
             public void onMessage(Object msg) {
-                if (msg != null && msg instanceof JoinMessage) {
-                    JoinMessage joinRequest = (JoinMessage) msg;
+                if (msg != null && msg instanceof SplitBrainJoinMessage) {
+                    SplitBrainJoinMessage joinRequest = (SplitBrainJoinMessage) msg;
                     if (node.getThisAddress() != null && !node.getThisAddress().equals(joinRequest.getAddress())) {
                         q.add(joinRequest);
                     }
@@ -119,7 +119,7 @@ public class MulticastJoiner extends AbstractJoiner {
         node.multicastService.addMulticastListener(listener);
         node.multicastService.send(node.createJoinRequest(false));
         try {
-            JoinMessage joinInfo = q.poll(3, TimeUnit.SECONDS);
+            SplitBrainJoinMessage joinInfo = q.poll(3, TimeUnit.SECONDS);
             if (joinInfo != null) {
                 if (node.clusterService.getMember(joinInfo.getAddress()) != null) {
                     if (logger.isFineEnabled()) {
@@ -135,7 +135,7 @@ public class MulticastJoiner extends AbstractJoiner {
                     Thread.sleep(2 * node.getProperties().getMillis(GroupProperty.WAIT_SECONDS_BEFORE_JOIN));
                 }
 
-                JoinMessage response = sendSplitBrainJoinMessage(joinInfo.getAddress());
+                SplitBrainJoinMessage response = sendSplitBrainJoinMessage(joinInfo.getAddress());
                 if (shouldMerge(response)) {
                     logger.warning(node.getThisAddress() + " is merging [multicast] to " + joinInfo.getAddress());
                     startClusterMerge(joinInfo.getAddress());

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.version.Version;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * A {@code JoinMessage} issued by the master node of a subcluster to the master of another subcluster
+ * while searching for other clusters for split brain recovery.
+ */
+public class SplitBrainJoinMessage extends JoinMessage {
+
+    protected Version clusterVersion;
+
+    public SplitBrainJoinMessage() {
+    }
+
+    public SplitBrainJoinMessage(byte packetVersion, int buildNumber, Version version, Address address, String uuid,
+                                 boolean liteMember, ConfigCheck configCheck, Collection<Address> memberAddresses,
+                                 int dataMemberCount, Version clusterVersion) {
+        super(packetVersion, buildNumber, version, address, uuid, liteMember, configCheck, memberAddresses, dataMemberCount);
+        this.clusterVersion = clusterVersion;
+    }
+
+    @Override
+    public void readData(ObjectDataInput in)
+            throws IOException {
+        super.readData(in);
+        clusterVersion = in.readObject();
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out)
+            throws IOException {
+        super.writeData(out);
+        out.writeObject(clusterVersion);
+    }
+
+    @Override
+    public String toString() {
+        return "SplitBrainJoinMessage{"
+                + "packetVersion=" + packetVersion
+                + ", buildNumber=" + buildNumber
+                + ", codebaseVersion=" + version
+                + ", clusterVersion=" + clusterVersion
+                + ", address=" + address
+                + ", uuid='" + uuid + '\''
+                + ", liteMember=" + liteMember
+                + ", memberCount=" + getMemberCount()
+                + ", dataMemberCount=" + dataMemberCount
+                + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClusterDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.SPLIT_BRAIN_JOIN_MESSAGE;
+    }
+
+    public Version getClusterVersion() {
+        return clusterVersion;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -20,7 +20,7 @@ package com.hazelcast.test.mocknetwork;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.AbstractJoiner;
 import com.hazelcast.internal.cluster.impl.ClusterJoinManager;
-import com.hazelcast.internal.cluster.impl.JoinMessage;
+import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
 
@@ -153,7 +153,7 @@ class MockJoiner extends AbstractJoiner {
         possibleAddresses.remove(node.getThisAddress());
         possibleAddresses.removeAll(node.getClusterService().getMemberAddresses());
         for (Address address : possibleAddresses) {
-            JoinMessage response = sendSplitBrainJoinMessage(address);
+            SplitBrainJoinMessage  response = sendSplitBrainJoinMessage(address);
             if (shouldMerge(response)) {
                 startClusterMerge(address);
             }


### PR DESCRIPTION
A separate `JoinMessage` subclass is introduced, specifically for split-brain handling.
In `JoinCheckOperation` and `AbstractJoiner.shouldMerge`, we ensure clusters' `major.minor` versions match before merging.
Introduces extension hooks in `SplitBrainTestSupport` to allow for tests which result in separate clusters.