### PR TITLE
Backport https://github.com/hazelcast/hazelcast/pull/9273

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -109,12 +109,6 @@ public interface ClientEndpoint extends Client {
     void setClientVersion(String version);
 
     /**
-     * Sets the connection and updates the connected address to the address of the socket.
-     * @param connection The connection of the endpoint
-     */
-    void setConnection(Connection connection);
-
-    /**
      *
      * @return true if any listeners are registered or transactions exist for the endpoint
      */

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
@@ -47,13 +47,6 @@ public interface ClientEndpointManager {
     ClientEndpoint getEndpoint(Connection connection);
 
     /**
-     * Gets the endpoint of a client with a provided client uuid.
-     * @param clientUuid The uuid of the client for which you want the endpoint.
-     * @return The found endpoint or null of no endpoint was found.
-     */
-     ClientEndpoint getEndpoint(String clientUuid);
-
-    /**
      * Gets all the endpoints for a given client.
      *
      * @param clientUuid the uuid of the client
@@ -93,10 +86,11 @@ public interface ClientEndpointManager {
      * todo: what happens when the endpoint was never registered
      *
      * @param endpoint the endpoint to remove.
+     * @param reason The reason why the endpoint is being removed
      * @throws java.lang.NullPointerException if endpoint is null.
-     * @see #removeEndpoint(ClientEndpoint, boolean)
+     * @see #removeEndpoint(ClientEndpoint, boolean, String)
      */
-    void removeEndpoint(ClientEndpoint endpoint);
+    void removeEndpoint(ClientEndpoint endpoint, String reason);
 
     /**
      * Removes an endpoint and optionally closes it immediately.
@@ -104,10 +98,18 @@ public interface ClientEndpointManager {
      * todo: what happens when the endpoint already is removed
      * todo: what happens when the endpoint was never registered
      *
-     * @param endpoint the endpoint to remove.
+     * @param ce the endpoint to remove.
      * @param closeImmediately if the endpoint is immediately closed.
+     * @param reason The reason why the endpoint is being removed.
      * @throws java.lang.NullPointerException if endpoint is null.
-     * @see #removeEndpoint(ClientEndpoint)
+     * @see #removeEndpoint(ClientEndpoint, String)
      */
-    void removeEndpoint(ClientEndpoint endpoint, boolean closeImmediately);
+    void removeEndpoint(ClientEndpoint ce, boolean closeImmediately, String reason);
+
+    /**
+     *
+     * @param clientUuid The uuid of the desired client conection
+     * @return Any connection with the provided client uuid which is live
+     */
+    Connection findLiveConnectionFor(String clientUuid);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -45,11 +45,11 @@ import java.util.concurrent.ConcurrentMap;
 public final class ClientEndpointImpl implements ClientEndpoint {
 
     private final ClientEngineImpl clientEngine;
-    private volatile Connection conn;
-    private ConcurrentMap<String, TransactionContext> transactionContextMap
+    private final Connection conn;
+    private final ConcurrentMap<String, TransactionContext> transactionContextMap
             = new ConcurrentHashMap<String, TransactionContext>();
-    private ConcurrentHashMap<String, Callable> removeListenerActions = new ConcurrentHashMap<String, Callable>();
-    private volatile SocketAddress socketAddress;
+    private final ConcurrentHashMap<String, Callable> removeListenerActions = new ConcurrentHashMap<String, Callable>();
+    private final SocketAddress socketAddress;
 
     private LoginContext loginContext;
     private ClientPrincipal principal;
@@ -61,20 +61,15 @@ public final class ClientEndpointImpl implements ClientEndpoint {
 
     public ClientEndpointImpl(ClientEngineImpl clientEngine, Connection conn) {
         this.clientEngine = clientEngine;
-        setConnection(conn);
-        this.clientVersion = BuildInfo.UNKNOWN_HAZELCAST_VERSION;
-        this.clientVersionString = "Unknown";
-    }
-
-    @Override
-    public void setConnection(Connection connection) {
-        this.conn = connection;
-        if (connection instanceof TcpIpConnection) {
-            TcpIpConnection tcpIpConnection = (TcpIpConnection) connection;
+        this.conn = conn;
+        if (conn instanceof TcpIpConnection) {
+            TcpIpConnection tcpIpConnection = (TcpIpConnection) conn;
             socketAddress = tcpIpConnection.getSocketChannelWrapper().socket().getRemoteSocketAddress();
         } else {
             socketAddress = null;
         }
+        this.clientVersion = BuildInfo.UNKNOWN_HAZELCAST_VERSION;
+        this.clientVersionString = "Unknown";
     }
 
     @Override
@@ -89,7 +84,15 @@ public final class ClientEndpointImpl implements ClientEndpoint {
 
     @Override
     public boolean isAlive() {
-        return conn.isAlive();
+        if (conn.isAlive()) {
+            return true;
+        }
+        String clientUuid = getUuid();
+        if (null != clientUuid) {
+            Connection connection = clientEngine.getEndpointManager().findLiveConnectionFor(clientUuid);
+            return null != connection;
+        }
+        return false;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -55,8 +55,6 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
     @Probe(name = "count", level = MANDATORY)
     private final ConcurrentMap<Connection, ClientEndpoint> endpoints =
             new ConcurrentHashMap<Connection, ClientEndpoint>();
-    private final ConcurrentMap<String, ClientEndpoint> clientEndpoints =
-            new ConcurrentHashMap<String, ClientEndpoint>();
 
     @Probe(name = "totalRegistrations", level = MANDATORY)
     private MwCounter totalRegistrations = newMwCounter();
@@ -91,43 +89,29 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
     }
 
     @Override
-    public ClientEndpoint getEndpoint(String clientUuid) {
-        return clientEndpoints.get(clientUuid);
-    }
-
-    @Override
     public void registerEndpoint(ClientEndpoint endpoint) {
         checkNotNull(endpoint, "endpoint can't be null");
 
         final Connection conn = endpoint.getConnection();
-        ClientEndpoint existingEndpoint = endpoints.put(conn, endpoint);
-        clientEndpoints.put(endpoint.getUuid(), endpoint);
-        if (existingEndpoint != null && endpoint != existingEndpoint) {
-            if (existingEndpoint.isFirstConnection()) {
-                logger.severe("An endpoint (first connection) already exists for connection:" + conn);
-            } else {
-                logger.info("Changed " + conn + " as the first connection for " + endpoint);
-            }
+        if (endpoints.putIfAbsent(conn, endpoint) != null) {
+            logger.severe("An endpoint already exists for connection:" + conn);
         } else {
-            if (endpoint != existingEndpoint) {
-                totalRegistrations.inc();
-            }
+            totalRegistrations.inc();
         }
     }
 
     @Override
-    public void removeEndpoint(ClientEndpoint endpoint) {
-        removeEndpoint(endpoint, false);
+    public void removeEndpoint(ClientEndpoint endpoint, String reason) {
+        removeEndpoint(endpoint, false, reason);
     }
 
     @Override
-    public void removeEndpoint(final ClientEndpoint ce, boolean closeImmediately) {
+    public void removeEndpoint(final ClientEndpoint ce, boolean closeImmediately, final String reason) {
         checkNotNull(ce, "endpoint can't be null");
 
         ClientEndpointImpl endpoint = (ClientEndpointImpl) ce;
 
         endpoints.remove(endpoint.getConnection());
-        clientEndpoints.remove(endpoint.getUuid());
         logger.info("Destroying " + endpoint);
         try {
             endpoint.destroy();
@@ -138,7 +122,7 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
         final Connection connection = endpoint.getConnection();
         if (closeImmediately) {
             try {
-                connection.close(null, null);
+                connection.close(reason, null);
             } catch (Throwable e) {
                 logger.warning("While closing client connection: " + connection, e);
             }
@@ -147,7 +131,7 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
                 public void run() {
                     if (connection.isAlive()) {
                         try {
-                            connection.close(null, null);
+                            connection.close(reason, null);
                         } catch (Throwable e) {
                             logger.warning("While closing client connection: " + e.toString());
                         }
@@ -169,7 +153,7 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
             String ownerUuid = endpoint.getPrincipal().getOwnerUuid();
             if (memberUuid.equals(ownerUuid)) {
                 iterator.remove();
-                removeEndpoint(endpoint, true);
+                removeEndpoint(endpoint, true, "Cleanup of disconnected client resources");
             }
         }
     }
@@ -187,5 +171,18 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
     @Override
     public int size() {
         return endpoints.size();
+    }
+
+    @Override
+    public Connection findLiveConnectionFor(String clientUuid) {
+        for (ClientEndpoint endpoint : endpoints.values()) {
+            if (clientUuid.equals(endpoint.getUuid())) {
+                Connection connection = endpoint.getConnection();
+                if (connection.isAlive()) {
+                    return connection;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -106,10 +106,10 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
     }
 
     @Override
-    public void removeEndpoint(final ClientEndpoint ce, boolean closeImmediately, final String reason) {
-        checkNotNull(ce, "endpoint can't be null");
+    public void removeEndpoint(final ClientEndpoint clientEndpoint, boolean closeImmediately, final String reason) {
+        checkNotNull(clientEndpoint, "endpoint can't be null");
 
-        ClientEndpointImpl endpoint = (ClientEndpointImpl) ce;
+        ClientEndpointImpl endpoint = (ClientEndpointImpl) clientEndpoint;
 
         endpoints.remove(endpoint.getConnection());
         logger.info("Destroying " + endpoint);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -353,7 +353,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
 
         Set<ClientEndpoint> endpoints = endpointManager.getEndpoints(clientUuid);
         for (ClientEndpoint endpoint : endpoints) {
-            endpointManager.removeEndpoint(endpoint, true);
+            endpointManager.removeEndpoint(endpoint, true, "Resources are being cleaned up for client " + clientUuid);
         }
 
         NodeEngineImpl nodeEngine = node.getNodeEngine();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -97,7 +97,7 @@ public class ClientHeartbeatMonitor implements Runnable {
                     return;
                 }
 
-                clientEndpointManager.removeEndpoint(clientEndpoint, true);
+                clientEndpointManager.removeEndpoint(clientEndpoint, true, message);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -222,6 +222,8 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
         if (null != clientUuid) {
             Connection conn = endpointManager.findLiveConnectionFor(clientUuid);
             if (null != conn) {
+                // update the connection for this task so that the new messages will use this new live connection
+                connection = conn;
                 return conn;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -59,39 +59,14 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractCallableM
         super(clientMessage, node, connection);
     }
 
-    protected void setEndpoint() {
-        if (connection.isAlive()) {
-            checkExistingEndpoint();
-            if (null == endpoint) {
-                endpoint = new ClientEndpointImpl(clientEngine, this.connection);
-            }
-        } else {
-            handleEndpointNotCreatedConnectionNotAlive();
-        }
-    }
-
-    private void checkExistingEndpoint() {
-        if (null != principal) {
-            endpoint = endpointManager.getEndpoint(principal.getUuid());
-            if (null != endpoint) {
-                Connection previousConnection = endpoint.getConnection();
-                if (null != previousConnection && !connection.equals(previousConnection)) {
-                    previousConnection.close("A new authentication request from the same client with uuid " + clientUuid
-                            + " is received. Closing the existing connection for this endpoint.", null);
-                }
-                endpoint.setConnection(connection);
-            }
-        }
-    }
-
     @Override
-    protected ClientEndpoint getEndpoint() {
+    protected ClientEndpointImpl getEndpoint() {
         if (connection.isAlive()) {
-            return endpoint;
+            return new ClientEndpointImpl(clientEngine, connection);
         } else {
             handleEndpointNotCreatedConnectionNotAlive();
-            return null;
         }
+        return null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
@@ -62,7 +62,6 @@ public class AuthenticationCustomCredentialsMessageTask
         if (parameters.clientHazelcastVersionExist) {
             clientVersion = parameters.clientHazelcastVersion;
         }
-        setEndpoint();
         return parameters;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
@@ -50,7 +50,6 @@ public class AuthenticationMessageTask extends AuthenticationBaseMessageTask<Cli
         if (parameters.clientHazelcastVersionExist) {
             clientVersion = parameters.clientHazelcastVersion;
         }
-        setEndpoint();
         return parameters;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/PingMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/PingMessageTask.java
@@ -68,4 +68,9 @@ public class PingMessageTask extends AbstractCallableMessageTask<ClientPingCodec
     public Object[] getParameters() {
         return null;
     }
+
+    @Override
+    protected Connection findSendConnection() {
+        return connection;
+    }
 }


### PR DESCRIPTION
Backports https://github.com/hazelcast/hazelcast/pull/9273

Reverted some of the the changes that was done as part of listener registration fix in terms of endpoint management. I previously changed to reuse the same endpoint for the reconnecting client in order to make the old existing listener be able to deliver the event messages to the same client that was reconnected (Doing this in AbstractBaseTask.sendClientMessage).

Also, added a reason to be printed when the endpoint is being destroyed. Since, this is an internal interface, I am hoping that this won't be a problem.