### PR TITLE
Simple HTTP based healthcheck implementation for cloud environments that support rolling restarts like Openshift or Google Cloud Engine

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
@@ -37,6 +37,7 @@ public final class TextCommandConstants {
     public static final byte[] ERROR = stringToBytes("ERROR");
     public static final byte[] CLIENT_ERROR = stringToBytes("CLIENT_ERROR ");
     public static final byte[] SERVER_ERROR = stringToBytes("SERVER_ERROR ");
+    public static final byte[] MIME_TEXT_PLAIN = stringToBytes("text/plain");
 
     private static final int SECOND = 60;
     private static final int MINUTE = 60;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -38,6 +38,7 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String URI_WAN_SYNC_ALL_MAPS = "/hazelcast/rest/wan/sync/allmaps";
     public static final String URI_MANCENTER_WAN_CLEAR_QUEUES = "/hazelcast/rest/mancenter/clearWanQueues";
     public static final String URI_ADD_WAN_CONFIG = "/hazelcast/rest/wan/addWanConfig";
+    public static final String URI_HEALTH_URL = "/hazelcast/health";
 
     protected HttpCommandProcessor(TextCommandService textCommandService) {
         super(textCommandService);

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -65,6 +65,8 @@ public interface IOService {
 
     boolean isRestEnabled();
 
+    boolean isHealthcheckEnabled();
+
     void removeEndpoint(Address endpoint);
 
     void onSuccessfulConnection(Address address);

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -134,6 +134,11 @@ public class NodeIOService implements IOService {
     }
 
     @Override
+    public boolean isHealthcheckEnabled() {
+        return node.getProperties().getBoolean(GroupProperty.HTTP_HEALTHCHECK_ENABLED);
+    }
+
+    @Override
     public void removeEndpoint(final Address endPoint) {
         nodeEngine.getExecutionService().execute(ExecutionService.IO_EXECUTOR, new Runnable() {
             @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/Protocols.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Protocols.java
@@ -52,7 +52,7 @@ public final class Protocols {
         }
 
         if (TEXT.equals(protocol)) {
-            return "Test Protocol";
+            return "Text Protocol";
         }
 
         return "Unknown Protocol";

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -169,6 +169,9 @@ public final class GroupProperty {
     public static final HazelcastProperty REST_ENABLED
             = new HazelcastProperty("hazelcast.rest.enabled", false);
 
+    public static final HazelcastProperty HTTP_HEALTHCHECK_ENABLED
+            = new HazelcastProperty("hazelcast.http.healthcheck.enabled", false);
+
     public static final HazelcastProperty MAP_LOAD_CHUNK_SIZE
             = new HazelcastProperty("hazelcast.map.load.chunk.size", 1000);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.ascii;
 
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.ascii.rest.HttpCommandProcessor;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -81,6 +82,13 @@ public class HTTPCommunicator {
 
     public String getClusterInfo() throws IOException {
         String url = address + "cluster";
+        return doGet(url);
+
+    }
+
+    public String getClusterHealth() throws IOException {
+        String baseAddress = instance.getCluster().getLocalMember().getSocketAddress().toString();
+        String url = "http:/" + baseAddress + HttpCommandProcessor.URI_HEALTH_URL;
         return doGet(url);
 
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -133,6 +133,11 @@ public class MockIOService implements IOService {
     }
 
     @Override
+    public boolean isHealthcheckEnabled() {
+        return false;
+    }
+
+    @Override
     public void removeEndpoint(Address endpoint) {
     }
 


### PR DESCRIPTION
This PR adds a very basic health check to the Hazelcast HTTP subsystem that provides information about the current health status (ongoing migrations, cluster size, ...). That way monitoring solutions or ready / health checks can be implemented on the cloud environment side.

The information provided are minimal to not interfere too much with the cluster load. Requests to `http://xxx.xxx.xxx.xxx:5701/hazelcast/health` are accepted whenever the property `hazelcast.http.healthcheck.enabled` is set to true. In this case a GET request provides a result like the following:
```
Hazelcast::NodeState=ACTIVE
Hazelcast::ClusterState=ACTIVE
Hazelcast::ClusterSafe=TRUE
Hazelcast::MigrationQueueSize=0
Hazelcast::ClusterSize=1
```

Based on this result the check can make assumptions like "the cluster is not yet safe, I cannot go on with rolling restarts".