### PR TITLE
Reset hot restart data before join

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -108,8 +108,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             }
             long joinStartTime = Clock.currentTimeMillis();
             Connection connection;
-            while (node.isRunning() && !node.joined()
-                    && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
+            while (shouldRetry() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
 
                 connection = node.connectionManager.getOrConnect(targetAddress);
                 if (connection == null) {
@@ -144,8 +143,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             long maxJoinMillis = getMaxJoinMillis();
             long startTime = Clock.currentTimeMillis();
 
-            while (node.isRunning() && !node.joined()
-                    && (Clock.currentTimeMillis() - startTime < maxJoinMillis)) {
+            while (shouldRetry() && (Clock.currentTimeMillis() - startTime < maxJoinMillis)) {
 
                 tryToJoinPossibleAddresses(possibleAddresses);
                 if (node.joined()) {
@@ -323,7 +321,7 @@ public class TcpIpJoiner extends AbstractJoiner {
         long maxMasterJoinTime = getMaxJoinTimeToMasterNode();
         long start = Clock.currentTimeMillis();
 
-        while (node.isRunning() && !node.joined() && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
+        while (shouldRetry() && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
 
             Address master = node.getMasterAddress();
             if (master != null) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -333,4 +333,8 @@ public class DefaultNodeExtension implements NodeExtension {
     public ClusterHotRestartStatusDTO getCurrentClusterHotRestartStatus() {
         return new ClusterHotRestartStatusDTO();
     }
+
+    @Override
+    public void resetHotRestartData() {
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -267,4 +267,10 @@ public interface NodeExtension {
      * be returned if Hot Restart is not available (not EE) or not enabled.
      */
     ClusterHotRestartStatusDTO getCurrentClusterHotRestartStatus();
+
+    /**
+     * Resets local hot restart data and gets a new uuid, if the local node hasn't completed the start process and
+     * it is excluded in cluster start.
+     */
+    void resetHotRestartData();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.operations.AuthenticationFailureOperation;
 import com.hazelcast.internal.cluster.impl.operations.AuthorizationOperation;
 import com.hazelcast.internal.cluster.impl.operations.BeforeJoinCheckFailureOperation;
+import com.hazelcast.internal.cluster.impl.operations.SendExcludedMemberUuidsOperation;
 import com.hazelcast.internal.cluster.impl.operations.ChangeClusterStateOperation;
 import com.hazelcast.internal.cluster.impl.operations.ConfigMismatchOperation;
 import com.hazelcast.internal.cluster.impl.operations.FinalizeJoinOperation;
@@ -90,8 +91,9 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public static final int VERSION = 32;
     public static final int CLUSTER_STATE_CHANGE = 33;
     public static final int SPLIT_BRAIN_JOIN_MESSAGE = 34;
+    public static final int SEND_EXCLUDED_MEMBER_UUIDS = 35;
 
-    private static final int LEN = SPLIT_BRAIN_JOIN_MESSAGE + 1;
+    private static final int LEN = SEND_EXCLUDED_MEMBER_UUIDS + 1;
 
     @Override
     public int getFactoryId() {
@@ -275,6 +277,11 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
         constructors[SPLIT_BRAIN_JOIN_MESSAGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new SplitBrainJoinMessage();
+            }
+        };
+        constructors[SEND_EXCLUDED_MEMBER_UUIDS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new SendExcludedMemberUuidsOperation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
+import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.operations.HeartbeatOperation;
 import com.hazelcast.internal.cluster.impl.operations.MasterConfirmationOperation;
 import com.hazelcast.internal.cluster.impl.operations.MemberInfoUpdateOperation;
@@ -35,6 +36,7 @@ import com.hazelcast.util.EmptyStatement;
 
 import java.net.ConnectException;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -418,14 +420,17 @@ public class ClusterHeartbeatManager {
         if (!node.isMaster()) {
             return;
         }
+
         Collection<MemberImpl> members = clusterService.getMemberImpls();
-        MemberInfoUpdateOperation op = new MemberInfoUpdateOperation(
-                createMemberInfoList(members), clusterClock.getClusterTime(), null, false);
+        List<MemberInfo> memberInfos = createMemberInfoList(members);
 
         for (MemberImpl member : members) {
             if (member.localMember()) {
                 continue;
             }
+
+            MemberInfoUpdateOperation op = new MemberInfoUpdateOperation(member.getUuid(), memberInfos,
+                    clusterClock.getClusterTime(), null, false);
             nodeEngine.getOperationService().send(op, member.getAddress());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -201,9 +201,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         if (thisAddress.equals(target)) {
             return;
         }
+        MemberImpl member = getMember(target);
+        String memberUuid = member != null ? member.getUuid() : null;
         Collection<MemberImpl> members = getMemberImpls();
-        MemberInfoUpdateOperation op = new MemberInfoUpdateOperation(
-                createMemberInfoList(members), clusterClock.getClusterTime(), null, false);
+        MemberInfoUpdateOperation op = new MemberInfoUpdateOperation(memberUuid, createMemberInfoList(members),
+                                                                     clusterClock.getClusterTime(), null, false);
         nodeEngine.getOperationService().send(op, target);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -51,8 +51,7 @@ public class MulticastJoiner extends AbstractJoiner {
         long maxJoinMillis = getMaxJoinMillis();
         Address thisAddress = node.getThisAddress();
 
-        while (node.isRunning() && !node.joined()
-                && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
+        while (shouldRetry() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
 
             // clear master node
             node.setMasterAddress(null);
@@ -77,8 +76,7 @@ public class MulticastJoiner extends AbstractJoiner {
         long maxMasterJoinTime = getMaxJoinTimeToMasterNode();
         long start = Clock.currentTimeMillis();
 
-        while (node.isRunning() && !node.joined()
-                && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
+        while (shouldRetry() && Clock.currentTimeMillis() - start < maxMasterJoinTime) {
 
             Address master = node.getMasterAddress();
             if (master != null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
@@ -54,10 +54,10 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
     public FinalizeJoinOperation() {
     }
 
-    public FinalizeJoinOperation(Collection<MemberInfo> members, PostJoinOperation postJoinOp, long masterTime,
+    public FinalizeJoinOperation(String targetUuid, Collection<MemberInfo> members, PostJoinOperation postJoinOp, long masterTime,
                                  String clusterId, long clusterStartTime, ClusterState clusterState, Version clusterVersion,
                                  PartitionRuntimeState partitionRuntimeState) {
-        super(members, masterTime, partitionRuntimeState, true);
+        super(targetUuid, members, masterTime, partitionRuntimeState, true);
         this.postJoinOp = postJoinOp;
         this.clusterId = clusterId;
         this.clusterStartTime = clusterStartTime;
@@ -65,10 +65,10 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
         this.clusterVersion = clusterVersion;
     }
 
-    public FinalizeJoinOperation(Collection<MemberInfo> members, PostJoinOperation postJoinOp, long masterTime,
+    public FinalizeJoinOperation(String targetUuid, Collection<MemberInfo> members, PostJoinOperation postJoinOp, long masterTime,
                                  String clusterId, long clusterStartTime, ClusterState clusterState, Version clusterVersion,
                                  PartitionRuntimeState partitionRuntimeState, boolean sendResponse) {
-        super(members, masterTime, partitionRuntimeState, sendResponse);
+        super(targetUuid, members, masterTime, partitionRuntimeState, sendResponse);
         this.postJoinOp = postJoinOp;
         this.clusterId = clusterId;
         this.clusterStartTime = clusterStartTime;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SendExcludedMemberUuidsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SendExcludedMemberUuidsOperation.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl.operations;
+
+import com.hazelcast.instance.NodeExtension;
+import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Collections.unmodifiableSet;
+
+/**
+ * Sends excluded member uuids to a member which is in that set.
+ * We need this operation because we don't allow an excluded member to join to the cluster.
+ * Therefore, we notify it so that the excluded member can force-start itself.
+ */
+public class SendExcludedMemberUuidsOperation extends AbstractClusterOperation {
+
+
+    private Set<String> excludedMemberUuids;
+
+    public SendExcludedMemberUuidsOperation() {
+    }
+
+    public SendExcludedMemberUuidsOperation(Set<String> excludedMemberUuids) {
+        this.excludedMemberUuids = excludedMemberUuids != null ? excludedMemberUuids : Collections.<String>emptySet();
+    }
+
+    @Override
+    public void run() {
+        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
+        NodeExtension nodeExtension = nodeEngine.getNode().getNodeExtension();
+        nodeExtension.handleExcludedMemberUuids(getCallerAddress(), excludedMemberUuids);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(excludedMemberUuids.size());
+        for (String uuid : excludedMemberUuids) {
+            out.writeUTF(uuid);
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int size = in.readInt();
+        Set<String> excludedMemberUuids = new HashSet<String>();
+        for (int i = 0; i < size; i++) {
+            excludedMemberUuids.add(in.readUTF());
+        }
+
+        this.excludedMemberUuids = unmodifiableSet(excludedMemberUuids);
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.SEND_EXCLUDED_MEMBER_UUIDS;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -49,7 +49,7 @@ class MockJoiner extends AbstractJoiner {
 
             Address previousJoinAddress = null;
             long joinAddressTimeout = 0;
-            while (node.isRunning() && !node.joined() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
+            while (shouldRetry() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
                 try {
                     Address joinAddress = getJoinAddress();
                     verifyInvariant(joinAddress != null, "joinAddress should not be null");
@@ -85,12 +85,6 @@ class MockJoiner extends AbstractJoiner {
                 }
             }
         }
-
-        final boolean joined = node.joined();
-        if (!joined) {
-            node.shutdown(true);
-        }
-        verifyInvariant(joined, node.getThisAddress() + " should have been joined to " + node.getMasterAddress());
     }
 
     private Address getJoinAddress() {


### PR DESCRIPTION
Joiner impls check if the node needs to reset its hot restart data. If that it is the case, the node resets its hot restart data to be able to join to the cluster.

This change pollutes join mechanism because of hot restart mechanics. However, without it, users have to clear hot restart data manually if they start excluded nodes after the cluster is started.

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/1141