### PR TITLE
small fix for aws address translator

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -603,7 +603,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     private void authenticated(Address target, ClientConnection connection) {
-        ClientConnection oldConnection = connections.put(connection.getRemoteEndpoint(), connection);
+        ClientConnection oldConnection = connections.put(addressTranslator.translate(connection.getRemoteEndpoint()), connection);
         if (oldConnection == null) {
             fireConnectionAddedEvent(connection);
         }


### PR DESCRIPTION
This modification doesn't affect default translator.

In Aws, due to public/private terms, we need to convert ip-address sometimes.

This fix is tested from me and from an user.