### PR TITLE
Retain call ID after invocation completes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
@@ -38,24 +38,25 @@ public final class OperationAccessor {
     }
 
     /**
-     * Sets the callId for the Operation.
-     *
-     * @param op the Operatior that is updated for its callId.
-     * @param callId the callId.
-     * @see Operation#setCallId(long)
-     * @see Operation#getCallId()
+     * Assigns the supplied call ID to the supplied operation, thereby activating it.
+     * Refer to Operation#setCallId(long) and Operation#getCallId() for detailed semantics.
      */
     public static void setCallId(Operation op, long callId) {
         op.setCallId(callId);
     }
 
     /**
-     * Resets the callId for the Operation to zero. For details see {@link Operation#resetCallId()}
+     * Marks the supplied operation as "not active".
      *
-     * @param op the Operation on which to reset the callId
+     * @param op the Operation to deactivate
+     * @see Operation#deactivate()
      */
-    public static long resetCallId(Operation op) {
-        return op.resetCallId();
+    public static boolean deactivate(Operation op) {
+        return op.deactivate();
+    }
+
+    public static boolean hasActiveInvocation(Operation op) {
+        return op.hasActiveInvocation();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -27,6 +27,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 
 import static com.hazelcast.internal.partition.InternalPartition.MAX_BACKUP_COUNT;
+import static com.hazelcast.spi.OperationAccessor.hasActiveInvocation;
 import static com.hazelcast.spi.OperationAccessor.setCallId;
 import static java.lang.Math.min;
 
@@ -256,8 +257,8 @@ final class OperationBackupHandler {
         return backupOp;
     }
 
-    private Backup newBackup(BackupAwareOperation backupAwareOp, Object backupOp, long[] replicaVersions,
-            int replicaIndex, boolean respondBack) {
+    private static Backup newBackup(BackupAwareOperation backupAwareOp, Object backupOp, long[] replicaVersions,
+                                    int replicaIndex, boolean respondBack) {
         Operation op = (Operation) backupAwareOp;
         Backup backup;
         if (backupOp instanceof Operation) {
@@ -269,9 +270,8 @@ final class OperationBackupHandler {
         }
 
         backup.setPartitionId(op.getPartitionId()).setReplicaIndex(replicaIndex);
-        final long callId = op.getCallId();
-        if (callId != 0) {
-            setCallId(backup, callId);
+        if (hasActiveInvocation(op)) {
+            setCallId(backup, op.getCallId());
         }
         return backup;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -413,7 +413,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         if (op.getCallId() == 0) {
             if (op.returnsResponse()) {
                 throw new HazelcastException(
-                        "Op: " + op + " can not return response without call-id!");
+                        "Operation " + op + " wants to return a response, but doesn't have a call ID");
             }
             handler = createEmptyResponseHandler();
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequenceWithBackpressureTest.java
@@ -17,7 +17,6 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
 
-import static com.hazelcast.spi.OperationAccessor.resetCallId;
 import static com.hazelcast.spi.OperationAccessor.setCallId;
 import static com.hazelcast.spi.impl.operationservice.impl.CallIdSequence.CallIdSequenceWithBackpressure.MAX_DELAY_MS;
 import static org.junit.Assert.assertEquals;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -5,6 +5,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.RequireAssertEnabled;
@@ -16,8 +17,10 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.ExecutionException;
 
+import static com.hazelcast.spi.OperationAccessor.hasActiveInvocation;
 import static com.hazelcast.spi.properties.GroupProperty.BACKPRESSURE_ENABLED;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
@@ -107,7 +110,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
         invocationRegistry.register(invocation);
         invocationRegistry.deregister(invocation);
 
-        assertEquals(0, invocation.op.getCallId());
+        assertFalse(hasActiveInvocation(invocation.op));
     }
 
     @Test


### PR DESCRIPTION
* Operation.getCallId() on an inactive operation now keeps returning the call ID of the last invocation, until another call ID is set.
* Operation.setCallId() prevents overwriting the call ID on an active operation.
* Operation.deactivate() must now be used to deactivate the operation.
* Operation.hasActiveInvocation() can be used to check activation state of operation.