### PR TITLE
Retry the invocation only if managed to deregister

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -114,16 +114,18 @@ public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider
     }
 
     /**
-     * Deregisters an invocation. If the associated operation is inactive, the call is ignored.
+     * Deregisters an invocation. If the associated operation is inactive, takes no action and returns {@code false}.
      * This ensures the idempotence of deregistration.
      * @param invocation The Invocation to deregister.
+     * @return {@code true} if this call deregistered the invocation; {@code false} if the invocation wasn't registered
      */
-    public void deregister(Invocation invocation) {
+    public boolean deregister(Invocation invocation) {
         if (!deactivate(invocation.op)) {
-            return;
+            return false;
         }
         invocations.remove(invocation.op.getCallId());
         callIdSequence.complete();
+        return true;
     }
 
     /**


### PR DESCRIPTION
Avoids a race between two retrying threads which could result in a leak inside the Invocation Registry. If two threads initiate the retrying of the same operation, each thread will create a new call ID, but only the last call ID update will be preserved by the Operation instance. Upon completion, the overwritten call ID will fail to be removed from the Invocation Registry.

If the operation was never registered, every thread is allowed to retry it. This is because invocation can fail even before registration and then deregistration always fails. Allowing retrying to all threads seems safe because there is no risk of concurrent retrying of an operation that didn't even make it to registration.

The race is still there that can lead to multiple concurrent operation retries. Only one retry invocation will be found in the registry; others will be unaccounted for.

Also, if the invocation was registered before, but then a retry fails before re-registering, this will lead to the loss of any progress in retrying. It is currently thought that failing before re-registering won't ever happen.