### PR TITLE
Invocation cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastOverloadException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastOverloadException.java
@@ -30,4 +30,8 @@ public class HazelcastOverloadException extends HazelcastException {
     public HazelcastOverloadException(String message) {
         super(message);
     }
+
+    public HazelcastOverloadException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/CallsPerMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/CallsPerMember.java
@@ -66,7 +66,7 @@ public final class CallsPerMember implements LiveOperations {
     public OperationControl toOpControl(Address address) {
         CategorizedCallIds callIds = callIdsByMember.get(address);
         if (callIds == null) {
-            throw new IllegalArgumentException("unknown address");
+            throw new IllegalArgumentException("Address not recognized as a member of this cluster: " + address);
         }
         return new OperationControl(toArray(callIds.liveOps), toArray(callIds.opsToCancel));
     }
@@ -103,7 +103,7 @@ public final class CallsPerMember implements LiveOperations {
         return array;
     }
 
-    static final class CategorizedCallIds {
+    private static final class CategorizedCallIds {
         final List<Long> liveOps = new ArrayList<Long>();
         final List<Long> opsToCancel = new ArrayList<Long>();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/LiveOperations.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/LiveOperations.java
@@ -19,11 +19,18 @@ package com.hazelcast.spi;
 import com.hazelcast.nio.Address;
 
 /**
- * Collects per member the callIds of all live operations.
+ * {@link InvocationMonitor} passes instances of this type to each {@link LiveOperationsTracker}
+ * so it can contribute the call IDs of invocations it is responsible for.
  * The object is not thread-safe and is recycled.
  */
 public interface LiveOperations {
 
+    /**
+     * Registers an invocation with this object.
+     *
+     * @param address address of the sender of the operation
+     * @param callId call ID of the operation
+     */
     void add(Address address, long callId);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -200,7 +200,7 @@ public abstract class Operation implements DataSerializable {
      * positive call ID.
      * @return {@code true} if the operation's invocation is active; {@code false} otherwise
      */
-    final boolean hasActiveInvocation() {
+    final boolean isActive() {
         return callId > 0;
     }
 
@@ -217,7 +217,7 @@ public abstract class Operation implements DataSerializable {
             return true;
         }
         if (callId > 0) {
-            throw new IllegalStateException("Operation concurrently re-activated while executing deactivate()");
+            throw new IllegalStateException("Operation concurrently re-activated while executing deactivate(). " + this);
         }
         return false;
     }
@@ -231,17 +231,18 @@ public abstract class Operation implements DataSerializable {
     // Accessed using OperationAccessor
     final void setCallId(long newId) {
         if (newId <= 0) {
-            throw new IllegalArgumentException("Attempted to set non-positive call ID " + newId);
+            throw new IllegalArgumentException(String.format("Attempted to set non-positive call ID %d on %s",
+                    newId, this));
         }
-        final long c = this.callId;
+        final long c = callId;
         if (c > 0) {
             throw new IllegalStateException(String.format(
-                    "Attempt to overwrite the call ID of an active operation: current %d, requested %d",
-                    this.callId, newId));
+                    "Attempt to overwrite the call ID of an active operation: current %d, requested %d. %s",
+                    callId, newId, this));
         }
         if (!CALL_ID.compareAndSet(this, c, newId)) {
             throw new IllegalStateException(String.format("Concurrent modification of call ID. Initially observed %d,"
-                    + " then attempted to set %d, then observed %d", c, newId, callId));
+                    + " then attempted to set %d, then observed %d. %s", c, newId, callId, this));
         }
         onSetCallId(newId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -77,7 +77,7 @@ public abstract class Operation implements DataSerializable {
     private transient Connection connection;
     private transient OperationResponseHandler responseHandler;
 
-    public Operation() {
+    protected Operation() {
         setFlag(true, BITMASK_VALIDATE_TARGET);
         setFlag(true, BITMASK_CALL_TIMEOUT_64_BIT);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationAccessor.java
@@ -46,17 +46,15 @@ public final class OperationAccessor {
     }
 
     /**
-     * Marks the supplied operation as "not active".
-     *
-     * @param op the Operation to deactivate
-     * @see Operation#deactivate()
+     * Marks the supplied operation as "not active". Refer to {@link Operation#deactivate()) for
+     * detailed semantics.
      */
     public static boolean deactivate(Operation op) {
         return op.deactivate();
     }
 
     public static boolean hasActiveInvocation(Operation op) {
-        return op.hasActiveInvocation();
+        return op.isActive();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationControl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationControl.java
@@ -32,6 +32,8 @@ import java.io.IOException;
  * </ol>
  * Operations are identified by their Call ID.
  */
+@SuppressFBWarnings(value = "EI", justification =
+        "The priority is minimizing garbage. The caller guarantees not to mutate the long[] arrays.")
 public final class OperationControl implements IdentifiedDataSerializable {
 
     private long[] runningOperations;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
@@ -181,7 +181,8 @@ abstract class CallIdSequence {
                     return;
                 }
                 if (System.currentTimeMillis() >= deadline) {
-                    throw new TimeoutException("Timed out trying to acquire another call ID");
+                    throw new TimeoutException(String.format("Timed out trying to acquire another call ID."
+                        + " maxConcurrentInvocations = %d, backoffTimeout = %d", maxConcurrentInvocations, backoffTimeoutMs));
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
@@ -16,11 +16,10 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.core.HazelcastOverloadException;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.util.concurrent.BackoffIdleStrategy;
 import com.hazelcast.util.concurrent.IdleStrategy;
 
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
@@ -31,11 +30,11 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 /**
  * Responsible for generating invocation callIds.
  * <p>
- * It is very important that for each {@link #next(Invocation)}, there is a matching {@link #complete()}.
+ * It is very important that for each {@link #next(boolean)} there is a matching {@link #complete()}.
  * If they don't match, the number of concurrent invocations will grow/shrink without bound over time.
  * This can lead to OOME or deadlock.
  * <p>
- * When backpressure is enabled and there are too many concurrent invocations, calls of {@link #next(Invocation)}
+ * When backpressure is enabled and there are too many concurrent invocations, calls of {@link #next(boolean)}
  * will block using a spin-loop with exponential backoff.
  * <p/>
  * Currently a single CallIdSequence is used for all partitions, so there is contention. Also one partition
@@ -52,27 +51,32 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  */
 abstract class CallIdSequence {
 
-    // just for testing purposes.
-    abstract long getLastCallId();
-
     /**
      * Returns the maximum concurrent invocations supported. Integer.MAX_VALUE means there is no max.
      *
      * @return the maximum concurrent invocation.
      */
-    public abstract int getMaxConcurrentInvocations();
+    abstract int getMaxConcurrentInvocations();
 
     /**
-     * Creates the next call-id.
+     * Generates the next unique call ID. If called with {@code isUrgent == false} and the implementation
+     * supports backpressure, it will not return unless the number of outstanding invocations is within the
+     * configured limit. Instead it will block until the condition is met and eventually throw a timeout exception.
      *
-     * @param invocation the Invocation to create a call-id for.
-     * @return the generated callId.
-     * @throws AssertionError if invocation.op.callId not equals 0
+     * @param isUrgent {@code true} means we're need a call ID for an urgent operation
+     * @return the generated call ID
+     * @throws TimeoutException if the outstanding invocation count hasn't dropped below the configured limit
+     * within the configured timeout
      */
-    public abstract long next(Invocation invocation);
+    abstract long next(boolean isUrgent) throws TimeoutException;
 
     /** Not idempotent: must be called exactly once per invocation. */
-    public abstract void complete();
+    abstract void complete();
+
+    /** Returns the last issued call ID.
+     * <strong>ONLY FOR TESTING. Must not be used for production code.</strong>
+     */
+    abstract long getLastCallId();
 
     static final class CallIdSequenceWithoutBackpressure extends CallIdSequence {
 
@@ -92,8 +96,7 @@ abstract class CallIdSequence {
         }
 
         @Override
-        public long next(Invocation invocation) {
-            assert !invocation.isActive() : "Invocation is already in progress:" + invocation;
+        public long next(boolean isUrgent) {
             return HEAD.incrementAndGet(this);
         }
 
@@ -145,15 +148,10 @@ abstract class CallIdSequence {
         }
 
         @Override
-        public long next(Invocation invocation) {
-            final Operation op = invocation.op;
-            assert !invocation.isActive() : "Invocation is already in progress:" + invocation;
-
-            if (!op.isUrgent() && !hasSpace()) {
-                waitForSpace(invocation);
+        public long next(boolean isUrgent) throws TimeoutException {
+            if (!isUrgent && !hasSpace()) {
+                waitForSpace();
             }
-            // must generate a sequence even if the invocation is going to skip registration
-            // because this information is used to determine the number of in-flight invocations
             return next();
         }
 
@@ -175,46 +173,17 @@ abstract class CallIdSequence {
             return longs.get(INDEX_HEAD) - longs.get(INDEX_TAIL) < maxConcurrentInvocations;
         }
 
-        private void waitForSpace(Invocation invocation) {
+        private void waitForSpace() throws TimeoutException {
             long deadline = System.currentTimeMillis() + backoffTimeoutMs;
             for (long idleCount = 0; ; idleCount++) {
                 IDLER.idle(idleCount);
-
                 if (hasSpace()) {
                     return;
                 }
-
                 if (System.currentTimeMillis() >= deadline) {
-                    throw new HazelcastOverloadException("Failed to get a callId for invocation: " + invocation);
+                    throw new TimeoutException("Timed out trying to acquire another call ID");
                 }
             }
-        }
-
-        static boolean sleep(long delayMs) {
-            try {
-                Thread.sleep(delayMs);
-                return false;
-            } catch (InterruptedException e) {
-               return true;
-            }
-        }
-
-        /**
-         * Calculates the next delay using an exponential increase in time until either the MAX_DELAY_MS is reached or
-         * till the remainingTimeoutMs is reached.
-         */
-        static long nextDelay(long remainingTimeoutMs, long delayMs) {
-            delayMs *= 2;
-
-            if (delayMs > MAX_DELAY_MS) {
-                delayMs = MAX_DELAY_MS;
-            }
-
-            if (delayMs > remainingTimeoutMs) {
-                delayMs = remainingTimeoutMs;
-            }
-
-            return delayMs;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static com.hazelcast.nio.Bits.CACHE_LINE_LENGTH;
 import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
-import static com.hazelcast.spi.OperationAccessor.hasActiveInvocation;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -94,7 +93,7 @@ abstract class CallIdSequence {
 
         @Override
         public long next(Invocation invocation) {
-            assert !hasActiveInvocation(invocation.op) : "Invocation is already in progress:" + invocation;
+            assert !invocation.isActive() : "Invocation is already in progress:" + invocation;
             return HEAD.incrementAndGet(this);
         }
 
@@ -148,7 +147,7 @@ abstract class CallIdSequence {
         @Override
         public long next(Invocation invocation) {
             final Operation op = invocation.op;
-            assert !hasActiveInvocation(invocation.op) : "Invocation is already in progress:" + invocation;
+            assert !invocation.isActive() : "Invocation is already in progress:" + invocation;
 
             if (!op.isUrgent() && !hasSpace()) {
                 waitForSpace(invocation);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -566,6 +566,8 @@ public abstract class Invocation implements OperationResponseHandler {
         }
     }
 
+    // This is an idempotent operation
+    // because both invocationRegistry.deregister() and future.complete() are idempotent.
     private void complete(Object value) {
         context.invocationRegistry.deregister(this);
         future.complete(value);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -206,6 +206,10 @@ public abstract class Invocation implements OperationResponseHandler {
 
     abstract ExceptionAction onException(Throwable t);
 
+    boolean isActive() {
+        return hasActiveInvocation(op);
+    }
+
     /**
      * Initializes the invocation target.
      *
@@ -446,7 +450,7 @@ public abstract class Invocation implements OperationResponseHandler {
     private void invoke0(boolean isAsync) {
         if (invokeCount > 0) {
             throw new IllegalStateException("This invocation is already in progress");
-        } else if (hasActiveInvocation(op)) {
+        } else if (isActive()) {
             throw new IllegalStateException(
                     "Attempt to reuse the same operation in multiple invocations. Operation is " + op);
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -110,8 +110,13 @@ public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider
         } catch (TimeoutException e) {
             throw new HazelcastOverloadException("Failed to start invocation due to overload: " + invocation, e);
         }
-        // Fails with exception if the operation is already active
-        setCallId(invocation.op, callId);
+        try {
+            // Fails with IllegalStateException if the operation is already active
+            setCallId(invocation.op, callId);
+        } catch (IllegalStateException e) {
+            callIdSequence.complete();
+            throw e;
+        }
         invocations.put(callId, invocation);
         if (!alive) {
             invocation.notifyError(new HazelcastInstanceNotActiveException());

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -108,7 +108,7 @@ public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider
         try {
             callId = callIdSequence.next(invocation.op.isUrgent());
         } catch (TimeoutException e) {
-            throw new HazelcastOverloadException("Failed to start invocation due to overload: " + invocation);
+            throw new HazelcastOverloadException("Failed to start invocation due to overload: " + invocation, e);
         }
         // Fails with exception if the operation is already active
         setCallId(invocation.op, callId);

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationCallIdTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationCallIdTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.Clock;
+import junit.framework.AssertionFailedError;
+import org.joda.time.Seconds;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OperationCallIdTest {
+
+    @Rule
+    public final ExpectedException exceptionRule = ExpectedException.none();
+
+    final Operation op = new MockOperation();
+
+    @Test
+    public void when_callIdNotSet_thenIsZero() {
+        assertEquals(0, op.getCallId());
+    }
+
+    @Test
+    public void when_setCallIdInitial_thenActive() throws Exception {
+        op.setCallId(1);
+        assertEquals(1, op.getCallId());
+        assertTrue(op.isActive());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void when_setZeroCallId_thenFail() throws Exception {
+        op.setCallId(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void when_setNegativeCallId_thenFail() {
+        op.setCallId(-1);
+    }
+
+    @Test
+    public void when_setCallIdOnActiveOp_thenFail() {
+        // Given
+        op.setCallId(1);
+        assertTrue(op.isActive());
+
+        // Then
+        exceptionRule.expect(IllegalStateException.class);
+
+        // When
+        op.setCallId(1);
+    }
+
+    @Test
+    public void when_deactivateActiveOp_thenInactive() {
+        // Given
+        op.setCallId(1);
+        assertTrue(op.isActive());
+
+        // When
+        op.deactivate();
+
+        // Then
+        assertFalse(op.isActive());
+    }
+
+    @Test
+    public void when_deactivateInitialStateOp_thenNothingHappens() {
+        // Given
+        assertFalse(op.isActive());
+
+        // When
+        op.deactivate();
+
+        // Then
+        assertFalse(op.isActive());
+    }
+
+    @Test
+    public void when_deactivateDeactivatedOp_thenNothingHappens() {
+        // Given
+        op.setCallId(1);
+        op.deactivate();
+        assertFalse(op.isActive());
+
+        // When
+        op.deactivate();
+
+        // Then
+        assertFalse(op.isActive());
+    }
+
+    @Test
+    public void when_getCallIdOnDeactivatedOp_thenCallIdPreserved() {
+        // Given
+        final int mockCallId = 1;
+        op.setCallId(mockCallId);
+        op.deactivate();
+
+        // When
+        long callId = op.getCallId();
+
+        // Then
+        assertEquals(callId, mockCallId);
+    }
+
+    @Test
+    public void when_setCallIdOnDeactivatedOp_thenReactivated() {
+        // Given
+        op.setCallId(1);
+        op.deactivate();
+
+        // When
+        int newCallId = 2;
+        op.setCallId(newCallId);
+
+        // Then
+        assertTrue(op.isActive());
+        assertEquals(newCallId, op.getCallId());
+    }
+
+    @Test
+    public void when_concurrentlySetCallId_thenOnlyOneSucceeds() {
+        new ConcurrentExcerciser().run();
+    }
+}
+
+class MockOperation extends Operation {
+
+    @Override
+    public void run() throws Exception {
+    }
+}
+
+class ConcurrentExcerciser {
+    final Operation op = new MockOperation();
+    volatile AssertionFailedError testFailure;
+    volatile int activationCount;
+
+    void run() {
+        final Thread reader = new Thread() {
+            @Override
+            public void run() {
+                try {
+                    long previousCallId = 0;
+                    while (!interrupted()) {
+                        long callId;
+                        while ((callId = op.getCallId()) == previousCallId) {
+                            // Wait until a writer thread sets a call ID
+                        }
+                        activationCount++;
+                        long deadline = System.currentTimeMillis() + SECONDS.toMillis(1);
+                        while (System.currentTimeMillis() < deadline) {
+                            assertEquals(callId, op.getCallId());
+                        }
+                        op.deactivate();
+                        previousCallId = callId;
+                    }
+                } catch (AssertionFailedError e) {
+                    testFailure = e;
+                }
+            }
+        };
+        final int writerCount = 4;
+        final Thread[] writers = new Thread[writerCount];
+        for (int i = 0; i < writers.length; i++) {
+            final int initialCallId = i + 1;
+            writers[i] = new Thread() {
+                @Override
+                public void run() {
+                    long nextCallId = initialCallId;
+                    while (!interrupted()) {
+                        try {
+                            op.setCallId(nextCallId);
+                            nextCallId += writerCount;
+                        } catch (IllegalStateException e) {
+                            // Things are working as expected
+                        }
+                    }
+                }
+            };
+        }
+        try {
+            reader.start();
+            for (Thread t : writers) {
+                t.start();
+            }
+            final long deadline = System.currentTimeMillis() + SECONDS.toMillis(5);
+            while (System.currentTimeMillis() < deadline) {
+                if (testFailure != null) {
+                    throw testFailure;
+                }
+                LockSupport.parkNanos(MILLISECONDS.toNanos(1));
+            }
+        } finally {
+            reader.interrupt();
+            for (Thread t : writers) {
+                t.interrupt();
+            }
+        }
+        assertTrue("Failed to activate the operation at least twice", activationCount >= 2);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupAwareOperation.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentMap;
 
 class DummyBackupAwareOperation extends Operation implements BackupAwareOperation {
 
-    public final static ConcurrentMap<String, Integer> backupCompletedMap = new ConcurrentHashMap<String, Integer>();
+    public static final ConcurrentMap<String, Integer> backupCompletedMap = new ConcurrentHashMap<String, Integer>();
 
     public int syncBackupCount;
     public int asyncBackupCount;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -110,7 +110,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
         invocationRegistry.register(invocation);
         invocationRegistry.deregister(invocation);
 
-        assertFalse(hasActiveInvocation(invocation.op));
+        assertFalse(invocation.isActive());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -4,8 +4,11 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
+import com.hazelcast.spi.impl.operationservice.impl.CallIdSequence.CallIdSequenceWithBackpressure;
+import com.hazelcast.spi.impl.operationservice.impl.Invocation.Context;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.RequireAssertEnabled;
@@ -14,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import java.util.concurrent.ExecutionException;
 
@@ -30,18 +34,13 @@ import static org.junit.Assert.fail;
 public class InvocationRegistryTest extends HazelcastTestSupport {
 
     private InvocationRegistry invocationRegistry;
-    private OperationServiceImpl operationService;
-    private HazelcastInstance local;
+    private ILogger logger;
 
     @Before
     public void setup() {
-        Config config = new Config();
-        config.setProperty(BACKPRESSURE_ENABLED.getName(), "false");
-        local = createHazelcastInstance(config);
-        warmUpPartitions(local);
-
-        operationService = (OperationServiceImpl) getOperationService(local);
-        invocationRegistry = operationService.invocationRegistry;
+        logger = Mockito.mock(ILogger.class);
+        final int capacity = 2;
+        invocationRegistry = new InvocationRegistry(logger, new CallIdSequenceWithBackpressure(capacity, 1000));
     }
 
     private Invocation newInvocation() {
@@ -49,7 +48,8 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     }
 
     private Invocation newInvocation(Operation op) {
-        Invocation.Context context = operationService.invocationContext;
+        Invocation.Context context = new Context(null, null, null, null, null,
+                1000, invocationRegistry, null, "", logger, null, null, null, null, null, null, null, null);
         return new PartitionInvocation(context, op, 0, 0, 0, false);
     }
 
@@ -68,23 +68,21 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     }
 
     @Test
-    @RequireAssertEnabled
-    public void register_whenAlreadyRegistered_thenAssertionError() {
+    public void register_whenAlreadyRegistered_thenException() {
         Operation op = new DummyBackupAwareOperation();
         Invocation invocation = newInvocation(op);
         invocationRegistry.register(invocation);
-        long oldCallId = invocationRegistry.getLastCallId();
-
-        try {
-            invocationRegistry.register(invocation);
-            fail();
-        } catch (AssertionError expected) {
-
+        final long originalCallId = invocationRegistry.getLastCallId();
+        for (int i = 0; i < 10; i++) {
+            try {
+                invocationRegistry.register(invocation);
+                fail();
+            } catch (IllegalStateException e) {
+                // expected
+            }
+            assertSame(invocation, invocationRegistry.get(originalCallId));
+            assertEquals(originalCallId, invocation.op.getCallId());
         }
-
-        assertSame(invocation, invocationRegistry.get(oldCallId));
-        assertEquals(oldCallId, invocationRegistry.getLastCallId());
-        assertEquals(oldCallId, invocation.op.getCallId());
     }
 
     // ====================== deregister ===============================
@@ -141,7 +139,6 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
         assertEquals(2, invocationRegistry.size());
     }
 
-    // ===================== onMemberLeft ============================
 
     // ===================== reset ============================
 


### PR DESCRIPTION
* fix call ID sequence leak in `InvocationRegistry.register()`
* add a convenience method `Invocation.isActive()`
* improve diagnostic messages in exceptions
* add more Javadoc and code comments
* reduce the coupling of `CallIdSequence.next()`: instead of the whole `Invocation` instance, now it just takes a boolean argument. This dramatically simplifies unit testing.
* reuse `BackoffIdleStrategy` in `CallIdSequence#waitForSpace` 
* add tests for the improved call ID logic on Operation
* silence the `warn` logging on double completion of invocation futures: don't complain when the double completion involves a cancelation.