### PR TITLE
Backport https://github.com/hazelcast/hazelcast/pull/9271

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -113,4 +113,10 @@ public interface ClientEndpoint extends Client {
      * @param connection The connection of the endpoint
      */
     void setConnection(Connection connection);
+
+    /**
+     *
+     * @return true if any listeners are registered or transactions exist for the endpoint
+     */
+    boolean resourcesExist();
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -234,6 +234,11 @@ public final class ClientEndpointImpl implements ClientEndpoint {
         removeListenerActions.clear();
     }
 
+    @Override
+    public boolean resourcesExist() {
+        return !removeListenerActions.isEmpty() || !transactionContextMap.isEmpty();
+    }
+
     public void destroy() throws LoginException {
         clearAllListeners();
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -27,8 +27,6 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.Clock;
 
-import java.util.logging.Level;
-
 import static com.hazelcast.util.StringUtil.timeToString;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -94,8 +92,12 @@ public class ClientHeartbeatMonitor implements Runnable {
                 String message = "Client heartbeat is timed out, closing connection to " + connection
                         + ". Now: " + timeToString(currentTimeMillis)
                         + ". LastTimePacketReceived: " + timeToString(lastTimePacketReceived);
-                logger.log(Level.WARNING, message);
                 connection.close(message, null);
+                if (clientEndpoint.resourcesExist()) {
+                    return;
+                }
+
+                clientEndpointManager.removeEndpoint(clientEndpoint, true);
             }
         }
     }


### PR DESCRIPTION
Fix for https://github.com/hazelcast/hazelcast/issues/8777. Changed so that only the endpoints without outstanding listeners or transactions is destroyed.

Backports https://github.com/hazelcast/hazelcast/pull/9271 