### PR TITLE
Fix issue with MockConnectionManager.stop when nodes stopped concurrently

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.util.ExceptionUtil;
 import org.junit.Before;
 import org.junit.runners.Parameterized;
 
@@ -130,6 +131,7 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
             return Collections.singleton(address);
         } else {
             final CountDownLatch latch = new CountDownLatch(count);
+            final Throwable[] error = new Throwable[1];
             Collection<Address> addresses = new HashSet<Address>();
 
             for (int i = 0; i < count; i++) {
@@ -138,12 +140,20 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
 
                 new Thread() {
                     public void run() {
-                        TestUtil.terminateInstance(hz);
-                        latch.countDown();
+                        try {
+                            TestUtil.terminateInstance(hz);
+                        } catch (Throwable e) {
+                            error[0] = e;
+                        } finally {
+                            latch.countDown();
+                        }
                     }
                 }.start();
             }
             assertTrue(latch.await(2, TimeUnit.MINUTES));
+            if (error[0] != null) {
+                ExceptionUtil.sneakyThrow(error[0]);
+            }
             return addresses;
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -130,9 +130,13 @@ public class MockConnectionManager implements ConnectionManager {
                 ILogger otherLogger = otherNode.getLogger(MockConnectionManager.class);
                 otherLogger.fine(localMember + " will be removed from the cluster if present, "
                         + "because it has requested to leave.");
-                ClusterServiceImpl clusterService = otherNode.getClusterService();
-                clusterService.removeAddress(localMember.getAddress(), localMember.getUuid(),
-                        "Connection manager is stopped on " + localMember);
+                try {
+                    ClusterServiceImpl clusterService = otherNode.getClusterService();
+                    clusterService.removeAddress(localMember.getAddress(), localMember.getUuid(),
+                            "Connection manager is stopped on " + localMember);
+                } catch (Throwable e) {
+                    otherLogger.warning("While removing " + thisAddress, e);
+                }
             }
         }
         for (Connection connection : mapConnections.values()) {


### PR DESCRIPTION
When nodes terminates concurrently, `clusterService.removeAddress` can fail because
target node is already shutdown.

This issue is introduced by https://github.com/hazelcast/hazelcast/pull/9310