### PR TITLE
Fix issue with MockConnectionManager.stop when nodes stopped concurrently

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -130,9 +130,13 @@ public class MockConnectionManager implements ConnectionManager {
                 ILogger otherLogger = otherNode.getLogger(MockConnectionManager.class);
                 otherLogger.fine(localMember + " will be removed from the cluster if present, "
                         + "because it has requested to leave.");
-                ClusterServiceImpl clusterService = otherNode.getClusterService();
-                clusterService.removeAddress(localMember.getAddress(), localMember.getUuid(),
-                        "Connection manager is stopped on " + localMember);
+                try {
+                    ClusterServiceImpl clusterService = otherNode.getClusterService();
+                    clusterService.removeAddress(localMember.getAddress(), localMember.getUuid(),
+                            "Connection manager is stopped on " + localMember);
+                } catch (Throwable e) {
+                    otherLogger.warning("While removing " + thisAddress, e);
+                }
             }
         }
         for (Connection connection : mapConnections.values()) {


### PR DESCRIPTION
When nodes terminates concurrently, `clusterService.removeAddress` can fail because
target node is already shutdown.

This issue is introduced by https://github.com/hazelcast/hazelcast/pull/9311