### PR TITLE
Multicast joiner should send SplitBrainJoinMessage when searching for…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -117,7 +117,7 @@ public class MulticastJoiner extends AbstractJoiner {
             }
         };
         node.multicastService.addMulticastListener(listener);
-        node.multicastService.send(node.createJoinRequest(false));
+        node.multicastService.send(node.createSplitBrainJoinMessage());
         try {
             SplitBrainJoinMessage joinInfo = q.poll(3, TimeUnit.SECONDS);
             if (joinInfo != null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -125,7 +125,7 @@ public class NodeMulticastListener implements MulticastListener {
     }
 
     private boolean isJoinMessage(Object msg) {
-        return msg != null && msg instanceof JoinMessage;
+        return msg != null && msg instanceof JoinMessage && !(msg instanceof SplitBrainJoinMessage);
     }
 
     private boolean isValidJoinMessage(Object msg) {


### PR DESCRIPTION
… other clusters.

Fixes regression introduced by #9281 in multicast joiner split brain handling.