### PR TITLE
Distributed Classloading

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -128,6 +128,8 @@ public class Config {
 
     private HotRestartPersistenceConfig hotRestartPersistenceConfig = new HotRestartPersistenceConfig();
 
+    private DistributedClassloadingConfig distributedClassloadingConfig = new DistributedClassloadingConfig();
+
     private String licenseKey;
 
     private boolean liteMember;
@@ -1259,6 +1261,28 @@ public class Config {
      */
     public Config setLiteMember(boolean liteMember) {
         this.liteMember = liteMember;
+        return this;
+    }
+
+    /**
+     * Get current configuration of distributed classloading.
+     *
+     * @since 3.8
+     *
+     */
+    public DistributedClassloadingConfig getDistributedClassloadingConfig() {
+        return distributedClassloadingConfig;
+    }
+
+    /**
+     * Set distributed classloading configuration
+     *
+     * @param distributedClassloadingConfig
+     * @since 3.8
+     * @return distributed classloading configuration
+     */
+    public Config setDistributedClassloadingConfig(DistributedClassloadingConfig distributedClassloadingConfig) {
+        this.distributedClassloadingConfig = distributedClassloadingConfig;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/DistributedClassloadingConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DistributedClassloadingConfig.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.spi.annotation.Beta;
+
+/**
+ * Configuration of distributed classloading. When enabled it allows members to load classes from other members.
+ * This simplifies deployment as you do not have to deploy your domain classes into classpath of all cluster members.
+ *
+ */
+
+@Beta
+public class DistributedClassloadingConfig {
+
+    /**
+     * Controls caching of caches loaded from remote members
+     */
+    public enum ClassCacheMode {
+        /**
+         * Never caches loaded classes. This is suitable for loading runnables, callables, entry processors, etc.
+         *
+         */
+        OFF,
+
+        /**
+         * Cache indefinitely. This is suitable when you load long-living objects, such as domain objects stored
+         * in a map.
+         *
+         */
+        ETERNAL,
+    }
+
+    /**
+     * Controls how to react on receiving a classloading request from a remote member
+     *
+     */
+    public enum ProviderMode {
+        /**
+         * Never serves classes to other members. This member will never server classes to remote members.
+          */
+        OFF,
+
+        /**
+         * Serve classes from local classpath only. Classes loaded from other members will be used locally,
+         * but they won't be served to other members.
+         *
+         */
+        LOCAL_CLASSES_ONLY,
+
+        /**
+         * Serve classes loaded from both local classpath and from other members.
+         *
+         */
+        LOCAL_AND_CACHED_CLASSES
+    }
+
+    private ClassCacheMode classCacheMode = ClassCacheMode.ETERNAL;
+    private ProviderMode providerMode = ProviderMode.LOCAL_AND_CACHED_CLASSES;
+    private String blacklistedPrefixes;
+    private String whitelistedPrefixes;
+    private String providerFilter;
+    private boolean enabled;
+
+    /**
+     * Enable or disable distributed classloading. Default: {{@code false}}
+     *
+     * @param enabled
+     * @return
+     */
+    public DistributedClassloadingConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Returns true when distributed classloading is enabled
+     *
+     * @return {{@code true}} when distributed classloading is enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Filter to constraint members to be used for classloading request when a class
+     * is not available locally.
+     *
+     * Filter format: <code>HAS_ATTRIBUTE:foo</code> this will send classloading requests
+     * only to members which has a member attribute <code>foo</code> set. Value is ignored,
+     * it can be any type. A present of the attribute is sufficient.
+     *
+     * This facility allows to have a control on classloading. You can e.g. start Hazelcast lite
+     * members dedicated for class-serving.
+     *
+     * Example usage:
+     * This member will load classes only from members with the <code>class-provider</code> attribute set.
+     * It won't ask any other member to provide a locally unavailable class:
+     * <code>
+     *     Config hazelcastConfig = new Config();
+     *
+     *     DistributedClassloadingConfig distributedClassloadingConfig = hazelcastConfig.getDistributedClassloadingConfig();
+     *     distributedClassloadingConfig.setProviderFilter(HAS_ATTRIBUTE:class-provider);
+     *
+     *     HazecastInstance instance = Hazelcast.newHazelcastInstance(hazelcastConfig);
+     * </code>
+     *
+     *
+     * This member is marked with the <code>class-provider</code> attribute - the member configured above may him
+     * it to provide a class which is not locally available:
+     * <code>
+     *     Config hazelcastConfig = new Config();
+     *
+     *     MemberAttributeConfig memberAttributes = hazelcastConfig.getMemberAttributeConfig();
+     *     memberAttributes.setAttribute("class-provider", "true");
+     *
+     *     HazecastInstance instance = Hazelcast.newHazelcastInstance(hazelcastConfig);
+     * </code>
+     *
+     *
+     * Setting the filter to null will allow to load classes from all members.
+     *
+     * Default: {{@code null}}
+     *
+     *
+     * @see {@link com.hazelcast.core.Member#setStringAttribute(String, String)}
+     * @param providerFilter
+     * @return this instance of DistributedClassloadingConfig for easy method-chaining.
+     */
+    public DistributedClassloadingConfig setProviderFilter(String providerFilter) {
+        this.providerFilter = providerFilter;
+        return this;
+    }
+
+    /**
+     * Get current filter or {{@code null}} when no filter is defined.
+     *
+     * @see #setProviderFilter(String)
+     * @return current filter or {{@code null}} when no filter is defined.
+     */
+    public String getProviderFilter() {
+        return providerFilter;
+    }
+
+    /**
+     * Comma separated list of prefixes of classes which will never be loaded remotely.
+     * A prefix can be a package name or a classname.
+     *
+     * For example setting a blacklist prefix to <code>com.foo</code> will disable remote loading of all classes
+     * from the <code>com.foo</code> package, but also classes from all sub-packages won't be loaded.
+     * Eg. <code>com.foo.bar.MyClass</code> will be black-listed too.
+     *
+     * When you set the blacklist to <code>com.foo.Class</code> then the Class will obviously be black-listed,
+     * but a class <code>com.foo.ClassSuffix</code> will be blacklisted too.
+     *
+     * Setting the prefixes to {{@code null}} will disable the blacklist
+     * Default: {{@code null}}
+     *
+     * @param blacklistedPrefixes
+     * @return this instance of DistributedClassloadingConfig for easy method-chaining.
+     */
+    public DistributedClassloadingConfig setBlacklistedPrefixes(String blacklistedPrefixes) {
+        this.blacklistedPrefixes = blacklistedPrefixes;
+        return this;
+    }
+
+    /**
+     * Return currently configured blacklist prefixes.
+     *
+     * @see #setBlacklistedPrefixes(String)
+     * @return currently configured blacklist prefixes
+     */
+    public String getBlacklistedPrefixes() {
+        return blacklistedPrefixes;
+    }
+
+    /**
+     * Comma separated list of prefixes of classes which will be loaded remotely.
+     *
+     * Use this to enable distributed loading of selected classes only and disable remote loading for all
+     * other classes. This gives you a nice control over classloading.
+     *
+     * The prefixes are interpreted by using the same rules as desribed at {{@link #setBlacklistedPrefixes(String)}}
+     *
+     * Setting the prefix to {{@code null}} will disable the white-list and all non-blacklisted classes will be allowed
+     * to load from remote members.
+     *
+     * @param whitelistedPrefixes
+     * @return this instance of DistributedClassloadingConfig for easy method-chaining.
+     */
+    public DistributedClassloadingConfig setWhitelistedPrefixes(String whitelistedPrefixes) {
+        this.whitelistedPrefixes = whitelistedPrefixes;
+        return this;
+    }
+
+    /**
+     * Return currently configured whitelist prefixes
+     *
+     * @return currently configured whitelist prefixes
+     */
+    public String getWhitelistedPrefixes() {
+        return whitelistedPrefixes;
+    }
+
+    /**
+     * Configure behaviour when providing classes to remote members.
+     *
+     * Default: {@link ProviderMode#LOCAL_AND_CACHED_CLASSES}
+     *
+     * @see {@link ProviderMode}
+     * @param providerMode
+     * @return this instance of DistributedClassloadingConfig for easy method-chaining.
+     */
+    public DistributedClassloadingConfig setProviderMode(ProviderMode providerMode) {
+        this.providerMode = providerMode;
+        return this;
+    }
+
+    /**
+     * Return the current ProviderMode
+     *
+     * @return current ProviderMode
+     */
+    public ProviderMode getProviderMode() {
+        return providerMode;
+    }
+
+    /**
+     * Configure caching of classes loaded from remote members.
+     *
+     * Default: {@link ClassCacheMode#ETERNAL}
+     *
+     * @see {@link ClassCacheMode}
+     * @param classCacheMode
+     * @return this instance of DistributedClassloadingConfig for easy method-chaining.
+     */
+    public DistributedClassloadingConfig setClassCacheMode(ClassCacheMode classCacheMode) {
+        this.classCacheMode = classCacheMode;
+        return this;
+    }
+
+    /**
+     * Return the current ClassCacheMode
+     *
+     * @return current ProviderMode
+     */
+    public ClassCacheMode getClassCacheMode() {
+        return classCacheMode;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -20,6 +20,8 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
+import com.hazelcast.config.DistributedClassloadingConfig.ClassCacheMode;
+import com.hazelcast.config.DistributedClassloadingConfig.ProviderMode;
 import com.hazelcast.config.EvictionConfig.MaxSizePolicy;
 import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
 import com.hazelcast.config.PartitionGroupConfig.MemberGroupType;
@@ -91,6 +93,7 @@ import static com.hazelcast.config.XmlElements.SERVICES;
 import static com.hazelcast.config.XmlElements.SET;
 import static com.hazelcast.config.XmlElements.TOPIC;
 import static com.hazelcast.config.XmlElements.WAN_REPLICATION;
+import static com.hazelcast.config.XmlElements.DISTRIBUTED_CLASSLOADING;
 import static com.hazelcast.config.XmlElements.canOccurMultipleTimes;
 import static com.hazelcast.internal.config.ConfigValidator.checkEvictionConfig;
 import static com.hazelcast.util.Preconditions.checkHasText;
@@ -342,6 +345,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleLiteMember(node);
         } else if (HOT_RESTART_PERSISTENCE.isEqual(nodeName)) {
             handleHotRestartPersistence(node);
+        } else if (DISTRIBUTED_CLASSLOADING.isEqual(nodeName)) {
+            handleDistributedClassLoading(node);
         } else {
             return true;
         }
@@ -354,6 +359,42 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             throw new InvalidConfigurationException("Instance name in XML configuration is empty");
         }
         config.setInstanceName(instanceName);
+    }
+
+    private void handleDistributedClassLoading(Node dcRoot) {
+        DistributedClassloadingConfig dcConfig = new DistributedClassloadingConfig();
+        Node attrEnabled = dcRoot.getAttributes().getNamedItem("enabled");
+        boolean enabled = getBooleanValue(getTextContent(attrEnabled));
+        dcConfig.setEnabled(enabled);
+
+        String classCacheModeName = "class-cache-mode";
+        String providerModeName = "provider-mode";
+        String blacklistPrefixesName = "blacklist-prefixes";
+        String whitelistPrefixesName = "whitelist-prefixes";
+        String providerFilterName = "provider-filter";
+
+        for (Node n : childElements(dcRoot)) {
+            String name = cleanNodeName(n);
+            if (classCacheModeName.equals(name)) {
+                String value = getTextContent(n);
+                ClassCacheMode classCacheMode = ClassCacheMode.valueOf(value);
+                dcConfig.setClassCacheMode(classCacheMode);
+            } else if (providerModeName.equals(name)) {
+                String value = getTextContent(n);
+                ProviderMode providerMode = ProviderMode.valueOf(value);
+                dcConfig.setProviderMode(providerMode);
+            } else if (blacklistPrefixesName.equals(name)) {
+                String value = getTextContent(n);
+                dcConfig.setBlacklistedPrefixes(value);
+            } else if (whitelistPrefixesName.equals(name)) {
+                String value = getTextContent(n);
+                dcConfig.setWhitelistedPrefixes(value);
+            } else if (providerFilterName.equals(name)) {
+                String value = getTextContent(n);
+                dcConfig.setProviderFilter(value);
+            }
+        }
+        config.setDistributedClassloadingConfig(dcConfig);
     }
 
     private void handleHotRestartPersistence(Node hrRoot) {

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -51,6 +51,7 @@ enum XmlElements {
     QUORUM("quorum", true),
     LITE_MEMBER("lite-member", false),
     HOT_RESTART_PERSISTENCE("hot-restart-persistence", false),
+    DISTRIBUTED_CLASSLOADING("distributed-classloading", false),
     ;
 
     final String name;

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -115,6 +115,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
 
     final HazelcastInstanceCacheManager hazelcastCacheManager;
 
+    @SuppressWarnings("checkstyle:executablestatementcount")
     protected HazelcastInstanceImpl(String name, Config config, NodeContext nodeContext)
             throws Exception {
         this.name = name;
@@ -143,6 +144,10 @@ public class HazelcastInstanceImpl implements HazelcastInstance {
 
             this.healthMonitor = new HealthMonitor(node).start();
             this.hazelcastCacheManager = new HazelcastInstanceCacheManager(this);
+            ClassLoader classLoader = node.getConfigClassLoader();
+            if (classLoader instanceof HazelcastInstanceAware) {
+                ((HazelcastInstanceAware) classLoader).setHazelcastInstance(this);
+            }
         } catch (Throwable e) {
             try {
                 // Terminate the node by terminating node engine,

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/DistributedClassLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/DistributedClassLoader.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+public class DistributedClassLoader extends ClassLoader {
+
+    private static final ILogger LOG = Logger.getLogger(DistributedClassLoader.class);
+
+    private DistributedClassloadingService distributedClassloadingService;
+
+    public DistributedClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
+    public void setDistributedClassloadingService(DistributedClassloadingService service) {
+        this.distributedClassloadingService = service;
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve)
+            throws ClassNotFoundException {
+        Class<?> clazz = null;
+
+        if (distributedClassloadingService != null) {
+            //this looks racy, but it's an optimistic optimization - if the class is already loaded
+            //by the classloading service then it means the parent classloader failed to load it at some point in time.
+            // -> we can use it directly without consulting the parent classloader
+            //when the class is not found then we will consult the parent classloader and eventually the classloading
+            //service
+            clazz = distributedClassloadingService.findLoadedClass(name);
+        }
+        if (clazz == null) {
+            try {
+                return super.loadClass(name, resolve);
+            } catch (ClassNotFoundException e) {
+                if (distributedClassloadingService == null) {
+                    LOG.finest("Distributed classloader is not initialized yet. ");
+                    throw e;
+                }
+                clazz = distributedClassloadingService.handleClassNotFoundException(name);
+                if (resolve) {
+                    resolveClass(clazz);
+                }
+                return clazz;
+            }
+        }
+        return clazz;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/DistributedClassloadingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/DistributedClassloadingService.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading;
+
+import com.hazelcast.config.DistributedClassloadingConfig;
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.distributedclassloading.impl.ClassData;
+import com.hazelcast.internal.distributedclassloading.impl.ClassLocator;
+import com.hazelcast.internal.distributedclassloading.impl.ClassSource;
+import com.hazelcast.internal.util.filter.Filter;
+import com.hazelcast.internal.distributedclassloading.impl.ClassDataProvider;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.ManagedService;
+import com.hazelcast.spi.NodeEngine;
+
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.internal.distributedclassloading.impl.filter.ClassNameFilterParser.parseClassNameFilters;
+import static com.hazelcast.internal.distributedclassloading.impl.filter.MemberProviderFilterParser.parseMemberFilter;
+
+public final class DistributedClassloadingService implements ManagedService {
+    public static final String SERVICE_NAME = "distributed-classloading-service";
+
+    private volatile boolean enabled;
+
+    private ClassDataProvider provider;
+    private ClassLocator locator;
+
+    @Override
+    public void init(NodeEngine nodeEngine, Properties properties) {
+        DistributedClassloadingConfig config = nodeEngine.getConfig().getDistributedClassloadingConfig();
+        if (!config.isEnabled()) {
+            return;
+        }
+
+        ClassLoader parent = nodeEngine.getConfigClassLoader().getParent();
+        Filter<String> classNameFilter = parseClassNameFilters(config);
+        Filter<Member> memberFilter = parseMemberFilter(config.getProviderFilter());
+        ConcurrentMap<String, ClassSource> classMap = new ConcurrentHashMap<String, ClassSource>();
+
+        DistributedClassloadingConfig.ProviderMode providerMode = config.getProviderMode();
+        ILogger providerLogger = nodeEngine.getLogger(ClassDataProvider.class);
+        provider = new ClassDataProvider(providerMode, parent, classMap, providerLogger);
+
+        DistributedClassloadingConfig.ClassCacheMode classCacheMode = config.getClassCacheMode();
+        locator = new ClassLocator(classMap, parent, classNameFilter, memberFilter, classCacheMode, nodeEngine);
+        enabled = config.isEnabled();
+    }
+
+    //called by operations sent by other members
+    public ClassData getClassDataOrNull(String className) {
+        if (!enabled) {
+            return null;
+        }
+        return provider.getClassDataOrNull(className);
+    }
+
+    //called by distributed classloader on this member
+    public Class<?> handleClassNotFoundException(String name)
+            throws ClassNotFoundException {
+        if (!enabled) {
+            throw new ClassNotFoundException("Distributed Classloading is not enabled. Cannot find class " + name);
+        }
+        return locator.handleClassNotFoundException(name);
+    }
+
+    //called by distributed classloader on this member
+    public Class<?> findLoadedClass(String name) {
+        if (!enabled) {
+            return null;
+        }
+        return locator.findLoadedClass(name);
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void shutdown(boolean terminate) {
+
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassData.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+
+/**
+ * Bytecode of a class.
+ *
+ * It's wrapped inside own object as it allows to add additional metadata and maintain compatibility
+ * with Hazelcast Rolling Upgrade.
+ *
+ */
+public class ClassData implements IdentifiedDataSerializable {
+
+    private byte[] classDefinition;
+
+    public ClassData() {
+
+    }
+
+    @SuppressFBWarnings({"MS_EXPOSE_REP", "EI_EXPOSE_REP"})
+    public ClassData(byte[] classDefinition) {
+        this.classDefinition = classDefinition;
+    }
+
+    @SuppressFBWarnings({"MS_EXPOSE_REP", "EI_EXPOSE_REP"})
+    public byte[] getClassDefinition() {
+        return classDefinition;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClassloadingSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClassloadingSerializerHook.CLASS_DATA;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeByteArray(classDefinition);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        classDefinition = in.readByteArray();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassDataProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassDataProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl;
+
+import com.hazelcast.config.DistributedClassloadingConfig;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.IOUtil;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.nio.IOUtil.toByteArray;
+
+/**
+ * Provides {@link ClassData} to remote members.
+ *
+ * It may consult a local class cache when enabled and then it delegates to a local classloader.
+ *
+ */
+public final class ClassDataProvider {
+    private final DistributedClassloadingConfig.ProviderMode providerMode;
+    private final ClassLoader parent;
+    private final ConcurrentMap<String, ClassSource> classSourceMap;
+    private final ILogger logger;
+
+    public ClassDataProvider(DistributedClassloadingConfig.ProviderMode providerMode,
+                             ClassLoader parent,
+                             ConcurrentMap<String, ClassSource> classSourceMap,
+                             ILogger logger) {
+        this.providerMode = providerMode;
+        this.parent = parent;
+        this.classSourceMap = classSourceMap;
+        this.logger = logger;
+    }
+
+    public ClassData getClassDataOrNull(String className) {
+        if (providerMode == DistributedClassloadingConfig.ProviderMode.OFF) {
+            return null;
+        }
+        ClassData classData = null;
+        byte[] bytecode = loadBytecodeFromParent(className);
+        if (bytecode == null && providerMode == DistributedClassloadingConfig.ProviderMode.LOCAL_AND_CACHED_CLASSES) {
+            bytecode = loadBytecodeFromCache(className);
+        }
+        if (bytecode != null) {
+            classData = new ClassData(bytecode);
+        }
+        return classData;
+    }
+
+    private byte[] loadBytecodeFromCache(String className) {
+        ClassSource classSource = classSourceMap.get(className);
+        if (classSource == null) {
+            return null;
+        }
+        return classSource.getBytecode();
+    }
+
+    private byte[] loadBytecodeFromParent(String className) {
+        String resource = className.replace('.', '/').concat(".class");
+        InputStream is = null;
+        try {
+            is = parent.getResourceAsStream(resource);
+            if (is != null) {
+                try {
+                    return toByteArray(is);
+                } catch (IOException e) {
+                    logger.severe(e);
+                }
+            }
+        } finally {
+            IOUtil.closeResource(is);
+        }
+        return null;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassLocator.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl;
+
+import com.hazelcast.config.DistributedClassloadingConfig;
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.distributedclassloading.DistributedClassLoader;
+import com.hazelcast.internal.distributedclassloading.DistributedClassloadingService;
+import com.hazelcast.internal.util.filter.Filter;
+import com.hazelcast.internal.distributedclassloading.impl.operation.ClassDataFinderOperation;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.OperationService;
+
+import java.io.Closeable;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ * Provides classes to a local member.
+ *
+ * It's called by {@link DistributedClassLoader} when a class
+ * is not found on a local classpath.
+ *
+ * The current implementation can consult a cache and when the class is not found then it consults
+ * remote members.
+ *
+ */
+public final class ClassLocator {
+    private final ConcurrentMap<String, ClassSource> classSourceMap;
+    private final ClassLoader parent;
+    private final Filter<String> classNameFilter;
+    private final Filter<Member> memberFilter;
+    private final DistributedClassloadingConfig.ClassCacheMode classCacheMode;
+    private final NodeEngine nodeEngine;
+    private final ClassloadingMutexProvider mutexFactory = new ClassloadingMutexProvider();
+    private final ILogger logger;
+
+    public ClassLocator(ConcurrentMap<String, ClassSource> classSourceMap,
+                        ClassLoader parent, Filter<String> classNameFilter, Filter<Member> memberFilter,
+                        DistributedClassloadingConfig.ClassCacheMode classCacheMode, NodeEngine nodeEngine) {
+        this.classSourceMap = classSourceMap;
+        this.parent = parent;
+        this.classNameFilter = classNameFilter;
+        this.memberFilter = memberFilter;
+        this.classCacheMode = classCacheMode;
+        this.nodeEngine = nodeEngine;
+        this.logger = nodeEngine.getLogger(ClassLocator.class);
+    }
+
+    public static void onStartDeserialization() {
+        ThreadLocalClassCache.onStartDeserialization();
+    }
+
+    public static void onFinishDeserialization() {
+        ThreadLocalClassCache.onFinishDeserialization();
+    }
+
+    public Class<?> handleClassNotFoundException(String name)
+            throws ClassNotFoundException {
+        if (!classNameFilter.accept(name)) {
+            throw new ClassNotFoundException("Class " + name + " is not allowed to be loaded from other members.");
+        }
+        Class<?> clazz = tryToGetClassFromLocalCache(name);
+        if (clazz != null) {
+            return clazz;
+        }
+        return tryToGetClassFromRemote(name);
+    }
+
+    private Class<?> tryToGetClassFromRemote(String name) throws ClassNotFoundException {
+        //we need to acquire a classloading lock before defining a class
+        //Java 7+ can use locks with per-class granularity while Java 6
+        //has to use a single lock.
+        //mutexFactory abstract these differences away
+        Closeable classMutex = mutexFactory.getMutexForClass(name);
+        try {
+            synchronized (classMutex) {
+                ClassSource classSource = classSourceMap.get(name);
+                if (classSource != null) {
+                    if (logger.isFineEnabled()) {
+                        logger.finest("Class " + name + " is already in a local cache. ");
+                    }
+                    return classSource.getClazz();
+                }
+                byte[] classDef = fetchBytecodeFromRemote(name);
+                if (classDef == null) {
+                    throw new ClassNotFoundException("Failed to load class " + name + " from other members.");
+                }
+                return defineAndCacheClass(name, classDef);
+            }
+        } finally {
+            IOUtil.closeResource(classMutex);
+        }
+    }
+
+    private Class<?> tryToGetClassFromLocalCache(String name) {
+        ClassSource classSource = classSourceMap.get(name);
+        if (classSource != null) {
+            if (logger.isFineEnabled()) {
+                logger.finest("Class " + name + " is already in a local cache. ");
+            }
+            return classSource.getClazz();
+        }
+
+        classSource = ThreadLocalClassCache.getFromCache(name);
+        if (classSource != null) {
+            return classSource.getClazz();
+        }
+        return null;
+    }
+
+    //called while holding class lock
+    private Class<?> defineAndCacheClass(String name, byte[] classDef) {
+        ClassSource classSource = new ClassSource(name, classDef, parent, this);
+        classSource.define();
+        if (classCacheMode != DistributedClassloadingConfig.ClassCacheMode.OFF) {
+            classSourceMap.put(name, classSource);
+        } else {
+            ThreadLocalClassCache.store(name, classSource);
+        }
+        return classSource.getClazz();
+    }
+
+    //called while holding class lock
+    private byte[] fetchBytecodeFromRemote(String className) {
+        ClusterService cluster = nodeEngine.getClusterService();
+        ClassData classData;
+        boolean interrupted = false;
+        for (Member member : cluster.getMembers()) {
+            if (isCandidateMember(member)) {
+                continue;
+            }
+            try {
+                classData = tryToFetchClassDataFromMember(className, member);
+                if (classData != null) {
+                    if (logger.isFineEnabled()) {
+                        logger.finest("Loaded class " + className + " from " + member);
+                    }
+                    byte[] classDef = classData.getClassDefinition();
+                    if (classDef != null) {
+                        if (interrupted) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return classDef;
+                    }
+                }
+            } catch (InterruptedException e) {
+                //question: should we give-up on loading and this point and simply throw ClassNotFoundException?
+                interrupted = true;
+            } catch (Exception e) {
+                if (logger.isFinestEnabled()) {
+                    logger.finest("Unable to get class data for class " + className
+                            + " from member " + member, e);
+                }
+            }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        return null;
+    }
+
+    private ClassData tryToFetchClassDataFromMember(String className, Member member) throws ExecutionException,
+            InterruptedException {
+        OperationService operationService = nodeEngine.getOperationService();
+
+        ClassDataFinderOperation op = new ClassDataFinderOperation(className);
+        Future<ClassData> classDataFuture = operationService.invokeOnTarget(DistributedClassloadingService.SERVICE_NAME,
+                op, member.getAddress());
+        return classDataFuture.get();
+    }
+
+    private boolean isCandidateMember(Member member) {
+        if (member.localMember()) {
+            return true;
+        }
+        if (!memberFilter.accept(member)) {
+            return true;
+        }
+        return false;
+    }
+
+    public Class<?> findLoadedClass(String name) {
+        ClassSource classSource = classSourceMap.get(name);
+        if (classSource == null) {
+            return null;
+        }
+        return classSource.getClazz();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassSource.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Classloader created on a local member to define a class from a bytecode loaded from a remote source.
+ *
+ * We use a classloader per each class loaded from a remote source as it allows us to discard the classloader
+ * and reload the class via another classloader as we see fit.
+ *
+ * Delegation model:
+ * 1. When the request matches the specific classname then it will provide the class on its own
+ * 2. Then it delegates to the parent classloader - that's usually a regular classloader loading classes
+ *    from a local classpath only
+ * 3. Finally it delegates to {@link ClassLocator} which may initiate a remote lookup
+ *
+ */
+public final class ClassSource extends ClassLoader {
+
+    private final byte[] bytecode;
+    private final ClassLocator classLocator;
+    private Class clazz;
+    private final String name;
+
+    @SuppressFBWarnings({"MS_EXPOSE_REP", "EI_EXPOSE_REP"})
+    public ClassSource(String classname, byte[] bytecode, ClassLoader parent, ClassLocator classLocator) {
+        super(parent);
+        this.bytecode = bytecode;
+        this.name = classname;
+        this.classLocator = classLocator;
+    }
+
+    public Class<?> define() {
+        clazz = defineClass(name, bytecode, 0, bytecode.length);
+        return clazz;
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (name.equals(this.name)) {
+            return clazz;
+        }
+        try {
+            return super.loadClass(name, resolve);
+        } catch (ClassNotFoundException e) {
+            return classLocator.handleClassNotFoundException(name);
+        }
+    }
+
+    @SuppressFBWarnings({"MS_EXPOSE_REP", "EI_EXPOSE_REP"})
+    public byte[] getBytecode() {
+        return bytecode;
+    }
+
+    public Class getClazz() {
+        return clazz;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassloadingMutexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassloadingMutexProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl;
+
+import com.hazelcast.util.ContextMutexFactory;
+
+import java.io.Closeable;
+
+/**
+ * Java 7+ onwards allows parallel classloading. Therefore we can define use a lock with per-class granularity.
+ * However in Java 6 we have to use a fat global lock.
+ *
+ * This abstraction provides a suitable mutex depending on the version of underlying platform.
+ *
+ * The provided mutexes are closeable as we want to know when the granular mutexes from Java are no longer needed.
+ *
+ */
+public class ClassloadingMutexProvider {
+    private static final String JAVA_VERSION_WHERE_PARALLEL_CLASSLOADING_IS_NOT_POSSIBLE = "1.6";
+    private static final boolean USE_PARALLEL_LOADING = isParallelClassLoadingPossible();
+
+
+    private final ContextMutexFactory mutexFactory = new ContextMutexFactory();
+    private final GlobalMutex globalMutex = new GlobalMutex();
+
+    public Closeable getMutexForClass(String classname) {
+        if (USE_PARALLEL_LOADING) {
+            return mutexFactory.mutexFor(classname);
+        } else {
+            return globalMutex;
+        }
+    }
+
+    private static boolean isParallelClassLoadingPossible() {
+        String implVersion = Runtime.class.getPackage().getImplementationVersion();
+        return !implVersion.startsWith(JAVA_VERSION_WHERE_PARALLEL_CLASSLOADING_IS_NOT_POSSIBLE);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassloadingSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassloadingSerializerHook.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl;
+
+import com.hazelcast.internal.distributedclassloading.impl.operation.ClassDataFinderOperation;
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.CLASSLOADING_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.CLASSLOADING_DS_FACTORY_ID;
+
+public class ClassloadingSerializerHook implements DataSerializerHook {
+    public static final int F_ID = FactoryIdHelper.getFactoryId(CLASSLOADING_DS_FACTORY, CLASSLOADING_DS_FACTORY_ID);
+
+    public static final int CLASS_DATA = 0;
+    public static final int CLASS_DATA_FINDER_OP = 1;
+
+    public static final int LEN = CLASS_DATA_FINDER_OP + 1;
+
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
+        constructors[CLASS_DATA] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new ClassData();
+            }
+        };
+        constructors[CLASS_DATA_FINDER_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new ClassDataFinderOperation();
+            }
+        };
+        return new ArrayDataSerializableFactory(constructors);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/GlobalMutex.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/GlobalMutex.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl;
+
+import java.io.Closeable;
+
+/**
+ * This is used in Java 6 only. It implements the {@link Closeable} to have a consistent usage with
+ * fine grained mutexes provided by {@link com.hazelcast.util.ContextMutexFactory}
+ *
+ */
+public final class GlobalMutex implements Closeable {
+    public void close() {
+
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ThreadLocalClassCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ThreadLocalClassCache.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Thread-Local Class Cache is useful when the regular class-cache is disabled - we want to keep classes cached
+ * at very least for the duration of a single deserialization request. Otherwise things may get funky with e.g.
+ * class hierarchies.
+ *
+ */
+public final class ThreadLocalClassCache {
+    public static final ThreadLocal<ThreadLocalClassCache> THREAD_LOCAL_CLASS_CACHE = new ThreadLocal<ThreadLocalClassCache>();
+
+    private int counter = 1;
+    private Map<String, ClassSource> map = new HashMap<String, ClassSource>();
+
+    private ThreadLocalClassCache() {
+
+    }
+
+    private int decCounter() {
+        counter--;
+        return counter;
+    }
+
+    private void incCounter() {
+        counter++;
+    }
+
+    public static void onStartDeserialization() {
+        ThreadLocalClassCache threadLocalClassCache = THREAD_LOCAL_CLASS_CACHE.get();
+        if (threadLocalClassCache != null) {
+            threadLocalClassCache.incCounter();
+        }
+    }
+
+    public static void onFinishDeserialization() {
+        ThreadLocalClassCache threadLocalClassCache = THREAD_LOCAL_CLASS_CACHE.get();
+        if (threadLocalClassCache != null && threadLocalClassCache.decCounter() == 0) {
+            THREAD_LOCAL_CLASS_CACHE.remove();
+        }
+    }
+
+    public static void store(String name, ClassSource classSource) {
+        ThreadLocalClassCache threadLocalClassCache = THREAD_LOCAL_CLASS_CACHE.get();
+        if (threadLocalClassCache == null) {
+            threadLocalClassCache = new ThreadLocalClassCache();
+            THREAD_LOCAL_CLASS_CACHE.set(threadLocalClassCache);
+        }
+        threadLocalClassCache.map.put(name, classSource);
+    }
+
+    public static ClassSource getFromCache(String name) {
+        ThreadLocalClassCache threadLocalClassCache = THREAD_LOCAL_CLASS_CACHE.get();
+        if (threadLocalClassCache != null) {
+            return threadLocalClassCache.map.get(name);
+        }
+        return null;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/ClassBlacklistFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/ClassBlacklistFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl.filter;
+
+import com.hazelcast.internal.util.filter.Filter;
+import com.hazelcast.util.collection.ArrayUtils;
+
+/**
+ * Match all classes unless they are in the explicit blacklist
+ *
+ */
+public class ClassBlacklistFilter implements Filter<String> {
+
+    private final String[] blacklist;
+
+    public ClassBlacklistFilter(String...blacklisted) {
+        blacklist = ArrayUtils.createCopy(blacklisted);
+    }
+
+
+    @Override
+    public boolean accept(String className) {
+        for (String blacklisted : blacklist) {
+            if (className.startsWith(blacklisted)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/ClassNameFilterParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/ClassNameFilterParser.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl.filter;
+
+import com.hazelcast.config.DistributedClassloadingConfig;
+import com.hazelcast.internal.util.filter.AndFilter;
+import com.hazelcast.internal.util.filter.Filter;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public final class ClassNameFilterParser {
+    private static final String[] BUILTIN_BLACKLIST_PREFIXES = {
+            "javax.",
+            "java.",
+            "sun.",
+            "com.hazelcast.",
+    };
+
+    private ClassNameFilterParser() {
+
+    }
+
+    public static Filter<String> parseClassNameFilters(DistributedClassloadingConfig config) {
+        Filter<String> classFilter = parseBlackList(config);
+        String whitelistedPrefixes = config.getWhitelistedPrefixes();
+        Set<String> whitelistSet = parsePrefixes(whitelistedPrefixes);
+        if (!whitelistSet.isEmpty()) {
+            ClassWhitelistFilter whitelistFilter = new ClassWhitelistFilter(whitelistSet.toArray(new String[]{}));
+            classFilter = new AndFilter<String>(classFilter, whitelistFilter);
+        }
+        return classFilter;
+    }
+
+    private static Filter<String> parseBlackList(DistributedClassloadingConfig config) {
+        String blacklistedPrefixes = config.getBlacklistedPrefixes();
+        Set<String> blacklistSet = parsePrefixes(blacklistedPrefixes);
+        blacklistSet.addAll(Arrays.asList(BUILTIN_BLACKLIST_PREFIXES));
+        return new ClassBlacklistFilter(blacklistSet.toArray(new String[0]));
+    }
+
+    private static Set<String> parsePrefixes(String prefixes) {
+        Set<String> blacklistSet = new HashSet<String>();
+        if (prefixes == null) {
+            return blacklistSet;
+        }
+
+        prefixes = prefixes.trim();
+        String[] prefixArray = prefixes.split(",");
+        for (String prefix : prefixArray) {
+            blacklistSet.add(prefix.trim());
+        }
+        return blacklistSet;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/ClassWhitelistFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/ClassWhitelistFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl.filter;
+
+import com.hazelcast.internal.util.filter.Filter;
+import com.hazelcast.util.collection.ArrayUtils;
+
+/**
+ * Match only classes in the whitelist. No other classes matches
+ *
+ */
+public class ClassWhitelistFilter implements Filter<String> {
+
+    private final String[] whitelist;
+
+    public ClassWhitelistFilter(String...whitelisted) {
+        whitelist = ArrayUtils.createCopy(whitelisted);
+    }
+
+
+    @Override
+    public boolean accept(String className) {
+        for (String blacklisted : whitelist) {
+            if (className.startsWith(blacklisted)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/MemberAttributeFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/MemberAttributeFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl.filter;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.util.filter.Filter;
+
+public class MemberAttributeFilter implements Filter<Member> {
+    private final String attribute;
+
+    public MemberAttributeFilter(String attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public boolean accept(Member member) {
+        return member.getAttributes().keySet().contains(attribute);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/MemberProviderFilterParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/filter/MemberProviderFilterParser.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl.filter;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.util.filter.AlwaysApplyFilter;
+import com.hazelcast.internal.util.filter.Filter;
+
+public final class MemberProviderFilterParser {
+    private static final String HAS_ATTRIBUTE_PREFIX = "HAS_ATTRIBUTE:";
+
+    private MemberProviderFilterParser() {
+
+    }
+
+    public static Filter<Member> parseMemberFilter(String providerFilter) {
+        if (providerFilter == null) {
+            return AlwaysApplyFilter.newInstance();
+        }
+        providerFilter = providerFilter.trim();
+        if (providerFilter.startsWith(HAS_ATTRIBUTE_PREFIX)) {
+            providerFilter = providerFilter.substring(HAS_ATTRIBUTE_PREFIX.length());
+            providerFilter = providerFilter.trim();
+            return new MemberAttributeFilter(providerFilter);
+        } else if (providerFilter.isEmpty()) {
+            return AlwaysApplyFilter.newInstance();
+        } else {
+            throw new IllegalArgumentException("Unknown provider filter: " + providerFilter);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/operation/ClassDataFinderOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/operation/ClassDataFinderOperation.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.distributedclassloading.impl.operation;
+
+import com.hazelcast.internal.distributedclassloading.impl.ClassData;
+import com.hazelcast.internal.distributedclassloading.DistributedClassloadingService;
+import com.hazelcast.internal.distributedclassloading.impl.ClassloadingSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.UrgentSystemOperation;
+
+import java.io.IOException;
+
+public final class ClassDataFinderOperation extends Operation implements UrgentSystemOperation, IdentifiedDataSerializable {
+
+    private String className;
+    private ClassData response;
+
+    public ClassDataFinderOperation(String className) {
+        this.className = className;
+    }
+
+    public ClassDataFinderOperation() {
+    }
+
+    @Override
+    public ClassData getResponse() {
+        return response;
+    }
+
+    @Override
+    public void run() throws Exception {
+        DistributedClassloadingService service = getService();
+        response = service.getClassDataOrNull(className);
+    }
+
+    @Override
+    public String getServiceName() {
+        return DistributedClassloadingService.SERVICE_NAME;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        out.writeUTF(className);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        className = in.readUTF();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ClassloadingSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ClassloadingSerializerHook.CLASS_DATA_FINDER_OP;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Module related to distributed classloading
+ */
+package com.hazelcast.internal.distributedclassloading;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.serialization.impl;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.internal.distributedclassloading.impl.ClassLocator;
 import com.hazelcast.internal.serialization.InputOutputFactory;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.bufferpool.BufferPool;
@@ -170,6 +171,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         BufferPool pool = bufferPoolThreadLocal.get();
         BufferObjectDataInput in = pool.takeInputBuffer(data);
         try {
+            ClassLocator.onStartDeserialization();
             final int typeId = data.getType();
             final SerializerAdapter serializer = serializerFor(typeId);
             if (serializer == null) {
@@ -187,6 +189,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         } catch (Throwable e) {
             throw handleException(e);
         } finally {
+            ClassLocator.onFinishDeserialization();
             pool.returnInputBuffer(in);
         }
     }
@@ -205,6 +208,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         BufferPool pool = bufferPoolThreadLocal.get();
         BufferObjectDataInput in = pool.takeInputBuffer(data);
         try {
+            ClassLocator.onStartDeserialization();
             final int typeId = data.getType();
             final SerializerAdapter serializer = serializerFor(typeId);
             if (serializer == null) {
@@ -222,6 +226,7 @@ public abstract class AbstractSerializationService implements InternalSerializat
         } catch (Throwable e) {
             throw handleException(e);
         } finally {
+            ClassLocator.onFinishDeserialization();
             pool.returnInputBuffer(in);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -122,6 +122,9 @@ public final class FactoryIdHelper {
     public static final String SCHEDULED_EXECUTOR_DS_FACTORY = "hazelcast.serialization.ds.scheduled.executor";
     public static final int SCHEDULED_EXECUTOR_DS_FACTORY_ID = -39;
 
+    public static final String CLASSLOADING_DS_FACTORY = "hazelcast.serialization.ds.classloading";
+    public static final int CLASSLOADING_DS_FACTORY_ID = -40;
+
     // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/filter/AlwaysApplyFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/filter/AlwaysApplyFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.filter;
+
+/**
+ * Always matching filter
+ *
+ * @param <T>
+ */
+public final class AlwaysApplyFilter<T> implements Filter<T> {
+    private AlwaysApplyFilter() {
+
+    }
+
+    public static <T> AlwaysApplyFilter<T> newInstance() {
+        return new AlwaysApplyFilter<T>();
+    }
+
+    @Override
+    public boolean accept(T object) {
+        return true;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/filter/AndFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/filter/AndFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.filter;
+
+/**
+ * Filter matching only when both sub-filters are matching
+ *
+ * @param <T>
+ */
+public final class AndFilter<T> implements Filter<T> {
+
+    private final Filter<T> filter1;
+    private final Filter<T> filter2;
+
+    public AndFilter(Filter<T> filter1, Filter<T> filter2) {
+        this.filter1 = filter1;
+        this.filter2 = filter2;
+    }
+
+    @Override
+    public boolean accept(T object) {
+        return filter1.accept(object) && filter2.accept(object);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/filter/Filter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/filter/Filter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.filter;
+
+/**
+ * Decide whether an object matches a condition or not.
+ *
+ * @param <T>
+ */
+public interface Filter<T> {
+
+    /**
+     * Return {{@code true}} when object matches a condition
+     *
+     * @param object
+     * @return {{true}} when object matches a condition
+     */
+    boolean accept(T object);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/filter/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/filter/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides various {@link com.hazelcast.internal.util.filter.Filter}
+ *
+ */
+package com.hazelcast.internal.util.filter;

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
@@ -468,6 +468,21 @@ public final class IOUtil {
         }
     }
 
+    public static byte[] toByteArray(InputStream is) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        drainTo(is, baos);
+        return baos.toByteArray();
+    }
+
+    public static void drainTo(InputStream input, OutputStream output) throws IOException {
+        byte[] buffer = new byte[1024];
+        int n;
+        while (-1 != (n = input.read(buffer))) {
+            output.write(buffer, 0, n);
+        }
+    }
+
+
     private static final class ClassLoaderAwareObjectInputStream extends ObjectInputStream {
 
         private final ClassLoader classLoader;

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -26,3 +26,4 @@ com.hazelcast.client.impl.ClientDataSerializerHook
 com.hazelcast.internal.management.ManagementDataSerializerHook
 com.hazelcast.internal.ascii.TextProtocolsDataSerializerHook
 com.hazelcast.scheduledexecutor.impl.ScheduledExecutorDataSerializerHook
+com.hazelcast.internal.distributedclassloading.impl.ClassloadingSerializerHook

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -64,6 +64,7 @@
                 <xs:element name="quorum" type="quorum" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="lite-member" type="lite-member" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="hot-restart-persistence" type="hot-restart-persistence" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="distributed-classloading" type="distributed-classloading" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -2863,6 +2864,91 @@
             <xs:annotation>
                 <xs:documentation>
                     True to set the node as a lite member, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="distributed-classloading">
+        <xs:all>
+            <xs:element name="class-cache-mode" default="ETERNAL">
+                <xs:annotation>
+                    <xs:documentation>
+                        Controls caching of caches loaded from remote members
+
+                        OFF: Never caches loaded classes. This is suitable for loading runnables, callebles,
+                        entry processors, etc.
+                        ETERNAL: Cache indefinitely. This is suitable when you load long-living objects,
+                        such as domain objects stored in a map.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="non-space-string">
+                        <xs:enumeration value="OFF"/>
+                        <xs:enumeration value="ETERNAL"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="provider-mode" default="LOCAL_AND_CACHED_CLASSES">
+                <xs:annotation>
+                    <xs:documentation>
+                        Controls how to react on receiving a classloading request from a remote member
+
+                        OFF: Never serve classes to other members. This member will never server classes to remote
+                        members.
+                        LOCAL_CLASSES_ONLY: Serve classes from local classpath only. Classes loaded from other members
+                        will be used locally, but they won't be served to other members.
+                        LOCAL_AND_CACHED_CLASSES: Server classes loaded from both local classpath and from other members.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="non-space-string">
+                        <xs:enumeration value="OFF"/>
+                        <xs:enumeration value="LOCAL_CLASSES_ONLY"/>
+                        <xs:enumeration value="LOCAL_AND_CACHED_CLASSES"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="blacklist-prefixes" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Filter to constraint members to be used for classloading request when a class
+                        is not available locally.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="whitelist-prefixes" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Command separated list of prefixes of classes which will be loaded remotely.
+
+                        Use this to enable distributed loading of selected classes only and disable remote loading for all
+                        other classes. This gives you a nice control over classloading.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="provider-filter" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Filter to constraint members to be used for classloading request when a class
+                        is not available locally.
+
+                        Filter format: HAS_ATTRIBUTE:foo this will send classloading requests
+                        only to members which has a member attribute foo set. Value is ignored,
+                        it can be any type. A present of the attribute is sufficient.
+
+                        This facility allows to have a control on classloading. You can e.g. start Hazelcast lite
+                        members dedicated for class-serving.
+
+                        Setting the filter to null will allow to load classes from all members.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable distributed classloading on this member, false otherwise.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.collection.impl.queue.QueueStoreWrapper;
 import com.hazelcast.config.helpers.DummyMapStore;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -50,7 +49,6 @@ import java.util.Properties;
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static java.io.File.createTempFile;
-import static java.io.File.listRoots;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1302,6 +1300,27 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
 
         Config config = new InMemoryXmlConfig(xml);
         assertEquals(name, config.getInstanceName());
+    }
+
+    @Test
+    public void testDistributedClassloading() {
+        String xml = HAZELCAST_START_TAG
+                + "<distributed-classloading enabled=\"true\">"
+                    + "<class-cache-mode>OFF</class-cache-mode>"
+                    + "<provider-mode>LOCAL_CLASSES_ONLY</provider-mode>"
+                    + "<blacklist-prefixes>com.blacklisted,com.other.blacklisted</blacklist-prefixes>"
+                    + "<whitelist-prefixes>com.whitelisted,com.other.whitelisted</whitelist-prefixes>"
+                    + "<provider-filter>HAS_ATTRIBUTE:foo</provider-filter>"
+                + "</distributed-classloading>"
+                + HAZELCAST_END_TAG;
+        Config config = new InMemoryXmlConfig(xml);
+        DistributedClassloadingConfig dcConfig = config.getDistributedClassloadingConfig();
+        assertTrue(dcConfig.isEnabled());
+        assertEquals(DistributedClassloadingConfig.ClassCacheMode.OFF, dcConfig.getClassCacheMode());
+        assertEquals(DistributedClassloadingConfig.ProviderMode.LOCAL_CLASSES_ONLY, dcConfig.getProviderMode());
+        assertEquals("com.blacklisted,com.other.blacklisted", dcConfig.getBlacklistedPrefixes());
+        assertEquals("com.whitelisted,com.other.whitelisted", dcConfig.getWhitelistedPrefixes());
+        assertEquals("HAS_ATTRIBUTE:foo", dcConfig.getProviderFilter());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/distributedclassloading/impl/ClassDataProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/distributedclassloading/impl/ClassDataProviderTest.java
@@ -1,0 +1,71 @@
+package com.hazelcast.internal.distributedclassloading.impl;
+
+import com.hazelcast.config.DistributedClassloadingConfig;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.config.DistributedClassloadingConfig.ProviderMode.LOCAL_AND_CACHED_CLASSES;
+import static com.hazelcast.config.DistributedClassloadingConfig.ProviderMode.LOCAL_CLASSES_ONLY;
+import static com.hazelcast.config.DistributedClassloadingConfig.ProviderMode.OFF;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClassDataProviderTest {
+
+    @Test
+    public void givenProviderModeSetToOFF_whenMapClassContainsClass_thenReturnNull() throws Exception {
+        DistributedClassloadingConfig.ProviderMode providerMode = OFF;
+        String className = "className";
+        ClassSource classSource = newMockClassSource(className);
+        ClassLoader parent = getClass().getClassLoader();
+        ClassDataProvider provider = createClassDataProvider(providerMode, className, classSource, parent);
+        ClassData classData = provider.getClassDataOrNull(className);
+        assertNull(classData);
+    }
+
+    @Test
+    public void givenProviderModeSetToLOCAL_CLASSES_ONLY_whenMapClassContainsClass_thenReturnNull() throws Exception {
+        DistributedClassloadingConfig.ProviderMode providerMode = LOCAL_CLASSES_ONLY;
+        String className = "className";
+        ClassSource classSource = newMockClassSource(className);
+        ClassLoader parent = getClass().getClassLoader();
+        ClassDataProvider provider = createClassDataProvider(providerMode, className, classSource, parent);
+        ClassData classData = provider.getClassDataOrNull(className);
+        assertNull(classData);
+    }
+
+    @Test
+    public void givenProviderModeSetToLOCAL_AND_CACHED_CLASSES_whenMapClassContainsClass_thenReturnIt() throws Exception {
+        DistributedClassloadingConfig.ProviderMode providerMode = LOCAL_AND_CACHED_CLASSES;
+        String className = "className";
+        ClassSource classSource = newMockClassSource(className);
+        ClassLoader parent = getClass().getClassLoader();
+        ClassDataProvider provider = createClassDataProvider(providerMode, className, classSource, parent);
+        ClassData classData = provider.getClassDataOrNull(className);
+        assertNotNull(classData.getClassDefinition());
+    }
+
+
+    private ClassDataProvider createClassDataProvider(DistributedClassloadingConfig.ProviderMode providerMode,
+                                                      String className, ClassSource classSource, ClassLoader parent) {
+        ILogger logger = mock(ILogger.class);
+        ConcurrentMap<String, ClassSource> classSourceMap = new ConcurrentHashMap<String, ClassSource>();
+        classSourceMap.put(className, classSource);
+        return new ClassDataProvider(providerMode, parent, classSourceMap, logger);
+    }
+
+    private static ClassSource newMockClassSource(String classname) {
+        return new ClassSource(classname, new byte[0], null, null);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/distributedclassloading/impl/filter/DistributedClassloadingSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/distributedclassloading/impl/filter/DistributedClassloadingSmokeTest.java
@@ -1,0 +1,197 @@
+package com.hazelcast.internal.distributedclassloading.impl.filter;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.DistributedClassloadingConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.FilteringClassLoader;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import distributedclassloading.IncrementingEntryProcessor;
+import distributedclassloading.blacklisted.BlacklistedEP;
+import distributedclassloading.whitelisted.WhitelistedEP;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DistributedClassloadingSmokeTest extends HazelcastTestSupport {
+
+    private TestHazelcastInstanceFactory factory;
+
+    @Parameterized.Parameter
+    public DistributedClassloadingConfig.ClassCacheMode classCacheMode;
+
+    @Parameterized.Parameters(name = "ClassCacheMode:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {DistributedClassloadingConfig.ClassCacheMode.ETERNAL},
+                {DistributedClassloadingConfig.ClassCacheMode.OFF},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        factory = createHazelcastInstanceFactory(2);
+    }
+
+    @Test(expected = HazelcastSerializationException.class)
+    public void testDistributedClassloadingIsDisabledByDefault() {
+        //this test also validate the EP is filtered locally and has to be loaded from the other member
+        Config i1Config = new Config();
+
+        Config i2Config = new Config();
+        FilteringClassLoader filteringCL = new FilteringClassLoader(asList("distributedclassloading"), null);
+        i2Config.setClassLoader(filteringCL);
+
+        IncrementingEntryProcessor incrementingEntryProcessor = new IncrementingEntryProcessor();
+        executeSimpleTestScenario(i1Config, i2Config, incrementingEntryProcessor);
+    }
+
+    @Test
+    public void givenSomeMemberCanAccessTheEP_whenTheEPIsFilteredLocally_thenItWillBeLoadedOverNetwork() {
+        Config i1Config = new Config();
+        i1Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setClassCacheMode(classCacheMode);
+
+        Config i2Config = new Config();
+        FilteringClassLoader filteringCL = new FilteringClassLoader(asList("distributedclassloading"), null);
+        i2Config.setClassLoader(filteringCL);
+        i2Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setClassCacheMode(classCacheMode);
+
+        IncrementingEntryProcessor incrementingEntryProcessor = new IncrementingEntryProcessor();
+        executeSimpleTestScenario(i1Config, i2Config, incrementingEntryProcessor);
+    }
+
+    @Test(expected = HazelcastSerializationException.class)
+    public void givenTheEPButItIsBlacklisted_whenTheEPIsFilteredLocally_thenItWillFailToLoadIt() {
+        Config i1Config = new Config();
+        i1Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setClassCacheMode(classCacheMode);
+
+
+        Config i2Config = new Config();
+        FilteringClassLoader filteringCL = new FilteringClassLoader(asList("distributedclassloading"), null);
+        i2Config.setClassLoader(filteringCL);
+        i2Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setBlacklistedPrefixes("distributedclassloading.blacklisted")
+                .setClassCacheMode(classCacheMode);
+
+        EntryProcessor<Integer, Integer> myEP = new BlacklistedEP();
+        executeSimpleTestScenario(i1Config, i2Config, myEP);
+    }
+
+    @Test(expected = HazelcastSerializationException.class)
+    public void givenTheEPButItIsNotOnTheWhitelist_whenTheEPIsFilteredLocally_thenItWillFailToLoadIt() {
+        Config i1Config = new Config();
+        i1Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setClassCacheMode(classCacheMode);
+
+
+        Config i2Config = new Config();
+        FilteringClassLoader filteringCL = new FilteringClassLoader(asList("distributedclassloading"), null);
+        i2Config.setClassLoader(filteringCL);
+        i2Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setWhitelistedPrefixes("Distributedclassloading.whitelisted")
+                .setClassCacheMode(classCacheMode);
+
+        EntryProcessor<Integer, Integer> myEP = new IncrementingEntryProcessor();
+        executeSimpleTestScenario(i1Config, i2Config, myEP);
+    }
+
+    @Test
+    public void givenTheEPIsOnTheWhitelist_whenTheEPIsFilteredLocally_thenItWillLoadIt() {
+        Config i1Config = new Config();
+        i1Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setClassCacheMode(classCacheMode);
+
+        Config i2Config = new Config();
+        FilteringClassLoader filteringCL = new FilteringClassLoader(asList("distributedclassloading"), null);
+        i2Config.setClassLoader(filteringCL);
+        i2Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setWhitelistedPrefixes("distributedclassloading.whitelisted, distributedclassloading")
+                .setClassCacheMode(classCacheMode);
+
+        EntryProcessor<Integer, Integer> myEP = new WhitelistedEP();
+        executeSimpleTestScenario(i1Config, i2Config, myEP);
+    }
+
+    @Test(expected = HazelcastSerializationException.class)
+    public void givenProviderFilterUsesMemberAttribute_whenNoMemberHasMatchingAttribute_thenClassLoadingRequestFails() {
+        Config i1Config = new Config();
+        i1Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setClassCacheMode(classCacheMode);
+
+        Config i2Config = new Config();
+        FilteringClassLoader filteringCL = new FilteringClassLoader(asList("distributedclassloading"), null);
+        i2Config.setClassLoader(filteringCL);
+        i2Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setProviderFilter("HAS_ATTRIBUTE:foo")
+                .setClassCacheMode(classCacheMode);
+
+        EntryProcessor<Integer, Integer> myEP = new IncrementingEntryProcessor();
+        executeSimpleTestScenario(i1Config, i2Config, myEP);
+    }
+
+    @Test
+    public void givenProviderFilterUsesMemberAttribute_whenSomeMemberHasMatchingAttribute_thenClassLoadingRequestSucceed() {
+        Config i1Config = new Config();
+        i1Config.getMemberAttributeConfig().setStringAttribute("foo", "bar");
+        i1Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setClassCacheMode(classCacheMode);
+
+        Config i2Config = new Config();
+        FilteringClassLoader filteringCL = new FilteringClassLoader(asList("distributedclassloading"), null);
+        i2Config.setClassLoader(filteringCL);
+        i2Config.getDistributedClassloadingConfig()
+                .setEnabled(true)
+                .setProviderFilter("HAS_ATTRIBUTE:foo")
+                .setClassCacheMode(classCacheMode);
+
+        EntryProcessor<Integer, Integer> myEP = new IncrementingEntryProcessor();
+        executeSimpleTestScenario(i1Config, i2Config, myEP);
+    }
+
+    private void executeSimpleTestScenario(Config i1Config, Config i2Config, EntryProcessor<Integer, Integer> ep) {
+        int keyCount = 100;
+
+        HazelcastInstance i1 = factory.newHazelcastInstance(i1Config);
+        HazelcastInstance i2 = factory.newHazelcastInstance(i2Config);
+        IMap<Integer, Integer> map = i1.getMap(randomName());
+
+        for (int i = 0; i < keyCount; i++) {
+            map.put(i, 0);
+        }
+        map.executeOnEntries(ep);
+        for (int i = 0; i < keyCount; i++) {
+            assertEquals(1, (int) map.get(i));
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/distributedclassloading/impl/filter/MemberProviderFilterParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/distributedclassloading/impl/filter/MemberProviderFilterParserTest.java
@@ -1,0 +1,73 @@
+package com.hazelcast.internal.distributedclassloading.impl.filter;
+
+import com.google.common.collect.ImmutableMap;
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.util.filter.AlwaysApplyFilter;
+import com.hazelcast.internal.util.filter.Filter;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MemberProviderFilterParserTest extends HazelcastTestSupport {
+
+    @Test
+    public void whenStringIsNull_thenReturnAlwaysMatchingInstance() {
+        Filter<Member> memberFilter = MemberProviderFilterParser.parseMemberFilter(null);
+        assertTrue(memberFilter instanceof AlwaysApplyFilter);
+    }
+
+    @Test
+    public void whenStringIsWhitespace_thenReturnAlwaysMatchingInstance() {
+        Filter<Member> memberFilter = MemberProviderFilterParser.parseMemberFilter("  ");
+        assertTrue(memberFilter instanceof AlwaysApplyFilter);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void whenStringHasUnknownPrefix_thenThrowIllegalArgumentException() {
+        Filter<Member> memberFilter = MemberProviderFilterParser.parseMemberFilter("FOOO");
+    }
+
+    @Test
+    public void givenMemberAttributeFilterIsUsed_whenMemberAttributeIsPresent_thenFilterMatches() {
+        Filter<Member> memberFilter = MemberProviderFilterParser.parseMemberFilter("HAS_ATTRIBUTE:foo");
+        Map<String, Object> attributes = ImmutableMap.of(
+                "foo", (Object)"bar"
+        );
+        Member mockMember = createMockMemberWithAttributes(attributes);
+        assertTrue(memberFilter.accept(mockMember));
+    }
+
+    @Test
+    public void givenMemberAttributeFilterIsUsed_whenMemberAttributeIsNotPresent_thenFilterDoesNotMatch() {
+        Filter<Member> memberFilter = MemberProviderFilterParser.parseMemberFilter("HAS_ATTRIBUTE:foo");
+        Map<String, Object> attributes = ImmutableMap.of(
+                "bar", (Object)"other"
+        );
+        Member mockMember = createMockMemberWithAttributes(attributes);
+        assertFalse(memberFilter.accept(mockMember));
+    }
+
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(MemberProviderFilterParser.class);
+    }
+
+    private static Member createMockMemberWithAttributes(Map<String, Object> attributes) {
+        Member mockMember = mock(Member.class);
+        when(mockMember.getAttributes()).thenReturn(attributes);
+        return mockMember;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/filter/AlwaysApplyFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/filter/AlwaysApplyFilterTest.java
@@ -1,0 +1,27 @@
+package com.hazelcast.internal.util.filter;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AlwaysApplyFilterTest {
+
+    @Test
+    public void whenPassedNull_thenMatches() {
+        AlwaysApplyFilter<?> f = AlwaysApplyFilter.newInstance();
+        assertTrue(f.accept(null));
+    }
+
+    @Test
+    public void whenPassedObject_thenMatches() {
+        AlwaysApplyFilter<Object> f = AlwaysApplyFilter.newInstance();
+        assertTrue(f.accept(new Object()));
+    }
+}

--- a/hazelcast/src/test/java/distributedclassloading/IncrementingEntryProcessor.java
+++ b/hazelcast/src/test/java/distributedclassloading/IncrementingEntryProcessor.java
@@ -1,0 +1,23 @@
+package distributedclassloading;
+
+import com.hazelcast.map.AbstractEntryProcessor;
+
+import java.util.Map;
+
+/**
+ * This test class is intentionally in its own package
+ * as Hazelcast as a special rules for loading classes
+ * from com.hazelcast.* package.
+ *
+ */
+public class IncrementingEntryProcessor extends AbstractEntryProcessor<Integer, Integer> {
+
+    @Override
+    public Object process(Map.Entry<Integer, Integer> entry) {
+        Integer origValue = entry.getValue();
+        Integer newValue = origValue + 1;
+        entry.setValue(newValue);
+
+        return newValue;
+    }
+}

--- a/hazelcast/src/test/java/distributedclassloading/blacklisted/BlacklistedEP.java
+++ b/hazelcast/src/test/java/distributedclassloading/blacklisted/BlacklistedEP.java
@@ -1,0 +1,10 @@
+package distributedclassloading.blacklisted;
+
+import distributedclassloading.IncrementingEntryProcessor;
+
+/**
+ * Used in test of distributed  classloading blacklist/whitelisting
+ *
+ */
+public final class BlacklistedEP extends IncrementingEntryProcessor {
+}

--- a/hazelcast/src/test/java/distributedclassloading/whitelisted/WhitelistedEP.java
+++ b/hazelcast/src/test/java/distributedclassloading/whitelisted/WhitelistedEP.java
@@ -1,0 +1,10 @@
+package distributedclassloading.whitelisted;
+
+import distributedclassloading.IncrementingEntryProcessor;
+
+/**
+ * Used in test of distributed classloading blacklist/whitelisting
+ *
+ */
+public final class WhitelistedEP extends IncrementingEntryProcessor {
+}


### PR DESCRIPTION
Allow to configure a member to load locally unavailable classes
from other cluster members. This can massively simplifies Hazelcast
deployment.

It's released as Beta - it's a feature small in LoC, but big
in impossible impact. Beta feateure means both API and behaviour
can change without a notice.

Clients cannot provide classes in the first version, Lite Members
can be a workaround for some use-cases.