### PR TITLE
Remove active migration immediately when migration is completed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -26,8 +26,10 @@ public interface InternalPartitionService extends IPartitionService {
 
     /**
      * Retry count for migration operations.
+     * <p>
+     * Current Invocation mechanism retries first 5 invocations without pausing.
      */
-    int MIGRATION_RETRY_COUNT = 6;
+    int MIGRATION_RETRY_COUNT = 12;
 
     /**
      * Retry pause for migration operations.

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -262,8 +262,12 @@ public class PartitionStateManager {
         return newState;
     }
 
-    void setMigrating(int partitionId, boolean migrating) {
-        partitions[partitionId].setMigrating(migrating);
+    public void setMigratingFlag(int partitionId) {
+        partitions[partitionId].setMigrating(true);
+    }
+
+    public void clearMigratingFlag(int partitionId) {
+        partitions[partitionId].setMigrating(false);
     }
 
     void updateReplicaAddresses(int partitionId, Address[] replicaAddresses) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.partition.PartitionStateVersionMismatchException;
 import com.hazelcast.internal.partition.impl.InternalMigrationListener;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.MigrationManager;
+import com.hazelcast.internal.partition.impl.PartitionStateManager;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -121,6 +122,8 @@ abstract class BaseMigrationOperation extends AbstractOperation
             throw new RetryableHazelcastException("Cannot set active migration to " + migrationInfo
                     + ". Current active migration is " + currentActiveMigration);
         }
+        PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
+        partitionStateManager.setMigratingFlag(migrationInfo.getPartitionId());
     }
 
     void onMigrationStart() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionReplicaManager;
+import com.hazelcast.internal.partition.impl.PartitionStateManager;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -61,7 +62,8 @@ public final class FinalizeMigrationOperation extends AbstractOperation
         }
 
         InternalPartitionServiceImpl partitionService = getService();
-        partitionService.getMigrationManager().removeActiveMigration(getPartitionId());
+        PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
+        partitionStateManager.clearMigratingFlag(migrationInfo.getPartitionId());
 
         if (success) {
             nodeEngine.onPartitionMigrate(migrationInfo);


### PR DESCRIPTION
Active migration can be removed immediately when migration is completed
without waiting finalization phase. Having partition migrating flag set
is enough to protect partition.
Migrating flag is cleared after finalization is completed.

See previous PR: https://github.com/hazelcast/hazelcast/pull/9235

Backport of https://github.com/hazelcast/hazelcast/pull/9342