### PR TITLE
Add "on task done" callback to InvocationFuture

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -241,6 +241,13 @@ public abstract class InvocationBuilder {
         return executionCallback;
     }
 
+    /**
+     * Sets a callback that will respond to the "task done" event for the invocation this builder is about to create.
+     * It occurs upon the release of computational and other resources used by the task underlying the invocation.
+     * The user loses interest in the computation as soon as the invocation's future is canceled, but our
+     * internal concern is keeping track of resource usage. Therefore we need a lifecycle event independent
+     * of the regular future completion/cancelation.
+     */
     public InvocationBuilder setDoneCallback(Runnable doneCallback) {
         this.doneCallback = doneCallback;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InvocationBuilder.java
@@ -58,6 +58,7 @@ public abstract class InvocationBuilder {
     protected final int partitionId;
     protected final Address target;
     protected ExecutionCallback<Object> executionCallback;
+    protected Runnable doneCallback;
 
     protected long callTimeout = DEFAULT_CALL_TIMEOUT;
     protected int replicaIndex;
@@ -238,6 +239,11 @@ public abstract class InvocationBuilder {
 
     protected ExecutionCallback getTargetExecutionCallback() {
         return executionCallback;
+    }
+
+    public InvocationBuilder setDoneCallback(Runnable doneCallback) {
+        this.doneCallback = doneCallback;
+        return this;
     }
 
     public abstract <E> InternalCompletableFuture<E> invoke();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -164,6 +164,7 @@ public abstract class Invocation implements OperationResponseHandler {
     final long tryPauseMillis;
     final long callTimeoutMillis;
 
+    /** Refer to {@link com.hazelcast.spi.InvocationBuilder#setDoneCallback(Runnable)} for an explanation */
     private final Runnable taskDoneCallback;
 
     Invocation(Context context, Operation op, Runnable taskDoneCallback, int tryCount, long tryPauseMillis,

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationBuilderImpl.java
@@ -50,10 +50,10 @@ class InvocationBuilderImpl extends InvocationBuilder {
         if (target == null) {
             op.setPartitionId(partitionId).setReplicaIndex(replicaIndex);
             invocation = new PartitionInvocation(
-                    context, op, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+                    context, op, doneCallback, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
         } else {
             invocation = new TargetInvocation(
-                    context, op, target, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
+                    context, op, target, doneCallback, tryCount, tryPauseMillis, callTimeout, resultDeserialized);
         }
 
         InternalCompletableFuture future = invocation.invoke();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/PartitionInvocation.java
@@ -29,9 +29,14 @@ import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
  */
 final class PartitionInvocation extends Invocation {
 
+    PartitionInvocation(Context context, Operation op, Runnable doneCallback, int tryCount, long tryPauseMillis,
+                        long callTimeoutMillis, boolean deserialize) {
+        super(context, op, doneCallback, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
+    }
+
     PartitionInvocation(Context context, Operation op, int tryCount, long tryPauseMillis,
-                               long callTimeoutMillis, boolean deserialize) {
-        super(context, op, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
+                        long callTimeoutMillis, boolean deserialize) {
+        this(context, op, null, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/TargetInvocation.java
@@ -31,10 +31,15 @@ final class TargetInvocation extends Invocation {
 
     private final Address target;
 
+    TargetInvocation(Context context, Operation op, Address target, Runnable doneCallback,
+                     int tryCount, long tryPauseMillis, long callTimeoutMillis, boolean deserialize) {
+        super(context, op, doneCallback, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
+        this.target = target;
+    }
+
     TargetInvocation(Context context, Operation op, Address target,
                      int tryCount, long tryPauseMillis, long callTimeoutMillis, boolean deserialize) {
-        super(context, op, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
-        this.target = target;
+        this(context, op, target, null, tryCount, tryPauseMillis, callTimeoutMillis, deserialize);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler_NotifyTest.java
@@ -53,7 +53,7 @@ public class InboundResponseHandler_NotifyTest extends HazelcastTestSupport {
 
     private Invocation newInvocation(Operation op) {
         Invocation.Context context = operationService.invocationContext;
-        Invocation invocation = new PartitionInvocation(context, op , 0, 0, 0, false);
+        Invocation invocation = new PartitionInvocation(context, op, 0, 0, 0, false);
         invocation.invTarget = getAddress(local);
         return invocation;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -1,17 +1,13 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.impl.operationservice.impl.CallIdSequence.CallIdSequenceWithBackpressure;
 import com.hazelcast.spi.impl.operationservice.impl.Invocation.Context;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,8 +17,6 @@ import org.mockito.Mockito;
 
 import java.util.concurrent.ExecutionException;
 
-import static com.hazelcast.spi.OperationAccessor.hasActiveInvocation;
-import static com.hazelcast.spi.properties.GroupProperty.BACKPRESSURE_ENABLED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NotifyCallTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NotifyCallTimeoutTest.java
@@ -25,14 +25,13 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class Invocation_NotifyCallTimeoutTest extends HazelcastTestSupport {
 
-    private HazelcastInstance hz;
     private OperationServiceImpl operationService;
     private Node node;
     private WaitNotifyKeyImpl waitNotifyKey = new WaitNotifyKeyImpl();
 
     @Before
     public void setup() {
-        hz = createHazelcastInstance();
+        HazelcastInstance hz = createHazelcastInstance();
         node = getNode(hz);
         operationService = (OperationServiceImpl) getOperationService(hz);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TaskDoneTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_TaskDoneTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class Invocation_TaskDoneTest extends HazelcastTestSupport {
+
+    private InternalOperationService operationService;
+
+    @Before
+    public void before() {
+        operationService = getOperationService(createHazelcastInstance());
+    }
+
+    @Test
+    public void when_invocationDone_thenCallbackRuns() {
+        // Given
+        final DummyOperation op = new DummyOperation(null);
+        final DoneCallback cb = new DoneCallback();
+
+        // When
+        operationService.createInvocationBuilder("mockService", op, 0).setDoneCallback(cb).invoke();
+
+        // Then
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertTrue(cb.done);
+            }
+        });
+    }
+
+    @Test
+    public void when_invocationFutureCanceled_thenCallbackRunsEventually() throws InterruptedException {
+        // Given
+        final LatchAwaitOperation latchAwaitOp = new LatchAwaitOperation();
+        final DoneCallback cb = new DoneCallback();
+        final ICompletableFuture<Object> fut =
+                operationService.createInvocationBuilder("mockService", latchAwaitOp, 0).setDoneCallback(cb).invoke();
+        final FailedLatchExecutionCallback canceledCallback = new FailedLatchExecutionCallback();
+        fut.andThen(canceledCallback);
+
+        // When
+        fut.cancel(true);
+        assertOpenEventually(canceledCallback.latch);
+
+        // Then
+        assertFalse(cb.done);
+        latchAwaitOp.latch.countDown();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertTrue(cb.done);
+            }
+        });
+    }
+
+    static class DoneCallback implements Runnable {
+        volatile boolean done;
+        @Override
+        public void run() {
+            done = true;
+        }
+    }
+
+    static class LatchAwaitOperation extends Operation {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public void run() throws Exception {
+            latch.await();
+        }
+    }
+
+    static class FailedLatchExecutionCallback implements ExecutionCallback<Object> {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        @Override
+        public void onFailure(Throwable t) {
+            latch.countDown();
+        }
+
+        @Override
+        public void onResponse(Object response) { }
+    }
+}


### PR DESCRIPTION
After implementing `cancel` on Invocation's future, the future's completion status no longer matches the completion of the underlying computational task. As soon as the future is canceled, the user loses interest in the result of the computation, but internally nothing changes for us until the task actually stops executing and releases its resources. We now need a separate signal and an associated callback that runs when the task is done.

This PR introduces a small and low-impact addition to `Invocation`, but is crucial for Jet.