### PR TITLE
Introduced map#removeAll with predicate

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -39,6 +39,7 @@ import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicate;
 import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.MapUtil;
 import com.hazelcast.util.executor.CompletedFuture;
@@ -142,6 +143,12 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         boolean removed = super.removeInternal(keyData, valueData);
         invalidateNearCache(keyData);
         return removed;
+    }
+
+    @Override
+    protected void removeAllInternal(Predicate predicate) {
+        super.removeAllInternal(predicate);
+        nearCache.clear();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapRemoveAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapRemoveAllTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.FalsePredicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMapRemoveAllTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static final int MAP_SIZE = 1000;
+    private static final int NODE_COUNT = 3;
+
+    private TestHazelcastFactory factory;
+    private HazelcastInstance client;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new TestHazelcastFactory();
+        factory.newInstances(new Config(), NODE_COUNT);
+
+        client = factory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void throws_exception_whenPredicateNull() throws Exception {
+        expectedException.expect(NullPointerException.class);
+        expectedException.expectMessage("predicate cannot be null");
+
+        IMap map = client.getMap("test");
+        map.removeAll(null);
+    }
+
+    @Test
+    public void removes_all_entries_whenPredicateTrue() throws Exception {
+        IMap map = client.getMap("test");
+
+        for (int i = 0; i < MAP_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        map.removeAll(TruePredicate.INSTANCE);
+
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    public void removes_no_entries_whenPredicateFalse() throws Exception {
+        IMap map = client.getMap("test");
+
+        for (int i = 0; i < MAP_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        map.removeAll(FalsePredicate.INSTANCE);
+
+        assertEquals(MAP_SIZE, map.size());
+    }
+
+    @Test
+    public void removes_odd_keys_whenPredicateOdd() throws Exception {
+        IMap<Integer, Integer> map = client.getMap("test");
+
+        for (int i = 0; i < MAP_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        map.removeAll(new OddFinderPredicate());
+
+        assertEquals(500, map.size());
+    }
+
+    private static final class OddFinderPredicate implements Predicate<Integer, Integer> {
+        @Override
+        public boolean apply(Map.Entry<Integer, Integer> mapEntry) {
+            return mapEntry.getKey() % 2 != 0;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -181,6 +181,16 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      */
     boolean remove(Object key, Object value);
 
+
+    /**
+     * Removes all entries which match with the supplied predicate.
+     * If this map has index, matching entries will be found via index search, otherwise they will be found by full-scan.
+     *
+     * @param predicate matching entries with this predicate will be removed from this map
+     * @throws NullPointerException if the specified predicate is null.
+     */
+    void removeAll(Predicate<K, V> predicate);
+
     /**
      * Removes the mapping for a key from this map if it is present
      * (optional operation).

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryRemovingProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryRemovingProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.map.AbstractEntryProcessor;
+
+import java.util.Map;
+
+public class EntryRemovingProcessor extends AbstractEntryProcessor {
+
+    public static final EntryRemovingProcessor ENTRY_REMOVING_PROCESSOR = new EntryRemovingProcessor();
+
+    public EntryRemovingProcessor() {
+    }
+
+    public Object process(Map.Entry entry) {
+        ((LazyMapEntry) entry).remove();
+        return null;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyMapEntry.java
@@ -68,6 +68,16 @@ public class LazyMapEntry extends CachedQueryEntry implements Serializable {
     }
 
 
+    /**
+     * Similar to calling {@link #setValue} with null but doesn't return old-value hence no extra deserialization.
+     */
+    public void remove() {
+        modified = true;
+        valueObject = null;
+        valueData = null;
+    }
+
+
     public boolean isModified() {
         return modified;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -211,6 +211,13 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
+    public void removeAll(Predicate<K, V> predicate) {
+        checkNotNull(predicate, "predicate cannot be null");
+
+        removeAllInternal(predicate);
+    }
+
+    @Override
     public void delete(Object k) {
         checkNotNull(k, NULL_KEY_IS_NOT_ALLOWED);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -262,6 +262,12 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
+    protected void removeAllInternal(Predicate predicate) {
+        super.removeAllInternal(predicate);
+        nearCache.clear();
+    }
+
+    @Override
     protected void deleteInternal(Data key) {
         super.deleteInternal(key);
         invalidateCache(key);

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveAllTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.FalsePredicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapRemoveAllTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static final int MAP_SIZE = 1000;
+    private static final int NODE_COUNT = 3;
+
+    private TestHazelcastInstanceFactory factory;
+    private HazelcastInstance member;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = createHazelcastInstanceFactory(NODE_COUNT);
+        HazelcastInstance[] instances = factory.newInstances();
+        member = instances[1];
+    }
+
+    @Test
+    public void throws_exception_whenPredicateNull() throws Exception {
+        expectedException.expect(NullPointerException.class);
+        expectedException.expectMessage("predicate cannot be null");
+
+        IMap map = member.getMap("test");
+        map.removeAll(null);
+    }
+
+    @Test
+    public void removes_all_entries_whenPredicateTrue() throws Exception {
+        IMap map = member.getMap("test");
+
+        for (int i = 0; i < MAP_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        map.removeAll(TruePredicate.INSTANCE);
+
+        assertEquals(0, map.size());
+    }
+
+    @Test
+    public void removes_no_entries_whenPredicateFalse() throws Exception {
+        IMap map = member.getMap("test");
+
+        for (int i = 0; i < MAP_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        map.removeAll(FalsePredicate.INSTANCE);
+
+        assertEquals(MAP_SIZE, map.size());
+    }
+
+    @Test
+    public void removes_odd_keys_whenPredicateOdd() throws Exception {
+        IMap<Integer, Integer> map = member.getMap("test");
+
+        for (int i = 0; i < MAP_SIZE; i++) {
+            map.put(i, i);
+        }
+
+        map.removeAll(new OddFinderPredicate());
+
+        assertEquals(500, map.size());
+    }
+
+    private static final class OddFinderPredicate implements Predicate<Integer, Integer> {
+        @Override
+        public boolean apply(Map.Entry<Integer, Integer> mapEntry) {
+            return mapEntry.getKey() % 2 != 0;
+        }
+    }
+}


### PR DESCRIPTION
Adds `map#removeAll(predicate)` method. It can be used to remove all entries which match with the supplied predicate. If a map has index, matching entries will be found via index search, otherwise they will be found by full-scan. 