### PR TITLE
Small joiner fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -23,7 +23,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeExtension;
-import com.hazelcast.instance.NodeState;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.impl.operations.MemberRemoveOperation;
 import com.hazelcast.internal.cluster.impl.operations.MergeClustersOperation;
@@ -159,7 +158,7 @@ public abstract class AbstractJoiner implements Joiner {
         if (logger.isFineEnabled()) {
             logger.fine("PostJoin master: " + node.getMasterAddress() + ", isMaster: " + node.isMaster());
         }
-        if (node.getState() != NodeState.ACTIVE) {
+        if (!node.isRunning()) {
             return;
         }
         if (tryCount.incrementAndGet() == JOIN_TRY_COUNT) {


### PR DESCRIPTION
- AbstractJoiner should check whether node is running, not node state. Node state can be not active when cluster state is passive too, that doesn't mean node is shutting down.

- MockJoiner should hold mutex only for join cycle period, otherwise other nodes cannot join until one joins or gives up.