### PR TITLE
Jet flow-control packet + Packet.flags cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/StandardMemoryAccessor.java
@@ -20,7 +20,6 @@ import com.hazelcast.internal.memory.MemoryAccessor;
 
 import java.lang.reflect.Field;
 
-import static com.hazelcast.internal.memory.impl.AlignmentUtil.IS_PLATFORM_BIG_ENDIAN;
 import static com.hazelcast.internal.memory.impl.UnsafeUtil.UNSAFE;
 import static com.hazelcast.internal.memory.impl.UnsafeUtil.UNSAFE_AVAILABLE;
 
@@ -37,11 +36,6 @@ public final class StandardMemoryAccessor extends UnsafeBasedMemoryAccessor {
         if (!UNSAFE_AVAILABLE) {
             throw new IllegalStateException(getClass().getName() + " can only be used only when Unsafe is available!");
         }
-    }
-
-    @Override
-    public boolean isBigEndian() {
-        return IS_PLATFORM_BIG_ENDIAN;
     }
 
     // Address-based memory access

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
@@ -43,6 +43,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.nativeOrder;
+
 public class DefaultSerializationServiceBuilder
         implements SerializationServiceBuilder {
 
@@ -69,7 +72,7 @@ public class DefaultSerializationServiceBuilder
 
     protected boolean useNativeByteOrder;
 
-    protected ByteOrder byteOrder = ByteOrder.BIG_ENDIAN;
+    protected ByteOrder byteOrder = BIG_ENDIAN;
 
     protected boolean enableCompression;
 
@@ -300,15 +303,11 @@ public class DefaultSerializationServiceBuilder
 
     protected InputOutputFactory createInputOutputFactory() {
         if (byteOrder == null) {
-            byteOrder = ByteOrder.BIG_ENDIAN;
+            byteOrder = useNativeByteOrder ? nativeOrder() : BIG_ENDIAN;
         }
-        if (useNativeByteOrder || byteOrder == ByteOrder.nativeOrder()) {
-            byteOrder = ByteOrder.nativeOrder();
-            if (allowUnsafe && GlobalMemoryAccessorRegistry.MEM_AVAILABLE) {
-                return new UnsafeInputOutputFactory();
-            }
-        }
-        return new ByteArrayInputOutputFactory(byteOrder);
+        return byteOrder == nativeOrder() && allowUnsafe && GlobalMemoryAccessorRegistry.MEM_AVAILABLE
+                ? new UnsafeInputOutputFactory()
+                : new ByteArrayInputOutputFactory(byteOrder);
     }
 
     private void addConfigDataSerializableFactories(Map<Integer, DataSerializableFactory> dataSerializableFactories,

--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -38,21 +38,51 @@ public final class Packet extends HeapData implements OutboundFrame {
 
     public static final byte VERSION = 4;
 
-    public static final int FLAG_OP = 1 << 0;
-    public static final int FLAG_RESPONSE = 1 << 1;
-    public static final int FLAG_EVENT = 1 << 2;
-    public static final int FLAG_URGENT = 1 << 4;
-    public static final int FLAG_BIND = 1 << 5;
 
-    /**
-     * A flag to indicate this is a special control packet for the operation system like invocation-heartbeats.
-     */
+    //             PACKET HEADER FLAGS
+    //
+    // Flags are dispatched against in a cascade:
+    // 1. URGENT (bit 4)
+    // 2. Packet type (bits 0, 2, 5, 7)
+    // 3. Flags specific to a given packet type (bits 1, 6)
+
+
+    // 1. URGENT flag
+
+    /** Marks the packet as Urgent  */
+    public static final int FLAG_URGENT = 1 << 4;
+
+
+    // 2. Packet type flags, mutually exclusive
+
+    /** Marks the packet type as Operation */
+    public static final int FLAG_OP = 1 << 0;
+    /** Marks the packet type as Event */
+    public static final int FLAG_EVENT = 1 << 2;
+    /** Marks the packet type as Bind message */
+    public static final int FLAG_BIND = 1 << 5;
+    /** Marks the packet as Jet */
+    public static final int FLAG_JET = 1 << 7;
+
+
+    // 3. Type-specific flags. Same bits can be reused within each type
+
+    // 3.a Operation packet flags
+
+    /** Marks an Operation packet as Response */
+    public static final int FLAG_OP_RESPONSE = 1 << 1;
+    /** Marks an Operation packet as Operation control (like invocation-heartbeats) */
     public static final int FLAG_OP_CONTROL = 1 << 6;
 
-    /**
-     * Flag to indicate this will be a Jet packet
-     */
-    public static final int FLAG_JET = 1 << 7;
+
+    // 3.b Jet packet flags
+
+    /** Marks a Jet packet as Flow control */
+    public static final int FLAG_JET_FLOW_CONTROL = 1 << 1;
+
+
+    //            END OF HEADER FLAG SECTION
+
 
 
     private static final int HEADER_SIZE = BYTE_SIZE_IN_BYTES + SHORT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES + INT_SIZE_IN_BYTES;
@@ -308,7 +338,7 @@ public final class Packet extends HeapData implements OutboundFrame {
     public String toString() {
         return "Packet{"
                 + "flags=" + flags
-                + ", isResponse=" + isFlagSet(Packet.FLAG_RESPONSE)
+                + ", isResponse=" + isFlagSet(Packet.FLAG_OP_RESPONSE)
                 + ", isOperation=" + isFlagSet(Packet.FLAG_OP)
                 + ", isEvent=" + isFlagSet(Packet.FLAG_EVENT)
                 + ", partitionId=" + partitionId

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -330,8 +330,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
         }
         BindMessage bind = new BindMessage(ioService.getThisAddress(), remoteEndPoint, replyBack);
         byte[] bytes = ioService.getSerializationService().toBytes(bind);
-        Packet packet = new Packet(bytes);
-        packet.raiseFlags(Packet.FLAG_BIND);
+        Packet packet = new Packet(bytes).setPacketType(Packet.Type.BIND);
         connection.write(packet);
         //now you can send anything...
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -331,7 +331,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
         BindMessage bind = new BindMessage(ioService.getThisAddress(), remoteEndPoint, replyBack);
         byte[] bytes = ioService.getSerializationService().toBytes(bind);
         Packet packet = new Packet(bytes);
-        packet.setFlag(Packet.FLAG_BIND);
+        packet.raiseFlags(Packet.FLAG_BIND);
         connection.write(packet);
         //now you can send anything...
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -409,8 +409,8 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
                 }
             }
         } else {
-            Packet packet = new Packet(serializationService.toBytes(eventEnvelope), orderKey);
-            packet.raiseFlags(Packet.FLAG_EVENT);
+            Packet packet = new Packet(serializationService.toBytes(eventEnvelope), orderKey)
+                    .setPacketType(Packet.Type.EVENT);
 
             if (!nodeEngine.getNode().getConnectionManager().transmit(packet, subscriber)) {
                 if (nodeEngine.isRunning()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -410,7 +410,7 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
             }
         } else {
             Packet packet = new Packet(serializationService.toBytes(eventEnvelope), orderKey);
-            packet.setFlag(Packet.FLAG_EVENT);
+            packet.raiseFlags(Packet.FLAG_EVENT);
 
             if (!nodeEngine.getNode().getConnectionManager().transmit(packet, subscriber)) {
                 if (nodeEngine.isRunning()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
@@ -36,7 +36,7 @@ import java.util.concurrent.BlockingQueue;
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutOfMemoryError;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.nio.Packet.FLAG_OP;
-import static com.hazelcast.nio.Packet.FLAG_RESPONSE;
+import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkTrue;
@@ -85,7 +85,7 @@ public class AsyncInboundResponseHandler implements PacketHandler, MetricsProvid
     public void handle(Packet packet) {
         checkNotNull(packet, "packet can't be null");
         checkTrue(packet.isFlagSet(FLAG_OP), "FLAG_OP should be set");
-        checkTrue(packet.isFlagSet(FLAG_RESPONSE), "FLAG_RESPONSE should be set");
+        checkTrue(packet.isFlagSet(FLAG_OP_RESPONSE), "FLAG_OP_RESPONSE should be set");
 
         responseThread.responseQueue.add(packet);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -452,7 +452,7 @@ class InvocationMonitor implements PacketHandler, MetricsProvider {
                 scheduler.execute(new ProcessOperationControlTask(opControl));
             } else {
                 Packet packet = new Packet(serializationService.toBytes(opControl))
-                        .setAllFlags(FLAG_OP | FLAG_OP_CONTROL | FLAG_URGENT);
+                        .resetFlagsTo(FLAG_OP | FLAG_OP_CONTROL | FLAG_URGENT);
                 nodeEngine.getNode().getConnectionManager().transmit(packet, address);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -53,7 +53,6 @@ import java.util.logging.Level;
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutOfMemoryError;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
-import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_CONTROL;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_BACKUP_TIMEOUT_MILLIS;
@@ -452,7 +451,8 @@ class InvocationMonitor implements PacketHandler, MetricsProvider {
                 scheduler.execute(new ProcessOperationControlTask(opControl));
             } else {
                 Packet packet = new Packet(serializationService.toBytes(opControl))
-                        .resetFlagsTo(FLAG_OP | FLAG_OP_CONTROL | FLAG_URGENT);
+                        .setPacketType(Packet.Type.OPERATION)
+                        .raiseFlags(FLAG_OP_CONTROL | FLAG_URGENT);
                 nodeEngine.getNode().getConnectionManager().transmit(packet, address);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -408,10 +408,10 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         byte[] bytes = serializationService.toBytes(op);
         int partitionId = op.getPartitionId();
         Packet packet = new Packet(bytes, partitionId)
-                .setFlag(FLAG_OP);
+                .raiseFlags(FLAG_OP);
 
         if (op.isUrgent()) {
-            packet.setFlag(FLAG_URGENT);
+            packet.raiseFlags(FLAG_URGENT);
         }
 
         ConnectionManager connectionManager = node.getConnectionManager();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -63,7 +63,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
-import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_CALL_TIMEOUT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_DESERIALIZE_RESULT;
@@ -407,8 +406,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
 
         byte[] bytes = serializationService.toBytes(op);
         int partitionId = op.getPartitionId();
-        Packet packet = new Packet(bytes, partitionId)
-                .raiseFlags(FLAG_OP);
+        Packet packet = new Packet(bytes, partitionId).setPacketType(Packet.Type.OPERATION);
 
         if (op.isUrgent()) {
             packet.raiseFlags(FLAG_URGENT);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
@@ -88,10 +88,10 @@ public final class OutboundResponseHandler implements OperationResponseHandler {
 
         byte[] bytes = serializationService.toBytes(response);
         Packet packet = new Packet(bytes, -1)
-                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE);
+                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE);
 
         if (response.isUrgent()) {
-            packet.setFlag(FLAG_URGENT);
+            packet.raiseFlags(FLAG_URGENT);
         }
 
         ConnectionManager connectionManager = node.getConnectionManager();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
@@ -29,7 +29,6 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
 
-import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -69,7 +68,7 @@ public final class OutboundResponseHandler implements OperationResponseHandler {
         }
     }
 
-    private Response toResponse(Operation operation, Object obj) {
+    private static Response toResponse(Operation operation, Object obj) {
         if (obj instanceof Throwable) {
             return new ErrorResponse((Throwable) obj, operation.getCallId(), operation.isUrgent());
         } else if (!(obj instanceof Response)) {
@@ -88,7 +87,8 @@ public final class OutboundResponseHandler implements OperationResponseHandler {
 
         byte[] bytes = serializationService.toBytes(response);
         Packet packet = new Packet(bytes, -1)
-                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE);
+                .setPacketType(Packet.Type.OPERATION)
+                .raiseFlags(FLAG_OP_RESPONSE);
 
         if (response.isUrgent()) {
             packet.raiseFlags(FLAG_URGENT);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
@@ -30,7 +30,7 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
 
 import static com.hazelcast.nio.Packet.FLAG_OP;
-import static com.hazelcast.nio.Packet.FLAG_RESPONSE;
+import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -88,7 +88,7 @@ public final class OutboundResponseHandler implements OperationResponseHandler {
 
         byte[] bytes = serializationService.toBytes(response);
         Packet packet = new Packet(bytes, -1)
-                .setAllFlags(FLAG_OP | FLAG_RESPONSE);
+                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE);
 
         if (response.isUrgent()) {
             packet.setFlag(FLAG_URGENT);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImpl.java
@@ -76,7 +76,7 @@ public final class PacketDispatcherImpl implements PacketDispatcher {
             } else if (packet.isFlagSet(FLAG_JET)) {
                 jetService.handle(packet);
             } else {
-                logger.severe("Unknown packet type! Header: " + packet.getFlags());
+                logger.severe("Unknown packet type! Header flags: " + Integer.toBinaryString(packet.getFlags()));
             }
         } catch (Throwable t) {
             inspectOutOfMemoryError(t);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImpl.java
@@ -27,7 +27,7 @@ import static com.hazelcast.nio.Packet.FLAG_EVENT;
 import static com.hazelcast.nio.Packet.FLAG_JET;
 import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_CONTROL;
-import static com.hazelcast.nio.Packet.FLAG_RESPONSE;
+import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 
 /**
  * Default {@link PacketDispatcher} implementation.
@@ -62,7 +62,7 @@ public final class PacketDispatcherImpl implements PacketDispatcher {
     public void dispatch(Packet packet) {
         try {
             if (packet.isFlagSet(FLAG_OP)) {
-                if (packet.isFlagSet(FLAG_RESPONSE)) {
+                if (packet.isFlagSet(FLAG_OP_RESPONSE)) {
                     responseHandler.handle(packet);
                 } else if (packet.isFlagSet(FLAG_OP_CONTROL)) {
                     invocationMonitor.handle(packet);

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
@@ -98,8 +98,8 @@ public class PacketTest {
     @Test
     public void setFlag() {
         Packet packet = new Packet();
-        packet.setFlag(FLAG_OP);
-        packet.setFlag(FLAG_URGENT);
+        packet.raiseFlags(FLAG_OP);
+        packet.raiseFlags(FLAG_URGENT);
 
         assertEquals(FLAG_OP | FLAG_URGENT, packet.getFlags());
     }
@@ -107,8 +107,8 @@ public class PacketTest {
     @Test
     public void isFlagSet() {
         Packet packet = new Packet();
-        packet.setFlag(FLAG_OP);
-        packet.setFlag(FLAG_URGENT);
+        packet.raiseFlags(FLAG_OP);
+        packet.raiseFlags(FLAG_URGENT);
 
         assertTrue(packet.isFlagSet(FLAG_OP));
         assertTrue(packet.isFlagSet(FLAG_URGENT));
@@ -118,7 +118,7 @@ public class PacketTest {
     @Test
     public void setAllFlags() {
         Packet packet = new Packet();
-        packet.setAllFlags(FLAG_OP | FLAG_URGENT);
+        packet.resetFlagsTo(FLAG_OP | FLAG_URGENT);
 
         assertEquals(FLAG_OP | FLAG_URGENT, packet.getFlags());
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
@@ -98,7 +98,7 @@ public class PacketTest {
     @Test
     public void setFlag() {
         Packet packet = new Packet();
-        packet.raiseFlags(FLAG_OP);
+        packet.setPacketType(Packet.Type.OPERATION);
         packet.raiseFlags(FLAG_URGENT);
 
         assertEquals(FLAG_OP | FLAG_URGENT, packet.getFlags());
@@ -107,7 +107,7 @@ public class PacketTest {
     @Test
     public void isFlagSet() {
         Packet packet = new Packet();
-        packet.raiseFlags(FLAG_OP);
+        packet.setPacketType(Packet.Type.OPERATION);
         packet.raiseFlags(FLAG_URGENT);
 
         assertTrue(packet.isFlagSet(FLAG_OP));

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberReadHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MemberReadHandlerTest.java
@@ -50,7 +50,7 @@ public class MemberReadHandlerTest extends TcpIpConnection_AbstractTest {
     public void whenPriorityPacket() throws Exception {
         ByteBuffer buffer = ByteBuffer.allocate(1000);
         Packet packet = new Packet(serializationService.toBytes("foobar"));
-        packet.setFlag(Packet.FLAG_URGENT);
+        packet.raiseFlags(Packet.FLAG_URGENT);
         packet.writeTo(buffer);
 
         buffer.flip();
@@ -93,7 +93,7 @@ public class MemberReadHandlerTest extends TcpIpConnection_AbstractTest {
         packet3.writeTo(buffer);
 
         Packet packet4 = new Packet(serializationService.toBytes("packet4"));
-        packet4.setFlag(Packet.FLAG_URGENT);
+        packet4.raiseFlags(Packet.FLAG_URGENT);
         packet4.writeTo(buffer);
 
         buffer.flip();

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_BaseTest.java
@@ -66,7 +66,7 @@ public abstract class TcpIpConnection_BaseTest extends TcpIpConnection_AbstractT
         TcpIpConnection c = connect(connManagerA, addressB);
 
         Packet packet = new Packet(serializationService.toBytes("foo"));
-        packet.setFlag(Packet.FLAG_URGENT);
+        packet.raiseFlags(Packet.FLAG_URGENT);
 
         boolean result = c.write(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressBaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_TransferStressBaseTest.java
@@ -213,7 +213,7 @@ public abstract class TcpIpConnection_TransferStressBaseTest extends TcpIpConnec
             DummyPayload payload = payloads[random.nextInt(payloads.length)];
             Packet packet = new Packet(serializationService.toBytes(payload));
             if (payload.isUrgent()) {
-                packet.setFlag(Packet.FLAG_URGENT);
+                packet.raiseFlags(Packet.FLAG_URGENT);
             }
             return packet;
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
@@ -35,7 +35,8 @@ public class OperationExecutorImpl_HandlePacketTest extends OperationExecutorImp
 
         final NormalResponse normalResponse = new NormalResponse(null, 1, 0, false);
         final Packet packet = new Packet(serializationService.toBytes(normalResponse), 0)
-                .resetFlagsTo(FLAG_OP_RESPONSE | FLAG_OP);
+                .setPacketType(Packet.Type.OPERATION)
+                .raiseFlags(FLAG_OP_RESPONSE);
         executor.handle(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -55,7 +56,7 @@ public class OperationExecutorImpl_HandlePacketTest extends OperationExecutorImp
 
         final DummyOperation operation = new DummyOperation(0);
         final Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId())
-                .raiseFlags(FLAG_OP);
+                .setPacketType(Packet.Type.OPERATION);
         executor.handle(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -74,7 +75,7 @@ public class OperationExecutorImpl_HandlePacketTest extends OperationExecutorImp
 
         final DummyOperation operation = new DummyOperation(Operation.GENERIC_PARTITION_ID);
         final Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId())
-                .raiseFlags(FLAG_OP);
+                .setPacketType(Packet.Type.OPERATION);
         executor.handle(packet);
 
         assertTrueEventually(new AssertTask() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
@@ -35,7 +35,7 @@ public class OperationExecutorImpl_HandlePacketTest extends OperationExecutorImp
 
         final NormalResponse normalResponse = new NormalResponse(null, 1, 0, false);
         final Packet packet = new Packet(serializationService.toBytes(normalResponse), 0)
-                .setAllFlags(FLAG_OP_RESPONSE | FLAG_OP);
+                .resetFlagsTo(FLAG_OP_RESPONSE | FLAG_OP);
         executor.handle(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -55,7 +55,7 @@ public class OperationExecutorImpl_HandlePacketTest extends OperationExecutorImp
 
         final DummyOperation operation = new DummyOperation(0);
         final Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId())
-                .setFlag(FLAG_OP);
+                .raiseFlags(FLAG_OP);
         executor.handle(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -74,7 +74,7 @@ public class OperationExecutorImpl_HandlePacketTest extends OperationExecutorImp
 
         final DummyOperation operation = new DummyOperation(Operation.GENERIC_PARTITION_ID);
         final Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId())
-                .setFlag(FLAG_OP);
+                .raiseFlags(FLAG_OP);
         executor.handle(packet);
 
         assertTrueEventually(new AssertTask() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
@@ -12,7 +12,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.nio.Packet.FLAG_OP;
-import static com.hazelcast.nio.Packet.FLAG_RESPONSE;
+import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -35,7 +35,7 @@ public class OperationExecutorImpl_HandlePacketTest extends OperationExecutorImp
 
         final NormalResponse normalResponse = new NormalResponse(null, 1, 0, false);
         final Packet packet = new Packet(serializationService.toBytes(normalResponse), 0)
-                .setAllFlags(FLAG_RESPONSE | FLAG_OP);
+                .setAllFlags(FLAG_OP_RESPONSE | FLAG_OP);
         executor.handle(packet);
 
         assertTrueEventually(new AssertTask() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
@@ -37,8 +37,8 @@ public class OperationThreadTest extends OperationExecutorImpl_AbstractTest {
         initExecutor();
 
         DummyOperation operation = new DummyOperation(Operation.GENERIC_PARTITION_ID);
-        Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.raiseFlags(Packet.FLAG_OP);
+        Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId())
+                .setPacketType(Packet.Type.OPERATION);
 
         doThrow(new OutOfMemoryError()).when(handler).run(packet);
 
@@ -102,8 +102,8 @@ public class OperationThreadTest extends OperationExecutorImpl_AbstractTest {
     public void executePacket_withInvalid_partitionId() {
         final int partitionId = Integer.MAX_VALUE;
         Operation operation = new DummyPartitionOperation(partitionId);
-        Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.raiseFlags(Packet.FLAG_OP);
+        Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId())
+                .setPacketType(Packet.Type.OPERATION);
 
         testExecute_withInvalid_partitionId(packet);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThreadTest.java
@@ -1,7 +1,6 @@
 package com.hazelcast.spi.impl.operationexecutor.impl;
 
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
-import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
@@ -39,7 +38,7 @@ public class OperationThreadTest extends OperationExecutorImpl_AbstractTest {
 
         DummyOperation operation = new DummyOperation(Operation.GENERIC_PARTITION_ID);
         Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.setFlag(Packet.FLAG_OP);
+        packet.raiseFlags(Packet.FLAG_OP);
 
         doThrow(new OutOfMemoryError()).when(handler).run(packet);
 
@@ -104,7 +103,7 @@ public class OperationThreadTest extends OperationExecutorImpl_AbstractTest {
         final int partitionId = Integer.MAX_VALUE;
         Operation operation = new DummyPartitionOperation(partitionId);
         Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.setFlag(Packet.FLAG_OP);
+        packet.raiseFlags(Packet.FLAG_OP);
 
         testExecute_withInvalid_partitionId(packet);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
@@ -49,7 +49,8 @@ public class AsyncInboundResponseHandlerTest extends HazelcastTestSupport {
     @Test
     public void whenNoProblemPacket() throws Exception {
         final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)))
-                .raiseFlags(FLAG_OP| FLAG_OP_RESPONSE);
+                .setPacketType(Packet.Type.OPERATION)
+                .raiseFlags(FLAG_OP_RESPONSE);
         asyncHandler.handle(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -63,10 +64,12 @@ public class AsyncInboundResponseHandlerTest extends HazelcastTestSupport {
     @Test
     public void whenPacketThrowsException() throws Exception {
         final Packet badPacket = new Packet(serializationService.toBytes(new NormalResponse("bad", 1, 0, false)))
-                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE);
+                .setPacketType(Packet.Type.OPERATION)
+                .raiseFlags(FLAG_OP_RESPONSE);
 
         final Packet goodPacket = new Packet(serializationService.toBytes(new NormalResponse("good", 1, 0, false)))
-                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE);
+                .setPacketType(Packet.Type.OPERATION)
+                .raiseFlags(FLAG_OP_RESPONSE);
 
         doThrow(new ExpectedRuntimeException()).when(responsePacketHandler).handle(badPacket);
 
@@ -89,7 +92,8 @@ public class AsyncInboundResponseHandlerTest extends HazelcastTestSupport {
         assertJoinable(asyncHandler.responseThread);
 
         final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)))
-                .resetFlagsTo(FLAG_OP| FLAG_OP_RESPONSE);
+                .setPacketType(Packet.Type.OPERATION)
+                .raiseFlags(FLAG_OP_RESPONSE);
 
         asyncHandler.handle(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
@@ -49,7 +49,7 @@ public class AsyncInboundResponseHandlerTest extends HazelcastTestSupport {
     @Test
     public void whenNoProblemPacket() throws Exception {
         final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)))
-                .setFlag(FLAG_OP| FLAG_OP_RESPONSE);
+                .raiseFlags(FLAG_OP| FLAG_OP_RESPONSE);
         asyncHandler.handle(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -63,10 +63,10 @@ public class AsyncInboundResponseHandlerTest extends HazelcastTestSupport {
     @Test
     public void whenPacketThrowsException() throws Exception {
         final Packet badPacket = new Packet(serializationService.toBytes(new NormalResponse("bad", 1, 0, false)))
-                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE);
+                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE);
 
         final Packet goodPacket = new Packet(serializationService.toBytes(new NormalResponse("good", 1, 0, false)))
-                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE);
+                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE);
 
         doThrow(new ExpectedRuntimeException()).when(responsePacketHandler).handle(badPacket);
 
@@ -89,7 +89,7 @@ public class AsyncInboundResponseHandlerTest extends HazelcastTestSupport {
         assertJoinable(asyncHandler.responseThread);
 
         final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)))
-                .setAllFlags(FLAG_OP| FLAG_OP_RESPONSE);
+                .resetFlagsTo(FLAG_OP| FLAG_OP_RESPONSE);
 
         asyncHandler.handle(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
@@ -22,7 +22,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.nio.Packet.FLAG_OP;
-import static com.hazelcast.nio.Packet.FLAG_RESPONSE;
+import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -49,7 +49,7 @@ public class AsyncInboundResponseHandlerTest extends HazelcastTestSupport {
     @Test
     public void whenNoProblemPacket() throws Exception {
         final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)))
-                .setFlag(FLAG_OP|FLAG_RESPONSE);
+                .setFlag(FLAG_OP| FLAG_OP_RESPONSE);
         asyncHandler.handle(packet);
 
         assertTrueEventually(new AssertTask() {
@@ -63,10 +63,10 @@ public class AsyncInboundResponseHandlerTest extends HazelcastTestSupport {
     @Test
     public void whenPacketThrowsException() throws Exception {
         final Packet badPacket = new Packet(serializationService.toBytes(new NormalResponse("bad", 1, 0, false)))
-                .setAllFlags(FLAG_OP | FLAG_RESPONSE);
+                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE);
 
         final Packet goodPacket = new Packet(serializationService.toBytes(new NormalResponse("good", 1, 0, false)))
-                .setAllFlags(FLAG_OP | FLAG_RESPONSE);
+                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE);
 
         doThrow(new ExpectedRuntimeException()).when(responsePacketHandler).handle(badPacket);
 
@@ -89,7 +89,7 @@ public class AsyncInboundResponseHandlerTest extends HazelcastTestSupport {
         assertJoinable(asyncHandler.responseThread);
 
         final Packet packet = new Packet(serializationService.toBytes(new NormalResponse("foo", 1, 0, false)))
-                .setAllFlags(FLAG_OP|FLAG_RESPONSE);
+                .setAllFlags(FLAG_OP| FLAG_OP_RESPONSE);
 
         asyncHandler.handle(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
@@ -60,7 +60,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenOperationPacket() throws Exception {
         Packet packet = new Packet()
-                .setAllFlags(FLAG_OP);
+                .resetFlagsTo(FLAG_OP);
 
         dispatcher.dispatch(packet);
 
@@ -72,7 +72,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenUrgentOperationPacket() throws Exception {
         Packet packet = new Packet()
-                .setAllFlags(FLAG_OP | FLAG_URGENT);
+                .resetFlagsTo(FLAG_OP | FLAG_URGENT);
 
         dispatcher.dispatch(packet);
 
@@ -85,7 +85,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenOperationResponsePacket() throws Exception {
         Packet packet = new Packet()
-                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE);
+                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE);
 
         dispatcher.dispatch(packet);
 
@@ -96,7 +96,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenUrgentOperationResponsePacket() throws Exception {
         Packet packet = new Packet()
-                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE | FLAG_URGENT);
+                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE | FLAG_URGENT);
 
         dispatcher.dispatch(packet);
 
@@ -108,7 +108,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenOperationControlPacket() throws Exception {
         Packet packet = new Packet()
-                .setAllFlags(FLAG_OP | FLAG_OP_CONTROL);
+                .resetFlagsTo(FLAG_OP | FLAG_OP_CONTROL);
 
         dispatcher.dispatch(packet);
 
@@ -121,7 +121,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenEventPacket() throws Exception {
         Packet packet = new Packet()
-                .setFlag(FLAG_EVENT);
+                .raiseFlags(FLAG_EVENT);
 
         dispatcher.dispatch(packet);
 
@@ -132,7 +132,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenBindPacket() throws Exception {
         Packet packet = new Packet()
-                .setFlag(FLAG_BIND);
+                .raiseFlags(FLAG_BIND);
 
         dispatcher.dispatch(packet);
 
@@ -143,7 +143,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenJetPacket() throws Exception {
         Packet packet = new Packet()
-                .setFlag(FLAG_JET);
+                .raiseFlags(FLAG_JET);
 
         dispatcher.dispatch(packet);
 
@@ -166,7 +166,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenProblemHandlingPacket_thenSwallowed() throws Exception {
         Packet packet = new Packet()
-                .setFlag(FLAG_OP);
+                .raiseFlags(FLAG_OP);
 
         Mockito.doThrow(new ExpectedRuntimeException()).when(operationExecutor).handle(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
@@ -19,7 +19,7 @@ import static com.hazelcast.nio.Packet.FLAG_EVENT;
 import static com.hazelcast.nio.Packet.FLAG_JET;
 import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_CONTROL;
-import static com.hazelcast.nio.Packet.FLAG_RESPONSE;
+import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -85,7 +85,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenOperationResponsePacket() throws Exception {
         Packet packet = new Packet()
-                .setAllFlags(FLAG_OP | FLAG_RESPONSE);
+                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE);
 
         dispatcher.dispatch(packet);
 
@@ -96,7 +96,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     @Test
     public void whenUrgentOperationResponsePacket() throws Exception {
         Packet packet = new Packet()
-                .setAllFlags(FLAG_OP | FLAG_RESPONSE | FLAG_URGENT);
+                .setAllFlags(FLAG_OP | FLAG_OP_RESPONSE | FLAG_URGENT);
 
         dispatcher.dispatch(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
@@ -14,9 +14,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import static com.hazelcast.nio.Packet.FLAG_BIND;
-import static com.hazelcast.nio.Packet.FLAG_EVENT;
-import static com.hazelcast.nio.Packet.FLAG_JET;
 import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_CONTROL;
 import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
@@ -120,8 +117,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
 
     @Test
     public void whenEventPacket() throws Exception {
-        Packet packet = new Packet()
-                .raiseFlags(FLAG_EVENT);
+        Packet packet = new Packet().setPacketType(Packet.Type.EVENT);
 
         dispatcher.dispatch(packet);
 
@@ -131,8 +127,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
 
     @Test
     public void whenBindPacket() throws Exception {
-        Packet packet = new Packet()
-                .raiseFlags(FLAG_BIND);
+        Packet packet = new Packet().setPacketType(Packet.Type.BIND);
 
         dispatcher.dispatch(packet);
 
@@ -142,9 +137,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
 
     @Test
     public void whenJetPacket() throws Exception {
-        Packet packet = new Packet()
-                .raiseFlags(FLAG_JET);
-
+        Packet packet = new Packet().setPacketType(Packet.Type.JET);
         dispatcher.dispatch(packet);
 
         verify(jetService).handle(packet);
@@ -154,7 +147,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     // unrecognized packets are logged. No handlers is contacted.
     @Test
     public void whenUnrecognizedPacket_thenSwallowed() throws Exception {
-        Packet packet = new Packet();
+        Packet packet = new Packet().setPacketType(Packet.Type.NULL);
 
         dispatcher.dispatch(packet);
 
@@ -165,8 +158,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
     // when one of the handlers throws an exception, the exception is logged but not rethrown
     @Test
     public void whenProblemHandlingPacket_thenSwallowed() throws Exception {
-        Packet packet = new Packet()
-                .raiseFlags(FLAG_OP);
+        Packet packet = new Packet().setPacketType(Packet.Type.OPERATION);
 
         Mockito.doThrow(new ExpectedRuntimeException()).when(operationExecutor).handle(packet);
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -196,7 +196,7 @@ public abstract class HazelcastTestSupport {
         ConnectionManager connectionManager = getConnectionManager(local);
 
         Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.setFlag(Packet.FLAG_OP);
+        packet.raiseFlags(Packet.FLAG_OP);
         packet.setConn(connectionManager.getConnection(getAddress(remote)));
         return packet;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -195,9 +195,9 @@ public abstract class HazelcastTestSupport {
         InternalSerializationService serializationService = getSerializationService(local);
         ConnectionManager connectionManager = getConnectionManager(local);
 
-        Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId());
-        packet.raiseFlags(Packet.FLAG_OP);
-        packet.setConn(connectionManager.getConnection(getAddress(remote)));
+        Packet packet = new Packet(serializationService.toBytes(operation), operation.getPartitionId())
+                .setPacketType(Packet.Type.OPERATION)
+                .setConn(connectionManager.getConnection(getAddress(remote)));
         return packet;
     }
 


### PR DESCRIPTION
* redefine the three packet type flags (bits 0, 2, 5) as an encoded integer discriminating up to 7 types. Define the new `JET` type as type 3.
* add new `Packet.FLAG_JET_FLOW_CONTROL` flag
* rename flag-related methods to make more sense
* fix Javadoc to reflect the actual behavior of flag methods
* use the `char` type instead of `short` to store the flags bitfield (without this, using the bit 15 of flags would break `isFlagSet()` due to sign extension)
* rename `FLAG_RESPONSE` to `FLAG_OP_RESPONSE`
* improve documentation of flags and group them according to how they are acted upon by the receiver

Additional cleanup:
* clean up logic in `createInputOutputFactory()`
* delete identical overriding method in `StandardMemoryAccessor`
