### PR TITLE
Expose hot restart service on Cluster service

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
@@ -21,6 +21,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipListener;
+import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.version.ClusterVersion;
 
@@ -77,6 +78,11 @@ public class ClientClusterProxy implements Cluster {
 
     @Override
     public ClusterVersion getClusterVersion() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public HotRestartService getHotRestartService() {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -17,6 +17,7 @@
 package com.hazelcast.core;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionOptions;
@@ -191,6 +192,15 @@ public interface Cluster {
      * @since 3.8
      */
     ClusterVersion getClusterVersion();
+
+    /**
+     * Returns the Hot Restart service for interacting with Hot Restart. Can return null if Hot Restart is not available
+     * (not EE) or not enabled.
+     *
+     * @return the hot restart service
+     * @throws UnsupportedOperationException if the hot restart service is not supported on this instance (e.g. on client)
+     */
+    HotRestartService getHotRestartService();
 
     /**
      * Changes state of the cluster to the {@link ClusterState#PASSIVE} transactionally,

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/HotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/HotRestartService.java
@@ -17,10 +17,10 @@
 package com.hazelcast.hotrestart;
 
 /**
- * Service for starting cluster-wide hot restart data backups, determining the local backup state and interrupting a currently
- * running local hot restart backup.
+ * Service for interacting with Hot Restart. For example - starting cluster-wide hot restart data backups, determining the
+ * local backup state and interrupting a currently running local hot restart backup.
  */
-public interface HotRestartBackupService {
+public interface HotRestartService {
     /** The prefix for each hot restart backup directory. The backup sequence is appended to this prefix. */
     String BACKUP_DIR_PREFIX = "backup-";
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -23,7 +23,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.PartitioningStrategy;
-import com.hazelcast.hotrestart.HotRestartBackupService;
+import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.internal.cluster.ClusterStateListener;
 import com.hazelcast.internal.cluster.ClusterVersionListener;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
@@ -300,7 +300,7 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
-    public HotRestartBackupService getHotRestartBackupService() {
+    public HotRestartService getHotRestartBackupService() {
         logger.warning("Hot restart data backup features are only available on Hazelcast Enterprise!");
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -18,7 +18,7 @@ package com.hazelcast.instance;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.HotRestartPersistenceConfig;
-import com.hazelcast.hotrestart.HotRestartBackupService;
+import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.JoinRequest;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
@@ -237,7 +237,7 @@ public interface NodeExtension {
      *
      * @return the hot restart data backup service
      */
-    HotRestartBackupService getHotRestartBackupService();
+    HotRestartService getHotRestartBackupService();
 
     /**
      * Creates a UUID for local member

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -21,7 +21,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.core.Member;
-import com.hazelcast.hotrestart.HotRestartBackupService;
+import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.ascii.TextCommandService;
@@ -247,10 +247,10 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String res;
         try {
             if (checkCredentials(command)) {
-                final HotRestartBackupService backupService = textCommandService.getNode().getNodeExtension()
-                                                                                .getHotRestartBackupService();
-                if (backupService != null) {
-                    backupService.backup();
+                final HotRestartService hotRestartService = textCommandService.getNode().getNodeExtension()
+                                                                          .getHotRestartBackupService();
+                if (hotRestartService != null) {
+                    hotRestartService.backup();
                 }
                 res = "success";
             } else {
@@ -266,10 +266,10 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String res;
         try {
             if (checkCredentials(command)) {
-                final HotRestartBackupService backupService = textCommandService.getNode().getNodeExtension()
-                                                                                .getHotRestartBackupService();
-                if (backupService != null) {
-                    backupService.interruptBackupTask();
+                final HotRestartService hotRestartService = textCommandService.getNode().getNodeExtension()
+                                                                          .getHotRestartBackupService();
+                if (hotRestartService != null) {
+                    hotRestartService.interruptBackupTask();
                 }
                 res = "success";
             } else {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -25,6 +25,7 @@ import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.core.MemberSelector;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
+import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.LifecycleServiceImpl;
 import com.hazelcast.instance.MemberImpl;
@@ -917,6 +918,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     @Override
     public ClusterVersion getClusterVersion() {
         return clusterStateManager.getClusterVersion();
+    }
+
+    @Override
+    public HotRestartService getHotRestartService() {
+        return node.getNodeExtension().getHotRestartBackupService();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -28,7 +28,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.hotrestart.BackupTaskState;
 import com.hazelcast.hotrestart.BackupTaskStatus;
-import com.hazelcast.hotrestart.HotRestartBackupService;
+import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
@@ -178,7 +178,7 @@ public class TimedMemberStateFactory {
     }
 
     private void createHotRestartState(MemberStateImpl memberState) {
-        final HotRestartBackupService backupService = instance.node.getNodeExtension().getHotRestartBackupService();
+        final HotRestartService backupService = instance.node.getNodeExtension().getHotRestartBackupService();
         final HotRestartStateImpl state = new HotRestartStateImpl(backupService != null
                 ? backupService.getBackupTaskStatus()
                 : new BackupTaskStatus(BackupTaskState.NOT_STARTED, 0, 0));


### PR DESCRIPTION
Expose Hot restart service via API on Cluster service. This needs some cleanup in a separate PR since there is an existing `HotRestartService` in EE.