### PR TITLE
Cleanup change cluster version endpoints

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
@@ -95,4 +95,13 @@ public class ClientClusterProxy implements Cluster {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public void changeClusterVersion(ClusterVersion version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void changeClusterVersion(ClusterVersion version, TransactionOptions options) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -240,4 +240,57 @@ public interface Cluster {
      * @since 3.6
      */
     void shutdown(TransactionOptions transactionOptions);
+
+    /**
+     * Changes the cluster version transactionally. Internally this method uses the same transaction infrastructure as
+     * {@link #changeClusterState(ClusterState)} and the transaction defaults are the same in this case as well
+     * ({@code TWO_PHASE} transaction with durability 1 by default).
+     * <p/>
+     * If the requested cluster version is same as the current one, nothing happens.
+     * <p/>
+     * If a member of the cluster is not compatible with the given cluster {@code version}, as implemented by
+     * {@link com.hazelcast.instance.NodeExtension#isNodeVersionCompatibleWith(ClusterVersion)}, then a
+     * {@link com.hazelcast.internal.cluster.impl.VersionMismatchException} is thrown.
+     * <p/>
+     * If an invalid version transition is requested, for example changing to a different major version, an
+     * {@link IllegalArgumentException} is thrown.
+     * <p/>
+     * If a membership change occurs in the cluster during locking phase, a new member joins or
+     * an existing member leaves, then this method will fail with an {@code IllegalStateException}.
+     * <p/>
+     * Likewise, once locking phase is completed successfully, {@link Cluster#getClusterState()}
+     * will report being {@link ClusterState#IN_TRANSITION}, disallowing membership changes until the new cluster version is
+     * committed.
+     *
+     * @param version new version of the cluster
+     * @since 3.8
+     */
+    void changeClusterVersion(ClusterVersion version);
+
+    /**
+     * Changes the cluster version transactionally, with the transaction options provided. Internally this method uses the same
+     * transaction infrastructure as {@link #changeClusterState(ClusterState, TransactionOptions)}. The transaction
+     * options must specify a {@code TWO_PHASE} transaction.
+     * <p/>
+     * If the requested cluster version is same as the current one, nothing happens.
+     * <p/>
+     * If a member of the cluster is not compatible with the given cluster {@code version}, as implemented by
+     * {@link com.hazelcast.instance.NodeExtension#isNodeVersionCompatibleWith(ClusterVersion)}, then a
+     * {@link com.hazelcast.internal.cluster.impl.VersionMismatchException} is thrown.
+     * <p/>
+     * If an invalid version transition is requested, for example changing to a different major version, an
+     * {@link IllegalArgumentException} is thrown.
+     * <p/>
+     * If a membership change occurs in the cluster during locking phase, a new member joins or
+     * an existing member leaves, then this method will fail with an {@code IllegalStateException}.
+     * <p/>
+     * Likewise, once locking phase is completed successfully, {@link Cluster#getClusterState()}
+     * will report being {@link ClusterState#IN_TRANSITION}, disallowing membership changes until the new cluster version is
+     * committed.
+     *
+     * @param version new version of the cluster
+     * @param options options by which to execute the transaction
+     * @since 3.8
+     */
+    void changeClusterVersion(ClusterVersion version, TransactionOptions options);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -27,7 +27,6 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String URI_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/state";
     public static final String URI_CHANGE_CLUSTER_STATE_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/changeState";
     public static final String URI_CLUSTER_VERSION_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/version";
-    public static final String URI_CHANGE_CLUSTER_VERSION_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/changeVersion";
     public static final String URI_SHUTDOWN_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/clusterShutdown";
     public static final String URI_FORCESTART_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/forceStart";
     public static final String URI_PARTIALSTART_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/partialStart";

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
 import com.hazelcast.internal.ascii.TextCommandService;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.ConnectionManager;
@@ -48,6 +49,8 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
             handleCluster(command);
         } else if (uri.startsWith(URI_HEALTH_URL)) {
             handleHealthcheck(command);
+        } else if (uri.startsWith(URI_CLUSTER_VERSION_URL)) {
+            handleGetClusterVersion(command);
         } else {
             command.send400();
         }
@@ -74,6 +77,15 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         res.append("Hazelcast::MigrationQueueSize=").append(migrationQueueSize).append("\n");
         res.append("Hazelcast::ClusterSize=").append(clusterSize).append("\n");
         command.setResponse(MIME_TEXT_PLAIN, stringToBytes(res.toString()));
+    }
+
+    private void handleGetClusterVersion(HttpGetCommand command) {
+        String res = "{\"status\":\"${STATUS}\",\"version\":\"${VERSION}\"}";
+        Node node = textCommandService.getNode();
+        ClusterService clusterService = node.getClusterService();
+        res = res.replace("${STATUS}", "success");
+        res = res.replace("${VERSION}", clusterService.getClusterVersion().toString());
+        command.setResponse(HttpCommand.CONTENT_TYPE_JSON, stringToBytes(res));
     }
 
     private void handleCluster(HttpGetCommand command) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -63,8 +63,6 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             } else if (uri.startsWith(URI_CHANGE_CLUSTER_STATE_URL)) {
                 handleChangeClusterState(command);
             } else if (uri.startsWith(URI_CLUSTER_VERSION_URL)) {
-                handleGetClusterVersion(command);
-            } else if (uri.startsWith(URI_CHANGE_CLUSTER_VERSION_URL)) {
                 handleChangeClusterVersion(command);
             } else if (uri.startsWith(URI_SHUTDOWN_CLUSTER_URL)) {
                 handleClusterShutdown(command);
@@ -195,31 +193,6 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         }
         command.setResponse(HttpCommand.CONTENT_TYPE_JSON, stringToBytes(res));
     }
-
-    private void handleGetClusterVersion(HttpPostCommand command) throws UnsupportedEncodingException {
-        byte[] data = command.getData();
-        String[] strList = bytesToString(data).split("&");
-        String groupName = URLDecoder.decode(strList[0], "UTF-8");
-        String groupPass = URLDecoder.decode(strList[1], "UTF-8");
-        String res = "{\"status\":\"${STATUS}\",\"version\":\"${VERSION}\"}";
-        try {
-            Node node = textCommandService.getNode();
-            ClusterService clusterService = node.getClusterService();
-            GroupConfig groupConfig = node.getConfig().getGroupConfig();
-            if (!(groupConfig.getName().equals(groupName) && groupConfig.getPassword().equals(groupPass))) {
-                res = res.replace("${STATUS}", "forbidden");
-                res = res.replace("${VERSION}", "null");
-            } else {
-                res = res.replace("${STATUS}", "success");
-                res = res.replace("${VERSION}", clusterService.getClusterVersion().toString());
-            }
-        } catch (Throwable throwable) {
-            res = res.replace("${STATUS}", "fail");
-            res = res.replace("${VERSION}", "null");
-        }
-        command.setResponse(HttpCommand.CONTENT_TYPE_JSON, stringToBytes(res));
-    }
-
 
     private void handleForceStart(HttpPostCommand command) throws UnsupportedEncodingException {
         byte[] data = command.getData();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterService.java
@@ -16,16 +16,12 @@
 
 package com.hazelcast.internal.cluster;
 
-import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberSelector;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.CoreService;
-import com.hazelcast.transaction.TransactionOptions;
-import com.hazelcast.version.ClusterVersion;
-import com.hazelcast.version.MemberVersion;
 
 import java.util.Collection;
 
@@ -127,56 +123,4 @@ public interface ClusterService extends CoreService, Cluster {
      */
     String getClusterId();
 
-    /**
-     * Changes the cluster version transactionally. Internally this method uses the same transaction infrastructure as
-     * {@link #changeClusterState(ClusterState)} and the transaction defaults are the same in this case as well
-     * ({@code TWO_PHASE} transaction with durability 1 by default).
-     * <p/>
-     * If the requested cluster version is same as the current one, nothing happens.
-     * <p/>
-     * If a node of the cluster is not compatible with the given cluster {@code version}, as implemented by
-     * {@link com.hazelcast.instance.NodeExtension#isNodeVersionCompatibleWith(MemberVersion)}, then a
-     * {@link com.hazelcast.internal.cluster.impl.VersionMismatchException} is thrown.
-     * <p/>
-     * If an invalid version transition is requested, for example changing to a different major version, an
-     * {@link IllegalArgumentException} is thrown.
-     * <p/>
-     * If a membership change occurs in the cluster during locking phase, a new member joins or
-     * an existing member leaves, then this method will fail with an {@code IllegalStateException}.
-     * <p/>
-     * Likewise, once locking phase is completed successfully, {@link Cluster#getClusterState()}
-     * will report being {@link ClusterState#IN_TRANSITION}, disallowing membership changes until the new cluster version is
-     * committed.
-     *
-     * @param version new version of the cluster
-     * @since 3.8
-     */
-    void changeClusterVersion(ClusterVersion version);
-
-    /**
-     * Changes the cluster version transactionally, with the transaction options provided. Internally this method uses the same
-     * transaction infrastructure as {@link #changeClusterState(ClusterState, TransactionOptions)}. The transaction
-     * options must specify a {@code TWO_PHASE} transaction.
-     * <p/>
-     * If the requested cluster version is same as the current one, nothing happens.
-     * <p/>
-     * If a node of the cluster is not compatible with the given cluster {@code version}, as implemented by
-     * {@link com.hazelcast.instance.NodeExtension#isNodeVersionCompatibleWith(MemberVersion)}, then a
-     * {@link com.hazelcast.internal.cluster.impl.VersionMismatchException} is thrown.
-     * <p/>
-     * If an invalid version transition is requested, for example changing to a different major version, an
-     * {@link IllegalArgumentException} is thrown.
-     * <p/>
-     * If a membership change occurs in the cluster during locking phase, a new member joins or
-     * an existing member leaves, then this method will fail with an {@code IllegalStateException}.
-     * <p/>
-     * Likewise, once locking phase is completed successfully, {@link Cluster#getClusterState()}
-     * will report being {@link ClusterState#IN_TRANSITION}, disallowing membership changes until the new cluster version is
-     * committed.
-     *
-     * @param version new version of the cluster
-     * @param options options by which to execute the transaction
-     * @since 3.8
-     */
-    void changeClusterVersion(ClusterVersion version, TransactionOptions options);
 }

--- a/hazelcast/src/main/resources/cluster.sh
+++ b/hazelcast/src/main/resources/cluster.sh
@@ -70,7 +70,7 @@ if [ -z "$PASSWORD" ]; then
 fi
 
 if [ -z "$ADDRESS" ]; then
-    echo "No specific ip address is defined, running script with default ip : '127.0.0.1."
+    echo "No specific ip address is defined, running script with default ip : '127.0.0.1'."
     ADDRESS="127.0.0.1"
 fi
 
@@ -230,7 +230,7 @@ fi
 if [ "$OPERATION" = "get-cluster-version" ]; then
     echo "Getting cluster version on ip ${ADDRESS} on port ${PORT}"
 	request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/version"
- 	response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+ 	response=$(curl --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
  	if [ "$STATUS" = "fail" ];then
         echo "An error occured while listing !";
@@ -257,7 +257,7 @@ if [ "$OPERATION" = "change-cluster-version" ]; then
     fi
 
     echo "Changing cluster version to ${CLUSTER_VERSION} on ip ${ADDRESS} on port ${PORT}"
-    request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/changeVersion"
+    request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/version"
     response=$(curl --data "${GROUPNAME}&${PASSWORD}&${CLUSTER_VERSION}" --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
 


### PR DESCRIPTION
* Better REST API endpoints for getting & changing cluster version:
 `GET /hazelcast/rest/management/cluster/version` to get the cluster version
 `POST /hazelcast/rest/management/cluster/version` to change cluster version
* Methods for changing cluster version have been pulled up to `Cluster` interface from `ClusterService`. Users who do not wish to enable REST API, can use `hzInstance.getCluster().changeClusterVersion` to change cluster version via Java API.