### PR TITLE
Fixed keyStateMarker problems

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheKeyStateMarkerStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheKeyStateMarkerStressTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.impl.nearcache;
+
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.client.cache.impl.ClientCacheProxy;
+import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.map.impl.nearcache.KeyStateMarker;
+import com.hazelcast.map.impl.nearcache.KeyStateMarkerImpl;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.spi.CachingProvider;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
+import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE;
+import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.INVALIDATE;
+import static com.hazelcast.util.RandomPicker.getInt;
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(NightlyTest.class)
+public class ClientCacheKeyStateMarkerStressTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameter
+    public NearCacheConfig.LocalUpdatePolicy localUpdatePolicy;
+
+    @Parameterized.Parameters(name = "localUpdatePolicy:{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {CACHE},
+                {INVALIDATE},
+        });
+    }
+
+    private final int KEY_SPACE = 10000;
+    private final int TEST_RUN_SECONDS = 60;
+    private final int GET_ALL_THREAD_COUNT = 2;
+    private final int PUT_ALL_THREAD_COUNT = 1;
+    private final int GET_THREAD_COUNT = 1;
+    private final int PUT_THREAD_COUNT = 1;
+    private final int PUT_IF_ABSENT_THREAD_COUNT = 1;
+    private final int CLEAR_THREAD_COUNT = 1;
+    private final int REMOVE_THREAD_COUNT = 1;
+    private final String cacheName = "test";
+    private final AtomicBoolean stop = new AtomicBoolean();
+
+    private TestHazelcastFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new TestHazelcastFactory();
+        stop.set(false);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void final_state_of_all_slots_are_unmarked() throws Exception {
+        HazelcastInstance member = factory.newHazelcastInstance();
+        CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(member);
+        final CacheManager serverCacheManager = provider.getCacheManager();
+
+        factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+
+        // populated from member.
+        CacheConfig cacheConfig = new CacheConfig();
+        cacheConfig.getEvictionConfig()
+                .setMaximumSizePolicy(ENTRY_COUNT)
+                .setSize(MAX_VALUE);
+        final Cache memberCache = serverCacheManager.createCache(cacheName, cacheConfig);
+        for (int i = 0; i < KEY_SPACE; i++) {
+            memberCache.put(i, i);
+        }
+
+        ClientConfig clientConfig = new ClientConfig();
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setInvalidateOnChange(true).setLocalUpdatePolicy(localUpdatePolicy)
+                .getEvictionConfig()
+                .setMaximumSizePolicy(ENTRY_COUNT)
+                .setSize(MAX_VALUE);
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+
+        List<Thread> threads = new ArrayList<Thread>();
+
+        // member
+        for (int i = 0; i < PUT_THREAD_COUNT; i++) {
+            Put put = new Put(memberCache);
+            threads.add(put);
+        }
+
+        // client
+        HazelcastClientProxy client = (HazelcastClientProxy) factory.newHazelcastClient(clientConfig);
+        CachingProvider clientCachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
+
+        CacheManager cacheManager = clientCachingProvider.getCacheManager();
+        final Cache clientCache = cacheManager.createCache(cacheName, cacheConfig);
+
+        for (int i = 0; i < GET_ALL_THREAD_COUNT; i++) {
+            GetAll getAll = new GetAll(clientCache);
+            threads.add(getAll);
+        }
+
+        for (int i = 0; i < PUT_ALL_THREAD_COUNT; i++) {
+            PutAll putAll = new PutAll(clientCache);
+            threads.add(putAll);
+        }
+
+        for (int i = 0; i < PUT_IF_ABSENT_THREAD_COUNT; i++) {
+            PutIfAbsent putIfAbsent = new PutIfAbsent(clientCache);
+            threads.add(putIfAbsent);
+        }
+
+        for (int i = 0; i < GET_THREAD_COUNT; i++) {
+            Get get = new Get(clientCache);
+            threads.add(get);
+        }
+
+        for (int i = 0; i < REMOVE_THREAD_COUNT; i++) {
+            Remove remove = new Remove(clientCache);
+            threads.add(remove);
+        }
+
+        for (int i = 0; i < CLEAR_THREAD_COUNT; i++) {
+            Clear clear = new Clear(clientCache);
+            threads.add(clear);
+        }
+
+        // start threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // stress for a while
+        sleepSeconds(TEST_RUN_SECONDS);
+
+        // stop threads
+        stop.set(true);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertAllKeysInUnmarkedState(clientCache);
+    }
+
+    private void assertAllKeysInUnmarkedState(Cache clientCache) {
+        ClientCacheProxy proxy = ((ClientCacheProxy) clientCache);
+        NearCache nearCache = proxy.getNearCache();
+        KeyStateMarker keyStateMarker = proxy.getKeyStateMarker();
+        AtomicIntegerArray marks = ((KeyStateMarkerImpl) keyStateMarker).getMarks();
+
+        String msg = format("nearCacheSize=%d,localUpdatePolicy=%s, markerStates=(%s)",
+                nearCache.size(), localUpdatePolicy, keyStateMarker);
+
+        for (int i = 0; i < marks.length(); i++) {
+            assertEquals(msg, 0, marks.get(i));
+        }
+    }
+
+    private class Put extends Thread {
+        private final Cache cache;
+
+        private Put(Cache cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    cache.put(i, getInt(KEY_SPACE));
+                }
+                sleepAtLeastMillis(5000);
+            } while (!stop.get());
+        }
+    }
+
+    private class Remove extends Thread {
+        private final Cache cache;
+
+        private Remove(Cache cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    cache.remove(i);
+                }
+                sleepAtLeastMillis(1000);
+            } while (!stop.get());
+        }
+    }
+
+    private class PutIfAbsent extends Thread {
+        private final Cache cache;
+
+        private PutIfAbsent(Cache cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    cache.putIfAbsent(i, getInt(MAX_VALUE));
+                }
+                sleepAtLeastMillis(1000);
+            } while (!stop.get());
+        }
+    }
+
+    private class Clear extends Thread {
+        private final Cache cache;
+
+        private Clear(Cache cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public void run() {
+            do {
+                cache.clear();
+                sleepAtLeastMillis(5000);
+            } while (!stop.get());
+        }
+    }
+
+    private class GetAll extends Thread {
+        private final Cache cache;
+
+        private GetAll(Cache cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public void run() {
+            HashSet keys = new HashSet();
+            for (int i = 0; i < KEY_SPACE; i++) {
+                keys.add(i);
+            }
+
+            do {
+                cache.getAll(keys);
+                sleepAtLeastMillis(10);
+            } while (!stop.get());
+        }
+    }
+
+    private class PutAll extends Thread {
+        private final Cache cache;
+
+        private PutAll(Cache cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public void run() {
+            HashMap map = new HashMap();
+            do {
+                map.clear();
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.put(i, getInt(MAX_VALUE));
+                }
+
+                cache.putAll(map);
+                sleepAtLeastMillis(2000);
+            } while (!stop.get());
+        }
+    }
+
+    private class Get extends Thread {
+        private final Cache cache;
+
+        private Get(Cache cache) {
+            this.cache = cache;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    cache.get(i);
+                }
+            } while (!stop.get());
+        }
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapKeyStateMarkerStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapKeyStateMarkerStressTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.proxy.NearCachedClientMapProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.map.impl.nearcache.KeyStateMarker;
+import com.hazelcast.map.impl.nearcache.KeyStateMarkerImpl;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+import static com.hazelcast.util.RandomPicker.getInt;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class ClientMapKeyStateMarkerStressTest extends HazelcastTestSupport {
+
+    private final int KEY_SPACE = 10000;
+    private final int TEST_RUN_SECONDS = 60;
+    private final int GET_ALL_THREAD_COUNT = 3;
+    private final int GET_THREAD_COUNT = 2;
+    private final int PUT_THREAD_COUNT = 1;
+    private final int CLEAR_THREAD_COUNT = 1;
+    private final int REMOVE_THREAD_COUNT = 1;
+    private final String mapName = "test";
+    private final AtomicBoolean stop = new AtomicBoolean();
+
+    private TestHazelcastFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new TestHazelcastFactory();
+        stop.set(false);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void final_state_of_all_slots_are_unmarked() throws Exception {
+        HazelcastInstance member = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addNearCacheConfig(newNearCacheConfig());
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+
+        IMap memberMap = member.getMap(mapName);
+        // initial population of imap from member
+        for (int i = 0; i < KEY_SPACE; i++) {
+            memberMap.put(i, i);
+        }
+
+        List<Thread> threads = new ArrayList<Thread>();
+
+        // member
+        for (int i = 0; i < PUT_THREAD_COUNT; i++) {
+            Put put = new Put(memberMap);
+            threads.add(put);
+        }
+
+        // client
+        IMap clientMap = client.getMap(mapName);
+
+        for (int i = 0; i < GET_ALL_THREAD_COUNT; i++) {
+            GetAll getAll = new GetAll(clientMap);
+            threads.add(getAll);
+        }
+
+        for (int i = 0; i < GET_THREAD_COUNT; i++) {
+            Get get = new Get(clientMap);
+            threads.add(get);
+        }
+
+        for (int i = 0; i < REMOVE_THREAD_COUNT; i++) {
+            Remove remove = new Remove(clientMap);
+            threads.add(remove);
+        }
+
+        for (int i = 0; i < CLEAR_THREAD_COUNT; i++) {
+            Clear clear = new Clear(clientMap);
+            threads.add(clear);
+        }
+
+        // start threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // stress for a while
+        sleepSeconds(TEST_RUN_SECONDS);
+
+        // stop threads
+        stop.set(true);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertAllKeysInUnmarkedState(clientMap);
+    }
+
+    private void assertAllKeysInUnmarkedState(IMap clientMap) {
+        NearCachedClientMapProxy proxy = (NearCachedClientMapProxy) clientMap;
+        NearCache nearCache = proxy.getNearCache();
+        KeyStateMarker keyStateMarker = proxy.getKeyStateMarker();
+        AtomicIntegerArray marks = ((KeyStateMarkerImpl) keyStateMarker).getMarks();
+
+        String msg = format("nearCacheSize=%d, markerStates=(%s)", nearCache.size(), keyStateMarker);
+
+        for (int i = 0; i < marks.length(); i++) {
+            assertEquals(msg, 0, marks.get(i));
+        }
+    }
+
+    private class Put extends Thread {
+        private final IMap map;
+
+        private Put(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.put(i, getInt(KEY_SPACE));
+                }
+                sleepAtLeastMillis(100);
+            } while (!stop.get());
+        }
+    }
+
+    private class Remove extends Thread {
+        private final IMap map;
+
+        private Remove(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.remove(i);
+                }
+                sleepAtLeastMillis(100);
+            } while (!stop.get());
+        }
+    }
+
+    private class Clear extends Thread {
+        private final IMap map;
+
+        private Clear(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                map.clear();
+                sleepAtLeastMillis(3000);
+            } while (!stop.get());
+        }
+    }
+
+    private class GetAll extends Thread {
+        private final IMap map;
+
+        private GetAll(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            HashSet keys = new HashSet();
+            for (int i = 0; i < KEY_SPACE; i++) {
+                keys.add(i);
+            }
+
+            do {
+                map.getAll(keys);
+                sleepAtLeastMillis(2);
+            } while (!stop.get());
+        }
+    }
+
+    private class Get extends Thread {
+        private final IMap map;
+
+        private Get(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.get(i);
+                }
+            } while (!stop.get());
+        }
+    }
+
+
+    protected NearCacheConfig newNearCacheConfig() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setName(mapName);
+        nearCacheConfig.setInvalidateOnChange(true);
+        return nearCacheConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTask.java
@@ -91,7 +91,7 @@ public final class RepairingTask implements Runnable {
         this.localUuid = localUuid;
     }
 
-    protected int checkMaxToleratedMissCount(HazelcastProperties properties) {
+    private int checkMaxToleratedMissCount(HazelcastProperties properties) {
         int maxToleratedMissCount = properties.getInteger(MAX_TOLERATED_MISS_COUNT);
         return checkNotNegative(maxToleratedMissCount,
                 format("max-tolerated-miss-count cannot be < 0 but found %d", maxToleratedMissCount));

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/InvalidationAwareWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/InvalidationAwareWrapper.java
@@ -65,7 +65,7 @@ public final class InvalidationAwareWrapper<K, V> implements NearCache<K, V> {
 
     @Override
     public boolean remove(K key) {
-        keyStateMarker.tryRemove(key);
+        keyStateMarker.removeIfMarked(key);
         return nearCache.remove(key);
     }
 
@@ -76,13 +76,13 @@ public final class InvalidationAwareWrapper<K, V> implements NearCache<K, V> {
 
     @Override
     public void clear() {
-        keyStateMarker.init();
+        keyStateMarker.unmarkAllForcibly();
         nearCache.clear();
     }
 
     @Override
     public void destroy() {
-        keyStateMarker.init();
+        keyStateMarker.unmarkAllForcibly();
         nearCache.destroy();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/KeyStateMarker.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/KeyStateMarker.java
@@ -19,9 +19,9 @@ package com.hazelcast.map.impl.nearcache;
 /**
  * Used to assign a {@link STATE} to a key.
  *
- * That {@link STATE} is used when deciding whether or not a key can be puttable to a Near Cache.
+ * That {@link STATE} is used when deciding whether or not a key can be put-able to near cache.
  * Because there is a possibility that an invalidation for a key can be received before putting that
- * key into Near Cache, in that case, key should not be put into Near Cache.
+ * key into near cache, in that case, key should not be put into near cache.
  */
 public interface KeyStateMarker {
 
@@ -30,40 +30,40 @@ public interface KeyStateMarker {
      */
     KeyStateMarker TRUE_MARKER = new KeyStateMarker() {
         @Override
-        public boolean tryMark(Object key) {
+        public boolean markIfUnmarked(Object key) {
             return true;
         }
 
         @Override
-        public boolean tryUnmark(Object key) {
+        public boolean unmarkIfMarked(Object key) {
             return true;
         }
 
         @Override
-        public boolean tryRemove(Object key) {
+        public boolean removeIfMarked(Object key) {
             return true;
         }
 
         @Override
-        public void forceUnmark(Object key) {
+        public void unmarkForcibly(Object key) {
 
         }
 
         @Override
-        public void init() {
+        public void unmarkAllForcibly() {
 
         }
     };
 
-    boolean tryMark(Object key);
+    boolean markIfUnmarked(Object key);
 
-    boolean tryUnmark(Object key);
+    boolean unmarkIfMarked(Object key);
 
-    boolean tryRemove(Object key);
+    boolean removeIfMarked(Object key);
 
-    void forceUnmark(Object key);
+    void unmarkForcibly(Object key);
 
-    void init();
+    void unmarkAllForcibly();
 
     enum STATE {
         UNMARKED(0),

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MemberMapKeyStateMarkerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MemberMapKeyStateMarkerStressTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+import static com.hazelcast.util.RandomPicker.getInt;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class MemberMapKeyStateMarkerStressTest extends HazelcastTestSupport {
+
+    private final int KEY_SPACE = 10000;
+    private final int TEST_RUN_SECONDS = 60;
+    private final int GET_ALL_THREAD_COUNT = 3;
+    private final int GET_THREAD_COUNT = 2;
+    private final int PUT_THREAD_COUNT = 1;
+    private final int CLEAR_THREAD_COUNT = 1;
+    private final int REMOVE_THREAD_COUNT = 1;
+    private final String mapName = "test";
+    private final AtomicBoolean stop = new AtomicBoolean();
+    private TestHazelcastInstanceFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new TestHazelcastInstanceFactory();
+        stop.set(false);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void final_state_of_all_slots_are_unmarked() throws Exception {
+
+        HazelcastInstance member1 = factory.newHazelcastInstance();
+        HazelcastInstance member2 = factory.newHazelcastInstance();
+
+        Config config = new Config();
+        config.getMapConfig(mapName).setNearCacheConfig(newNearCacheConfig());
+        HazelcastInstance nearCachedMember = factory.newHazelcastInstance(config);
+
+        IMap memberMap = member1.getMap(mapName);
+        // initial population of imap from member
+        for (int i = 0; i < KEY_SPACE; i++) {
+            memberMap.put(i, i);
+        }
+
+        List<Thread> threads = new ArrayList<Thread>();
+
+        // member
+        for (int i = 0; i < PUT_THREAD_COUNT; i++) {
+            Put put = new Put(memberMap);
+            threads.add(put);
+        }
+
+        // nearCachedMap
+        IMap nearCachedMap = nearCachedMember.getMap(mapName);
+
+        for (int i = 0; i < GET_ALL_THREAD_COUNT; i++) {
+            GetAll getAll = new GetAll(nearCachedMap);
+            threads.add(getAll);
+        }
+
+        for (int i = 0; i < GET_THREAD_COUNT; i++) {
+            Get get = new Get(nearCachedMap);
+            threads.add(get);
+        }
+
+        for (int i = 0; i < REMOVE_THREAD_COUNT; i++) {
+            Remove remove = new Remove(nearCachedMap);
+            threads.add(remove);
+        }
+
+        for (int i = 0; i < CLEAR_THREAD_COUNT; i++) {
+            Clear clear = new Clear(nearCachedMap);
+            threads.add(clear);
+        }
+
+        // start threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // stress for a while
+        sleepSeconds(TEST_RUN_SECONDS);
+
+        // stop threads
+        stop.set(true);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+
+        NearCachedMapProxyImpl proxy = (NearCachedMapProxyImpl) nearCachedMap;
+        AtomicIntegerArray marks = ((KeyStateMarkerImpl) proxy.getKeyStateMarker()).getMarks();
+
+        for (int i = 0; i < marks.length(); i++) {
+            assertEquals(0, marks.get(i));
+        }
+    }
+
+    private class Put extends Thread {
+        private final IMap map;
+
+        private Put(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.put(i, getInt(KEY_SPACE));
+                }
+                sleepAtLeastMillis(100);
+            } while (!stop.get());
+        }
+    }
+
+    private class Remove extends Thread {
+        private final IMap map;
+
+        private Remove(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.remove(i);
+                }
+                sleepAtLeastMillis(100);
+            } while (!stop.get());
+        }
+    }
+
+    private class Clear extends Thread {
+        private final IMap map;
+
+        private Clear(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                map.clear();
+                sleepAtLeastMillis(3000);
+            } while (!stop.get());
+        }
+    }
+
+    private class GetAll extends Thread {
+        private final IMap map;
+
+        private GetAll(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            HashSet keys = new HashSet();
+            for (int i = 0; i < KEY_SPACE; i++) {
+                keys.add(i);
+            }
+
+            do {
+                map.getAll(keys);
+                sleepAtLeastMillis(2);
+            } while (!stop.get());
+        }
+    }
+
+    private class Get extends Thread {
+        private final IMap map;
+
+        private Get(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.get(i);
+                }
+            } while (!stop.get());
+        }
+    }
+
+
+    protected NearCacheConfig newNearCacheConfig() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setName(mapName);
+        nearCacheConfig.setInvalidateOnChange(true);
+        return nearCacheConfig;
+    }
+}


### PR DESCRIPTION
for fix details: https://github.com/hazelcast/hazelcast/pull/9379#issue-193762415

-  Unmarked marked keys after getAll, this was effectively disabling near-cache usage.
-  Prevented key marking when local update policy is not cacheOnUpdate for icache#putAll
-  Renamed keyStateMarker interface methods to make it more readable
-  Added stress tests for imap&jcache