### PR TITLE
Fixed keyStateMarker problems

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapKeyStateMarkerStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapKeyStateMarkerStressTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.cache.impl.nearcache.NearCache;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.proxy.NearCachedClientMapProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.nearcache.KeyStateMarker;
+import com.hazelcast.map.impl.nearcache.StaleReadPreventerNearCacheWrapper;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+import static com.hazelcast.util.RandomPicker.getInt;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientMapKeyStateMarkerStressTest extends HazelcastTestSupport {
+
+    private final int KEY_SPACE = 10000;
+    private final int TEST_RUN_SECONDS = 30;
+    private final int GET_ALL_THREAD_COUNT = 3;
+    private final int GET_THREAD_COUNT = 2;
+    private final int PUT_THREAD_COUNT = 1;
+    private final int CLEAR_THREAD_COUNT = 1;
+    private final int REMOVE_THREAD_COUNT = 1;
+    private final String mapName = "test";
+    private final AtomicBoolean stop = new AtomicBoolean();
+
+    private TestHazelcastFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new TestHazelcastFactory();
+        stop.set(false);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void final_state_of_all_slots_are_unmarked() throws Exception {
+        HazelcastInstance member = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.addNearCacheConfig(newNearCacheConfig());
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+
+        IMap memberMap = member.getMap(mapName);
+        // initial population of imap from member
+        for (int i = 0; i < KEY_SPACE; i++) {
+            memberMap.put(i, i);
+        }
+
+        List<Thread> threads = new ArrayList<Thread>();
+
+        // member
+        for (int i = 0; i < PUT_THREAD_COUNT; i++) {
+            Put put = new Put(memberMap);
+            threads.add(put);
+        }
+
+        // client
+        IMap clientMap = client.getMap(mapName);
+
+        for (int i = 0; i < GET_ALL_THREAD_COUNT; i++) {
+            GetAll getAll = new GetAll(clientMap);
+            threads.add(getAll);
+        }
+
+        for (int i = 0; i < GET_THREAD_COUNT; i++) {
+            Get get = new Get(clientMap);
+            threads.add(get);
+        }
+
+        for (int i = 0; i < REMOVE_THREAD_COUNT; i++) {
+            Remove remove = new Remove(clientMap);
+            threads.add(remove);
+        }
+
+        for (int i = 0; i < CLEAR_THREAD_COUNT; i++) {
+            Clear clear = new Clear(clientMap);
+            threads.add(clear);
+        }
+
+        // start threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // stress for a while
+        sleepSeconds(TEST_RUN_SECONDS);
+
+        // stop threads
+        stop.set(true);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertAllKeysInUnmarkedState(clientMap);
+    }
+
+    private void assertAllKeysInUnmarkedState(IMap clientMap) {
+        NearCachedClientMapProxy proxy = (NearCachedClientMapProxy) clientMap;
+        NearCache nearCache = proxy.getNearCache();
+        KeyStateMarker keyStateMarker = proxy.getKeyStateMarker();
+        AtomicIntegerArray marks = ((StaleReadPreventerNearCacheWrapper) nearCache).getMarks();
+
+        String msg = format("nearCacheSize=%d, markerStates=(%s)", nearCache.size(), keyStateMarker);
+
+        for (int i = 0; i < marks.length(); i++) {
+            assertEquals(msg, 0, marks.get(i));
+        }
+    }
+
+    private class Put extends Thread {
+        private final IMap map;
+
+        private Put(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.put(i, getInt(KEY_SPACE));
+                }
+                sleepAtLeastMillis(100);
+            } while (!stop.get());
+        }
+    }
+
+    private class Remove extends Thread {
+        private final IMap map;
+
+        private Remove(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.remove(i);
+                }
+                sleepAtLeastMillis(100);
+            } while (!stop.get());
+        }
+    }
+
+    private class Clear extends Thread {
+        private final IMap map;
+
+        private Clear(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                map.clear();
+                sleepAtLeastMillis(3000);
+            } while (!stop.get());
+        }
+    }
+
+    private class GetAll extends Thread {
+        private final IMap map;
+
+        private GetAll(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            HashSet keys = new HashSet();
+            for (int i = 0; i < KEY_SPACE; i++) {
+                keys.add(i);
+            }
+
+            do {
+                map.getAll(keys);
+                sleepAtLeastMillis(2);
+            } while (!stop.get());
+        }
+    }
+
+    private class Get extends Thread {
+        private final IMap map;
+
+        private Get(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.get(i);
+                }
+            } while (!stop.get());
+        }
+    }
+
+
+    protected NearCacheConfig newNearCacheConfig() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setName(mapName);
+        nearCacheConfig.setInvalidateOnChange(true);
+        return nearCacheConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/StaleReadPreventerNearCacheWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/StaleReadPreventerNearCacheWrapper.java
@@ -37,8 +37,7 @@ public final class StaleReadPreventerNearCacheWrapper implements NearCache, KeyS
 
     private final NearCache nearCache;
     private final int markCount;
-
-    private volatile AtomicIntegerArray marks;
+    private final AtomicIntegerArray marks;
 
     private StaleReadPreventerNearCacheWrapper(NearCache nearCache, int markCount) {
         this.nearCache = nearCache;
@@ -131,7 +130,10 @@ public final class StaleReadPreventerNearCacheWrapper implements NearCache, KeyS
 
     @Override
     public void init() {
-        marks = new AtomicIntegerArray(markCount);
+        int slot = 0;
+        do {
+            marks.set(slot, UNMARKED.getState());
+        } while (++slot < marks.length());
     }
 
     private boolean casState(Object key, STATE expect, STATE update) {
@@ -146,5 +148,18 @@ public final class StaleReadPreventerNearCacheWrapper implements NearCache, KeyS
 
     public KeyStateMarker getKeyStateMarker() {
         return this;
+    }
+
+    // only used for testing purposes
+    public AtomicIntegerArray getMarks() {
+        return marks;
+    }
+
+    @Override
+    public String toString() {
+        return "StaleReadPreventerNearCacheWrapper{"
+                + "markCount=" + markCount
+                + ", marks=" + marks
+                + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheBatchInvalidationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheBatchInvalidationOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.nearcache.AbstractNearCacheInvalidator;
 import com.hazelcast.map.impl.nearcache.NearCacheInvalidator;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
@@ -49,8 +50,11 @@ public class NearCacheBatchInvalidationOperation extends MapOperation implements
             NearCacheInvalidator nearCacheInvalidator = nearCacheProvider.getNearCacheInvalidator();
             ((AbstractNearCacheInvalidator) nearCacheInvalidator).invalidateLocal(name, null, keys);
         } else {
-            getLogger().warning("Cache clear operation has been accepted while near cache is not enabled for "
-                    + name + " map. Possible configuration conflict among nodes.");
+            ILogger logger = getLogger();
+            if (logger.isFinestEnabled()) {
+                logger.finest("Near-cache invalidation operation has been accepted while near cache is not enabled for "
+                        + name + " map. Possible configuration conflict among nodes.");
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheSingleInvalidationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/NearCacheSingleInvalidationOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.nearcache.AbstractNearCacheInvalidator;
 import com.hazelcast.map.impl.nearcache.NearCacheInvalidator;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
@@ -45,8 +46,11 @@ public class NearCacheSingleInvalidationOperation extends MapOperation implement
             NearCacheInvalidator nearCacheInvalidator = nearCacheProvider.getNearCacheInvalidator();
             ((AbstractNearCacheInvalidator) nearCacheInvalidator).invalidateLocal(name, key, null);
         } else {
-            getLogger().warning("Cache clear operation has been accepted while near cache is not enabled for "
-                    + name + " map. Possible configuration conflict among nodes.");
+            ILogger logger = getLogger();
+            if (logger.isFinestEnabled()) {
+                logger.finest("Near-cache invalidation operation has been accepted while near cache is not enabled for "
+                        + name + " map. Possible configuration conflict among nodes.");
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cache.impl.nearcache.NearCache.NULL_OBJECT;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
@@ -86,11 +87,14 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         }
 
         boolean marked = keyStateMarker.tryMark(key);
-
-        value = super.getInternal(key);
-
-        if (marked) {
-            tryToPutNearCache(key, value);
+        try {
+            value = super.getInternal(key);
+            if (marked) {
+                tryToPutNearCache(key, value);
+            }
+        } catch (Throwable t) {
+            resetToUnmarkedState(key);
+            throw rethrow(t);
         }
 
         return value;
@@ -102,10 +106,14 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
                 nearCache.put(key, value);
             }
         } finally {
-            if (!keyStateMarker.tryUnmark(key)) {
-                invalidateCache(key);
-                keyStateMarker.forceUnmark(key);
-            }
+            resetToUnmarkedState(key);
+        }
+    }
+
+    private void resetToUnmarkedState(Data key) {
+        if (!keyStateMarker.tryUnmark(key)) {
+            invalidateCache(key);
+            keyStateMarker.forceUnmark(key);
         }
     }
 
@@ -124,7 +132,14 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
         final boolean marked = keyStateMarker.tryMark(key);
 
-        ICompletableFuture<Data> future = super.getAsyncInternal(key);
+        ICompletableFuture<Data> future;
+        try {
+            future = super.getAsyncInternal(key);
+        } catch (Throwable t) {
+            resetToUnmarkedState(key);
+            throw rethrow(t);
+        }
+
         future.andThen(new ExecutionCallback<Data>() {
             @Override
             public void onResponse(Data response) {
@@ -135,6 +150,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
             @Override
             public void onFailure(Throwable t) {
+                if (marked) {
+                    resetToUnmarkedState(key);
+                }
             }
         });
         return future;
@@ -270,25 +288,37 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     @Override
     protected void getAllObjectInternal(List<Data> keys, List resultingKeyValuePairs) {
-        getCachedValue(keys, resultingKeyValuePairs);
+        Map<Data, Boolean> keyStates = null;
+        try {
+            getCachedValue(keys, resultingKeyValuePairs);
+            keyStates = createHashMap(keys.size());
+            for (Data key : keys) {
+                keyStates.put(key, keyStateMarker.tryMark(key));
+            }
 
-        Map<Data, Boolean> keyStates = createHashMap(keys.size());
-        for (Data key : keys) {
-            keyStates.put(key, keyStateMarker.tryMark(key));
+            int currentSize = resultingKeyValuePairs.size();
+            super.getAllObjectInternal(keys, resultingKeyValuePairs);
+
+            // only add elements which are not in near-putCache.
+            for (int i = currentSize; i < resultingKeyValuePairs.size(); ) {
+                Data key = toData(resultingKeyValuePairs.get(i++));
+                Data value = toData(resultingKeyValuePairs.get(i++));
+
+                boolean marked = keyStates.remove(key);
+                if (marked) {
+                    tryToPutNearCache(key, value);
+                }
+            }
+        } finally {
+            unmarkRemainingMarkedKeys(keyStates);
         }
+    }
 
-
-        int currentSize = resultingKeyValuePairs.size();
-        super.getAllObjectInternal(keys, resultingKeyValuePairs);
-
-        // only add elements which are not in near-putCache.
-        for (int i = currentSize; i < resultingKeyValuePairs.size(); ) {
-            Data key = toData(resultingKeyValuePairs.get(i++));
-            Data value = toData(resultingKeyValuePairs.get(i++));
-
-            boolean marked = keyStates.get(key);
+    private void unmarkRemainingMarkedKeys(Map<Data, Boolean> markers) {
+        for (Map.Entry<Data, Boolean> entry : markers.entrySet()) {
+            Boolean marked = entry.getValue();
             if (marked) {
-                tryToPutNearCache(key, value);
+                keyStateMarker.forceUnmark(entry.getKey());
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MemberMapKeyStateMarkerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MemberMapKeyStateMarkerStressTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.nearcache;
+
+import com.hazelcast.cache.impl.nearcache.NearCache;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+import static com.hazelcast.util.RandomPicker.getInt;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class MemberMapKeyStateMarkerStressTest extends HazelcastTestSupport {
+
+    private final int KEY_SPACE = 10000;
+    private final int TEST_RUN_SECONDS = 30;
+    private final int GET_ALL_THREAD_COUNT = 3;
+    private final int GET_THREAD_COUNT = 2;
+    private final int PUT_THREAD_COUNT = 1;
+    private final int CLEAR_THREAD_COUNT = 1;
+    private final int REMOVE_THREAD_COUNT = 1;
+    private final String mapName = "test";
+    private final AtomicBoolean stop = new AtomicBoolean();
+    private TestHazelcastInstanceFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        factory = new TestHazelcastInstanceFactory();
+        stop.set(false);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void final_state_of_all_slots_are_unmarked() throws Exception {
+
+        HazelcastInstance member1 = factory.newHazelcastInstance();
+        HazelcastInstance member2 = factory.newHazelcastInstance();
+
+        Config config = new Config();
+        config.getMapConfig(mapName).setNearCacheConfig(newNearCacheConfig());
+        HazelcastInstance nearCachedMember = factory.newHazelcastInstance(config);
+
+        IMap memberMap = member1.getMap(mapName);
+        // initial population of imap from member
+        for (int i = 0; i < KEY_SPACE; i++) {
+            memberMap.put(i, i);
+        }
+
+        List<Thread> threads = new ArrayList<Thread>();
+
+        // member
+        for (int i = 0; i < PUT_THREAD_COUNT; i++) {
+            Put put = new Put(memberMap);
+            threads.add(put);
+        }
+
+        // nearCachedMap
+        IMap nearCachedMap = nearCachedMember.getMap(mapName);
+
+        for (int i = 0; i < GET_ALL_THREAD_COUNT; i++) {
+            GetAll getAll = new GetAll(nearCachedMap);
+            threads.add(getAll);
+        }
+
+        for (int i = 0; i < GET_THREAD_COUNT; i++) {
+            Get get = new Get(nearCachedMap);
+            threads.add(get);
+        }
+
+        for (int i = 0; i < REMOVE_THREAD_COUNT; i++) {
+            Remove remove = new Remove(nearCachedMap);
+            threads.add(remove);
+        }
+
+        for (int i = 0; i < CLEAR_THREAD_COUNT; i++) {
+            Clear clear = new Clear(nearCachedMap);
+            threads.add(clear);
+        }
+
+        // start threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // stress for a while
+        sleepSeconds(TEST_RUN_SECONDS);
+
+        // stop threads
+        stop.set(true);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertAllKeysInUnmarkedState(nearCachedMap);
+    }
+
+    private void assertAllKeysInUnmarkedState(IMap nearCachedMap) {
+        NearCache nearCache = ((NearCachedMapProxyImpl) nearCachedMap).getNearCache();
+        AtomicIntegerArray marks = ((StaleReadPreventerNearCacheWrapper) nearCache).getMarks();
+        KeyStateMarker keyStateMarker = ((StaleReadPreventerNearCacheWrapper) nearCache).getKeyStateMarker();
+
+        String msg = format("nearCacheSize=%d, markerStates=(%s)", nearCache.size(), keyStateMarker);
+
+        for (int i = 0; i < marks.length(); i++) {
+            assertEquals(msg, 0, marks.get(i));
+        }
+    }
+
+    private class Put extends Thread {
+        private final IMap map;
+
+        private Put(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.put(i, getInt(KEY_SPACE));
+                }
+                sleepAtLeastMillis(100);
+            } while (!stop.get());
+        }
+    }
+
+    private class Remove extends Thread {
+        private final IMap map;
+
+        private Remove(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.remove(i);
+                }
+                sleepAtLeastMillis(100);
+            } while (!stop.get());
+        }
+    }
+
+    private class Clear extends Thread {
+        private final IMap map;
+
+        private Clear(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                map.clear();
+                sleepAtLeastMillis(3000);
+            } while (!stop.get());
+        }
+    }
+
+    private class GetAll extends Thread {
+        private final IMap map;
+
+        private GetAll(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            HashSet keys = new HashSet();
+            for (int i = 0; i < KEY_SPACE; i++) {
+                keys.add(i);
+            }
+
+            do {
+                map.getAll(keys);
+                sleepAtLeastMillis(2);
+            } while (!stop.get());
+        }
+    }
+
+    private class Get extends Thread {
+        private final IMap map;
+
+        private Get(IMap map) {
+            this.map = map;
+        }
+
+        @Override
+        public void run() {
+            do {
+                for (int i = 0; i < KEY_SPACE; i++) {
+                    map.get(i);
+                }
+            } while (!stop.get());
+        }
+    }
+
+
+    protected NearCacheConfig newNearCacheConfig() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig();
+        nearCacheConfig.setName(mapName);
+        nearCacheConfig.setInvalidateOnChange(true);
+        return nearCacheConfig;
+    }
+}


### PR DESCRIPTION
- Unmarked marked keys after getAll, this was effectively disabling near-cache usage.
-  Added stress tests for imap client&member

__Fix :__
_step 1_- getAll first marks keys to fetch
_step 2_- after response returns all marked keys need to be set unmarked.

Source of problem in _step 2_ is returned response may not contain all marked keys (some keys may not be exist in imap at the time of call). Only unmarking returning keys will not be sufficient we need to unmark all previously marked keys. If we don't do that unmarking, some of previously marked keys can indefinitely stay in `removed` state (think an invalidation received for marked keys before response returns) and subsequent gets cannot touch near-cache because they expect a key in unmarked state to mark it.

