### PR TITLE
Put eventExecutor.shutdown back to client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -111,6 +111,7 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
     }
 
     public void shutdown() {
+        eventExecutor.shutdown();
         ClientExecutionServiceImpl.shutdownExecutor("registrationExecutor", registrationExecutor, logger);
     }
 


### PR DESCRIPTION
It seems it is removed when it should not.
To be able to find affected versiopns easily later,  here are the commits deletes this
It is deleted in 3.8 here
https://github.com/hazelcast/hazelcast/pull/8782/files#diff-4785c8d5812cf0e37314bb1f280640c9L92
It is deleted in 3.7.3 here
https://github.com/hazelcast/hazelcast/pull/9097/files#diff-4785c8d5812cf0e37314bb1f280640c9L92