### PR TITLE
Minor cleanup of Packet API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -35,6 +35,8 @@ import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
  * Since the Packet isn't used throughout the system, this design choice is visible locally.
  */
 @PrivateApi
+// Declaration order suppressed due to private static int FLAG_TYPEx declarations
+@SuppressWarnings("checkstyle:declarationorder")
 public final class Packet extends HeapData implements OutboundFrame {
 
     public static final byte VERSION = 4;
@@ -64,11 +66,11 @@ public final class Packet extends HeapData implements OutboundFrame {
     // header flags bitfield.
 
     /** Packet type bit 0. Historically the OPERATION type flag. */
-    public static final int FLAG_OP = 1 << 0;
+    private static final int FLAG_TYPE0 = 1 << 0;
     /** Packet type bit 1. Historically the EVENT type flag. */
-    public static final int FLAG_EVENT = 1 << 2;
+    private static final int FLAG_TYPE1 = 1 << 2;
     /** Packet type bit 2. Historically the BIND type flag. */
-    public static final int FLAG_BIND = 1 << 5;
+    private static final int FLAG_TYPE2 = 1 << 5;
 
     // 3. Type-specific flags. Same bits can be reused within each type
 
@@ -150,7 +152,7 @@ public final class Packet extends HeapData implements OutboundFrame {
      * @return {@code this} (for fluent interface)
      */
     public Packet setPacketType(Packet.Type type) {
-        int nonTypeFlags = flags & ~FLAG_OP & ~FLAG_EVENT & ~FLAG_BIND;
+        int nonTypeFlags = flags & (~FLAG_TYPE0 & ~FLAG_TYPE1 & ~FLAG_TYPE2);
         resetFlagsTo(type.headerEncoding | nonTypeFlags);
         return this;
     }
@@ -418,7 +420,7 @@ public final class Packet extends HeapData implements OutboundFrame {
         /**
          * The type of a Jet packet.
          * <p>
-         *  {@code ordinal = 3}
+         * {@code ordinal = 3}
          */
         JET {
             @Override
@@ -476,9 +478,9 @@ public final class Packet extends HeapData implements OutboundFrame {
 
         @SuppressWarnings("checkstyle:booleanexpressioncomplexity")
         private static int headerDecode(int flags) {
-            return (flags & FLAG_OP)
-                 | (flags & FLAG_EVENT) >> 1
-                 | (flags & FLAG_BIND) >> 3;
+            return (flags & FLAG_TYPE0)
+                 | (flags & FLAG_TYPE1) >> 1
+                 | (flags & FLAG_TYPE2) >> 3;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -185,11 +185,11 @@ public final class Packet extends HeapData implements OutboundFrame {
      * @param flagsToCheck the flags to check
      * @return {@code true} if any of the flags is set, {@code false} otherwise.
      */
-    public boolean isFlagSet(int flagsToCheck) {
-        return isFlagSet(flags, flagsToCheck);
+    public boolean isFlagRaised(int flagsToCheck) {
+        return isFlagRaised(flags, flagsToCheck);
     }
 
-    private static boolean isFlagSet(char flags, int flagsToCheck) {
+    private static boolean isFlagRaised(char flags, int flagsToCheck) {
         return (flags & flagsToCheck) != 0;
     }
 
@@ -211,7 +211,7 @@ public final class Packet extends HeapData implements OutboundFrame {
 
     @Override
     public boolean isUrgent() {
-        return isFlagSet(FLAG_URGENT);
+        return isFlagRaised(FLAG_URGENT);
     }
 
     /**
@@ -407,8 +407,8 @@ public final class Packet extends HeapData implements OutboundFrame {
         OPERATION {
             @Override
             public String describeFlags(char flags) {
-                return "[isResponse=" + isFlagSet(flags, FLAG_OP_RESPONSE)
-                        + ", isOpControl=" + isFlagSet(flags, FLAG_OP_CONTROL) + ']';
+                return "[isResponse=" + isFlagRaised(flags, FLAG_OP_RESPONSE)
+                        + ", isOpControl=" + isFlagRaised(flags, FLAG_OP_CONTROL) + ']';
             }
         },
         /**
@@ -425,7 +425,7 @@ public final class Packet extends HeapData implements OutboundFrame {
         JET {
             @Override
             public String describeFlags(char flags) {
-                return "[isFlowControl=" + isFlagSet(flags, FLAG_JET_FLOW_CONTROL) + ']';
+                return "[isFlowControl=" + isFlagRaised(flags, FLAG_JET_FLOW_CONTROL) + ']';
             }
         },
         /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberReadHandler.java
@@ -66,7 +66,7 @@ public class MemberReadHandler implements ReadHandler {
     }
 
     protected void handlePacket(Packet packet) {
-        if (packet.isFlagSet(Packet.FLAG_URGENT)) {
+        if (packet.isFlagRaised(Packet.FLAG_URGENT)) {
             priorityPacketsRead.inc();
         } else {
             normalPacketsRead.inc();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -176,10 +176,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
 
     public boolean isSocketInterceptorEnabled() {
         final SocketInterceptorConfig socketInterceptorConfig = ioService.getSocketInterceptorConfig();
-        if (socketInterceptorConfig != null && socketInterceptorConfig.isEnabled()) {
-            return true;
-        }
-        return false;
+        return socketInterceptorConfig != null && socketInterceptorConfig.isEnabled();
     }
 
     // just for testing
@@ -225,7 +222,7 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
 
     @Override
     public void handle(Packet packet) throws Exception {
-        assert packet.isFlagSet(Packet.FLAG_BIND);
+        assert packet.getPacketType() == Packet.Type.BIND;
 
         BindMessage bind = ioService.getSerializationService().toObject(packet);
         bind((TcpIpConnection) packet.getConn(), bind.getLocalAddress(), bind.getTargetAddress(), bind.shouldReply());

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
@@ -84,7 +84,7 @@ public class AsyncInboundResponseHandler implements PacketHandler, MetricsProvid
     public void handle(Packet packet) {
         checkNotNull(packet, "packet can't be null");
         checkTrue(packet.getPacketType() == Packet.Type.OPERATION, "Packet type is not OPERATION");
-        checkTrue(packet.isFlagSet(FLAG_OP_RESPONSE), "FLAG_OP_RESPONSE is not set");
+        checkTrue(packet.isFlagRaised(FLAG_OP_RESPONSE), "FLAG_OP_RESPONSE is not set");
         responseThread.responseQueue.add(packet);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
@@ -35,7 +35,6 @@ import java.util.concurrent.BlockingQueue;
 
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.inspectOutOfMemoryError;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
-import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -84,9 +83,8 @@ public class AsyncInboundResponseHandler implements PacketHandler, MetricsProvid
     @Override
     public void handle(Packet packet) {
         checkNotNull(packet, "packet can't be null");
-        checkTrue(packet.isFlagSet(FLAG_OP), "FLAG_OP should be set");
-        checkTrue(packet.isFlagSet(FLAG_OP_RESPONSE), "FLAG_OP_RESPONSE should be set");
-
+        checkTrue(packet.getPacketType() == Packet.Type.OPERATION, "Packet type is not OPERATION");
+        checkTrue(packet.isFlagSet(FLAG_OP_RESPONSE), "FLAG_OP_RESPONSE is not set");
         responseThread.responseQueue.add(packet);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImpl.java
@@ -59,9 +59,9 @@ public final class PacketDispatcherImpl implements PacketDispatcher {
         try {
             switch (packet.getPacketType()) {
                 case OPERATION:
-                    if (packet.isFlagSet(FLAG_OP_RESPONSE)) {
+                    if (packet.isFlagRaised(FLAG_OP_RESPONSE)) {
                         responseHandler.handle(packet);
-                    } else if (packet.isFlagSet(FLAG_OP_CONTROL)) {
+                    } else if (packet.isFlagRaised(FLAG_OP_CONTROL)) {
                         invocationMonitor.handle(packet);
                     } else {
                         operationExecutor.handle(packet);

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
@@ -89,7 +89,7 @@ public class AntiEntropyCorrectnessTest extends PartitionCorrectnessTestSupport 
 
         @Override
         public boolean allow(Packet packet, Address endpoint) {
-            return !packet.isFlagSet(Packet.FLAG_OP) || allowOperation(packet);
+            return packet.getPacketType() != Packet.Type.OPERATION || allowOperation(packet);
         }
 
         private boolean allowOperation(Packet packet) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/DirtyBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/DirtyBackupTest.java
@@ -94,7 +94,7 @@ public class DirtyBackupTest extends PartitionCorrectnessTestSupport {
 
         @Override
         public boolean allow(Packet packet, Address endpoint) {
-            return !packet.isFlagSet(Packet.FLAG_OP) || allowOperation(packet);
+            return packet.getPacketType() != Packet.Type.OPERATION || allowOperation(packet);
         }
 
         private boolean allowOperation(Packet packet) {

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
@@ -119,8 +119,8 @@ public class PacketTest {
         packet.raiseFlags(FLAG_URGENT);
 
         assertSame(Packet.Type.OPERATION, packet.getPacketType());
-        assertTrue(packet.isFlagSet(FLAG_URGENT));
-        assertFalse(packet.isFlagSet(FLAG_OP_CONTROL));
+        assertTrue(packet.isFlagRaised(FLAG_URGENT));
+        assertFalse(packet.isFlagRaised(FLAG_OP_CONTROL));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PacketTest.java
@@ -30,8 +30,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static com.hazelcast.nio.Packet.FLAG_EVENT;
-import static com.hazelcast.nio.Packet.FLAG_OP;
+import static com.hazelcast.nio.Packet.FLAG_OP_CONTROL;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
 import static com.hazelcast.nio.serialization.SerializationConcurrencyTest.Address;
 import static com.hazelcast.nio.serialization.SerializationConcurrencyTest.FACTORY_ID;
@@ -40,6 +39,7 @@ import static com.hazelcast.nio.serialization.SerializationConcurrencyTest.Porta
 import static com.hazelcast.nio.serialization.SerializationConcurrencyTest.PortablePerson;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -96,12 +96,20 @@ public class PacketTest {
     }
 
     @Test
-    public void setFlag() {
+    public void raiseFlags() {
         Packet packet = new Packet();
-        packet.setPacketType(Packet.Type.OPERATION);
         packet.raiseFlags(FLAG_URGENT);
 
-        assertEquals(FLAG_OP | FLAG_URGENT, packet.getFlags());
+        assertEquals(FLAG_URGENT, packet.getFlags());
+    }
+
+    @Test
+    public void setPacketType() {
+        Packet packet = new Packet();
+        for (Packet.Type type : Packet.Type.values()) {
+            packet.setPacketType(type);
+            assertSame(type, packet.getPacketType());
+        }
     }
 
     @Test
@@ -110,16 +118,17 @@ public class PacketTest {
         packet.setPacketType(Packet.Type.OPERATION);
         packet.raiseFlags(FLAG_URGENT);
 
-        assertTrue(packet.isFlagSet(FLAG_OP));
+        assertSame(Packet.Type.OPERATION, packet.getPacketType());
         assertTrue(packet.isFlagSet(FLAG_URGENT));
-        assertFalse(packet.isFlagSet(FLAG_EVENT));
+        assertFalse(packet.isFlagSet(FLAG_OP_CONTROL));
     }
 
     @Test
-    public void setAllFlags() {
-        Packet packet = new Packet();
-        packet.resetFlagsTo(FLAG_OP | FLAG_URGENT);
+    public void resetFlagsTo() {
+        Packet packet = new Packet().setPacketType(Packet.Type.OPERATION);
+        packet.resetFlagsTo(FLAG_URGENT);
 
-        assertEquals(FLAG_OP | FLAG_URGENT, packet.getFlags());
+        assertSame(Packet.Type.NULL, packet.getPacketType());
+        assertEquals(FLAG_URGENT, packet.getFlags());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -371,7 +371,7 @@ public class MockIOService implements IOService {
             @Override
             public void dispatch(Packet packet) {
                 try {
-                    if (packet.isFlagSet(Packet.FLAG_BIND)) {
+                    if (packet.getPacketType() == Packet.Type.BIND) {
                         connection.getConnectionManager().handle(packet);
                     } else {
                         PacketHandler handler = packetHandler;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_HandlePacketTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static org.junit.Assert.assertTrue;
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandlerTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/packetdispatcher/impl/PacketDispatcherImplTest.java
@@ -14,7 +14,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import static com.hazelcast.nio.Packet.FLAG_OP;
 import static com.hazelcast.nio.Packet.FLAG_OP_CONTROL;
 import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
@@ -56,8 +55,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
 
     @Test
     public void whenOperationPacket() throws Exception {
-        Packet packet = new Packet()
-                .resetFlagsTo(FLAG_OP);
+        Packet packet = new Packet().setPacketType(Packet.Type.OPERATION);
 
         dispatcher.dispatch(packet);
 
@@ -68,8 +66,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
 
     @Test
     public void whenUrgentOperationPacket() throws Exception {
-        Packet packet = new Packet()
-                .resetFlagsTo(FLAG_OP | FLAG_URGENT);
+        Packet packet = new Packet().setPacketType(Packet.Type.OPERATION).raiseFlags(FLAG_URGENT);
 
         dispatcher.dispatch(packet);
 
@@ -81,8 +78,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
 
     @Test
     public void whenOperationResponsePacket() throws Exception {
-        Packet packet = new Packet()
-                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE);
+        Packet packet = new Packet().setPacketType(Packet.Type.OPERATION).raiseFlags(FLAG_OP_RESPONSE);
 
         dispatcher.dispatch(packet);
 
@@ -92,8 +88,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
 
     @Test
     public void whenUrgentOperationResponsePacket() throws Exception {
-        Packet packet = new Packet()
-                .resetFlagsTo(FLAG_OP | FLAG_OP_RESPONSE | FLAG_URGENT);
+        Packet packet = new Packet().setPacketType(Packet.Type.OPERATION).raiseFlags(FLAG_OP_RESPONSE | FLAG_URGENT);
 
         dispatcher.dispatch(packet);
 
@@ -104,8 +99,7 @@ public class PacketDispatcherImplTest extends HazelcastTestSupport {
 
     @Test
     public void whenOperationControlPacket() throws Exception {
-        Packet packet = new Packet()
-                .resetFlagsTo(FLAG_OP | FLAG_OP_CONTROL);
+        Packet packet = new Packet().setPacketType(Packet.Type.OPERATION).raiseFlags(FLAG_OP_CONTROL);
 
         dispatcher.dispatch(packet);
 


### PR DESCRIPTION
This is a followup on the recent Packet API changes. It completely eliminates references to raw packet type flags and replaces them with appropriate type-oriented method calls `setPacketType` and `getPacketType`.

Also renames `isFlagSet()` to `isFlagRaised()`, to align it with `raiseFlags()`.