### PR TITLE
Clear local records before cache replication data is applied to local

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -87,6 +87,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
         ICacheService service = getService();
         for (Map.Entry<String, Map<Data, CacheRecord>> entry : data.entrySet()) {
             ICacheRecordStore cache = service.getOrCreateRecordStore(entry.getKey(), getPartitionId());
+            cache.clear();
             Map<Data, CacheRecord> map = entry.getValue();
 
             Iterator<Map.Entry<Data, CacheRecord>> iterator = map.entrySet().iterator();


### PR DESCRIPTION
Before applying replication data, local cache data must be cleared so that there is no left-over stale data on backup. 