### PR TITLE
Cleanup for changes made in  #8543

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientMembershipListener.java
@@ -30,6 +30,7 @@ import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -42,13 +43,12 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.spi.exception.TargetDisconnectedException.newTargetDisconnectedExceptionCausedByMemberLeftEvent;
 import static java.util.Collections.unmodifiableSet;
 
 class ClientMembershipListener extends ClientAddMembershipListenerCodec.AbstractEventHandler
         implements EventHandler<ClientMessage> {
 
-    public static final int INITIAL_MEMBERS_TIMEOUT_SECONDS = 5;
+    private static final int INITIAL_MEMBERS_TIMEOUT_SECONDS = 5;
 
     private final ILogger logger;
     private final Set<Member> members = new LinkedHashSet<Member>();
@@ -162,7 +162,7 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
         logger.info(membersString());
         final Connection connection = connectionManager.getConnection(member.getAddress());
         if (connection != null) {
-            connection.close(null, newTargetDisconnectedExceptionCausedByMemberLeftEvent(member, connection.toString()));
+            connection.close(null, newTargetDisconnectedExceptionCausedByMemberLeftEvent(connection));
         }
         MembershipEvent event = new MembershipEvent(client.getCluster(), member, MembershipEvent.MEMBER_REMOVED,
                 unmodifiableSet(members));
@@ -194,7 +194,7 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
             if (clusterService.getMember(address) == null) {
                 Connection connection = connectionManager.getConnection(address);
                 if (connection != null) {
-                    connection.close(null, newTargetDisconnectedExceptionCausedByMemberLeftEvent(member, connection.toString()));
+                    connection.close(null, newTargetDisconnectedExceptionCausedByMemberLeftEvent(connection));
                 }
             }
         }
@@ -203,6 +203,11 @@ class ClientMembershipListener extends ClientAddMembershipListenerCodec.Abstract
         }
 
         return events;
+    }
+
+    private Exception newTargetDisconnectedExceptionCausedByMemberLeftEvent(Connection connection) {
+        return new TargetDisconnectedException("The client has closed the connection to this member,"
+                + " after receiving a member left event from the cluster. " + connection);
     }
 
     private void memberAdded(Member member) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
@@ -160,7 +160,7 @@ public class ClientHeartbeatTest extends ClientTestSupport {
         blockMessagesFromInstance(instance2, client);
 
         expectedException.expect(TargetDisconnectedException.class);
-        expectedException.expectMessage(containsString("heartbeat problems"));
+        expectedException.expectMessage(containsString("Heartbeat"));
         map.put(keyOwnedByInstance2, randomString());
     }
 
@@ -178,7 +178,7 @@ public class ClientHeartbeatTest extends ClientTestSupport {
         blockMessagesFromInstance(instance2, client);
 
         expectedException.expect(TargetDisconnectedException.class);
-        expectedException.expectMessage(containsString("heartbeat problems"));
+        expectedException.expectMessage(containsString("Heartbeat"));
         try {
             map.putAsync(keyOwnedByInstance2, randomString()).get();
         } catch (ExecutionException e) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
@@ -16,12 +16,7 @@
 
 package com.hazelcast.spi.exception;
 
-import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
-
-import static com.hazelcast.util.StringUtil.timeToString;
-import static com.hazelcast.util.StringUtil.timeToStringFriendly;
-import static java.lang.String.format;
 
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that indicates that an operation is about to
@@ -44,34 +39,4 @@ public class TargetDisconnectedException extends RetryableHazelcastException {
         super(message, cause);
     }
 
-    public static Exception newTargetDisconnectedExceptionCausedByHeartbeat(Address memberAddress,
-                                                                            String connectionString,
-                                                                            long lastHeartbeatRequestedMillis,
-                                                                            long lastHeartbeatReceivedMillis,
-                                                                            long lastReadMillis,
-                                                                            Throwable cause) {
-        String msg = format(
-                "Disconnecting from member %s due to heartbeat problems. "
-                        + "Current time: %s. "
-                        + "Last heartbeat requested: %s. "
-                        + "Last heartbeat received: %s. "
-                        + "Last read: %s. "
-                        + "Connection %s",
-                memberAddress,
-                timeToString(System.currentTimeMillis()),
-                timeToStringFriendly(lastHeartbeatRequestedMillis),
-                timeToStringFriendly(lastHeartbeatReceivedMillis),
-                timeToStringFriendly(lastReadMillis),
-                connectionString);
-        return new TargetDisconnectedException(msg, cause);
-    }
-
-    public static Exception newTargetDisconnectedExceptionCausedByMemberLeftEvent(Member member, String connectionString) {
-        String msg = format(
-                "Closing connection to member %s."
-                        + " The client has closed the connection to this member,"
-                        + " after receiving a member left event from the cluster. Connection=%s",
-                member.getAddress(), connectionString);
-        return new TargetDisconnectedException(msg);
-    }
 }


### PR DESCRIPTION
In CleanResourceTask invocation.notifyException called twice.
, removing one of them. Could not add tests for this one
since AbstractInvocationFuture.complete can be called multiple
times. Calling twice not causing bug, but it was wrong.

Two static methods related to client is removed from
TargetDisconnectedException since it is also used in node and
methods specific to client should not be there

Detailed heartbeart related logging inside
newTargetDisconnectedExceptionCausedByHeartbeat is removed,
since these are already available in ClientConnection.toString.

ClientConnection.isClosed is removed since it nearly means !isAlive.
One caveat related to removing is race between closedTime and isAlive
boolean. To remove this race I also removed isAlive boolean.
isAlive means closedTime == 0 from now on.