### PR TITLE
Introduces constant for internal version property

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -96,6 +96,7 @@ import static com.hazelcast.config.XmlElements.SET;
 import static com.hazelcast.config.XmlElements.TOPIC;
 import static com.hazelcast.config.XmlElements.WAN_REPLICATION;
 import static com.hazelcast.config.XmlElements.canOccurMultipleTimes;
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 import static com.hazelcast.internal.config.ConfigValidator.checkEvictionConfig;
 import static com.hazelcast.util.Preconditions.checkHasText;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -234,7 +235,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
     private boolean shouldValidateTheSchema() {
         // in case of overridden hazelcast version there may be no schema with that version
         // this feature is used only in simulator testing.
-        return System.getProperty("hazelcast.internal.override.version") == null;
+        return System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION) == null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -36,6 +36,8 @@ public final class BuildInfoProvider {
      */
     public static final BuildInfo BUILD_INFO;
 
+    public static final String HAZELCAST_INTERNAL_OVERRIDE_VERSION = "hazelcast.internal.override.version";
+
     private static final ILogger LOGGER;
 
     static {
@@ -86,7 +88,7 @@ public final class BuildInfoProvider {
         int buildNumber = Integer.parseInt(build);
 
         // override version with a system property
-        String overridingVersion = System.getProperty("hazelcast.internal.override.version");
+        String overridingVersion = System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
         if (overridingVersion != null) {
             LOGGER.info("Overriding hazelcast version with system property value " + overridingVersion);
             version = overridingVersion;

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
@@ -33,6 +33,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 import static com.hazelcast.test.TestClusterUpgradeUtils.upgradeClusterMembers;
 
 /**
@@ -59,7 +60,7 @@ public class ClusterUpgradeTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        System.setProperty("hazelcast.internal.override.version", VERSION_2_1_0.toString());
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, VERSION_2_1_0.toString());
         clusterMembers = new HazelcastInstance[CLUSTER_MEMBERS_COUNT];
         for (int i=0; i < CLUSTER_MEMBERS_COUNT; i++) {
             clusterMembers[i] = factory.newHazelcastInstance(getConfig());
@@ -81,7 +82,7 @@ public class ClusterUpgradeTest extends HazelcastTestSupport {
 
     @Test
     public void test_addNodeOfLesserThanClusterVersion_notAllowed() {
-        System.setProperty("hazelcast.internal.override.version", VERSION_2_0_5.toString());
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, VERSION_2_0_5.toString());
         expectedException.expect(IllegalStateException.class);
         factory.newHazelcastInstance(getConfig());
     }
@@ -100,6 +101,6 @@ public class ClusterUpgradeTest extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
-        System.clearProperty("hazelcast.internal.override.version");
+        System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 
 import java.util.regex.Pattern;
 
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -95,10 +96,10 @@ public class BuildInfoProviderTest {
 
     @Test
     public void testOverrideBuildVersion() {
-        System.setProperty("hazelcast.internal.override.version", "99.99.99");
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, "99.99.99");
         BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
         assertEquals("99.99.99", buildInfo.getVersion());
-        System.clearProperty("hazelcast.internal.override.version");
+        System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/test/TestClusterUpgradeUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestClusterUpgradeUtils.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.version.ClusterVersion;
 import com.hazelcast.version.MemberVersion;
 
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.waitAllForSafeState;
@@ -36,11 +37,11 @@ public class TestClusterUpgradeUtils {
                                                          MemberVersion version,
                                                          Config config) {
         try {
-            System.setProperty("hazelcast.internal.override.version", version.toString());
+            System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, version.toString());
             return factory.newHazelcastInstance(config);
         }
         finally {
-            System.clearProperty("hazelcast.internal.override.version");
+            System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
         }
     }
 
@@ -53,7 +54,7 @@ public class TestClusterUpgradeUtils {
     public static void upgradeClusterMembers(TestHazelcastInstanceFactory factory, final HazelcastInstance[] membersToUpgrade,
                                              MemberVersion version, Config config, boolean assertClusterSize) {
         try {
-            System.setProperty("hazelcast.internal.override.version", version.toString());
+            System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, version.toString());
             // upgrade one by one each member of the cluster to the next version
             for (int i = 0; i < membersToUpgrade.length; i++) {
                 membersToUpgrade[i].shutdown();
@@ -74,7 +75,7 @@ public class TestClusterUpgradeUtils {
             }
         }
         finally {
-            System.clearProperty("hazelcast.internal.override.version");
+            System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
         }
     }
 


### PR DESCRIPTION
Refactor string used throughout tests to a constant.
Requires an EE counterpart.