### PR TITLE
CacheConfig name should be set explicitly to avoid wildcard name

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -21,7 +21,6 @@ import com.hazelcast.cache.impl.operation.CacheCreateConfigOperation;
 import com.hazelcast.cache.impl.operation.CacheGetConfigOperation;
 import com.hazelcast.cache.impl.operation.CacheManagementConfigOperation;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.HazelcastInstanceImpl;
@@ -30,7 +29,6 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
 
-import javax.cache.CacheException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -130,18 +128,10 @@ public class HazelcastServerCacheManager
                                                        boolean syncCreate) {
         CacheConfig<K, V> config = cacheService.getCacheConfig(cacheName);
         if (config == null) {
-            CacheSimpleConfig simpleConfig = cacheService.findCacheConfig(simpleCacheName);
-            if (simpleConfig != null) {
-                try {
-                    config = new CacheConfig(simpleConfig);
-                    config.setName(simpleCacheName);
-                    config.setManagerPrefix(cacheName.substring(0, cacheName.lastIndexOf(simpleCacheName)));
-                } catch (Exception e) {
-                    // Cannot create the actual config from the declarative one
-                    throw new CacheException(e);
-                }
-            }
-            if (config == null) {
+            config = cacheService.findCacheConfig(simpleCacheName);
+            if (config != null) {
+                config.setManagerPrefix(cacheName.substring(0, cacheName.lastIndexOf(simpleCacheName)));
+            } else {
                 // If still cache config not found, try to find it from partition
                 config = getCacheConfig(cacheName, simpleCacheName);
             }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -19,7 +19,6 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.cache.CacheStatistics;
 import com.hazelcast.cache.impl.event.CacheWanEventPublisher;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventFilter;
@@ -54,7 +53,7 @@ public interface ICacheService
 
     CacheConfig getCacheConfig(String name);
 
-    CacheSimpleConfig findCacheConfig(String simpleName);
+    CacheConfig findCacheConfig(String simpleName);
 
     Collection<CacheConfig> getCacheConfigs();
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
@@ -19,12 +19,10 @@ package com.hazelcast.cache.impl.operation;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.ReadonlyOperation;
 
-import javax.cache.CacheException;
 import java.io.IOException;
 
 /**
@@ -52,19 +50,12 @@ public class CacheGetConfigOperation
         final ICacheService service = getService();
         CacheConfig cacheConfig = service.getCacheConfig(name);
         if (cacheConfig == null) {
-            CacheSimpleConfig simpleConfig = service.findCacheConfig(simpleName);
-            if (simpleConfig != null) {
-                try {
-                    cacheConfig = new CacheConfig(simpleConfig);
-                    cacheConfig.setName(simpleName);
-                    cacheConfig.setManagerPrefix(name.substring(0, name.lastIndexOf(simpleName)));
-                    CacheConfig existingCacheConfig = service.putCacheConfigIfAbsent(cacheConfig);
-                    if (existingCacheConfig != null) {
-                        cacheConfig = existingCacheConfig;
-                    }
-                } catch (Exception e) {
-                    //Cannot create the actual config from the declarative one
-                    throw new CacheException(e);
+            cacheConfig = service.findCacheConfig(simpleName);
+            if (cacheConfig != null) {
+                cacheConfig.setManagerPrefix(name.substring(0, name.lastIndexOf(simpleName)));
+                CacheConfig existingCacheConfig = service.putCacheConfigIfAbsent(cacheConfig);
+                if (existingCacheConfig != null) {
+                    cacheConfig = existingCacheConfig;
                 }
             }
         }


### PR DESCRIPTION
`CacheConfig` name should be set explicitly when it's created from a `CacheSimpleConfig`
that is found via `AbstractCacheService.findCacheConfig()`. Otherwise,
created `CacheConfig` might have a wildcard name.

`AbstractCacheService.createDistributedObject()` is not handling this wildcard
name issue correctly, so changed `AbstractCacheService.findCacheConfig()` to return
a correct `CacheConfig` instead of `CacheSimpleConfig` and fixed all call-sites accordingly.

This error is causing https://hazelcast-l337.ci.cloudbees.com/view/migration/job/migration-data-loss/ and https://hazelcast-l337.ci.cloudbees.com/view/shutdown/job/shutdown-data-loss/ tests to fail, tests are configured with wildcard names and ICache is losing data consistently. Reason is, cache data is read using wrong name.
This issue appeared after the change that's replicating all proxies on post-join: https://github.com/hazelcast/hazelcast/pull/8752/commits/eaad1b49b604c0621ebc8a47680eec80cd36dfc9
If, during post-join, proxy is created before cache-config is replicated then cache proxy is created with wildcard name.

EE side PR: https://github.com/hazelcast/hazelcast-enterprise/pull/1193