### PR TITLE
Fix error in DiagnosticsLogWriter month 1 off

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/DiagnosticsLogWriter.java
@@ -120,7 +120,7 @@ public abstract class DiagnosticsLogWriter {
     private void appendDate() {
         write(calendar.get(DAY_OF_MONTH));
         write('-');
-        write(calendar.get(MONTH));
+        write(calendar.get(MONTH) + 1);
         write('-');
         write(calendar.get(YEAR));
     }


### PR DESCRIPTION
The month is one off because Date.MONTH is zero based.