### PR TITLE
update client protocol to version 1.4.0-6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -943,6 +943,11 @@
             <name>Maven2 Snapshot Repository</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
+        <repository>
+            <id>sonatype-release-repository</id>
+            <name>Sonatype Release Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.4.0-5</client.protocol.version>
+        <client.protocol.version>1.4.0-6</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
fixes [old .Net client not working](https://github.com/hazelcast/hazelcast-client-protocol/pull/50)
[old near cache invalidations](https://github.com/hazelcast/hazelcast-client-protocol/pull/49)