### PR TITLE
Log ignored member info update operation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
@@ -79,7 +79,7 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
 
     @Override
     public void run() throws Exception {
-        if (!isValid()) {
+        if (!checkValid()) {
             return;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
@@ -59,6 +59,7 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
 
     private static final int PARALLEL_REPLICATIONS = 10;
     private static final int BACKUP_SYNC_INTERVAL = 1;
+    private static final int MEMBER_LIST_PUBLISH_INTERVAL_SECONDS = 60;
 
     TestHazelcastInstanceFactory factory;
 
@@ -306,6 +307,7 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
 
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), String.valueOf(partitionCount));
         config.setProperty(GroupProperty.PARTITION_BACKUP_SYNC_INTERVAL.getName(), String.valueOf(BACKUP_SYNC_INTERVAL));
+        config.setProperty(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), String.valueOf(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS));
 
         int parallelReplications = antiEntropyEnabled ? PARALLEL_REPLICATIONS : 0;
         config.setProperty(GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS.getName(), String.valueOf(parallelReplications));


### PR DESCRIPTION
Additionally, do not update the partition table if MemberInfoUpdateOperation decides to ignore the member list update.
Another minor change: Reduce periodic member list publish interval in migration tests. It can happen that a joining node can miss a published member list if there are concurrent joins. Since periodic member list publish is 5 mins by default, tests can timeout before that node receives the up-to-date member list.