### PR TITLE
Removing fast closed connection in auth response

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -77,6 +77,4 @@ public interface ClientConnectionManager extends ConnectionListenable {
     void handleClientMessage(ClientMessage message, Connection connection);
 
     void addConnectionHeartbeatListener(ConnectionHeartbeatListener connectionHeartbeatListener);
-
-    void onClose(Connection connection);
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -65,7 +65,7 @@ public class ClientConnection implements SocketConnection, DiscardableMetricsPro
     private final SocketWriter writer;
     private final SocketReader reader;
     private final SocketChannelWrapper socketChannel;
-    private final ClientConnectionManager connectionManager;
+    private final ClientConnectionManagerImpl connectionManager;
     private final LifecycleService lifecycleService;
     private final HazelcastClientInstanceImpl client;
 
@@ -95,7 +95,7 @@ public class ClientConnection implements SocketConnection, DiscardableMetricsPro
                             int connectionId,
                             SocketChannelWrapper socketChannel) throws IOException {
         this.client = client;
-        this.connectionManager = client.getConnectionManager();
+        this.connectionManager = (ClientConnectionManagerImpl) client.getConnectionManager();
         this.lifecycleService = client.getLifecycleService();
         this.socketChannel = socketChannel;
         this.connectionId = connectionId;
@@ -107,7 +107,7 @@ public class ClientConnection implements SocketConnection, DiscardableMetricsPro
     public ClientConnection(HazelcastClientInstanceImpl client,
                             int connectionId) throws IOException {
         this.client = client;
-        this.connectionManager = client.getConnectionManager();
+        this.connectionManager = (ClientConnectionManagerImpl) client.getConnectionManager();
         this.lifecycleService = client.getLifecycleService();
         this.connectionId = connectionId;
         this.writer = null;
@@ -240,10 +240,6 @@ public class ClientConnection implements SocketConnection, DiscardableMetricsPro
         this.remoteEndpoint = remoteEndpoint;
     }
 
-    public Address getRemoteEndpoint() {
-        return remoteEndpoint;
-    }
-
     public InetSocketAddress getLocalSocketAddress() {
         return (InetSocketAddress) socketChannel.socket().getLocalSocketAddress();
     }
@@ -257,7 +253,7 @@ public class ClientConnection implements SocketConnection, DiscardableMetricsPro
         closeCause = cause;
         closeReason = reason;
 
-        String message = "Connection [" + getRemoteSocketAddress() + "] lost. Reason: ";
+        String message = this + " lost. Reason: ";
         if (cause != null) {
             message += cause.getClass().getName() + '[' + cause.getMessage() + ']';
         } else {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -49,10 +49,9 @@ public class ClientInvocation implements Runnable {
 
     public static final long RETRY_WAIT_TIME_IN_SECONDS = 1;
 
-    protected static final int UNASSIGNED_PARTITION = -1;
+    private static final int UNASSIGNED_PARTITION = -1;
 
-    protected final ClientInvocationFuture clientInvocationFuture;
-
+    private final ClientInvocationFuture clientInvocationFuture;
     private final ILogger logger;
     private final LifecycleService lifecycleService;
     private final ClientInvocationService invocationService;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientNonSmartListenerService.java
@@ -83,7 +83,7 @@ public class ClientNonSmartListenerService extends ClientListenerServiceImpl {
         ClientInvocationFuture future = invocation.invoke();
         String registrationId = registrationKey.getCodec().decodeAddResponse(future.get());
         handler.onListenerRegister();
-        Address address = future.getInvocation().getSendConnection().getRemoteEndpoint();
+        Address address = future.getInvocation().getSendConnection().getEndPoint();
         Member member = client.getClientClusterService().getMember(address);
         return new ClientEventRegistration(registrationId,
                 request.getCorrelationId(), member, registrationKey.getCodec());


### PR DESCRIPTION
Checking if connection is closed by remote before authentication complete, if that is the case
remove it back from active connections.
Race description from https://github.com/hazelcast/hazelcast/pull/8832.(A little bit changed)
- open a connection client -> member
- send auth message
- receive auth reply -> reply processing is offloaded to an executor. Did not start to run yet.
- member closes the connection -> the connection is trying to removed from map
						     but it was not there to begin with
- the executor start processing the auth reply -> it put the connection to the connection map.
- we end up with a closed connection in activeConnections map

Forward port for bug in https://github.com/hazelcast/hazelcast/pull/8832
Also all comments introduced there also copied to this pr. 