### PR TITLE
client.getDistributedObjects considers removed proxies too.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -140,8 +140,10 @@ import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.ServiceLoader;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
@@ -557,9 +559,20 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             ClientGetDistributedObjectsCodec.ResponseParameters resultParameters =
                     ClientGetDistributedObjectsCodec.decodeResponse(response);
 
-            Collection<DistributedObjectInfo> infoCollection = resultParameters.response;
-            for (DistributedObjectInfo distributedObjectInfo : infoCollection) {
+            Collection<? extends DistributedObject> distributedObjects = proxyManager.getDistributedObjects();
+            Set<DistributedObjectInfo> localDistributedObjects = new HashSet<DistributedObjectInfo>();
+            for (DistributedObject localInfo : distributedObjects) {
+                localDistributedObjects.add(new DistributedObjectInfo(localInfo.getServiceName(), localInfo.getName()));
+            }
+
+            Collection<DistributedObjectInfo> newDistributedObjectInfo = resultParameters.response;
+            for (DistributedObjectInfo distributedObjectInfo : newDistributedObjectInfo) {
+                localDistributedObjects.remove(distributedObjectInfo);
                 getDistributedObject(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
+            }
+
+            for (DistributedObjectInfo distributedObjectInfo : localDistributedObjects) {
+                proxyManager.removeProxy(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
             }
             return (Collection<DistributedObject>) proxyManager.getDistributedObjects();
         } catch (Exception e) {


### PR DESCRIPTION
Client does not listen distributed objects unless user specifically
adds a listener. When a proxy removed from a remote client/server,
client has no idea about it. When getDistributedObjects called,
now it compares the local proxies and removes the ones that removed
in the remote.

fixes #9423