### PR TITLE
Fix potential NPE in member operating in 3.6 client compatibility mode

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheMessageTask.java
@@ -79,7 +79,7 @@ public abstract class AbstractCacheMessageTask<P>
         if (BuildInfo.UNKNOWN_HAZELCAST_VERSION == getClientVersion()) {
             boolean compatibilityEnabled = nodeEngine.getProperties().getBoolean(GroupProperty.COMPATIBILITY_3_6_CLIENT_ENABLED);
             if (compatibilityEnabled) {
-                responseData = nodeEngine.toData(new LegacyCacheConfig((CacheConfig) response));
+                responseData = nodeEngine.toData(response == null ? null : new LegacyCacheConfig((CacheConfig) response));
             }
         }
 


### PR DESCRIPTION
When a member operates with the 3.6 client compatibility flag set, `CacheConfig` objects are wrapped in `LegacyCacheConfig` for serialization without taking into account the possibility of `CacheConfig` being `null`. For example, when a 3.6 client `CacheManager` tries to obtain a `Cache` with `getCache` which is not yet configured on the member side, then the member will fail to encode its response to the client with a `NullPointerException`.