### PR TITLE
Hot backup task state returns in progress after submission to HR

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/BackupTaskState.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/BackupTaskState.java
@@ -20,12 +20,24 @@ package com.hazelcast.hotrestart;
  * The state of the hot restart backup task
  */
 public enum BackupTaskState {
-    /** The backup task has not yet started. */
+    /** No backup task has yet been run */
+    NO_TASK,
+    /** The backup task has been submitted but not yet started. */
     NOT_STARTED,
     /** The backup task is currently in progress */
     IN_PROGRESS,
     /** The backup task has failed */
     FAILURE,
     /** The backup task completed successfully */
-    SUCCESS
+    SUCCESS;
+
+    /** Returns true if the backup task completed (successfully or with failure) */
+    public boolean isDone() {
+        return this == SUCCESS || this == FAILURE;
+    }
+
+    /** Returns if the backup task is in progress. The task could also not be started yet but will be. */
+    public boolean inProgress() {
+        return this == NOT_STARTED || this == IN_PROGRESS;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -26,8 +26,6 @@ import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.Member;
 import com.hazelcast.executor.impl.DistributedExecutorService;
-import com.hazelcast.hotrestart.BackupTaskState;
-import com.hazelcast.hotrestart.BackupTaskStatus;
 import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.MemberImpl;
@@ -179,9 +177,8 @@ public class TimedMemberStateFactory {
 
     private void createHotRestartState(MemberStateImpl memberState) {
         final HotRestartService backupService = instance.node.getNodeExtension().getHotRestartBackupService();
-        final HotRestartStateImpl state = new HotRestartStateImpl(backupService != null
-                ? backupService.getBackupTaskStatus()
-                : new BackupTaskStatus(BackupTaskState.NOT_STARTED, 0, 0));
+        final HotRestartStateImpl state = new HotRestartStateImpl(
+                backupService != null ? backupService.getBackupTaskStatus() : null);
         memberState.setHotRestartState(state);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/HotRestartStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/HotRestartStateImpl.java
@@ -43,19 +43,21 @@ public class HotRestartStateImpl implements HotRestartState {
     @Override
     public JsonObject toJson() {
         final JsonObject root = new JsonObject();
-        root.add("backupTaskState", backupTaskStatus.getState().name());
-        root.add("backupTaskCompleted", backupTaskStatus.getCompleted());
-        root.add("backupTaskTotal", backupTaskStatus.getTotal());
+        if (backupTaskStatus != null) {
+            root.add("backupTaskState", backupTaskStatus.getState().name());
+            root.add("backupTaskCompleted", backupTaskStatus.getCompleted());
+            root.add("backupTaskTotal", backupTaskStatus.getTotal());
+        }
         return root;
     }
 
     @Override
     public void fromJson(JsonObject json) {
-        final String jsonBackupTaskState = getString(json, "backupTaskState", BackupTaskState.NOT_STARTED.name());
+        final String jsonBackupTaskState = getString(json, "backupTaskState", null);
         final int jsonBackupTaskCompleted = JsonUtil.getInt(json, "backupTaskCompleted", 0);
         final int jsonBackupTaskTotal = JsonUtil.getInt(json, "backupTaskTotal", 0);
-        backupTaskStatus = new BackupTaskStatus(BackupTaskState.valueOf(jsonBackupTaskState),
-                jsonBackupTaskCompleted, jsonBackupTaskTotal);
+        backupTaskStatus = jsonBackupTaskState != null ? new BackupTaskStatus(BackupTaskState.valueOf(jsonBackupTaskState),
+                jsonBackupTaskCompleted, jsonBackupTaskTotal) : null;
     }
 
     @Override


### PR DESCRIPTION
Fix for racy check for hot backup state. The state could be SUCCESSFUL from a previous run even after a new task has been submitted but not yet started execution. 

This fix changes the state to NOT_STARTED as soon as the backup method has been invoked thus eliminating this race. - https://github.com/hazelcast/hazelcast-enterprise/issues/1197

EE : https://github.com/hazelcast/hazelcast-enterprise/pull/1201