### PR TITLE
Do not require cache writer/loader on client classpath

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
@@ -880,10 +880,24 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
+                                <xs:attribute name="cache-loader" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines the cache loader class name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
                                 <xs:attribute name="cache-writer-factory" type="xs:string" use="optional">
                                     <xs:annotation>
                                         <xs:documentation>
                                             Defines the cache writer factory class name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-writer" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines the cache writer class name.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestJCache.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/TestJCache.java
@@ -288,4 +288,15 @@ public class TestJCache {
         assertEquals(MyEvictionPolicyComparator.class, evictionConfig.getComparator().getClass());
     }
 
+    @Test
+    public void cacheConfigXmlTest_SimpleWriterLoader() throws IOException {
+        assertNotNull(instance1);
+
+        CacheSimpleConfig config =
+                instance1.getConfig().getCacheConfig("cacheWithSimpleWriterAndLoader");
+        assertNotNull(config);
+
+        assertEquals("com.hazelcast.config.CacheConfigTest$EmptyCacheWriter", config.getCacheWriter());
+        assertEquals("com.hazelcast.config.CacheConfigTest$MyCacheLoader", config.getCacheLoader());
+    }
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/context/test-jcache-application-context.xml
@@ -122,6 +122,10 @@
             <hz:cache name="cacheWithComparatorBean">
                 <hz:eviction size="50" max-size-policy="ENTRY_COUNT" comparator-bean="myEvictionPolicyComparator"/>
             </hz:cache>
+            <hz:cache name="cacheWithSimpleWriterAndLoader"
+                      cache-loader="com.hazelcast.config.CacheConfigTest$MyCacheLoader"
+                      cache-writer="com.hazelcast.config.CacheConfigTest$EmptyCacheWriter"
+            />
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -27,6 +27,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.CompleteConfiguration;
 import javax.cache.configuration.Factory;
+import javax.cache.configuration.FactoryBuilder;
 import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
 import javax.cache.event.CacheEntryEventFilter;
 import javax.cache.event.CacheEntryListener;
@@ -114,6 +115,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
         }
     }
 
+    @SuppressWarnings("checkstyle:cyclomaticcomplexity")
     public CacheConfig(CacheSimpleConfig simpleConfig) throws Exception {
         this.name = simpleConfig.getName();
         if (simpleConfig.getKeyType() != null) {
@@ -129,8 +131,14 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
         if (simpleConfig.getCacheLoaderFactory() != null) {
             this.cacheLoaderFactory = ClassLoaderUtil.newInstance(null, simpleConfig.getCacheLoaderFactory());
         }
+        if (simpleConfig.getCacheLoader() != null) {
+            this.cacheLoaderFactory = FactoryBuilder.factoryOf(simpleConfig.getCacheLoader());
+        }
         if (simpleConfig.getCacheWriterFactory() != null) {
             this.cacheWriterFactory = ClassLoaderUtil.newInstance(null, simpleConfig.getCacheWriterFactory());
+        }
+        if (simpleConfig.getCacheWriter() != null) {
+            this.cacheWriterFactory = FactoryBuilder.factoryOf(simpleConfig.getCacheWriter());
         }
         initExpiryPolicyFactoryConfig(simpleConfig);
         this.asyncBackupCount = simpleConfig.getAsyncBackupCount();

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -79,6 +79,9 @@ public class CacheSimpleConfig {
     private String cacheLoaderFactory;
     private String cacheWriterFactory;
 
+    private String cacheLoader;
+    private String cacheWriter;
+
     private ExpiryPolicyFactoryConfig expiryPolicyFactoryConfig;
     private List<CacheSimpleEntryListenerConfig> cacheEntryListeners;
 
@@ -310,7 +313,35 @@ public class CacheSimpleConfig {
      * @return The current cache config instance.
      */
     public CacheSimpleConfig setCacheLoaderFactory(String cacheLoaderFactory) {
+        if (cacheLoader != null && cacheLoaderFactory != null) {
+            throw new IllegalStateException("Cannot set cacheLoaderFactory to '" + cacheLoaderFactory
+                    + "', because cacheLoader is already set to '" + cacheLoader + "'.");
+        }
         this.cacheLoaderFactory = cacheLoaderFactory;
+        return this;
+    }
+
+    /**
+     * Get classname of a class to be used as {@link javax.cache.integration.CacheLoader}.
+     *
+     * @return classname to be used as {@link javax.cache.integration.CacheLoader}.
+     */
+    public String getCacheLoader() {
+        return cacheLoader;
+    }
+
+    /**
+     * Set classname of a class to be used as {@link javax.cache.integration.CacheLoader}.
+     *
+     * @param cacheLoader classname to be used as {@link javax.cache.integration.CacheLoader}.
+     * @return The current cache config instance.
+     */
+    public CacheSimpleConfig setCacheLoader(String cacheLoader) {
+        if (cacheLoader != null && cacheLoaderFactory != null) {
+            throw new IllegalStateException("Cannot set cacheLoader to '" + cacheLoader
+                    + "', because cacheLoaderFactory is already set to '" + cacheLoaderFactory + "'.");
+        }
+        this.cacheLoader = cacheLoader;
         return this;
     }
 
@@ -330,7 +361,36 @@ public class CacheSimpleConfig {
      * @return The current cache config instance.
      */
     public CacheSimpleConfig setCacheWriterFactory(String cacheWriterFactory) {
+        if (cacheWriter != null && cacheWriterFactory != null) {
+            throw new IllegalStateException("Cannot set cacheWriterFactory to '" + cacheWriterFactory
+                    + "', because cacheWriter is already set to '" + cacheWriter + "'.");
+        }
         this.cacheWriterFactory = cacheWriterFactory;
+        return this;
+    }
+
+    /**
+     * Get classname of a class to be used as {@link javax.cache.integration.CacheWriter}.
+     *
+     * @return classname to be used as {@link javax.cache.integration.CacheWriter}.
+     */
+    public String getCacheWriter() {
+        return cacheWriter;
+    }
+
+    /**
+     * Set classname of a class to be used as {@link javax.cache.integration.CacheWriter}.
+     *
+     * @param cacheWriter classname to be used as {@link javax.cache.integration.CacheWriter}.
+     * @return The current cache config instance.
+     *
+     */
+    public CacheSimpleConfig setCacheWriter(String cacheWriter) {
+        if (cacheWriter != null && cacheWriterFactory != null) {
+            throw new IllegalStateException("Cannot set cacheWriter to '" + cacheWriter
+                    + "', because cacheWriterFactory is already set to '" + cacheWriterFactory + "'.");
+        }
+        this.cacheWriter = cacheWriter;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -507,7 +507,9 @@ public class ConfigXmlGenerator {
             xml.append("<read-through>").append(c.isReadThrough()).append("</read-through>");
             xml.append("<write-through>").append(c.isWriteThrough()).append("</write-through>");
             checkAndFillCacheLoaderFactoryConfigXml(xml, c.getCacheLoaderFactory());
+            checkAndFillCacheLoaderConfigXml(xml, c.getCacheLoader());
             checkAndFillCacheWriterFactoryConfigXml(xml, c.getCacheWriterFactory());
+            checkAndFillCacheWriterConfigXml(xml, c.getCacheWriter());
             cacheExpiryPolicyFactoryConfigXmlGenerator(xml, c.getExpiryPolicyFactoryConfig());
             xml.append("<cache-entry-listeners>");
             for (CacheSimpleEntryListenerConfig el : c.getCacheEntryListeners()) {
@@ -543,11 +545,22 @@ public class ConfigXmlGenerator {
         }
     }
 
+    private void checkAndFillCacheWriterConfigXml(StringBuilder xml, String cacheWriter) {
+        if (!StringUtil.isNullOrEmpty(cacheWriter)) {
+            xml.append("<cache-writer class-name=\"").append(cacheWriter).append("\"/>");
+        }
+    }
+
     private void checkAndFillCacheLoaderFactoryConfigXml(StringBuilder xml, String cacheLoader) {
         if (!StringUtil.isNullOrEmpty(cacheLoader)) {
             xml.append("<cache-loader-factory class-name=\"").append(cacheLoader).append("\"/>");
         }
+    }
 
+    private void checkAndFillCacheLoaderConfigXml(StringBuilder xml, String cacheLoader) {
+        if (!StringUtil.isNullOrEmpty(cacheLoader)) {
+            xml.append("<cache-loader class-name=\"").append(cacheLoader).append("\"/>");
+        }
     }
 
     private void cacheExpiryPolicyFactoryConfigXmlGenerator(StringBuilder xml,

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1287,8 +1287,12 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 cacheConfig.setWriteThrough(getBooleanValue(value));
             } else if ("cache-loader-factory".equals(nodeName)) {
                 cacheConfig.setCacheLoaderFactory(getAttribute(n, "class-name"));
+            } else if ("cache-loader".equals(nodeName)) {
+                cacheConfig.setCacheLoader(getAttribute(n, "class-name"));
             } else if ("cache-writer-factory".equals(nodeName)) {
                 cacheConfig.setCacheWriterFactory(getAttribute(n, "class-name"));
+            } else if ("cache-writer".equals(nodeName)) {
+                cacheConfig.setCacheWriter(getAttribute(n, "class-name"));
             } else if ("expiry-policy-factory".equals(nodeName)) {
                 cacheConfig.setExpiryPolicyFactoryConfig(getExpiryPolicyFactoryConfig(n));
             } else if ("cache-entry-listeners".equals(nodeName)) {

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -429,12 +429,34 @@
                     </xs:attribute>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="cache-loader" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cache loader class name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="cache-writer-factory" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                     <xs:attribute name="class-name" use="required">
                         <xs:annotation>
                             <xs:documentation>
                                 The cache writer factory class name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cache-writer" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cache writer class name.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
@@ -1,0 +1,55 @@
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheSimpleConfigTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void givenCacheLoaderIsConfigured_whenConfigureCacheLoaderFactory_thenThrowIllegalStateException() {
+        CacheSimpleConfig config = new CacheSimpleConfig();
+        config.setCacheLoader("foo");
+
+        expectedException.expect(IllegalStateException.class);
+        config.setCacheLoaderFactory("bar");
+    }
+
+    @Test
+    public void givenCacheLoaderFactoryIsConfigured_whenConfigureCacheLoader_thenThrowIllegalStateException() {
+        CacheSimpleConfig config = new CacheSimpleConfig();
+        config.setCacheLoaderFactory("bar");
+
+        expectedException.expect(IllegalStateException.class);
+        config.setCacheLoader("foo");
+    }
+
+    @Test
+    public void givenCacheWriterIsConfigured_whenConfigureCacheWriterFactory_thenThrowIllegalStateException() {
+        CacheSimpleConfig config = new CacheSimpleConfig();
+        config.setCacheWriter("foo");
+
+        expectedException.expect(IllegalStateException.class);
+        config.setCacheWriterFactory("bar");
+    }
+
+    @Test
+    public void givenCacheWriterFactoryIsConfigured_whenConfigureCacheWriter_thenThrowIllegalStateException() {
+        CacheSimpleConfig config = new CacheSimpleConfig();
+        config.setCacheWriterFactory("bar");
+
+        expectedException.expect(IllegalStateException.class);
+        config.setCacheWriter("foo");
+    }
+}

--- a/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-jcache2.xml
@@ -15,7 +15,7 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.7.xsd"
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
@@ -43,6 +43,13 @@
         </cache-entry-listeners>
         <backup-count>1</backup-count>
         <async-backup-count>1</async-backup-count>
+    </cache>
+
+    <cache name="cache3">
+        <read-through>true</read-through>
+        <write-through>true</write-through>
+        <cache-loader class-name="com.hazelcast.config.CacheConfigTest$MyCacheLoader"/>
+        <cache-writer class-name="com.hazelcast.config.CacheConfigTest$EmptyCacheWriter"/>
     </cache>
 
     <cache name="testCache">


### PR DESCRIPTION
Fixes #9453

Previously we forced users to provide a factory have it on classpath of clients.
This is unnecessary as clients obviously do not use Writer/Loader.

It also makes declarative configuration simpler to use. Instead of forcing
users to implement a factory it's not possible to directly specify a class to use.

So instead of
<cache-loader-factory class-name="com.foo.MyCacheLoaderFactory" />
it's now possible to use:
<cache-loader class-name="com.package.YourMapLoaderImpl" />