### PR TITLE
Allow member without JCache in classpath to join cluster when no Cache configurations are defined

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -157,7 +157,7 @@ public final class ProxyManager {
     public void init(ClientConfig config) {
         // register defaults
         register(MapService.SERVICE_NAME, createServiceProxyFactory(MapService.class));
-        if (JCacheDetector.isJcacheAvailable(config.getClassLoader())) {
+        if (JCacheDetector.isJCacheAvailable(config.getClassLoader())) {
             register(ICacheService.SERVICE_NAME, new ClientCacheProxyFactory(client));
         }
         register(QueueService.SERVICE_NAME, ClientQueueProxy.class);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationServiceSupport.java
@@ -101,7 +101,7 @@ abstract class ClientInvocationServiceSupport implements ClientInvocationService
     }
 
     private ClientExceptionFactory initClientExceptionFactory() {
-        boolean jcacheAvailable = JCacheDetector.isJcacheAvailable(client.getClientConfig().getClassLoader());
+        boolean jcacheAvailable = JCacheDetector.isJCacheAvailable(client.getClientConfig().getClassLoader());
         return new ClientExceptionFactory(jcacheAvailable);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -41,7 +41,7 @@ import static com.hazelcast.spi.partition.MigrationEndpoint.SOURCE;
  * </ul>
  * </p>
  * <p><b>WARNING:</b>This service is an optionally registered service which is enabled when JCache
- * is located on the classpath, as determined by {@link JCacheDetector#isJcacheAvailable(ClassLoader)}.</p>
+ * is located on the classpath, as determined by {@link JCacheDetector#isJCacheAvailable(ClassLoader)}.</p>
  * <p>
  * If registered, it will provide all the above cache operations for all partitions of the node which it
  * is registered on.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
@@ -44,8 +44,8 @@ public final class JCacheDetector {
     private JCacheDetector() {
     }
 
-    public static boolean isJcacheAvailable(ClassLoader classLoader) {
-        return isJcacheAvailable(classLoader, null);
+    public static boolean isJCacheAvailable(ClassLoader classLoader) {
+        return isJCacheAvailable(classLoader, null);
     }
 
     /**
@@ -54,7 +54,7 @@ public final class JCacheDetector {
      *                    logs a warning against using this version.
      * @return {@code true} if JCache 1.0.0 is located in the classpath, otherwise {@code false}.
      */
-    public static boolean isJcacheAvailable(ClassLoader classLoader, ILogger logger) {
+    public static boolean isJCacheAvailable(ClassLoader classLoader, ILogger logger) {
         if (!ClassLoaderUtil.isClassAvailable(classLoader, JCACHE_CACHING_CLASSNAME)) {
             // no cache-api jar in the classpath
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
-import static com.hazelcast.cache.impl.JCacheDetector.isJcacheAvailable;
+import static com.hazelcast.cache.impl.JCacheDetector.isJCacheAvailable;
 
 public class PostJoinCacheOperation extends Operation implements IdentifiedDataSerializable {
 
@@ -48,7 +48,7 @@ public class PostJoinCacheOperation extends Operation implements IdentifiedDataS
 
     @Override
     public void run() throws Exception {
-        if (isJcacheAvailable(getNodeEngine().getConfigClassLoader())) {
+        if (isJCacheAvailable(getNodeEngine().getConfigClassLoader())) {
             ICacheService cacheService = getService();
             for (CacheConfig cacheConfig : configs) {
                 cacheService.putCacheConfigIfAbsent(cacheConfig);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperation.java
@@ -19,14 +19,19 @@ package com.hazelcast.cache.impl.operation;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.exception.ServiceNotFoundException;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
+import static com.hazelcast.cache.impl.JCacheDetector.isJcacheAvailable;
 
 public class PostJoinCacheOperation extends Operation implements IdentifiedDataSerializable {
 
@@ -38,14 +43,31 @@ public class PostJoinCacheOperation extends Operation implements IdentifiedDataS
 
     @Override
     public String getServiceName() {
-        return ICacheService.SERVICE_NAME;
+        return SERVICE_NAME;
     }
 
     @Override
     public void run() throws Exception {
-        ICacheService cacheService = getService();
-        for (CacheConfig cacheConfig : configs) {
-            cacheService.putCacheConfigIfAbsent(cacheConfig);
+        if (isJcacheAvailable(getNodeEngine().getConfigClassLoader())) {
+            ICacheService cacheService = getService();
+            for (CacheConfig cacheConfig : configs) {
+                cacheService.putCacheConfigIfAbsent(cacheConfig);
+            }
+        } else {
+            // if JCache is not in classpath and no Cache configurations need to be processed, do not fail the operation
+            // instead log a warning that if JCache API will be used then it will fail.
+            if (configs.isEmpty()) {
+                getLogger().warning("This member is joining a cluster whose members support JCache, however the cache-api "
+                        + "artifact is missing from this member's classpath. In case JCache API will be used, add cache-api "
+                        + "artifact in this member's classpath and restart the member.");
+            } else {
+                // JCache is already in use by other cluster members, so log an informative message to resolve the issue and
+                // throw the CacheService not found exception.
+                getLogger().severe("This member cannot support JCache because the cache-api artifact is missing from "
+                        + "its classpath. Add the JCache API JAR in the classpath and restart the member.");
+                throw new HazelcastException("Service with name '" + SERVICE_NAME + "' not found!",
+                        new ServiceNotFoundException("Service with name '" + SERVICE_NAME + "' not found!"));
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -134,7 +134,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     }
 
     private ClientExceptionFactory initClientExceptionFactory() {
-        boolean jcacheAvailable = JCacheDetector.isJcacheAvailable(nodeEngine.getConfigClassLoader());
+        boolean jcacheAvailable = JCacheDetector.isJCacheAvailable(nodeEngine.getConfigClassLoader());
         return new ClientExceptionFactory(jcacheAvailable);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -196,7 +196,7 @@ public final class ServiceManagerImpl implements ServiceManager {
     private void registerCacheServiceIfAvailable() {
         //CacheService Optional initialization
         //search for jcache api jar on classpath
-        if (JCacheDetector.isJcacheAvailable(nodeEngine.getConfigClassLoader(), logger)) {
+        if (JCacheDetector.isJCacheAvailable(nodeEngine.getConfigClassLoader(), logger)) {
             ICacheService service = createService(ICacheService.class);
             registerService(ICacheService.SERVICE_NAME, service);
         } else {

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/JCacheDetectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/JCacheDetectorTest.java
@@ -14,7 +14,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static com.hazelcast.cache.impl.JCacheDetector.isJcacheAvailable;
+import static com.hazelcast.cache.impl.JCacheDetector.isJCacheAvailable;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -46,7 +46,7 @@ public class JCacheDetectorTest extends HazelcastTestSupport {
         when(ClassLoaderUtil.isClassAvailable(any(ClassLoader.class), anyString()))
                 .thenReturn(true);
 
-        assertTrue(isJcacheAvailable(classLoader));
+        assertTrue(isJCacheAvailable(classLoader));
     }
 
     @Test
@@ -55,21 +55,21 @@ public class JCacheDetectorTest extends HazelcastTestSupport {
         when(ClassLoaderUtil.isClassAvailable(any(ClassLoader.class), anyString()))
                 .thenReturn(true);
 
-        assertTrue(isJcacheAvailable(classLoader, logger));
+        assertTrue(isJCacheAvailable(classLoader, logger));
     }
 
     @Test
     public void testIsJCacheAvailable_notFound() throws Exception {
         when(ClassLoaderUtil.isClassAvailable(any(ClassLoader.class), anyString()))
                 .thenReturn(false);
-        assertFalse(isJcacheAvailable(classLoader));
+        assertFalse(isJCacheAvailable(classLoader));
     }
 
     @Test
     public void testIsJCacheAvailable_notFound_withLogger() throws Exception {
         when(ClassLoaderUtil.isClassAvailable(any(ClassLoader.class), anyString()))
                 .thenReturn(false);
-        assertFalse(isJcacheAvailable(classLoader, logger));
+        assertFalse(isJCacheAvailable(classLoader, logger));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class JCacheDetectorTest extends HazelcastTestSupport {
                 .thenReturn(true)
                 .thenReturn(false);
 
-        assertFalse(isJcacheAvailable(classLoader));
+        assertFalse(isJCacheAvailable(classLoader));
     }
 
     @Test
@@ -88,6 +88,6 @@ public class JCacheDetectorTest extends HazelcastTestSupport {
         when(ClassLoaderUtil.isClassAvailable(any(ClassLoader.class), anyString()))
                 .thenReturn(true)
                 .thenReturn(false);
-        assertFalse(isJcacheAvailable(classLoader, logger));
+        assertFalse(isJCacheAvailable(classLoader, logger));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperationTest.java
@@ -68,7 +68,7 @@ public class PostJoinCacheOperationTest {
     @Test
     public void test_cachePostJoinOperationSucceeds_whenJCacheAvailable_noWarningIsLogged() throws Exception {
         // JCacheDetector finds JCache in classpath
-        when(JCacheDetector.isJcacheAvailable(classLoader)).thenReturn(true);
+        when(JCacheDetector.isJCacheAvailable(classLoader)).thenReturn(true);
         // node engine returns mock CacheService
         when(nodeEngine.getService(CacheService.SERVICE_NAME)).thenReturn(mock(ICacheService.class));
 
@@ -85,7 +85,7 @@ public class PostJoinCacheOperationTest {
 
     @Test
     public void test_cachePostJoinOperationSucceeds_whenJCacheNotAvailable_noCacheConfigs() throws Exception {
-        when(JCacheDetector.isJcacheAvailable(classLoader)).thenReturn(false);
+        when(JCacheDetector.isJCacheAvailable(classLoader)).thenReturn(false);
 
         PostJoinCacheOperation postJoinCacheOperation = new PostJoinCacheOperation();
         postJoinCacheOperation.setNodeEngine(nodeEngine);
@@ -102,7 +102,7 @@ public class PostJoinCacheOperationTest {
     @Test
     public void test_cachePostJoinOperationFails_whenJCacheNotAvailable_withCacheConfigs() throws Exception {
         // JCache is not available in classpath
-        when(JCacheDetector.isJcacheAvailable(classLoader)).thenReturn(false);
+        when(JCacheDetector.isJCacheAvailable(classLoader)).thenReturn(false);
         // node engine throws HazelcastException due to missing CacheService
         when(nodeEngine.getService(CacheService.SERVICE_NAME)).thenThrow(new HazelcastException("CacheService not found"));
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/operation/PostJoinCacheOperationTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.operation;
+
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.JCacheDetector;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test whether PostJoinCacheOperation logs warning, fails or succeeds under different JCache API availability
+ * in classpath.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(JCacheDetector.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PostJoinCacheOperationTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private NodeEngine nodeEngine = mock(NodeEngine.class);
+    private ClassLoader classLoader = mock(ClassLoader.class);
+    private ILogger logger = mock(ILogger.class);
+
+    @Before
+    public void setUp() {
+        PowerMockito.mockStatic(JCacheDetector.class);
+        when(nodeEngine.getConfigClassLoader()).thenReturn(classLoader);
+        when(nodeEngine.getLogger(any(Class.class))).thenReturn(logger);
+    }
+
+    @Test
+    public void test_cachePostJoinOperationSucceeds_whenJCacheAvailable_noWarningIsLogged() throws Exception {
+        // JCacheDetector finds JCache in classpath
+        when(JCacheDetector.isJcacheAvailable(classLoader)).thenReturn(true);
+        // node engine returns mock CacheService
+        when(nodeEngine.getService(CacheService.SERVICE_NAME)).thenReturn(mock(ICacheService.class));
+
+        PostJoinCacheOperation postJoinCacheOperation = new PostJoinCacheOperation();
+        postJoinCacheOperation.setNodeEngine(nodeEngine);
+
+        postJoinCacheOperation.run();
+
+        verify(nodeEngine).getConfigClassLoader();
+        verify(nodeEngine).getService(CacheService.SERVICE_NAME);
+        // verify logger was not invoked
+        verify(logger, never()).warning(anyString());
+    }
+
+    @Test
+    public void test_cachePostJoinOperationSucceeds_whenJCacheNotAvailable_noCacheConfigs() throws Exception {
+        when(JCacheDetector.isJcacheAvailable(classLoader)).thenReturn(false);
+
+        PostJoinCacheOperation postJoinCacheOperation = new PostJoinCacheOperation();
+        postJoinCacheOperation.setNodeEngine(nodeEngine);
+
+        postJoinCacheOperation.run();
+
+        verify(nodeEngine).getConfigClassLoader();
+        // verify a warning was logged
+        verify(logger).warning(anyString());
+        // verify CacheService instance was not requested in PostJoinCacheOperation.run
+        verify(nodeEngine, never()).getService(CacheService.SERVICE_NAME);
+    }
+
+    @Test
+    public void test_cachePostJoinOperationFails_whenJCacheNotAvailable_withCacheConfigs() throws Exception {
+        // JCache is not available in classpath
+        when(JCacheDetector.isJcacheAvailable(classLoader)).thenReturn(false);
+        // node engine throws HazelcastException due to missing CacheService
+        when(nodeEngine.getService(CacheService.SERVICE_NAME)).thenThrow(new HazelcastException("CacheService not found"));
+
+        // some CacheConfigs are added in the PostJoinCacheOperation (so JCache is actually in use in the rest of the cluster)
+        PostJoinCacheOperation postJoinCacheOperation = new PostJoinCacheOperation();
+        postJoinCacheOperation.addCacheConfig(new CacheConfig("test"));
+        postJoinCacheOperation.setNodeEngine(nodeEngine);
+
+        expectedException.expect(HazelcastException.class);
+        postJoinCacheOperation.run();
+
+        verify(nodeEngine).getConfigClassLoader();
+        verify(nodeEngine).getService(CacheService.SERVICE_NAME);
+        verify(logger, never()).warning(anyString());
+    }
+
+
+}


### PR DESCRIPTION
Allows a member without JCache API in its classpath to join a cluster whose members do have the JCache API, when JCache is not used (no `CacheConfig`s are already defined) and log a warning that if JCache API will be used, it will fail.
Also prints an informative `SEVERE` message in case `CacheConfig`s are delivered in the `PostJoinCacheOperation` but JCache API artifact is missing from the classpath (currently, a service not found exception is logged that indicates that `CacheService` is not available but does not provide information towards resolving the issue).

Fixes #9301 