### PR TITLE
Hot restart services refactoring

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -194,8 +194,7 @@ public interface Cluster {
     ClusterVersion getClusterVersion();
 
     /**
-     * Returns the Hot Restart service for interacting with Hot Restart. Can return null if Hot Restart is not available
-     * (not EE) or not enabled.
+     * Returns the Hot Restart service for interacting with Hot Restart.
      *
      * @return the hot restart service
      * @throws UnsupportedOperationException if the hot restart service is not supported on this instance (e.g. on client)

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/InternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/InternalHotRestartService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hotrestart;
+
+import com.hazelcast.config.HotRestartPersistenceConfig;
+import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
+import com.hazelcast.nio.Address;
+
+import java.util.Set;
+
+/**
+ * Internal service for interacting with hot restart related functionalities (e.g. force and partial start)
+ */
+public interface InternalHotRestartService {
+    /**
+     * Forces node to start by skipping hot-restart completely and removing all hot-restart data
+     * even if node is still on validation phase or loading hot-restart data.
+     *
+     * @return true if force start is triggered successfully. force start cannot be triggered if hot restart is disabled or
+     * the master is not known yet
+     */
+    boolean triggerForceStart();
+
+    /**
+     * Triggers partial start if the cluster cannot be started with full recovery and
+     * {@link HotRestartPersistenceConfig#clusterDataRecoveryPolicy} is set accordingly.
+     *
+     * @return true if partial start is triggered.
+     */
+    boolean triggerPartialStart();
+
+    /**
+     * Checks if the given member has been excluded during the cluster start or not.
+     * If returns true, it means that the given member is not allowed to join to the cluster.
+     *
+     * @param memberAddress address of the member to check
+     * @param memberUuid    uuid of the member to check
+     * @return true if the member has been excluded on cluster start.
+     */
+    boolean isMemberExcluded(Address memberAddress, String memberUuid);
+
+    /**
+     * Returns uuids of the members that have been excluded during the cluster start.
+     *
+     * @return uuids of the members that have been excluded during the cluster start
+     */
+    Set<String> getExcludedMemberUuids();
+
+    /**
+     * Handles the uuid set of excluded members only if this member is also excluded, and triggers the member force start process.
+     *
+     * @param sender              the member that has sent the excluded members set
+     * @param excludedMemberUuids uuids of the members that have been excluded during the cluster start
+     */
+    void handleExcludedMemberUuids(Address sender, Set<String> excludedMemberUuids);
+
+    /**
+     * Returns latest Hot Restart status as Management Center DTO. An empty status object will
+     * be returned if Hot Restart is not available (not EE) or not enabled.
+     */
+    ClusterHotRestartStatusDTO getCurrentClusterHotRestartStatus();
+
+    /**
+     * Resets local hot restart data and gets a new uuid, if the local node hasn't completed the start process and
+     * it is excluded in cluster start.
+     */
+    void resetHotRestartData();
+}

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/NoOpHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/NoOpHotRestartService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hotrestart;
+
+/**
+ * Empty implementation of HotRestartService to avoid null checks. This will provide default behaviour when hot restart is
+ * not available or not enabled.
+ */
+public class NoOpHotRestartService implements HotRestartService {
+
+    @Override
+    public void backup() {
+
+    }
+
+    @Override
+    public void backup(long backupSeq) {
+
+    }
+
+    @Override
+    public BackupTaskStatus getBackupTaskStatus() {
+        return new BackupTaskStatus(BackupTaskState.NOT_STARTED, 0, 0);
+    }
+
+    @Override
+    public void interruptLocalBackupTask() {
+
+    }
+
+    @Override
+    public void interruptBackupTask() {
+
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/NoopInternalHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/NoopInternalHotRestartService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.hotrestart;
+
+import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
+import com.hazelcast.nio.Address;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Empty implementation of InternalHotRestartService to avoid null checks. This will provide default behaviour when hot restart
+ * is not available or not enabled.
+ */
+public class NoopInternalHotRestartService implements InternalHotRestartService {
+    @Override
+    public boolean triggerForceStart() {
+        return false;
+    }
+
+    @Override
+    public boolean triggerPartialStart() {
+        return false;
+    }
+
+    @Override
+    public boolean isMemberExcluded(Address memberAddress, String memberUuid) {
+        return false;
+    }
+
+    @Override
+    public Set<String> getExcludedMemberUuids() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void handleExcludedMemberUuids(Address sender, Set<String> excludedMemberUuids) {
+
+    }
+
+    @Override
+    public ClusterHotRestartStatusDTO getCurrentClusterHotRestartStatus() {
+        return new ClusterHotRestartStatusDTO();
+    }
+
+    @Override
+    public void resetHotRestartData() {
+
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -24,11 +24,13 @@ import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.hotrestart.HotRestartService;
+import com.hazelcast.hotrestart.InternalHotRestartService;
+import com.hazelcast.hotrestart.NoOpHotRestartService;
+import com.hazelcast.hotrestart.NoopInternalHotRestartService;
 import com.hazelcast.internal.cluster.ClusterStateListener;
 import com.hazelcast.internal.cluster.ClusterVersionListener;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.VersionMismatchException;
-import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.internal.networking.ReadHandler;
 import com.hazelcast.internal.networking.SocketChannelWrapperFactory;
 import com.hazelcast.internal.networking.WriteHandler;
@@ -66,7 +68,6 @@ import com.hazelcast.wan.impl.WanReplicationServiceImpl;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.hazelcast.map.impl.MapServiceConstructor.getDefaultMapServiceConstructor;
@@ -288,21 +289,13 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
-    public boolean triggerForceStart() {
-        logger.warning("Force start is available when hot restart is active!");
-        return false;
+    public HotRestartService getHotRestartService() {
+        return new NoOpHotRestartService();
     }
 
     @Override
-    public boolean triggerPartialStart() {
-        logger.warning("Partial start is available when hot restart is active!");
-        return false;
-    }
-
-    @Override
-    public HotRestartService getHotRestartBackupService() {
-        logger.warning("Hot restart data backup features are only available on Hazelcast Enterprise!");
-        return null;
+    public InternalHotRestartService getInternalHotRestartService() {
+        return new NoopInternalHotRestartService();
     }
 
     @Override
@@ -321,28 +314,5 @@ public class DefaultNodeExtension implements NodeExtension {
             return (overriddenClusterVersion != null) ? MemberVersion.of(overriddenClusterVersion).asClusterVersion()
                                                         : node.getVersion().asClusterVersion();
         }
-    }
-
-    @Override
-    public boolean isMemberExcluded(Address memberAddress, String memberUuid) {
-        return false;
-    }
-
-    @Override
-    public Set<String> getExcludedMemberUuids() {
-        return Collections.emptySet();
-    }
-
-    @Override
-    public void handleExcludedMemberUuids(Address sender, Set<String> excludedMemberUuids) {
-    }
-
-    @Override
-    public ClusterHotRestartStatusDTO getCurrentClusterHotRestartStatus() {
-        return new ClusterHotRestartStatusDTO();
-    }
-
-    @Override
-    public void resetHotRestartData() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -17,11 +17,10 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.hotrestart.HotRestartService;
+import com.hazelcast.hotrestart.InternalHotRestartService;
 import com.hazelcast.internal.cluster.impl.JoinMessage;
 import com.hazelcast.internal.cluster.impl.JoinRequest;
-import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.internal.networking.ReadHandler;
 import com.hazelcast.internal.networking.SocketChannelWrapperFactory;
 import com.hazelcast.internal.networking.WriteHandler;
@@ -37,7 +36,6 @@ import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.version.ClusterVersion;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * NodeExtension is a <tt>Node</tt> extension mechanism to be able to plug different implementations of
@@ -214,30 +212,11 @@ public interface NodeExtension {
      */
     boolean registerListener(Object listener);
 
-    /**
-     * Forces node to start by skipping hot-restart completely and removing all hot-restart data
-     * even if node is still on validation phase or loading hot-restart data.
-     *
-     * @return true if force start is triggered successfully. force start cannot be triggered if hot restart is disabled or
-     * the master is not known yet
-     */
-    boolean triggerForceStart();
+    /** Returns the public hot restart service */
+    HotRestartService getHotRestartService();
 
-    /**
-     * Triggers partial start if the cluster cannot be started with full recovery and
-     * {@link HotRestartPersistenceConfig#clusterDataRecoveryPolicy} is set accordingly.
-     *
-     * @return true if partial start is triggered.
-     */
-    boolean triggerPartialStart();
-
-
-    /**
-     * Returns the hot restart data backup service or null if Hot Restart backup is not available (not EE) or not enabled
-     *
-     * @return the hot restart data backup service
-     */
-    HotRestartService getHotRestartBackupService();
+    /** Returns the internal hot restart service */
+    InternalHotRestartService getInternalHotRestartService();
 
     /**
      * Creates a UUID for local member
@@ -245,41 +224,4 @@ public interface NodeExtension {
      * @return new uuid
      */
     String createMemberUuid(Address address);
-
-    /**
-     * Checks if the given member has been excluded during the cluster start or not.
-     * If returns true, it means that the given member is not allowed to join to the cluster.
-     *
-     * @param memberAddress address of the member to check
-     * @param memberUuid uuid of the member to check
-     * @return true if the member has been excluded on cluster start.
-     */
-    boolean isMemberExcluded(Address memberAddress, String memberUuid);
-
-    /**
-     * Returns uuids of the members that have been excluded during the cluster start.
-     *
-     * @return uuids of the members that have been excluded during the cluster start
-     */
-    Set<String> getExcludedMemberUuids();
-
-    /**
-     * Handles the uuid set of excluded members only if this member is also excluded, and triggers the member force start process.
-     *
-     * @param sender the member that has sent the excluded members set
-     * @param excludedMemberUuids uuids of the members that have been excluded during the cluster start
-     */
-    void handleExcludedMemberUuids(Address sender, Set<String> excludedMemberUuids);
-
-    /**
-     * Returns latest Hot Restart status as Management Center DTO. An empty status object will
-     * be returned if Hot Restart is not available (not EE) or not enabled.
-     */
-    ClusterHotRestartStatusDTO getCurrentClusterHotRestartStatus();
-
-    /**
-     * Resets local hot restart data and gets a new uuid, if the local node hasn't completed the start process and
-     * it is excluded in cluster start.
-     */
-    void resetHotRestartData();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -21,7 +21,6 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.core.Member;
-import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.ascii.TextCommandService;
@@ -196,7 +195,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             if (!checkCredentials(command)) {
                 res = response(ResponseType.FORBIDDEN);
             } else {
-                boolean success = node.getNodeExtension().triggerForceStart();
+                boolean success = node.getNodeExtension().getInternalHotRestartService().triggerForceStart();
                 res = response(success ? ResponseType.SUCCESS : ResponseType.FAIL);
             }
         } catch (Throwable throwable) {
@@ -213,7 +212,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             if (!checkCredentials(command)) {
                 res = response(ResponseType.FORBIDDEN);
             } else {
-                boolean success = node.getNodeExtension().triggerPartialStart();
+                boolean success = node.getNodeExtension().getInternalHotRestartService().triggerPartialStart();
                 res = response(success ? ResponseType.SUCCESS : ResponseType.FAIL);
             }
         } catch (Throwable throwable) {
@@ -227,11 +226,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String res;
         try {
             if (checkCredentials(command)) {
-                final HotRestartService hotRestartService = textCommandService.getNode().getNodeExtension()
-                                                                              .getHotRestartBackupService();
-                if (hotRestartService != null) {
-                    hotRestartService.backup();
-                }
+                textCommandService.getNode().getNodeExtension().getHotRestartService().backup();
                 res = response(ResponseType.SUCCESS);
             } else {
                 res = response(ResponseType.FORBIDDEN);
@@ -247,11 +242,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         String res;
         try {
             if (checkCredentials(command)) {
-                final HotRestartService hotRestartService = textCommandService.getNode().getNodeExtension()
-                                                                              .getHotRestartBackupService();
-                if (hotRestartService != null) {
-                    hotRestartService.interruptBackupTask();
-                }
+                textCommandService.getNode().getNodeExtension().getHotRestartService().interruptBackupTask();
                 res = response(ResponseType.SUCCESS);
             } else {
                 res = response(ResponseType.FORBIDDEN);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -135,8 +135,7 @@ public abstract class AbstractJoiner implements Joiner {
         doJoin();
         if (!node.joined() && shouldResetHotRestartData()) {
             logger.warning("Could not join to the cluster because hot restart data must be reset.");
-            NodeExtension nodeExtension = node.getNodeExtension();
-            nodeExtension.resetHotRestartData();
+            node.getNodeExtension().getInternalHotRestartService().resetHotRestartData();
             reset();
             doJoin();
         }
@@ -148,8 +147,9 @@ public abstract class AbstractJoiner implements Joiner {
     }
 
     private boolean shouldResetHotRestartData() {
-        NodeExtension nodeExtension = node.getNodeExtension();
-        return !nodeExtension.isStartCompleted() && nodeExtension.isMemberExcluded(node.getThisAddress(), node.getThisUuid());
+        final NodeExtension nodeExtension = node.getNodeExtension();
+        return !nodeExtension.isStartCompleted()
+                && nodeExtension.getInternalHotRestartService().isMemberExcluded(node.getThisAddress(), node.getThisUuid());
     }
 
     private void postJoin() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.MemberSelector;
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.hotrestart.HotRestartService;
+import com.hazelcast.hotrestart.InternalHotRestartService;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.LifecycleServiceImpl;
 import com.hazelcast.instance.MemberImpl;
@@ -557,7 +558,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                         logger.fine(deadMember + " is dead, added to members left while cluster is " + clusterState + " state");
                     }
 
-                    if (!node.getNodeExtension().isMemberExcluded(deadAddress, deadMember.getUuid())) {
+                    final InternalHotRestartService hotRestartService = node.getNodeExtension().getInternalHotRestartService();
+                    if (!hotRestartService.isMemberExcluded(deadAddress, deadMember.getUuid())) {
                         MemberMap membersRemovedInNotActiveState = membersRemovedInNotActiveStateRef.get();
                         membersRemovedInNotActiveStateRef
                                 .set(MemberMap.cloneAdding(membersRemovedInNotActiveState, deadMember));
@@ -922,7 +924,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     @Override
     public HotRestartService getHotRestartService() {
-        return node.getNodeExtension().getHotRestartBackupService();
+        return node.getNodeExtension().getHotRestartService();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SendExcludedMemberUuidsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SendExcludedMemberUuidsOperation.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.instance.NodeExtension;
+import com.hazelcast.hotrestart.InternalHotRestartService;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -48,9 +48,10 @@ public class SendExcludedMemberUuidsOperation extends AbstractClusterOperation {
 
     @Override
     public void run() {
-        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        NodeExtension nodeExtension = nodeEngine.getNode().getNodeExtension();
-        nodeExtension.handleExcludedMemberUuids(getCallerAddress(), excludedMemberUuids);
+        final NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
+        final InternalHotRestartService hotRestartService = nodeEngine.getNode().getNodeExtension()
+                                                                      .getInternalHotRestartService();
+        hotRestartService.handleExcludedMemberUuids(getCallerAddress(), excludedMemberUuids);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -26,7 +26,6 @@ import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.Member;
 import com.hazelcast.executor.impl.DistributedExecutorService;
-import com.hazelcast.hotrestart.HotRestartService;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
@@ -176,9 +175,8 @@ public class TimedMemberStateFactory {
     }
 
     private void createHotRestartState(MemberStateImpl memberState) {
-        final HotRestartService backupService = instance.node.getNodeExtension().getHotRestartBackupService();
         final HotRestartStateImpl state = new HotRestartStateImpl(
-                backupService != null ? backupService.getBackupTaskStatus() : null);
+                instance.node.getNodeExtension().getHotRestartService().getBackupTaskStatus());
         memberState.setHotRestartState(state);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ForceStartNodeRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ForceStartNodeRequest.java
@@ -55,11 +55,8 @@ public class ForceStartNodeRequest implements ConsoleRequest {
         String resultString;
         HazelcastInstanceImpl instance = mcs.getHazelcastInstance();
         try {
-            if (instance.node.getNodeExtension().triggerForceStart()) {
-                resultString = SUCCESS_RESULT;
-            } else {
-                resultString = FAILED_RESULT;
-            }
+            resultString = instance.node.getNodeExtension().getInternalHotRestartService().triggerForceStart()
+                    ? SUCCESS_RESULT : FAILED_RESULT;
         } catch (Exception e) {
             ILogger logger = instance.node.getLogger(getClass());
             logger.warning("Problem on force start: ", e);

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetHotRestartStatusRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetHotRestartStatusRequest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.internal.management.request;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.hotrestart.InternalHotRestartService;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 
@@ -36,10 +36,9 @@ public class GetHotRestartStatusRequest implements ConsoleRequest {
 
     @Override
     public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
-        Node node = mcs.getHazelcastInstance().node;
-        NodeExtension nodeExtension = node.getNodeExtension();
-        ClusterHotRestartStatusDTO hotRestartStatus = nodeExtension.getCurrentClusterHotRestartStatus();
-        out.add("result", hotRestartStatus.toJson());
+        final Node node = mcs.getHazelcastInstance().node;
+        final InternalHotRestartService hotRestartService = node.getNodeExtension().getInternalHotRestartService();
+        out.add("result", hotRestartService.getCurrentClusterHotRestartStatus().toJson());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/TriggerPartialStartRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/TriggerPartialStartRequest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.internal.management.request;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.hotrestart.InternalHotRestartService;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.management.ManagementCenterService;
 
 import java.io.IOException;
@@ -46,8 +46,8 @@ public class TriggerPartialStartRequest implements ConsoleRequest {
     @Override
     public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
         Node node = mcs.getHazelcastInstance().node;
-        NodeExtension nodeExtension = node.getNodeExtension();
-        boolean done = nodeExtension.triggerPartialStart();
+        final InternalHotRestartService hotRestartService = node.getNodeExtension().getInternalHotRestartService();
+        final boolean done = hotRestartService.triggerPartialStart();
         String result = done ? SUCCESS_RESULT : FAILED_RESULT;
         out.add("result", result);
     }


### PR DESCRIPTION
This is the first step in a small cleanup of hot restart classes and methods. 
- Hot restart related methods were moved from the NodeExtension into the InternalHotRestartService interface. 
- Hot restart service implementations were renamed.
The next step would be to refactor the InternalHotRestartServiceImpl so that separate functionalities are in separate classes.
Once we start adding non-hot-backup related public methods, we can create a new public implementation class and just delegate to the Hot backup service for backup related methods. For now all public methods are hot-backup related hence no need for a separate public service.

EE PR : https://github.com/hazelcast/hazelcast-enterprise/pull/1209