### PR TITLE
Increase call timeout in Invocation_DetectHeartbeatTimeoutTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_DetectHeartbeatTimeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_DetectHeartbeatTimeoutTest.java
@@ -111,7 +111,7 @@ public class Invocation_DetectHeartbeatTimeoutTest extends HazelcastTestSupport 
     @Test
     public void whenExpiresEventually() {
         Config config = new Config();
-        config.setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "1000");
+        config.setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "5000");
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance local = factory.newHazelcastInstance(config);


### PR DESCRIPTION
 Fixes #8644

 Peter gave a sensible explanation in the GitHub issue:
 The system was so busy that the call failed to start within the given
 timeout of 1 second. So when it actually started, the call timeout was
 returned (so an active rejection of the operation).