### PR TITLE
Fixes problem caused by concurrent running authentications

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -208,7 +208,7 @@ public class ClientInvocation implements Runnable {
         executionServiceImpl.schedule(this, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);
     }
 
-    protected boolean shouldRetry() {
+    private boolean shouldRetry() {
         return System.currentTimeMillis() < retryTimeoutPointInMillis;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClusterListenerSupport.java
@@ -94,6 +94,10 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
         return ownerConnectionAddress;
     }
 
+    public void setOwnerConnectionAddress(Address ownerConnectionAddress) {
+        this.ownerConnectionAddress = ownerConnectionAddress;
+    }
+
     public void shutdown() {
         clusterExecutor.shutdown();
         try {
@@ -191,11 +195,8 @@ public abstract class ClusterListenerSupport implements ConnectionListener, Conn
             try {
                 triedAddresses.add(inetSocketAddress);
                 Address address = new Address(inetSocketAddress);
-                if (logger.isFinestEnabled()) {
-                    logger.finest("Trying to connect to " + address);
-                }
+                logger.info("Trying to connect to " + address + " as owner member");
                 connection = connectionManager.getOrConnect(address, true);
-                ownerConnectionAddress = connection.getEndPoint();
                 clientMembershipListener.listenMembershipEvents(ownerConnectionAddress);
                 client.getListenerService().onClusterConnect((ClientConnection) connection);
                 fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
@@ -19,12 +19,16 @@ package com.hazelcast.client.heartbeat;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.spi.impl.ClusterListenerSupport;
 import com.hazelcast.client.spi.impl.ConnectionHeartbeatListener;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.IMap;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.nio.Connection;
@@ -43,6 +47,7 @@ import org.junit.runner.RunWith;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -211,4 +216,67 @@ public class ClientHeartbeatTest extends ClientTestSupport {
         clientConfig.setProperty(ClientProperty.HEARTBEAT_INTERVAL.getName(), "500");
         return clientConfig;
     }
+
+
+    @Test
+    public void testAuthentication_whenHeartbeatResumed() throws Exception {
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+        ClientConfig config = new ClientConfig();
+        config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
+        HazelcastClientInstanceImpl hazelcastClientInstanceImpl = getHazelcastClientInstanceImpl(client);
+        final ClusterListenerSupport clientClusterService =
+                (ClusterListenerSupport) hazelcastClientInstanceImpl.getClientClusterService();
+
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                countDownLatch.countDown();
+            }
+        });
+
+        final HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();
+        blockMessagesFromInstance(instance2, client);
+
+        final HazelcastInstance instance3 = hazelcastFactory.newHazelcastInstance();
+        hazelcastInstance.shutdown();
+
+        //wait for disconnect from instance1 since it is shutdown  // CLIENT_DISCONNECTED event
+        //and wait for connect to from instance3 // CLIENT_CONNECTED event
+        assertOpenEventually(countDownLatch);
+
+        //verify and wait for authentication to 3 is complete
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                String uuid = instance3.getLocalEndpoint().getUuid();
+                assertEquals(uuid, getClientEngineImpl(instance3).getOwnerUuid(client.getLocalEndpoint().getUuid()));
+                assertEquals(uuid, getClientEngineImpl(instance2).getOwnerUuid(client.getLocalEndpoint().getUuid()));
+                assertEquals(uuid, clientClusterService.getPrincipal().getOwnerUuid());
+                assertEquals(instance3.getCluster().getLocalMember().getAddress(), clientClusterService.getOwnerConnectionAddress());
+            }
+        });
+
+        //unblock instance 2 for authentication response.
+        unblockMessagesFromInstance(instance2, client);
+
+        //trigger incoming messages from instance2
+        IExecutorService executorService = client.getExecutorService("s");
+        Future f = executorService.submitToMember(new DummySerializableCallable(), instance2.getCluster().getLocalMember());
+        f.get();
+
+        //late authentication response from instance2 should not be able to change state in both client and cluster
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                String uuid = instance3.getLocalEndpoint().getUuid();
+                assertEquals(uuid, getClientEngineImpl(instance3).getOwnerUuid(client.getLocalEndpoint().getUuid()));
+                assertEquals(uuid, getClientEngineImpl(instance2).getOwnerUuid(client.getLocalEndpoint().getUuid()));
+                assertEquals(uuid, clientClusterService.getPrincipal().getOwnerUuid());
+                assertEquals(instance3.getCluster().getLocalMember().getAddress(), clientClusterService.getOwnerConnectionAddress());
+            }
+        });
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ReAuthenticationOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ReAuthenticationOperationSupplier.java
@@ -23,13 +23,15 @@ import com.hazelcast.util.function.Supplier;
 public class ReAuthenticationOperationSupplier implements Supplier<Operation> {
 
     private final String uuid;
+    private final long authCorrelationId;
 
-    public ReAuthenticationOperationSupplier(String uuid) {
+    public ReAuthenticationOperationSupplier(String uuid, long authCorrelationId) {
         this.uuid = uuid;
+        this.authCorrelationId = authCorrelationId;
     }
 
     @Override
     public Operation get() {
-        return new ClientReAuthOperation(uuid);
+        return new ClientReAuthOperation(uuid, authCorrelationId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
@@ -17,6 +17,7 @@
 package com.hazelcast.util;
 
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 /**
@@ -43,6 +44,18 @@ public final class ConcurrencyUtil {
 
             if (updater.compareAndSet(obj, current, value)) {
                 return;
+            }
+        }
+    }
+
+    public static boolean setIfGreaterThan(AtomicLong oldValue, long newValue) {
+        while (true) {
+            long local = oldValue.get();
+            if (newValue <= local) {
+                return false;
+            }
+            if (oldValue.compareAndSet(local, newValue)) {
+                return true;
             }
         }
     }


### PR DESCRIPTION
We have a timeout for establishing connection. If owner connection
authentication takes longer than connection, client tries to
authenticate to another node. When first tried authentication message
runs later than the second one, it messes up states at both client
and cluster related to ownership of client.

As a solution,
1. ClientReauthOperation only if request has bigger correlation id
then it is already seen.
2. Server returns exception to client if there is a collusion with
correlation id's so that client does not apply an old auth.
3. When servers return successfully authenticated client applies
only if it has same correlation id with last send authentication message.