### PR TITLE
Fix invocation retry mechanism on node shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/CallIdSequence.java
@@ -63,12 +63,12 @@ abstract class CallIdSequence {
      * supports backpressure, it will not return unless the number of outstanding invocations is within the
      * configured limit. Instead it will block until the condition is met and eventually throw a timeout exception.
      *
-     * @param isUrgent {@code true} means we're need a call ID for an urgent operation
+     * @param force {@code true} means we need a call ID immediately, because of an urgent operation or a retry
      * @return the generated call ID
      * @throws TimeoutException if the outstanding invocation count hasn't dropped below the configured limit
      * within the configured timeout
      */
-    abstract long next(boolean isUrgent) throws TimeoutException;
+    abstract long next(boolean force) throws TimeoutException;
 
     /** Not idempotent: must be called exactly once per invocation. */
     abstract void complete();
@@ -96,7 +96,7 @@ abstract class CallIdSequence {
         }
 
         @Override
-        public long next(boolean isUrgent) {
+        public long next(boolean force) {
             return HEAD.incrementAndGet(this);
         }
 
@@ -148,8 +148,8 @@ abstract class CallIdSequence {
         }
 
         @Override
-        public long next(boolean isUrgent) throws TimeoutException {
-            if (!isUrgent && !hasSpace()) {
+        public long next(boolean force) throws TimeoutException {
+            if (!force && !hasSpace()) {
                 waitForSpace();
             }
             return next();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -181,6 +181,14 @@ class InvocationMonitor implements PacketHandler, MetricsProvider {
         scheduler.schedule(new OnMemberLeftTask(member), ON_MEMBER_LEFT_DELAY_MILLIS, MILLISECONDS);
     }
 
+    void execute(Runnable runnable) {
+        scheduler.execute(runnable);
+    }
+
+    void schedule(Runnable command, long delayMillis) {
+        scheduler.schedule(command, delayMillis, MILLISECONDS);
+    }
+
     @Override
     public void handle(Packet packet) {
         scheduler.execute(new ProcessOperationControlTask(packet));

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistry.java
@@ -106,7 +106,8 @@ public class InvocationRegistry implements Iterable<Invocation>, MetricsProvider
     public boolean register(Invocation invocation) {
         final long callId;
         try {
-            callId = callIdSequence.next(invocation.op.isUrgent());
+            boolean force = invocation.op.isUrgent() || invocation.isRetryCandidate();
+            callId = callIdSequence.next(force);
         } catch (TimeoutException e) {
             throw new HazelcastOverloadException("Failed to start invocation due to overload: " + invocation, e);
         }


### PR DESCRIPTION
When the node is shutting down, pending retries may be lost and invocation futures may not be notified. It is because we schedule retries via ExecutionService and we don't keep track of them via invocation registry etc. During shutdown, ExecutionService does not invoke pending tasks.

Here, we move retry tasks to invocation monitor's scheduler. By this way, we guarantee that all of them will run during shutdown. At any time, there can be at most 1 retry task running and we don't apply back pressure to it when it is put into the invocation registry.

Fixes https://github.com/hazelcast/hazelcast/issues/8655