### PR TITLE
Partition migrating flag should set/cleared on partition threads 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -266,10 +266,16 @@ public class PartitionStateManager {
     }
 
     public void setMigratingFlag(int partitionId) {
+        if (logger.isFinestEnabled()) {
+            logger.finest("Setting partition-migrating flag. partitionId=" + partitionId);
+        }
         partitions[partitionId].setMigrating(true);
     }
 
     public void clearMigratingFlag(int partitionId) {
+        if (logger.isFinestEnabled()) {
+            logger.finest("Clearing partition-migrating flag. partitionId=" + partitionId);
+        }
         partitions[partitionId].setMigrating(false);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
@@ -41,6 +41,10 @@ final class BeforePromotionOperation extends AbstractPromotionOperation {
     @Override
     public void beforeRun() throws Exception {
         sendMigrationEvent(STARTED);
+
+        InternalPartitionServiceImpl service = getService();
+        PartitionStateManager partitionStateManager = service.getPartitionStateManager();
+        partitionStateManager.setMigratingFlag(getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
@@ -74,9 +74,11 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
 
     @Override
     public void afterRun() throws Exception {
-        clearPartitionMigratingFlag();
-        MigrationEvent.MigrationStatus status = success ? COMPLETED : FAILED;
-        sendMigrationEvent(status);
+        InternalPartitionServiceImpl service = getService();
+        PartitionStateManager partitionStateManager = service.getPartitionStateManager();
+        partitionStateManager.clearMigratingFlag(getPartitionId());
+
+        sendMigrationEvent(success ? COMPLETED : FAILED);
     }
 
     private void shiftUpReplicaVersions() {
@@ -130,11 +132,5 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
                 logger.warning("While promoting partitionId=" + getPartitionId(), e);
             }
         }
-    }
-
-    private void clearPartitionMigratingFlag() {
-        InternalPartitionServiceImpl service = getService();
-        PartitionStateManager partitionStateManager = service.getPartitionStateManager();
-        partitionStateManager.clearMigratingFlag(getPartitionId());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.partition.operation;
 
-import com.hazelcast.core.MigrationEvent;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionEventManager;
 import com.hazelcast.internal.partition.impl.PartitionStateManager;
@@ -118,7 +117,7 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
             try {
                 service.commitMigration(event);
             } catch (Throwable e) {
-                logger.warning("While promoting partitionId=" + getPartitionId(), e);
+                logger.warning("While promoting " + getPartitionMigrationEvent(), e);
             }
         }
     }
@@ -129,7 +128,7 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
             try {
                 service.rollbackMigration(event);
             } catch (Throwable e) {
-                logger.warning("While promoting partitionId=" + getPartitionId(), e);
+                logger.warning("While promoting " + getPartitionMigrationEvent(), e);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -116,7 +116,6 @@ public class PromotionCommitOperation extends AbstractPartitionOperation impleme
             logger.fine("Submitting before promotion tasks for " + promotions.size() + " promotions.");
         }
         for (MigrationInfo promotion : promotions) {
-            partitionStateManager.setMigratingFlag(promotion.getPartitionId());
             operationService.execute(new BeforePromotionTask(this, promotion, nodeEngine, tasks));
         }
     }


### PR DESCRIPTION
Partition migrating flag should be always set & cleared on partition
operation threads. During promotion commit flag was being set on generic
operation thread. That was causing incorrect set/clear order.

Fixes #9436