### PR TITLE
Partition migrating flag should set/cleared on partition threads 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -263,10 +263,16 @@ public class PartitionStateManager {
     }
 
     public void setMigratingFlag(int partitionId) {
+        if (logger.isFinestEnabled()) {
+            logger.finest("Setting partition-migrating flag. partitionId=" + partitionId);
+        }
         partitions[partitionId].setMigrating(true);
     }
 
     public void clearMigratingFlag(int partitionId) {
+        if (logger.isFinestEnabled()) {
+            logger.finest("Clearing partition-migrating flag. partitionId=" + partitionId);
+        }
         partitions[partitionId].setMigrating(false);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.partition.operation;
 
+import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.internal.partition.impl.PartitionStateManager;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.PartitionMigrationEvent;
@@ -33,6 +35,10 @@ final class BeforePromotionOperation extends AbstractPromotionOperation {
     @Override
     public void beforeRun() throws Exception {
         sendMigrationEvent(STARTED);
+
+        InternalPartitionServiceImpl service = getService();
+        PartitionStateManager partitionStateManager = service.getPartitionStateManager();
+        partitionStateManager.setMigratingFlag(getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.internal.partition.operation;
 
-import com.hazelcast.core.MigrationEvent;
-import com.hazelcast.internal.partition.impl.InternalPartitionImpl;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionEventManager;
 import com.hazelcast.internal.partition.impl.PartitionStateManager;
@@ -114,7 +112,7 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
             try {
                 service.commitMigration(event);
             } catch (Throwable e) {
-                logger.warning("While promoting partitionId=" + getPartitionId(), e);
+                logger.warning("While promoting " + getPartitionMigrationEvent(), e);
             }
         }
     }
@@ -125,7 +123,7 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
             try {
                 service.rollbackMigration(event);
             } catch (Throwable e) {
-                logger.warning("While promoting partitionId=" + getPartitionId(), e);
+                logger.warning("While promoting " + getPartitionMigrationEvent(), e);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
@@ -70,9 +70,11 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
 
     @Override
     public void afterRun() throws Exception {
-        clearPartitionMigratingFlag();
-        MigrationEvent.MigrationStatus status = success ? COMPLETED : FAILED;
-        sendMigrationEvent(status);
+        InternalPartitionServiceImpl service = getService();
+        PartitionStateManager partitionStateManager = service.getPartitionStateManager();
+        partitionStateManager.clearMigratingFlag(getPartitionId());
+
+        sendMigrationEvent(success ? COMPLETED : FAILED);
     }
 
     private void shiftUpReplicaVersions() {
@@ -126,12 +128,5 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
                 logger.warning("While promoting partitionId=" + getPartitionId(), e);
             }
         }
-    }
-
-    private void clearPartitionMigratingFlag() {
-        final InternalPartitionServiceImpl service = getService();
-        PartitionStateManager partitionStateManager = service.getPartitionStateManager();
-        final InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(getPartitionId());
-        partition.setMigrating(false);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -22,9 +22,7 @@ import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
-import com.hazelcast.internal.partition.impl.InternalPartitionImpl;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
-import com.hazelcast.internal.partition.impl.PartitionStateManager;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -34,7 +32,6 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.Preconditions;
 
@@ -107,25 +104,26 @@ public class PromotionCommitOperation extends AbstractOperation implements Migra
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         InternalOperationService operationService = nodeEngine.getOperationService();
         InternalPartitionServiceImpl partitionService = getService();
-        PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
-        AtomicInteger tasks = new AtomicInteger(promotions.size());
 
         ILogger logger = getLogger();
-        if (logger.isFinestEnabled()) {
-            logger.finest("Submitting before promotion tasks for " + promotions);
-        } else if (logger.isFineEnabled()) {
-            logger.fine("Submitting before promotion tasks for " + promotions.size() + " promotions.");
+        if (logger.isFineEnabled()) {
+            logger.fine("Submitting BeforePromotionOperations for " + promotions.size() + " promotions.");
         }
+
+        Runnable beforePromotionsCallback = new BeforePromotionOperationCallback(this, new AtomicInteger(promotions.size()));
+
         for (MigrationInfo promotion : promotions) {
-            operationService.execute(new BeforePromotionTask(this, promotion, nodeEngine, tasks));
+            if (logger.isFinestEnabled()) {
+                logger.finest("Submitting BeforePromotionOperation for promotion: " + promotion);
+            }
+            int currentReplicaIndex = promotion.getDestinationCurrentReplicaIndex();
+            BeforePromotionOperation op = new BeforePromotionOperation(currentReplicaIndex, beforePromotionsCallback);
+            op.setPartitionId(promotion.getPartitionId()).setNodeEngine(nodeEngine).setService(partitionService);
+            operationService.execute(op);
         }
     }
 
     private void finalizePromotion() {
-        ILogger logger = getLogger();
-        if (logger.isFineEnabled()) {
-            logger.fine("Running promotion finalization for " + promotions.size() + " promotions.");
-        }
         NodeEngine nodeEngine = getNodeEngine();
         InternalPartitionServiceImpl partitionService = getService();
         OperationService operationService = nodeEngine.getOperationService();
@@ -133,67 +131,49 @@ public class PromotionCommitOperation extends AbstractOperation implements Migra
         partitionState.setEndpoint(getCallerAddress());
         success = partitionService.processPartitionRuntimeState(partitionState);
 
-        if (logger.isFinestEnabled()) {
-            logger.finest("Submitting finalize promotion operations for " + promotions);
-        } else if (logger.isFineEnabled()) {
-            logger.fine("Submitting finalize promotion operations for " + promotions.size() + " promotions.");
+        ILogger logger = getLogger();
+        if (logger.isFineEnabled()) {
+            logger.fine("Submitting FinalizePromotionOperations for " + promotions.size() + " promotions. Result: " + success);
         }
         for (MigrationInfo promotion : promotions) {
+            if (logger.isFinestEnabled()) {
+                logger.finest("Submitting FinalizePromotionOperation for promotion: " + promotion + ". Result: " + success);
+            }
             int currentReplicaIndex = promotion.getDestinationCurrentReplicaIndex();
             FinalizePromotionOperation op = new FinalizePromotionOperation(currentReplicaIndex, success);
             op.setPartitionId(promotion.getPartitionId()).setNodeEngine(nodeEngine).setService(partitionService);
-            operationService.executeOperation(op);
+            operationService.execute(op);
         }
     }
 
-    private static class BeforePromotionTask implements PartitionSpecificRunnable {
+    private static class BeforePromotionOperationCallback implements Runnable {
         private final PromotionCommitOperation promotionCommitOperation;
-        private final MigrationInfo promotion;
-        private final NodeEngineImpl nodeEngine;
         private final AtomicInteger tasks;
 
-        BeforePromotionTask(PromotionCommitOperation promotionCommitOperation, MigrationInfo promotion,
-                NodeEngineImpl nodeEngine, AtomicInteger tasks) {
+        BeforePromotionOperationCallback(PromotionCommitOperation promotionCommitOperation, AtomicInteger tasks) {
             this.promotionCommitOperation = promotionCommitOperation;
-            this.promotion = promotion;
-            this.nodeEngine = nodeEngine;
             this.tasks = tasks;
         }
 
         @Override
         public void run() {
-            try {
-                int currentReplicaIndex = promotion.getDestinationCurrentReplicaIndex();
-                BeforePromotionOperation op = new BeforePromotionOperation(currentReplicaIndex);
-                op.setPartitionId(promotion.getPartitionId()).setNodeEngine(nodeEngine)
-                        .setService(nodeEngine.getPartitionService());
-
-                InternalOperationService operationService = nodeEngine.getOperationService();
-                operationService.runOperationOnCallingThread(op);
-            } finally {
-                completeTask();
-            }
-        }
-
-        private void completeTask() {
             final int remainingTasks = tasks.decrementAndGet();
 
-            ILogger logger = nodeEngine.getLogger(getClass());
+            ILogger logger = promotionCommitOperation.getLogger();
             if (logger.isFinestEnabled()) {
                 logger.finest("Remaining before promotion tasks: " + remainingTasks);
             }
 
             if (remainingTasks == 0) {
-                logger.fine("All before promotion tasks are completed, re-submitting PromotionCommitOperation.");
-                promotionCommitOperation.beforeStateCompleted = true;
-                nodeEngine.getOperationService().executeOperation(promotionCommitOperation);
+                logger.fine("All before promotion tasks are completed.");
+                promotionCommitOperation.onBeforePromotionsComplete();
             }
         }
+    }
 
-        @Override
-        public int getPartitionId() {
-            return promotion.getPartitionId();
-        }
+    private void onBeforePromotionsComplete() {
+        beforeStateCompleted = true;
+        getNodeEngine().getOperationService().execute(this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -117,8 +117,6 @@ public class PromotionCommitOperation extends AbstractOperation implements Migra
             logger.fine("Submitting before promotion tasks for " + promotions.size() + " promotions.");
         }
         for (MigrationInfo promotion : promotions) {
-            InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(promotion.getPartitionId());
-            partition.setMigrating(true);
             operationService.execute(new BeforePromotionTask(this, promotion, nodeEngine, tasks));
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationAwareServiceEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationAwareServiceEventTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.partition;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
@@ -34,6 +35,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -45,7 +47,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -105,8 +107,7 @@ public class MigrationAwareServiceEventTest extends HazelcastTestSupport {
         }
         waitAllForSafeState(hz);
 
-        Queue<Object> responses = responseHandler.responses;
-        assertTrue("Unexpected responses: " + responses, responses.isEmpty());
+        assertThat(responseHandler.failures, Matchers.empty());
     }
 
     private Config newConfig(FailingOperationResponseHandler responseHandler) {
@@ -118,13 +119,16 @@ public class MigrationAwareServiceEventTest extends HazelcastTestSupport {
     }
 
     private static class FailingOperationResponseHandler implements OperationResponseHandler {
-        private final Queue<Object> responses = new ConcurrentLinkedQueue<Object>();
+        private final Queue<String> failures = new ConcurrentLinkedQueue<String>();
 
         @Override
-        public void sendResponse(Operation op, Object response) {
-            if (!(response instanceof RetryableHazelcastException)) {
-                responses.add(response);
-                System.err.println("Unexpected response " + response + " from " + op);
+        public void sendResponse(Operation operation, Object response) {
+            assert operation instanceof DummyPartitionAwareOperation : "Invalid operation: " + operation;
+            NodeEngine nodeEngine = operation.getNodeEngine();
+            if (!(response instanceof RetryableHazelcastException) && nodeEngine.isRunning()) {
+                DummyPartitionAwareOperation op = (DummyPartitionAwareOperation) operation;
+                failures.add("Unexpected response: " + response + ". Node: " + nodeEngine.getThisAddress()
+                        + ", Event: " + op.event + ", Type: " + op.type);
             }
         }
 
@@ -136,6 +140,9 @@ public class MigrationAwareServiceEventTest extends HazelcastTestSupport {
 
     private static class MigrationCommitRollbackTestingService implements MigrationAwareService, ManagedService {
         private static final String NAME = MigrationCommitRollbackTestingService.class.getSimpleName();
+        private static final String TYPE_COMMIT = "COMMIT";
+        private static final String TYPE_ROLLBACK = "ROLLBACK";
+
         private final FailingOperationResponseHandler responseHandler;
         private volatile NodeEngine nodeEngine;
 
@@ -159,23 +166,45 @@ public class MigrationAwareServiceEventTest extends HazelcastTestSupport {
 
         @Override
         public void commitMigration(PartitionMigrationEvent event) {
-            executePartitionOperation(event);
-        }
-
-        private void executePartitionOperation(PartitionMigrationEvent event) {
-            if (event.getNewReplicaIndex() != 0 && event.getCurrentReplicaIndex() != 0) {
-                return;
-            }
-
-            DummyPartitionAwareOperation op = new DummyPartitionAwareOperation(event);
-            op.setPartitionId(event.getPartitionId()).setReplicaIndex(event.getNewReplicaIndex());
-            op.setOperationResponseHandler(responseHandler);
-            nodeEngine.getOperationService().run(op);
+            checkPartition(event, TYPE_COMMIT);
         }
 
         @Override
         public void rollbackMigration(PartitionMigrationEvent event) {
-            executePartitionOperation(event);
+            checkPartition(event, TYPE_ROLLBACK);
+        }
+
+        private void checkPartition(PartitionMigrationEvent event, String type) {
+            if (event.getNewReplicaIndex() != 0 && event.getCurrentReplicaIndex() != 0) {
+                return;
+            }
+
+            checkPartitionMigrating(event, type);
+
+            if (event.getCurrentReplicaIndex() != -1) {
+                runPartitionOperation(event, type, event.getCurrentReplicaIndex());
+            }
+            if (event.getNewReplicaIndex() != -1) {
+                runPartitionOperation(event, type, event.getNewReplicaIndex());
+            }
+        }
+
+        private void runPartitionOperation(PartitionMigrationEvent event, String type, int replicaIndex) {
+            DummyPartitionAwareOperation op = new DummyPartitionAwareOperation(event, type);
+            op.setNodeEngine(nodeEngine).setPartitionId(event.getPartitionId()).setReplicaIndex(replicaIndex);
+            op.setOperationResponseHandler(responseHandler);
+            nodeEngine.getOperationService().run(op);
+        }
+
+        private void checkPartitionMigrating(PartitionMigrationEvent event, String type) {
+            InternalPartitionServiceImpl partitionService =
+                    (InternalPartitionServiceImpl) nodeEngine.getPartitionService();
+
+            InternalPartition partition = partitionService.getPartition(event.getPartitionId());
+            if (!partition.isMigrating() && nodeEngine.isRunning()) {
+                responseHandler.failures.add("Migrating flag is not set. Node: " + nodeEngine.getThisAddress()
+                        + ", Event: " + event + ", Type: " + type);
+            }
         }
 
         @Override
@@ -189,8 +218,11 @@ public class MigrationAwareServiceEventTest extends HazelcastTestSupport {
 
     private static class DummyPartitionAwareOperation extends Operation {
         private final PartitionMigrationEvent event;
-        DummyPartitionAwareOperation(PartitionMigrationEvent event) {
+        private final String type;
+
+        DummyPartitionAwareOperation(PartitionMigrationEvent event, String type) {
             this.event = event;
+            this.type = type;
         }
 
         @Override
@@ -200,11 +232,6 @@ public class MigrationAwareServiceEventTest extends HazelcastTestSupport {
         @Override
         public Object getResponse() {
             return Boolean.TRUE;
-        }
-
-        @Override
-        public String toString() {
-            return "TestPartitionAwareOperation{" + "event=" + event + '}';
         }
     }
 


### PR DESCRIPTION
Partition migrating flag should be always set & cleared on partition
operation threads. During promotion commit flag was being set on generic
operation thread. That was causing incorrect set/clear order.

Fixes #9436

Backport of #9517