### PR TITLE
Fixes regression caused by #8848

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -31,7 +31,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import javax.security.auth.login.LoginException;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -144,18 +143,6 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
                 endpoint.getSocketAddress(),
                 endpoint.getClientType());
         clientEngine.sendClientEvent(event);
-    }
-
-    public void removeEndpoints(String memberUuid) {
-        Iterator<ClientEndpoint> iterator = endpoints.values().iterator();
-        while (iterator.hasNext()) {
-            ClientEndpoint endpoint = iterator.next();
-            String ownerUuid = endpoint.getPrincipal().getOwnerUuid();
-            if (memberUuid.equals(ownerUuid)) {
-                iterator.remove();
-                removeEndpoint(endpoint, true, "Cleanup of disconnected client resources");
-            }
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -75,7 +75,6 @@ import javax.security.auth.login.LoginException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -442,24 +441,16 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     private class DestroyEndpointTask implements Runnable {
         private final String deadMemberUuid;
 
-        public DestroyEndpointTask(String deadMemberUuid) {
+        DestroyEndpointTask(String deadMemberUuid) {
             this.deadMemberUuid = deadMemberUuid;
         }
 
         @Override
         public void run() {
-            endpointManager.removeEndpoints(deadMemberUuid);
-            removeMappings();
-        }
-
-        void removeMappings() {
-            Iterator<Map.Entry<String, String>> iterator = ownershipMappings.entrySet().iterator();
-            while (iterator.hasNext()) {
-                Map.Entry<String, String> entry = iterator.next();
+            for (Map.Entry<String, String> entry : ownershipMappings.entrySet()) {
                 String clientUuid = entry.getKey();
                 String memberUuid = entry.getValue();
                 if (deadMemberUuid.equals(memberUuid)) {
-                    iterator.remove();
                     ClientDisconnectionOperation op = createClientDisconnectionOperation(clientUuid, deadMemberUuid);
                     nodeEngine.getOperationService().run(op);
                 }


### PR DESCRIPTION
Since the logic in ClientDisconnectionOperation change so that
cleanup can only done by that operation, cleanups made elsewhere
should have been removed but forgotten.

fixes #6991