### PR TITLE
Declare and impl TypedEntryProcessor and supporting cast

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -105,6 +105,7 @@ import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.MapPartitionLostEvent;
 import com.hazelcast.map.QueryCache;
+import com.hazelcast.map.TypedEntryProcessor;
 import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.ListenerAdapter;
@@ -1261,7 +1262,14 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         return executeOnKeyInternal(keyData, entryProcessor);
     }
 
-    public Object executeOnKeyInternal(Data keyData, EntryProcessor entryProcessor) {
+    @Override
+    public <R> R executeOnKey(K key, TypedEntryProcessor<K, V, R> entryProcessor) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        Data keyData = toData(key);
+        return executeOnKeyInternal(keyData, entryProcessor);
+    }
+
+    public <R> R executeOnKeyInternal(Data keyData, EntryProcessor entryProcessor) {
         ClientMessage request = MapExecuteOnKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, getThreadId());
         ClientMessage response = invoke(request, keyData);
         MapExecuteOnKeyCodec.ResponseParameters resultParameters = MapExecuteOnKeyCodec.decodeResponse(response);
@@ -1270,6 +1278,13 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public void submitToKey(K key, EntryProcessor entryProcessor, final ExecutionCallback callback) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        Data keyData = toData(key);
+        submitToKeyInternal(keyData, entryProcessor, callback);
+    }
+
+    @Override
+    public <R> void submitToKey(K key, TypedEntryProcessor<K, V, R> entryProcessor, final ExecutionCallback<R> callback) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         Data keyData = toData(key);
         submitToKeyInternal(keyData, entryProcessor, callback);
@@ -1295,11 +1310,18 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         return submitToKeyInternal(keyData, entryProcessor);
     }
 
-    public ICompletableFuture submitToKeyInternal(Data keyData, EntryProcessor entryProcessor) {
+    @Override
+    public <R> ICompletableFuture<R> submitToKey(K key, TypedEntryProcessor<K, V, R> entryProcessor) {
+        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
+        Data keyData = toData(key);
+        return submitToKeyInternal(keyData, entryProcessor);
+    }
+
+    public <R> ICompletableFuture<R> submitToKeyInternal(Data keyData, EntryProcessor entryProcessor) {
         ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, getThreadId());
         try {
             final ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);
-            return new ClientDelegatingFuture(future, getContext().getSerializationService(), SUBMIT_TO_KEY_RESPONSE_DECODER);
+            return new ClientDelegatingFuture<R>(future, getContext().getSerializationService(), SUBMIT_TO_KEY_RESPONSE_DECODER);
         } catch (Exception e) {
             throw rethrow(e);
         }
@@ -1313,21 +1335,38 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         return prepareResult(resultParameters.response);
     }
 
-    protected Map<K, Object> prepareResult(Collection<Entry<Data, Data>> entries) {
+    @Override
+    public <R> Map<K, R> executeOnEntries(TypedEntryProcessor<K, V, R> entryProcessor) {
+        ClientMessage request = MapExecuteOnAllKeysCodec.encodeRequest(name, toData(entryProcessor));
+        ClientMessage response = invoke(request);
+        MapExecuteOnAllKeysCodec.ResponseParameters resultParameters = MapExecuteOnAllKeysCodec.decodeResponse(response);
+        return prepareResult(resultParameters.response);
+    }
+
+    protected <R> Map<K, R> prepareResult(Collection<Entry<Data, Data>> entries) {
         if (CollectionUtil.isEmpty(entries)) {
             return emptyMap();
         }
 
-        Map<K, Object> result = MapUtil.createHashMap(entries.size());
+        Map<K, R> result = MapUtil.createHashMap(entries.size());
         for (Entry<Data, Data> entry : entries) {
             K key = toObject(entry.getKey());
-            result.put(key, toObject(entry.getValue()));
+            result.put(key, this.<R>toObject(entry.getValue()));
         }
         return result;
     }
 
     @Override
     public Map<K, Object> executeOnEntries(EntryProcessor entryProcessor, Predicate predicate) {
+        ClientMessage request = MapExecuteWithPredicateCodec.encodeRequest(name, toData(entryProcessor), toData(predicate));
+        ClientMessage response = invoke(request);
+
+        MapExecuteWithPredicateCodec.ResponseParameters resultParameters = MapExecuteWithPredicateCodec.decodeResponse(response);
+        return prepareResult(resultParameters.response);
+    }
+
+    @Override
+    public <R> Map<K, R> executeOnEntries(TypedEntryProcessor<K, V, R> entryProcessor, Predicate<K, V> predicate) {
         ClientMessage request = MapExecuteWithPredicateCodec.encodeRequest(name, toData(entryProcessor), toData(predicate));
         ClientMessage response = invoke(request);
 
@@ -1476,6 +1515,20 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
     @Override
     public Map<K, Object> executeOnKeys(Set<K> keys, EntryProcessor entryProcessor) {
+        checkNotNull(keys, NULL_KEY_IS_NOT_ALLOWED);
+        if (keys.isEmpty()) {
+            return emptyMap();
+        }
+        Collection<Data> dataCollection = objectToDataCollection(keys, getSerializationService());
+
+        ClientMessage request = MapExecuteOnKeysCodec.encodeRequest(name, toData(entryProcessor), dataCollection);
+        ClientMessage response = invoke(request);
+        MapExecuteOnKeysCodec.ResponseParameters resultParameters = MapExecuteOnKeysCodec.decodeResponse(response);
+        return prepareResult(resultParameters.response);
+    }
+
+    @Override
+    public <R> Map<K, R> executeOnKeys(Set<K> keys, TypedEntryProcessor<K, V, R> entryProcessor) {
         checkNotNull(keys, NULL_KEY_IS_NOT_ALLOWED);
         if (keys.isEmpty()) {
             return emptyMap();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -362,15 +362,15 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    public Object executeOnKeyInternal(Data keyData, EntryProcessor entryProcessor) {
-        Object response = super.executeOnKeyInternal(keyData, entryProcessor);
+    public <R> R executeOnKeyInternal(Data keyData, EntryProcessor entryProcessor) {
+        R response = super.executeOnKeyInternal(keyData, entryProcessor);
         invalidateNearCache(keyData);
         return response;
     }
 
     @Override
-    public ICompletableFuture submitToKeyInternal(Data keyData, EntryProcessor entryProcessor) {
-        ICompletableFuture future = super.submitToKeyInternal(keyData, entryProcessor);
+    public <R> ICompletableFuture<R> submitToKeyInternal(Data keyData, EntryProcessor entryProcessor) {
+        ICompletableFuture<R> future = super.submitToKeyInternal(keyData, entryProcessor);
         invalidateNearCache(keyData);
         return future;
     }
@@ -382,18 +382,18 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected Map<K, Object> prepareResult(Collection<Entry<Data, Data>> entrySet) {
+    protected <R> Map<K, R> prepareResult(Collection<Entry<Data, Data>> entrySet) {
         if (CollectionUtil.isEmpty(entrySet)) {
             return emptyMap();
         }
 
-        Map<K, Object> result = MapUtil.createHashMap(entrySet.size());
+        Map<K, R> result = MapUtil.createHashMap(entrySet.size());
         for (Entry<Data, Data> entry : entrySet) {
             Data dataKey = entry.getKey();
             invalidateNearCache(dataKey);
 
             K key = toObject(dataKey);
-            Object value = toObject(entry.getValue());
+            R value = toObject(entry.getValue());
             result.put(key, value);
         }
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -21,6 +21,7 @@ import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.QueryCache;
 import com.hazelcast.map.QueryResultSizeExceededException;
+import com.hazelcast.map.TypedEntryProcessor;
 import com.hazelcast.map.impl.LegacyAsyncMap;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.map.listener.MapPartitionLostListener;
@@ -1555,6 +1556,16 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     Object executeOnKey(K key, EntryProcessor entryProcessor);
 
     /**
+     * Applies the user defined TypedEntryProcessor to the entry mapped by the key.
+     * Returns the result of the process() method of TypedEntryProcessor, an object of type R.
+     * <p/>
+     *
+     * @return result of entry process.
+     * @throws NullPointerException if the specified key is null
+     */
+    <R> R executeOnKey(K key, TypedEntryProcessor<K, V, R> entryProcessor);
+
+    /**
      * Applies the user defined EntryProcessor to the entries mapped by the collection of keys.
      * the results mapped by each key in the collection.
      * <p/>
@@ -1566,6 +1577,17 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     Map<K, Object> executeOnKeys(Set<K> keys, EntryProcessor entryProcessor);
 
     /**
+     * Applies the user defined TypedEntryProcessor to the entries mapped by the collection of keys.
+     * the results mapped by each key in the collection.
+     * <p/>
+     *
+     * @return result of entry process.
+     * @throws NullPointerException     if the specified key is null.
+     * @throws IllegalArgumentException if the specified keys set is empty
+     */
+    <R> Map<K, R> executeOnKeys(Set<K> keys, TypedEntryProcessor<K, V, R> entryProcessor);
+
+    /**
      * Applies the user defined EntryProcessor to the entry mapped by the key with
      * specified ExecutionCallback to listen event status and returns immediately.
      *
@@ -1574,6 +1596,16 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * @param callback       to listen whether operation is finished or not.
      */
     void submitToKey(K key, EntryProcessor entryProcessor, ExecutionCallback callback);
+
+    /**
+     * Applies the user defined TypedEntryProcessor to the entry mapped by the key with
+     * specified ExecutionCallback to listen event status and returns immediately.
+     *
+     * @param key            key to be processed.
+     * @param entryProcessor processor to process the key.
+     * @param callback       to listen whether operation is finished or not.
+     */
+    <R> void submitToKey(K key, TypedEntryProcessor<K, V, R> entryProcessor, ExecutionCallback<R> callback);
 
     /**
      * Applies the user defined EntryProcessor to the entry mapped by the key.
@@ -1590,6 +1622,20 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     ICompletableFuture submitToKey(K key, EntryProcessor entryProcessor);
 
     /**
+     * Applies the user defined TypedEntryProcessor to the entry mapped by the key.
+     * Returns immediately with a ICompletableFuture representing that task.
+     * <p/>
+     * EntryProcessor is not cancellable, so calling ICompletableFuture.cancel() method
+     * won't cancel the operation of EntryProcessor.
+     *
+     * @param key            key to be processed
+     * @param entryProcessor processor to process the key
+     * @return ICompletableFuture from which the result of the operation can be retrieved.
+     * @see ICompletableFuture
+     */
+    <R> ICompletableFuture<R> submitToKey(K key, TypedEntryProcessor<K, V, R> entryProcessor);
+
+    /**
      * Applies the user defined EntryProcessor to the all entries in the map.
      * Returns the results mapped by each key in the map.
      * <p/>
@@ -1597,11 +1643,25 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     Map<K, Object> executeOnEntries(EntryProcessor entryProcessor);
 
     /**
+     * Applies the user defined TypedEntryProcessor to the all entries in the map.
+     * Returns the results mapped by each key in the map.
+     * <p/>
+     */
+    <R> Map<K, R> executeOnEntries(TypedEntryProcessor<K, V, R> entryProcessor);
+
+    /**
      * Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
      * Returns the results mapped by each key in the map.
      * <p/>
      */
     Map<K, Object> executeOnEntries(EntryProcessor entryProcessor, Predicate predicate);
+
+    /**
+     * Applies the user defined TypedEntryProcessor to the entries in the map which satisfies provided predicate.
+     * Returns the results mapped by each key in the map.
+     * <p/>
+     */
+    <R> Map<K, R> executeOnEntries(TypedEntryProcessor<K, V, R> entryProcessor, Predicate<K, V> predicate);
 
     /**
      * Applies the aggregation logic on all map entries and returns the result

--- a/hazelcast/src/main/java/com/hazelcast/map/AbstractTypedEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/AbstractTypedEntryProcessor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+/**
+ * An {@link AbstractEntryProcessor} that also implements {@link TypedEntryProcessor}.
+ * Like its parent, this class delegates backup entry processing to itself,
+ * but also returns from entry processing objects of type R
+ * @param <K> Type of key of a {@link java.util.Map.Entry}
+ * @param <V> Type of value of a {@link java.util.Map.Entry}
+ * @param <R> Type of object returned by {@link #process(Map.Entry)}
+ * @see AbstractEntryProcessor
+ */
+public abstract class AbstractTypedEntryProcessor<K, V, R> extends AbstractEntryProcessor<K, V>
+    implements TypedEntryProcessor<K, V, R> {
+    //No implementation needed here; this abstract class
+    //Merely enhances AbstractEntryProcessor with TypedEntryProcessor
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/TypedEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/TypedEntryProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import java.util.Map;
+
+/**
+ * Extends {@link EntryProcessor} by allowing the object returned by
+ * its sole method to be of a generic type R. This allows implementations
+ * to return objects of a specific type from processing IMap entries
+ * without the need for casting.
+ * @param <K> Type of key of a {@link java.util.Map.Entry}
+ * @param <V> Type of value of a {@link java.util.Map.Entry}
+ * @param <R> Type of object returned by {@link #process(Map.Entry)}
+ * @see EntryProcessor
+ */
+public interface TypedEntryProcessor<K, V, R> extends EntryProcessor<K, V> {
+    R process(Map.Entry<K, V> entry);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -28,6 +28,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.QueryCache;
+import com.hazelcast.map.TypedEntryProcessor;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.SimpleEntryView;
 import com.hazelcast.map.impl.iterator.MapPartitionIterator;
@@ -703,6 +704,15 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public Object executeOnKey(K key, EntryProcessor entryProcessor) {
+        return executeWithTypeOnKey(key, entryProcessor);
+    }
+
+    @Override
+    public <R> R executeOnKey(K key, TypedEntryProcessor<K, V, R> entryProcessor) {
+        return executeWithTypeOnKey(key, entryProcessor);
+    }
+
+    private <R> R executeWithTypeOnKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         Data result = executeOnKeyInternal(toData(key, partitionStrategy), entryProcessor);
@@ -711,6 +721,15 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public Map<K, Object> executeOnKeys(Set<K> keys, EntryProcessor entryProcessor) {
+        return executeWithTypeOnKeys(keys, entryProcessor);
+    }
+
+    @Override
+    public <R> Map<K, R> executeOnKeys(Set<K> keys, TypedEntryProcessor<K, V, R> entryProcessor) {
+        return executeWithTypeOnKeys(keys, entryProcessor);
+    }
+
+    private <R> Map<K, R> executeWithTypeOnKeys(Set<K> keys, EntryProcessor entryProcessor) {
         if (keys == null || keys.contains(null)) {
             throw new NullPointerException(NULL_KEY_IS_NOT_ALLOWED);
         }
@@ -733,7 +752,21 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
     }
 
     @Override
+    public <R> void submitToKey(K key, TypedEntryProcessor<K, V, R> entryProcessor, ExecutionCallback<R> callback) {
+        submitToKey(key, (EntryProcessor<K, V>) entryProcessor, callback);
+    }
+
+    @Override
     public ICompletableFuture submitToKey(K key, EntryProcessor entryProcessor) {
+        return submitWithTypeToKey(key, entryProcessor);
+    }
+
+    @Override
+    public <R> ICompletableFuture<R> submitToKey(K key, TypedEntryProcessor<K, V, R> entryProcessor) {
+        return submitWithTypeToKey(key, entryProcessor);
+    }
+
+    private <R> ICompletableFuture<R> submitWithTypeToKey(K key, EntryProcessor entryProcessor) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
         MapService service = getService();
@@ -744,11 +777,25 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public Map<K, Object> executeOnEntries(EntryProcessor entryProcessor) {
-        return executeOnEntries(entryProcessor, TruePredicate.INSTANCE);
+        return executeWithTypeOnEntries(entryProcessor, TruePredicate.INSTANCE);
+    }
+
+    @Override
+    public <R> Map<K, R> executeOnEntries(TypedEntryProcessor<K, V, R> entryProcessor) {
+        return executeWithTypeOnEntries(entryProcessor, TruePredicate.INSTANCE);
     }
 
     @Override
     public Map<K, Object> executeOnEntries(EntryProcessor entryProcessor, Predicate predicate) {
+        return executeWithTypeOnEntries(entryProcessor, predicate);
+    }
+
+    @Override
+    public <R> Map<K, R> executeOnEntries(TypedEntryProcessor<K, V, R> entryProcessor, Predicate<K, V> predicate) {
+        return executeWithTypeOnEntries(entryProcessor, predicate);
+    }
+
+    private <R> Map<K, R> executeWithTypeOnEntries(EntryProcessor entryProcessor, Predicate predicate) {
         List<Data> result = new ArrayList<Data>();
 
         executeOnEntriesInternal(entryProcessor, predicate, result);
@@ -756,12 +803,12 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
             return emptyMap();
         }
 
-        Map<K, Object> resultingMap = MapUtil.createHashMap(result.size() / 2);
+        Map<K, R> resultingMap = MapUtil.createHashMap(result.size() / 2);
         for (int i = 0; i < result.size(); ) {
             Data key = result.get(i++);
             Data value = result.get(i++);
 
-            resultingMap.put((K) toObject(key), toObject(value));
+            resultingMap.put((K) toObject(key), (R) toObject(value));
 
         }
         return resultingMap;

--- a/hazelcast/src/test/java/com/hazelcast/map/TypedEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TypedEntryProcessorTest.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.EntryObject;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.PredicateBuilder;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.query.SampleObjects.Employee;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class TypedEntryProcessorTest extends HazelcastTestSupport {
+
+    @Test
+    public void testMapEntryProcessor() {
+        Config cfg = getConfig();
+        cfg.getMapConfig("default").setInMemoryFormat(InMemoryFormat.OBJECT);
+
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(cfg);
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(cfg);
+
+        String instance1Key = generateKeyOwnedBy(instance1);
+        String instance2Key = generateKeyOwnedBy(instance2);
+
+        IMap<String, Integer> map = instance1.getMap("testMapEntryProcessor");
+        map.put(instance1Key, 23);
+        map.put(instance2Key, 42);
+
+        TypedEntryProcessor<Integer, Integer, String> entryProcessor = new IncrementorTypedEntryProcessor();
+        assertEquals(24 + "", map.executeOnKey(instance1Key, entryProcessor));
+        assertEquals(43 + "", map.executeOnKey(instance2Key, entryProcessor));
+
+        assertEquals((Integer) 24, map.get(instance1Key));
+        assertEquals((Integer) 43, map.get(instance2Key));
+    }
+
+    @Test
+    public void testMapEntryProcessorCallback() throws Exception {
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        Config cfg = getConfig();
+        cfg.getMapConfig("default").setInMemoryFormat(InMemoryFormat.OBJECT);
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(cfg);
+        nodeFactory.newHazelcastInstance(cfg);
+
+        IMap<Integer, Integer> map = instance1.getMap("testMapEntryProcessor");
+        map.put(1, 1);
+
+        TypedEntryProcessor<Integer, Integer, String> entryProcessor = new IncrementorTypedEntryProcessor();
+        final AtomicInteger result = new AtomicInteger(0);
+        final CountDownLatch latch = new CountDownLatch(1);
+        map.submitToKey(1, entryProcessor, new ExecutionCallback<String>() {
+            @Override
+            public void onResponse(String response) {
+                result.set(Integer.parseInt(response));
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                latch.countDown();
+            }
+        });
+
+        latch.await(10, TimeUnit.SECONDS);
+        assertEquals(2, result.get());
+    }
+
+    @Test
+    public void testSubmitToKey() throws Exception {
+        HazelcastInstance instance1 = createHazelcastInstance(getConfig());
+
+        IMap<Integer, Integer> map = instance1.getMap("testMapEntryProcessor");
+        map.put(1, 1);
+
+        Future<String> future = map.submitToKey(1, new IncrementorTypedEntryProcessor());
+        assertEquals(2 + "", future.get());
+        assertEquals(2, (int) map.get(1));
+    }
+
+    @Test
+    public void testSubmitToNonExistentKey() throws Exception {
+        HazelcastInstance instance1 = createHazelcastInstance(getConfig());
+
+        IMap<Integer, Integer> map = instance1.getMap("testMapEntryProcessor");
+
+        Future<String> future = map.submitToKey(11, new IncrementorTypedEntryProcessor());
+        assertEquals(1 + "", future.get());
+        assertEquals(1, (int) map.get(11));
+    }
+
+    @Test
+    public void testSubmitToKeyWithCallback() throws Exception {
+        HazelcastInstance instance1 = createHazelcastInstance(getConfig());
+
+        IMap<Integer, Integer> map = instance1.getMap("testMapEntryProcessor");
+        map.put(1, 1);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        ExecutionCallback<String> executionCallback = new ExecutionCallback<String>() {
+            @Override
+            public void onResponse(String response) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+            }
+        };
+
+        map.submitToKey(1, new IncrementorTypedEntryProcessor(), executionCallback);
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(2, (int) map.get(1));
+    }
+
+    @Test
+    public void testNotExistingEntryProcessor() {
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        Config cfg = getConfig();
+        cfg.getMapConfig("default").setInMemoryFormat(InMemoryFormat.OBJECT);
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(cfg);
+        nodeFactory.newHazelcastInstance(cfg);
+
+        IMap<Integer, Integer> map = instance1.getMap("testMapEntryProcessor");
+
+        TypedEntryProcessor<Integer, Integer, String> entryProcessor = new IncrementorTypedEntryProcessor();
+        assertEquals(1 + "", map.executeOnKey(1, entryProcessor));
+        assertEquals((Integer) 1, map.get(1));
+    }
+
+    @Test
+    public void testExecuteOnKeys() {
+        Config config = getConfig();
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(config);
+
+        IMap<Integer, Integer> map = instance1.getMap("testMapMultipleEntryProcessor");
+        IMap<Integer, Integer> map2 = instance2.getMap("testMapMultipleEntryProcessor");
+        for (int i = 0; i < 10; i++) {
+            map.put(i, 0);
+        }
+
+        Set<Integer> keys = new HashSet<Integer>();
+        keys.add(1);
+        keys.add(4);
+        keys.add(7);
+        keys.add(9);
+
+        Map<Integer, String> resultMap = map2.executeOnKeys(keys, new IncrementorTypedEntryProcessor());
+        assertEquals(1 + "", resultMap.get(1));
+        assertEquals(1 + "", resultMap.get(4));
+        assertEquals(1 + "", resultMap.get(7));
+        assertEquals(1 + "", resultMap.get(9));
+        assertEquals(1, (int) map.get(1));
+        assertEquals(0, (int) map.get(2));
+        assertEquals(0, (int) map.get(3));
+        assertEquals(1, (int) map.get(4));
+        assertEquals(0, (int) map.get(5));
+        assertEquals(0, (int) map.get(6));
+        assertEquals(1, (int) map.get(7));
+        assertEquals(0, (int) map.get(8));
+        assertEquals(1, (int) map.get(9));
+    }
+
+    @Test
+    public void testMapEntryProcessorAllKeys() {
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        Config cfg = getConfig();
+        cfg.getMapConfig("default").setInMemoryFormat(InMemoryFormat.OBJECT);
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(cfg);
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(cfg);
+
+        try {
+            IMap<Integer, Integer> map = instance1.getMap("testMapEntryProcessor");
+            int size = 100;
+            for (int i = 0; i < size; i++) {
+                map.put(i, i);
+            }
+
+            TypedEntryProcessor<Integer, Integer, String> entryProcessor = new IncrementorTypedEntryProcessor();
+            Map<Integer, String> res = map.executeOnEntries(entryProcessor);
+            for (int i = 0; i < size; i++) {
+                assertEquals(map.get(i), (Object) (i + 1));
+            }
+            for (int i = 0; i < size; i++) {
+                assertEquals(map.get(i) + "", res.get(i));
+            }
+        } finally {
+            instance1.shutdown();
+            instance2.shutdown();
+        }
+    }
+
+    @Test
+    public void testMapEntryProcessorWithPredicate() {
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        Config cfg = getConfig();
+        cfg.getMapConfig("default").setInMemoryFormat(InMemoryFormat.OBJECT);
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(cfg);
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(cfg);
+
+        try {
+            IMap<Integer, Employee> map = instance1.getMap("testMapEntryProcessor");
+            int size = 10;
+            for (int i = 0; i < size; i++) {
+                map.put(i, new Employee(i, "", 0, false, 0D, SampleObjects.State.STATE1));
+            }
+
+            TypedEntryProcessor<Integer, Employee, SampleObjects.State> entryProcessor = new ChangeStateEntryProcessor();
+            EntryObject entryObject = new PredicateBuilder().getEntryObject();
+            @SuppressWarnings("unchecked")
+            Predicate<Integer, Employee> predicate = entryObject.get("id").lessThan(5);
+            Map<Integer, SampleObjects.State> res = map.executeOnEntries(entryProcessor, predicate);
+
+            for (int i = 0; i < 5; i++) {
+                assertEquals(SampleObjects.State.STATE2, map.get(i).getState());
+            }
+            for (int i = 5; i < size; i++) {
+                assertEquals(SampleObjects.State.STATE1, map.get(i).getState());
+            }
+            for (int i = 0; i < 5; i++) {
+                assertEquals(res.get(i), SampleObjects.State.STATE2);
+            }
+        } finally {
+            instance1.shutdown();
+            instance2.shutdown();
+        }
+    }
+
+    private static class IncrementorTypedEntryProcessor
+            extends AbstractTypedEntryProcessor<Integer, Integer, String> implements Serializable {
+
+        @Override
+        public String process(Map.Entry<Integer, Integer> entry) {
+            Integer value = entry.getValue();
+            if (value == null) {
+                value = 0;
+            }
+            if (value == -1) {
+                entry.setValue(null);
+                return null;
+            }
+            value++;
+            entry.setValue(value);
+            return value + "";
+        }
+    }
+
+    private static class ChangeStateEntryProcessor
+            extends AbstractTypedEntryProcessor<Integer, Employee, SampleObjects.State> {
+
+        @Override
+        public SampleObjects.State process(Map.Entry<Integer, Employee> entry) {
+            Employee value = entry.getValue();
+            value.setState(SampleObjects.State.STATE2);
+            entry.setValue(value);
+            return value.getState();
+        }
+    }
+}


### PR DESCRIPTION
* Declare a new interface - TypedEntryProcessor - that extends EntryProcessor, but allows us to return objects whose type is determined by a third generic param

* Provide overloaded equivalents of methods on IMap interface that have a EntryProcessor argument so that it specifically handles TypedEntryProcessor, declaring a generic return type bound to TypedEntryProcessor.

This allows us to retain binary compatibility with existing EntryProcessor implementations in the wild, while still giving users an option to have the means to get results from entry processing of a specific type without casting.

This PR attempts to address the second part of #7028