### PR TITLE
Introduces test for Serializable classes conventions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregator.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.aggregation;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.io.Serializable;
 
 /**
@@ -34,6 +36,7 @@ import java.io.Serializable;
  * @param <R> result type
  * @since 3.8
  */
+@BinaryInterface
 public abstract class Aggregator<I, R> implements Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -136,8 +136,9 @@ public final class CacheDataSerializerHook
     public static final short CACHE_ASSIGN_AND_GET_UUIDS = 52;
     public static final short CACHE_ASSIGN_AND_GET_UUIDS_FACTORY = 53;
     public static final short CACHE_NEAR_CACHE_STATE_HOLDER = 54;
+    public static final short CACHE_EVENT_LISTENER_ADAPTOR = 55;
 
-    private static final int LEN = CACHE_NEAR_CACHE_STATE_HOLDER + 1;
+    private static final int LEN = CACHE_EVENT_LISTENER_ADAPTOR + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -406,6 +407,11 @@ public final class CacheDataSerializerHook
         constructors[CACHE_NEAR_CACHE_STATE_HOLDER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new CacheNearCacheStateHolder();
+            }
+        };
+        constructors[CACHE_EVENT_LISTENER_ADAPTOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheEventListenerAdaptor();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListenerAdaptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventListenerAdaptor.java
@@ -19,12 +19,14 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.ListenerWrapperEventFilter;
 import com.hazelcast.spi.NotifiableEventListener;
 import com.hazelcast.spi.serialization.SerializationService;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.Factory;
@@ -36,7 +38,7 @@ import javax.cache.event.CacheEntryListener;
 import javax.cache.event.CacheEntryRemovedListener;
 import javax.cache.event.CacheEntryUpdatedListener;
 import javax.cache.event.EventType;
-import java.io.Serializable;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 
@@ -57,25 +59,27 @@ import java.util.HashSet;
  * @see javax.cache.event.CacheEntryExpiredListener
  * @see javax.cache.event.CacheEntryEventFilter
  */
-@SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID",
-        justification = "Class is Serializable, but doesn't define serialVersionUID")
 public class CacheEventListenerAdaptor<K, V>
         implements CacheEventListener,
                    CacheEntryListenerProvider<K, V>,
                    NotifiableEventListener<CacheService>,
                    ListenerWrapperEventFilter,
-                   Serializable {
+                   IdentifiedDataSerializable {
 
-    private final transient CacheEntryListener<K, V> cacheEntryListener;
-    private final transient CacheEntryCreatedListener cacheEntryCreatedListener;
-    private final transient CacheEntryRemovedListener cacheEntryRemovedListener;
-    private final transient CacheEntryUpdatedListener cacheEntryUpdatedListener;
-    private final transient CacheEntryExpiredListener cacheEntryExpiredListener;
-    private final transient CacheEntryEventFilter<? super K, ? super V> filter;
-    private final boolean isOldValueRequired;
+    // all fields are effectively final
+    private transient CacheEntryListener<K, V> cacheEntryListener;
+    private transient CacheEntryCreatedListener cacheEntryCreatedListener;
+    private transient CacheEntryRemovedListener cacheEntryRemovedListener;
+    private transient CacheEntryUpdatedListener cacheEntryUpdatedListener;
+    private transient CacheEntryExpiredListener cacheEntryExpiredListener;
+    private transient CacheEntryEventFilter<? super K, ? super V> filter;
+    private boolean isOldValueRequired;
 
     private transient SerializationService serializationService;
     private transient ICache<K, V> source;
+
+    public CacheEventListenerAdaptor() {
+    }
 
     public CacheEventListenerAdaptor(ICache<K, V> source,
                                      CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration,
@@ -242,4 +246,25 @@ public class CacheEventListenerAdaptor<K, V>
         return this;
     }
 
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.CACHE_EVENT_LISTENER_ADAPTOR;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out)
+            throws IOException {
+
+    }
+
+    @Override
+    public void readData(ObjectDataInput in)
+            throws IOException {
+
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsMXBeanImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheStatisticsMXBeanImpl.java
@@ -17,7 +17,6 @@
 package com.hazelcast.cache.impl;
 
 import javax.cache.management.CacheStatisticsMXBean;
-import java.io.Serializable;
 
 /**
  * Implementation of {@link javax.cache.management.CacheStatisticsMXBean}
@@ -26,12 +25,9 @@ import java.io.Serializable;
  *     into one by accessing each node's statistics through JMX.
  * </p>
  */
-public class CacheStatisticsMXBeanImpl
-        implements CacheStatisticsMXBean, Serializable {
+public class CacheStatisticsMXBeanImpl implements CacheStatisticsMXBean {
 
-    private static final long serialVersionUID = -1;
-
-    private transient CacheStatisticsImpl statistics;
+    private CacheStatisticsImpl statistics;
 
     public CacheStatisticsMXBeanImpl(CacheStatisticsImpl statistics) {
         this.statistics = statistics;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheAddEntryListenerMessageTask.java
@@ -34,9 +34,7 @@ import com.hazelcast.security.permission.CachePermission;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.ListenerWrapperEventFilter;
 import com.hazelcast.spi.NotifiableEventListener;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import java.io.Serializable;
 import java.security.Permission;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -71,16 +69,13 @@ public class CacheAddEntryListenerMessageTask
         return registrationId;
     }
 
-    @SuppressFBWarnings(value = "SE_NO_SERIALVERSIONID",
-            justification = "Class is Serializable, but doesn't define serialVersionUID")
     private static final class CacheEntryListener
             implements CacheEventListener,
             NotifiableEventListener<CacheService>,
-            ListenerWrapperEventFilter,
-            Serializable {
+            ListenerWrapperEventFilter {
 
-        private final transient ClientEndpoint endpoint;
-        private final transient CacheAddEntryListenerMessageTask cacheAddEntryListenerMessageTask;
+        private final ClientEndpoint endpoint;
+        private final CacheAddEntryListenerMessageTask cacheAddEntryListenerMessageTask;
 
         private CacheEntryListener(ClientEndpoint endpoint,
                                    CacheAddEntryListenerMessageTask cacheAddEntryListenerMessageTask) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.eviction;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.io.Serializable;
 import java.util.Comparator;
 
@@ -23,6 +25,7 @@ import java.util.Comparator;
  * A kind of {@link java.util.Comparator} to be used while comparing
  * entries to be evicted.
  */
+@BinaryInterface
 public abstract class EvictionPolicyComparator<K, V, E extends EvictableEntryView<K, V>>
         implements Comparator<E>, Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/projection/Projection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/Projection.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.projection;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.io.Serializable;
 
 /**
@@ -41,7 +43,7 @@ import java.io.Serializable;
  * @param <O> output type
  * @since 3.8
  */
-
+@BinaryInterface
 public abstract class Projection<I, O> implements Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
@@ -16,8 +16,11 @@
 
 package com.hazelcast.spi.discovery.multicast.impl;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.io.Serializable;
 
+@BinaryInterface
 public class MulticastMemberInfo implements Serializable {
 
     private String host;


### PR DESCRIPTION
Annotates `Serializable` classes in which serializable form changes may break compatibility with `@BinaryInterface`.
- `Aggregator` & `Projection` is used in client-member communication
- `EvictionPolicyComparator` is used in `CacheEvictionConfig` which is itself a @BinaryInterface
- `MulticastMemberInfo` is used in `MulticastDiscoveryStrategy`

Additionally:
- `CacheEventListenerAdaptor` converted to IdentifiedDataSerializable
- Removed `Serializable` from `CacheStatisticsMXBeanImpl`, its only field is marked transient and it's in an internal package. The only use case I see could be if registered with a remote MBeanServer, but this use case is already broken (`statistics` field is `transient` so the deserialized object would not return any values).
- `CacheEntryListener` should not implement `Serializable`, I don't see it not serialized/deserialized anywhere.

Fixes #8890 