### PR TITLE
Apply join mechanism fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -103,7 +103,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                 logger.fine("Joining over target member " + targetAddress);
             }
             if (targetAddress.equals(node.getThisAddress()) || isLocalAddress(targetAddress)) {
-                node.setAsMaster();
+                clusterJoinManager.setAsMaster();
                 return;
             }
             long joinStartTime = Clock.currentTimeMillis();
@@ -136,7 +136,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             boolean foundConnection = tryInitialConnection(possibleAddresses);
             if (!foundConnection) {
                 logger.fine("This node will assume master role since no possible member where connected to.");
-                node.setAsMaster();
+                clusterJoinManager.setAsMaster();
                 return;
             }
 
@@ -153,7 +153,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                 if (isAllBlacklisted(possibleAddresses)) {
                     logger.fine(
                             "This node will assume master role since none of the possible members accepted join request.");
-                    node.setAsMaster();
+                    clusterJoinManager.setAsMaster();
                     return;
                 }
 
@@ -167,7 +167,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                             logger.fine("Setting myself as master after consensus!"
                                     + " Voting endpoints: " + votingEndpoints);
                         }
-                        node.setAsMaster();
+                        clusterJoinManager.setAsMaster();
                         claimingMaster = false;
                         return;
                     }
@@ -314,7 +314,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             if (logger.isFineEnabled()) {
                 logger.fine("Setting myself as master! No possible addresses remaining to connect...");
             }
-            node.setAsMaster();
+            clusterJoinManager.setAsMaster();
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -35,6 +35,7 @@ import com.hazelcast.core.MembershipListener;
 import com.hazelcast.core.MigrationListener;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.ascii.TextCommandServiceImpl;
+import com.hazelcast.internal.cluster.impl.ClusterJoinManager;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ConfigCheck;
 import com.hazelcast.internal.cluster.impl.DiscoveryJoiner;
@@ -688,7 +689,8 @@ public class Node {
         }
         if (joiner == null) {
             logger.warning("No join method is enabled! Starting standalone.");
-            setAsMaster();
+            ClusterJoinManager clusterJoinManager = clusterService.getClusterJoinManager();
+            clusterJoinManager.setAsMaster();
             return;
         }
 
@@ -738,17 +740,6 @@ public class Node {
             }
         }
         return null;
-    }
-
-    public void setAsMaster() {
-        logger.finest("This node is being set as the master");
-        masterAddress = address;
-        if (getClusterService().getClusterVersion() == null) {
-            getClusterService().getClusterStateManager().setClusterVersion(version.asClusterVersion());
-        }
-        setJoined();
-        getClusterService().getClusterClock().setClusterStartTime(Clock.currentTimeMillis());
-        getClusterService().setClusterId(UuidUtil.createClusterUuid());
     }
 
     public String getThisUuid() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -163,7 +163,7 @@ public abstract class AbstractJoiner implements Joiner {
         }
         if (tryCount.incrementAndGet() == JOIN_TRY_COUNT) {
             logger.warning("Join try count exceed limit, setting this node as master!");
-            node.setAsMaster();
+            clusterJoinManager.setAsMaster();
         }
 
         if (node.joined()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -24,7 +24,6 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.operations.AuthenticationFailureOperation;
 import com.hazelcast.internal.cluster.impl.operations.BeforeJoinCheckFailureOperation;
-import com.hazelcast.internal.cluster.impl.operations.SendExcludedMemberUuidsOperation;
 import com.hazelcast.internal.cluster.impl.operations.ConfigMismatchOperation;
 import com.hazelcast.internal.cluster.impl.operations.FinalizeJoinOperation;
 import com.hazelcast.internal.cluster.impl.operations.GroupMismatchOperation;
@@ -32,6 +31,7 @@ import com.hazelcast.internal.cluster.impl.operations.JoinRequestOperation;
 import com.hazelcast.internal.cluster.impl.operations.MasterDiscoveryOperation;
 import com.hazelcast.internal.cluster.impl.operations.MemberInfoUpdateOperation;
 import com.hazelcast.internal.cluster.impl.operations.PostJoinOperation;
+import com.hazelcast.internal.cluster.impl.operations.SendExcludedMemberUuidsOperation;
 import com.hazelcast.internal.cluster.impl.operations.SetMasterOperation;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
@@ -46,6 +46,8 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.FutureUtil;
+import com.hazelcast.util.UuidUtil;
+import com.hazelcast.version.MemberVersion;
 
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
@@ -76,6 +78,7 @@ import static java.lang.String.format;
  * If this is master node, it will handle join request and notify all other members
  * about newly joined member.
  */
+@SuppressWarnings("checkstyle:classfanoutcomplexity")
 public class ClusterJoinManager {
 
     private static final int CLUSTER_OPERATION_RETRY_COUNT = 100;
@@ -455,12 +458,57 @@ public class ClusterJoinManager {
                 logger.fine(format("Ignoring master response %s from %s, this node is already master",
                         masterAddress, callerAddress));
             } else {
-                node.setAsMaster();
+                setAsMaster();
             }
             return;
         }
 
         handleMasterResponse(masterAddress, callerAddress);
+    }
+
+    public boolean setMasterAddress(final Address master) {
+        clusterServiceLock.lock();
+        try {
+            if (node.joined()) {
+                logger.warning("Cannot set master address to " + master
+                        + " because node is already joined! Current master address: " + node.getMasterAddress());
+                return false;
+            }
+
+            node.setMasterAddress(master);
+            return true;
+        } finally {
+            clusterServiceLock.unlock();
+        }
+    }
+
+    public boolean setAsMaster() {
+        clusterServiceLock.lock();
+        try {
+            if (node.joined()) {
+                logger.warning("Cannot set as master because node is already joined!");
+                return false;
+            }
+
+            logger.finest("This node is being set as the master");
+            Address thisAddress = node.getThisAddress();
+            MemberVersion version = node.getVersion();
+
+            node.setMasterAddress(thisAddress);
+
+            if (clusterService.getClusterVersion() == null) {
+                clusterService.getClusterStateManager().setClusterVersion(version.asClusterVersion());
+            }
+
+            clusterService.getClusterClock().setClusterStartTime(Clock.currentTimeMillis());
+            clusterService.setClusterId(UuidUtil.createClusterUuid());
+            node.setJoined();
+
+            return true;
+        } finally {
+            clusterServiceLock.unlock();
+        }
+
     }
 
     private void handleMasterResponse(Address masterAddress, Address callerAddress) {
@@ -490,7 +538,7 @@ public class ClusterJoinManager {
                 logger.warning(format("Ambiguous master response: This node has a master %s, but does not have a connection"
                                 + " to %s. Sent master response as %s. Master field will be unset now...",
                         currentMaster, callerAddress, masterAddress));
-                node.setMasterAddress(null);
+                setMasterAddress(null);
             }
         } finally {
             clusterServiceLock.unlock();
@@ -498,7 +546,7 @@ public class ClusterJoinManager {
     }
 
     private void setMasterAndJoin(Address masterAddress) {
-        node.setMasterAddress(masterAddress);
+        setMasterAddress(masterAddress);
         node.connectionManager.getOrConnect(masterAddress);
         if (!sendJoinRequest(masterAddress, true)) {
             logger.warning("Could not create connection to possible master " + masterAddress);
@@ -660,7 +708,7 @@ public class ClusterJoinManager {
                 boolean createPostJoinOperation = (postJoinOps != null && postJoinOps.length > 0);
                 PostJoinOperation postJoinOp = (createPostJoinOperation ? new PostJoinOperation(postJoinOps) : null);
 
-                clusterService.updateMembers(memberInfos);
+                clusterService.updateMembers(memberInfos, node.getThisAddress());
 
                 int count = members.size() - 1 + joiningMembers.size();
                 List<Future> calls = new ArrayList<Future>(count);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -345,47 +345,103 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         return memberInfos;
     }
 
-    public void updateMembers(Collection<MemberInfo> members) {
+    public boolean finalizeJoin(Collection<MemberInfo> members, Address callerAddress, String clusterId,
+                                ClusterState clusterState, ClusterVersion clusterVersion,
+                                long clusterStartTime, long masterTime) {
         lock.lock();
         try {
-            MemberMap currentMemberMap = memberMapRef.get();
-
-            if (!shouldProcessMemberUpdate(currentMemberMap, members)) {
-                return;
-            }
-
-            String scopeId = thisAddress.getScopeId();
-            Collection<MemberImpl> newMembers = new LinkedList<MemberImpl>();
-            MemberImpl[] updatedMembers = new MemberImpl[members.size()];
-            int memberIndex = 0;
-            for (MemberInfo memberInfo : members) {
-                Address address = memberInfo.getAddress();
-                MemberImpl member = currentMemberMap.getMember(address);
-                if (member == null) {
-                    member = createMember(memberInfo, scopeId);
-                    newMembers.add(member);
-                    long now = clusterClock.getClusterTime();
-                    clusterHeartbeatManager.onHeartbeat(member, now);
-                    clusterHeartbeatManager.acceptMasterConfirmation(member, now);
-
-                    repairPartitionTableIfReturningMember(member);
-
+            if (!checkValidMaster(callerAddress)) {
+                if (logger.isFineEnabled()) {
+                    logger.fine("Not finalizing join because caller: " + callerAddress + " is not known master: "
+                            + getMasterAddress());
                 }
-                updatedMembers[memberIndex++] = member;
+                return false;
             }
 
-            setMembers(updatedMembers);
-            sendMembershipEvents(currentMemberMap.getMembers(), newMembers);
+            if (node.joined()) {
+                if (logger.isFineEnabled()) {
+                    logger.fine("Node is already joined... No need to finalize join...");
+                }
 
-            MemberMap membersRemovedInNotActiveState = membersRemovedInNotActiveStateRef.get();
-            membersRemovedInNotActiveStateRef.set(MemberMap.cloneExcluding(membersRemovedInNotActiveState, updatedMembers));
+                return false;
+            }
+
+            initialClusterState(clusterState, clusterVersion);
+            setClusterId(clusterId);
+            ClusterClockImpl clusterClock = getClusterClock();
+            clusterClock.setClusterStartTime(clusterStartTime);
+            clusterClock.setMasterTime(masterTime);
+            doUpdateMembers(members);
+            clusterHeartbeatManager.heartbeat();
 
             node.setJoined();
-            clusterHeartbeatManager.heartbeat();
-            logger.info(membersString());
+
+            return true;
         } finally {
             lock.unlock();
         }
+    }
+
+    public boolean updateMembers(Collection<MemberInfo> members, Address callerAddress) {
+        lock.lock();
+        try {
+            if (!checkValidMaster(callerAddress)) {
+                logger.warning("Not updating members because caller: " + callerAddress  + " is not known master: "
+                        + getMasterAddress());
+                return false;
+            }
+
+            if (!node.joined()) {
+                logger.warning("Not updating members received from caller: " + callerAddress +  " because node is not joined! ");
+                return false;
+            }
+
+            if (!shouldProcessMemberUpdate(memberMapRef.get(), members)) {
+                return false;
+            }
+
+            doUpdateMembers(members);
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean checkValidMaster(Address callerAddress) {
+        return  (callerAddress != null && callerAddress.equals(getMasterAddress()));
+    }
+
+    private void doUpdateMembers(Collection<MemberInfo> members) {
+        MemberMap currentMemberMap = memberMapRef.get();
+
+        String scopeId = thisAddress.getScopeId();
+        Collection<MemberImpl> newMembers = new LinkedList<MemberImpl>();
+        MemberImpl[] updatedMembers = new MemberImpl[members.size()];
+        int memberIndex = 0;
+        for (MemberInfo memberInfo : members) {
+            Address address = memberInfo.getAddress();
+            MemberImpl member = currentMemberMap.getMember(address);
+            if (member == null) {
+                member = createMember(memberInfo, scopeId);
+                newMembers.add(member);
+                long now = clusterClock.getClusterTime();
+                clusterHeartbeatManager.onHeartbeat(member, now);
+                clusterHeartbeatManager.acceptMasterConfirmation(member, now);
+
+                repairPartitionTableIfReturningMember(member);
+
+            }
+            updatedMembers[memberIndex++] = member;
+        }
+
+        setMembers(updatedMembers);
+        sendMembershipEvents(currentMemberMap.getMembers(), newMembers);
+
+        MemberMap membersRemovedInNotActiveState = membersRemovedInNotActiveStateRef.get();
+        membersRemovedInNotActiveStateRef.set(MemberMap.cloneExcluding(membersRemovedInNotActiveState, updatedMembers));
+
+        clusterHeartbeatManager.heartbeat();
+        logger.info(membersString());
     }
 
     private void repairPartitionTableIfReturningMember(MemberImpl member) {
@@ -508,7 +564,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         if (!node.joined()) {
             Address masterAddress = node.getMasterAddress();
             if (masterAddress != null && masterAddress.equals(connection.getEndPoint())) {
-                node.setMasterAddress(null);
+                clusterJoinManager.setMasterAddress(null);
             }
         }
     }
@@ -993,7 +1049,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         hazelcastInstance.getLifecycleService().shutdown();
     }
 
-    public void initialClusterState(ClusterState clusterState, ClusterVersion version) {
+    void initialClusterState(ClusterState clusterState, ClusterVersion version) {
         if (node.joined()) {
             throw new IllegalStateException("Cannot set initial state after node joined! -> " + clusterState);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -59,16 +59,16 @@ public class MulticastJoiner extends AbstractJoiner {
         while (shouldRetry() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
 
             // clear master node
-            node.setMasterAddress(null);
+            clusterJoinManager.setMasterAddress(null);
 
             Address masterAddress = getTargetAddress();
             if (masterAddress == null) {
                 masterAddress = findMasterWithMulticast();
             }
-            node.setMasterAddress(masterAddress);
+            clusterJoinManager.setMasterAddress(masterAddress);
 
             if (masterAddress == null || thisAddress.equals(masterAddress)) {
-                node.setAsMaster();
+                clusterJoinManager.setAsMaster();
                 return;
             }
 
@@ -100,7 +100,7 @@ public class MulticastJoiner extends AbstractJoiner {
             }
 
             if (isBlacklisted(master)) {
-                node.setMasterAddress(null);
+                clusterJoinManager.setMasterAddress(null);
                 return;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -101,9 +101,10 @@ public class NodeMulticastListener implements MulticastListener {
             if (!node.joined() && node.getMasterAddress() == null) {
                 String masterHost = joinMessage.getAddress().getHost();
                 if (trustedInterfaces.isEmpty() || matchAnyInterface(masterHost, trustedInterfaces)) {
+                    ClusterJoinManager clusterJoinManager = node.getClusterService().getClusterJoinManager();
                     //todo: why are we making a copy here of address?
                     Address masterAddress = new Address(joinMessage.getAddress());
-                    node.setMasterAddress(masterAddress);
+                    clusterJoinManager.setMasterAddress(masterAddress);
                 } else {
                     logJoinMessageDropped(masterHost);
                 }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
@@ -169,7 +169,7 @@ public class MemberListTest {
         members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
         members.add(new MemberInfo(m3.getAddress(), m3.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
         members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
-        n2.clusterService.updateMembers(members);
+        n2.clusterService.updateMembers(members, n2.getMasterAddress());
         n2.setMasterAddress(m2.getAddress());
 
         // Give the cluster some time to figure things out. The merge and heartbeat code should have kicked in by this point
@@ -212,7 +212,7 @@ public class MemberListTest {
         List<MemberInfo> members = new ArrayList<MemberInfo>();
         members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
         members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections.<String, Object>emptyMap(), n2.getVersion()));
-        n2.clusterService.updateMembers(members);
+        n2.clusterService.updateMembers(members, n2.getMasterAddress());
 
         // Give the cluster some time to figure things out. The merge and heartbeat code should have kicked in by this point
         sleepSeconds(30);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -19,7 +19,6 @@ package com.hazelcast.test.mocknetwork;
 
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.AbstractJoiner;
-import com.hazelcast.internal.cluster.impl.ClusterJoinManager;
 import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
@@ -42,7 +41,6 @@ class MockJoiner extends AbstractJoiner {
     public void doJoin() {
         registry.registerNode(node);
 
-        ClusterJoinManager clusterJoinManager = node.clusterService.getClusterJoinManager();
         final long joinStartTime = Clock.currentTimeMillis();
         final long maxJoinMillis = getMaxJoinMillis();
 
@@ -60,21 +58,21 @@ class MockJoiner extends AbstractJoiner {
 
                 if (node.getThisAddress().equals(joinAddress)) {
                     logger.fine("This node is found as master, no need to join.");
-                    node.setAsMaster();
+                    clusterJoinManager.setAsMaster();
                     break;
                 }
 
                 logger.fine("Sending join request to " + joinAddress);
                 if (!clusterJoinManager.sendJoinRequest(joinAddress, true)) {
                     logger.fine("Could not send join request to " + joinAddress);
-                    node.setMasterAddress(null);
+                    clusterJoinManager.setMasterAddress(null);
                 }
 
                 if (Clock.currentTimeMillis() > joinAddressTimeout) {
                     logger.warning("Resetting master address because join address timeout");
                     previousJoinAddress = null;
                     joinAddressTimeout = 0;
-                    node.setMasterAddress(null);
+                    clusterJoinManager.setMasterAddress(null);
                 }
             }
             try {


### PR DESCRIPTION
* Update joined flag and master address within cluster service lock so that master address cannot be reset in racy cases after the node is already joined.
* Verify master address within cluster service lock to eliminate races when there are in-flight member list update operations and master change.