### PR TITLE
Fixing timing issues AbstractListenersOnReconnectTest and clean up

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTe
     private IMap iMap;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         iMap = client.getMap(randomString());
         final EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {
             public void onEntryEvent(EntryEvent<Object, Object> event) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnec
     private IList iList;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         iList = client.getList(randomString());
         ItemListener listener = new ItemListener() {
             @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
@@ -9,8 +9,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -18,7 +16,7 @@ public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnRec
     private MultiMap multiMap;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         multiMap = client.getMultiMap(randomString());
         final EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {
             public void onEntryEvent(EntryEvent<Object, Object> event) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconne
     private IQueue iQueue;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         iQueue = client.getQueue(randomString());
         ItemListener listener = new ItemListener() {
             @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
     private ReplicatedMap replicatedMap;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         replicatedMap = client.getReplicatedMap(randomString());
         final EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {
             public void onEntryEvent(EntryEvent<Object, Object> event) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class SetItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class SetItemListenerOnReconnectTest extends AbstractListenersOnReconnect
     private ISet iSet;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         iSet = client.getSet(randomString());
         ItemListener listener = new ItemListener() {
             @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
@@ -9,8 +9,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class TopicOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -18,7 +16,7 @@ public class TopicOnReconnectTest extends AbstractListenersOnReconnectTest {
     private ITopic topic;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         topic = client.getTopic(randomString());
         MessageListener listener = new MessageListener() {
             @Override


### PR DESCRIPTION
Remove ignore from testClusterReconnectDueToHeartbeatNonSmartRouting
This test failure caused by a timing problem. Test not fails because
of listeners but not able to connect to cluster in time after heartbeat
problem.

All latch usages changed to use assertOpenEventually

sleep in testListenersTerminateRandomNodeInternal is removed.
Justification: since validation is done by assertTrueEventually, there is no need to sleep.

Tests using same internal method is grouped so that it easy to follow.

testListenersTerminateRandomNodeInternal tests were with single node,
changed them so that they open 3 nodes.
Justification: Terminating random node when there is only one node was not making any sense

Some renamings to make it more clear what is going on in the test.
testListenersInternal -> testListenersTerminateOwnerNode
testListenersForHeartbeat -> testListenersHeartbeatTimeoutToOwner

fixes #9280
fixes #9224
fixes #9276
fixes #8244
fixes #9488

backport of https://github.com/hazelcast/hazelcast/pull/9539