### PR TITLE
Fixing timing issues AbstractListenersOnReconnectTest and clean up

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -34,13 +34,11 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.test.AssertTask;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.client.spi.properties.ClientProperty.HEARTBEAT_TIMEOUT;
@@ -50,6 +48,10 @@ import static org.junit.Assert.assertTrue;
 public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport {
 
     protected HazelcastInstance client;
+    protected AtomicInteger eventCount;
+    private String registrationId;
+    private int clusterSize;
+
     private static final int EVENT_COUNT = 10;
 
     private static final int ENDPOINT_REMOVE_DELAY_MILLISECONDS = ClientEngineImpl.ENDPOINT_REMOVE_DELAY_SECONDS * 1000;
@@ -61,52 +63,25 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
         factory.terminateAll();
     }
 
-    private void testListenersInternal()
-            throws InterruptedException {
-        final int clusterSize = factory.getAllHazelcastInstances().size();
-        assertClusterSizeEventually(clusterSize, client);
-
-        final AtomicInteger eventCount = new AtomicInteger();
-        final String registrationId = addListener(eventCount);
-
-        final CountDownLatch disconnectedLatch = new CountDownLatch(1);
-        final CountDownLatch connectedLatch = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
-                    disconnectedLatch.countDown();
-                }
-                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
-                    connectedLatch.countDown();
-                }
-            }
-        });
-
-        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
-        HazelcastInstance server = getOwnerServer(factory,  clientInstanceImpl);
-        server.getLifecycleService().terminate();
-
-        factory.newHazelcastInstance();
-        assertClusterSizeEventually(clusterSize, client);
-
-        assertTrue(disconnectedLatch.await(30, TimeUnit.SECONDS));
-        assertTrue(connectedLatch.await(30, TimeUnit.SECONDS));
-
-        validateRegistrations(clusterSize, registrationId, clientInstanceImpl);
-
-        validateListenerFunctionality(eventCount);
-
-        assertTrue(removeListener(registrationId));
+    //-------------------------- testListenersTerminateRandomNode --------------------- //
+    @Test
+    public void testListenersNonSmartRoutingTerminateRandomNode() {
+        factory.newInstances(null, 3);
+        ClientConfig clientConfig = getNonSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+        testListenersTerminateRandomNode();
     }
 
-    private void testListenersTerminateRandomNodeInternal()
-            throws InterruptedException {
-        final int clusterSize = factory.getAllHazelcastInstances().size();
-        assertClusterSizeEventually(clusterSize, client);
+    @Test
+    public void testListenersSmartRoutingTerminateRandomNode() {
+        factory.newInstances(null, 3);
+        ClientConfig clientConfig = getSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+        testListenersTerminateRandomNode();
+    }
 
-        final AtomicInteger eventCount = new AtomicInteger();
-        final String registrationId = addListener(eventCount);
+    private void testListenersTerminateRandomNode() {
+        setupListener();
 
         terminateRandomNode();
 
@@ -129,20 +104,286 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
         factory.newHazelcastInstance();
 
-        assertTrue(memberAddedLatch.await(20, TimeUnit.SECONDS));
+        assertOpenEventually(memberAddedLatch);
+        validateRegistrationsAndListenerFunctionality();
+    }
 
+    //-------------------------- testListenersWaitMemberDestroy --------------------- //
+
+    @Test
+    public void testListenersWaitMemberDestroySmartRouting() {
+        factory.newInstances(null, 3);
+
+        ClientConfig clientConfig = getSmartClientConfig();
+        clientConfig
+                .setProperty(ClientProperty.HEARTBEAT_TIMEOUT.getName(), String.valueOf(2 * ENDPOINT_REMOVE_DELAY_MILLISECONDS));
+        client = factory.newHazelcastClient(clientConfig);
+        testListenersWaitMemberDestroy();
+    }
+
+    private void testListenersWaitMemberDestroy() {
+        setupListener();
+
+        Collection<HazelcastInstance> allHazelcastInstances = factory.getAllHazelcastInstances();
+
+        final CountDownLatch disconnectedLatch = new CountDownLatch(1);
+        final CountDownLatch connectedLatch = new CountDownLatch(1);
+        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
+                    disconnectedLatch.countDown();
+                }
+                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
+                    connectedLatch.countDown();
+                }
+            }
+        });
+
+        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
+        HazelcastInstance ownerMember = getOwnerServer(factory, clientInstanceImpl);
+        for (HazelcastInstance member : allHazelcastInstances) {
+            blockMessagesFromInstance(member, client);
+        }
+
+        ownerMember.getLifecycleService().terminate();
+
+        for (HazelcastInstance member : allHazelcastInstances) {
+            unblockMessagesFromInstance(member, client);
+        }
+
+        assertOpenEventually(disconnectedLatch);
+        assertOpenEventually(connectedLatch);
+
+        sleepAtLeastMillis(ENDPOINT_REMOVE_DELAY_MILLISECONDS + 2000);
+        clusterSize = clusterSize - 1;
+        validateRegistrationsAndListenerFunctionality();
+    }
+
+    //-------------------------- testListenersTemporaryNetworkBlockage --------------------- //
+
+    @Test
+    public void testTemporaryBlockedNoDisconnectionSmartRouting() {
+        factory.newHazelcastInstance();
+
+        ClientConfig clientConfig = getSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+
+        testListenersTemporaryNetworkBlockage();
+    }
+
+    @Test
+    public void testTemporaryBlockedNoDisconnectionNonSmartRouting() {
+        factory.newHazelcastInstance();
+
+        ClientConfig clientConfig = getNonSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+
+        testListenersTemporaryNetworkBlockage();
+    }
+
+    @Test
+    public void testTemporaryBlockedNoDisconnectionMultipleServerSmartRouting() {
+        factory.newInstances(null, 3);
+
+        ClientConfig clientConfig = getSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+
+        testListenersTemporaryNetworkBlockage();
+    }
+
+    @Test
+    public void testTemporaryBlockedNoDisconnectionMultipleServerNonSmartRouting() {
+        factory.newInstances(null, 3);
+
+        ClientConfig clientConfig = getNonSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+
+        testListenersTemporaryNetworkBlockage();
+    }
+
+    private void testListenersTemporaryNetworkBlockage() {
+        setupListener();
+
+        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
+        HazelcastInstance server = getOwnerServer(factory, clientInstanceImpl);
+
+
+        long timeout = clientInstanceImpl.getProperties().getMillis(HEARTBEAT_TIMEOUT);
+        long heartbeatTimeout = timeout > 0 ? timeout : Integer.parseInt(HEARTBEAT_TIMEOUT.getDefaultValue());
+        long waitTime = heartbeatTimeout / 2;
+
+        long endTime = System.currentTimeMillis() + waitTime;
+        blockMessagesFromInstance(server, client);
+        long sleepTime = endTime - System.currentTimeMillis();
+
+        if (sleepTime > 0) {
+            sleepMillis((int) sleepTime);
+        }
+
+        unblockMessagesFromInstance(server, client);
+
+        validateRegistrationsAndListenerFunctionality();
+    }
+
+    //-------------------------- testListenersHeartbeatTimeoutToOwner --------------------- //
+
+    @Test
+    public void testClusterReconnectDueToHeartbeatSmartRouting() {
+        factory.newHazelcastInstance();
+
+        ClientConfig clientConfig = getSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+
+        testListenersHeartbeatTimeoutToOwner();
+    }
+
+    @Test
+    public void testClusterReconnectMultipleServersDueToHeartbeatSmartRouting() {
+        factory.newInstances(null, 3);
+
+        ClientConfig clientConfig = getSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+
+        testListenersHeartbeatTimeoutToOwner();
+    }
+
+    @Test
+    public void testClusterReconnectDueToHeartbeatNonSmartRouting() {
+        factory.newHazelcastInstance();
+
+        ClientConfig clientConfig = getNonSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+
+        testListenersHeartbeatTimeoutToOwner();
+    }
+
+    @Test
+    public void testClusterReconnectMultipleServerDueToHeartbeatNonSmartRouting() {
+        factory.newInstances(null, 3);
+
+        ClientConfig clientConfig = getNonSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+
+        testListenersHeartbeatTimeoutToOwner();
+    }
+
+    private void testListenersHeartbeatTimeoutToOwner() {
+        setupListener();
+
+        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
+        HazelcastInstance server = getOwnerServer(factory, clientInstanceImpl);
+
+
+        final CountDownLatch disconnectedLatch = new CountDownLatch(1);
+        final CountDownLatch connectedLatch = new CountDownLatch(1);
+        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
+                    disconnectedLatch.countDown();
+                }
+                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
+                    connectedLatch.countDown();
+                }
+            }
+        });
+
+        blockMessagesFromInstance(server, client);
+        assertOpenEventually(disconnectedLatch);
+
+        unblockMessagesFromInstance(server, client);
+        assertOpenEventually(connectedLatch);
+
+        validateRegistrationsAndListenerFunctionality();
+    }
+
+
+    //-------------------------- testListenersTerminateOwnerNode --------------------- //
+
+    @Test
+    public void testListenersSmartRoutingMultipleServer() {
+        factory.newInstances(null, 3);
+
+        ClientConfig clientConfig = getSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+        testListenersTerminateOwnerNode();
+    }
+
+    @Test
+    public void testListenersNonSmartRoutingMultipleServer() {
+        factory.newInstances(null, 3);
+
+        ClientConfig clientConfig = getNonSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+        testListenersTerminateOwnerNode();
+    }
+
+    @Test
+    public void testListenersSmartRouting() {
+        factory.newHazelcastInstance();
+
+        ClientConfig clientConfig = getSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+        testListenersTerminateOwnerNode();
+    }
+
+    @Test
+    public void testListenersNonSmartRouting() {
+        factory.newHazelcastInstance();
+
+        ClientConfig clientConfig = getNonSmartClientConfig();
+        client = factory.newHazelcastClient(clientConfig);
+
+        testListenersTerminateOwnerNode();
+    }
+
+    private void testListenersTerminateOwnerNode() {
+        setupListener();
+
+        final CountDownLatch disconnectedLatch = new CountDownLatch(1);
+        final CountDownLatch connectedLatch = new CountDownLatch(1);
+        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
+                    disconnectedLatch.countDown();
+                }
+                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
+                    connectedLatch.countDown();
+                }
+            }
+        });
+
+        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
+        HazelcastInstance server = getOwnerServer(factory, clientInstanceImpl);
+        server.getLifecycleService().terminate();
+
+        factory.newHazelcastInstance();
         assertClusterSizeEventually(clusterSize, client);
 
-        // Since the connection may be disconnected from non-owner member, we need to wait enough time for any listener
-        // registration to the new member to be completed.
-        sleepSeconds(2);
+        assertOpenEventually(disconnectedLatch);
+        assertOpenEventually(connectedLatch);
 
+        validateRegistrationsAndListenerFunctionality();
+    }
+
+    //-------------------------- utility anc validation methods --------------------- //
+
+    private void setupListener() {
+        clusterSize = factory.getAllHazelcastInstances().size();
+        assertClusterSizeEventually(clusterSize, client);
+        eventCount = new AtomicInteger();
+        registrationId = addListener();
+    }
+
+    private void validateRegistrationsAndListenerFunctionality() {
+        assertClusterSizeEventually(clusterSize, client);
         validateRegistrations(clusterSize, registrationId, getHazelcastClientInstanceImpl(client));
-
-        validateListenerFunctionality(eventCount);
-
+        validateListenerFunctionality();
         assertTrue(removeListener(registrationId));
     }
+
 
     private void validateRegistrations(final int clusterSize, final String registrationId,
                                        final HazelcastClientInstanceImpl clientInstanceImpl) {
@@ -171,260 +412,7 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
         });
     }
 
-    private void testListenersWaitMemberDestroy()
-            throws InterruptedException {
-        Collection<HazelcastInstance> allHazelcastInstances = factory.getAllHazelcastInstances();
-        final int clusterSize = allHazelcastInstances.size();
-        assertClusterSizeEventually(clusterSize, client);
-
-        final AtomicInteger eventCount = new AtomicInteger();
-        final String registrationId = addListener(eventCount);
-
-        final CountDownLatch disconnectedLatch = new CountDownLatch(1);
-        final CountDownLatch connectedLatch = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
-                    disconnectedLatch.countDown();
-                }
-                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED== event.getState()) {
-                    connectedLatch.countDown();
-                }
-            }
-        });
-
-        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
-        HazelcastInstance ownerMember = getOwnerServer(factory,  clientInstanceImpl);
-        for (HazelcastInstance member : allHazelcastInstances) {
-            blockMessagesFromInstance(member, client);
-        }
-
-        ownerMember.getLifecycleService().terminate();
-
-        for (HazelcastInstance member : allHazelcastInstances) {
-            unblockMessagesFromInstance(member, client);
-        }
-
-        assertTrue(disconnectedLatch.await(30, TimeUnit.SECONDS));
-        assertTrue(connectedLatch.await(30, TimeUnit.SECONDS));
-
-        sleepAtLeastMillis(ENDPOINT_REMOVE_DELAY_MILLISECONDS + 2000);
-
-        validateRegistrations(clusterSize - 1, registrationId, clientInstanceImpl);
-
-        validateListenerFunctionality(eventCount);
-
-        assertTrue(removeListener(registrationId));
-    }
-
-    private void testListenersForHeartbeat()
-            throws InterruptedException {
-        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
-
-        HazelcastInstance server = getOwnerServer(factory,  clientInstanceImpl);
-
-        final int clusterSize = factory.getAllHazelcastInstances().size();
-        assertClusterSizeEventually(clusterSize, client);
-
-        final AtomicInteger eventCount = new AtomicInteger();
-        final String registrationId = addListener(eventCount);
-
-        final CountDownLatch disconnectedLatch = new CountDownLatch(1);
-        final CountDownLatch connectedLatch = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
-                    disconnectedLatch.countDown();
-                }
-                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED== event.getState()) {
-                    connectedLatch.countDown();
-                }
-            }
-        });
-
-        long timeout = clientInstanceImpl.getProperties().getMillis(HEARTBEAT_TIMEOUT);
-        long heartbeatTimeout = timeout > 0 ? timeout : Integer.parseInt(HEARTBEAT_TIMEOUT.getDefaultValue());
-        long waitTime = heartbeatTimeout + 1000;
-
-        blockMessagesFromInstance(server, client);
-
-        disconnectedLatch.await(waitTime, TimeUnit.MILLISECONDS);
-
-        unblockMessagesFromInstance(server, client);
-
-        assertTrue(connectedLatch.await(30, TimeUnit.SECONDS));
-
-        validateRegistrations(clusterSize, registrationId, clientInstanceImpl);
-
-        validateListenerFunctionality(eventCount);
-
-        assertTrue(removeListener(registrationId));
-    }
-
-    private void terminateRandomNode() {
-        int clusterSize = factory.getAllHazelcastInstances().size();
-        HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
-        factory.getAllHazelcastInstances().toArray(instances);
-        int randNode = new Random().nextInt(clusterSize);
-        instances[randNode].getLifecycleService().terminate();
-    }
-
-    @Test
-    public void testListenersNonSmartRouting()
-            throws InterruptedException {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = createClientConfig();
-        clientConfig.getNetworkConfig().setSmartRouting(false);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersInternal();
-    }
-
-    @Test
-    public void testListenersSmartRouting()
-            throws InterruptedException {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = createClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersInternal();
-    }
-
-    @Test
-    public void testListenersNonSmartRoutingTerminateRandomNode()
-            throws InterruptedException {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = createClientConfig();
-        clientConfig.getNetworkConfig().setSmartRouting(false);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTerminateRandomNodeInternal();
-    }
-
-    @Test
-    public void testListenersSmartRoutingTerminateRandomNode()
-            throws InterruptedException {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = createClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersTerminateRandomNodeInternal();
-    }
-
-    @Test
-    public void testListenersMemberDestroyEndpointTaskSmartRouting()
-            throws InterruptedException {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = createClientConfig();
-        clientConfig
-                .setProperty(ClientProperty.HEARTBEAT_TIMEOUT.getName(), String.valueOf(2 * ENDPOINT_REMOVE_DELAY_MILLISECONDS));
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersWaitMemberDestroy();
-    }
-
-    @Test
-    public void testClusterReconnectDueToHeartbeatSmartRouting()
-            throws InterruptedException {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersForHeartbeat();
-    }
-
-    @Test
-    public void testTemporaryBlockedNoDisconnectionSmartRouting()
-            throws InterruptedException {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTemporaryNetworkBlockage();
-    }
-
-    @Test
-    public void testTemporaryBlockedNoDisconnectionNonSmartRouting()
-            throws InterruptedException {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getNonSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTemporaryNetworkBlockage();
-    }
-
-    @Test
-    public void testTemporaryBlockedNoDisconnectionMultipleServerSmartRouting()
-            throws InterruptedException {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTemporaryNetworkBlockage();
-    }
-
-    @Test
-    public void testTemporaryBlockedNoDisconnectionMultipleServerNonSmartRouting()
-            throws InterruptedException {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getNonSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersTemporaryNetworkBlockage();
-    }
-
-    private void testListenersTemporaryNetworkBlockage() {
-        HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
-
-        HazelcastInstance server = getOwnerServer(factory,  clientInstanceImpl);
-
-        final int clusterSize = factory.getAllHazelcastInstances().size();
-        assertClusterSizeEventually(clusterSize, client);
-
-        final AtomicInteger eventCount = new AtomicInteger();
-        final String registrationId = addListener(eventCount);
-
-        final boolean smartRouting = clientInstanceImpl.getClientConfig().getNetworkConfig().isSmartRouting();
-        final int expectedRegistrationsSize = smartRouting ? clusterSize : 1;
-
-        assertEquals(expectedRegistrationsSize, getClientEventRegistrations(client, registrationId).size());
-
-        long timeout = clientInstanceImpl.getProperties().getMillis(HEARTBEAT_TIMEOUT);
-        long heartbeatTimeout = timeout > 0 ? timeout : Integer.parseInt(HEARTBEAT_TIMEOUT.getDefaultValue());
-        long waitTime = heartbeatTimeout / 2;
-
-        validateListenerFunctionality(eventCount);
-
-        long endTime = System.currentTimeMillis() + waitTime;
-        blockMessagesFromInstance(server, client);
-        long sleepTime = endTime - System.currentTimeMillis();
-
-        if (sleepTime > 0) {
-            sleepMillis((int)sleepTime);
-        }
-
-        unblockMessagesFromInstance(server, client);
-
-        assertEquals(expectedRegistrationsSize, getClientEventRegistrations(client, registrationId).size());
-
-        validateListenerFunctionality(eventCount);
-
-        assertTrue(removeListener(registrationId));
-    }
-
-    private void validateListenerFunctionality(final AtomicInteger eventCount) {
-        eventCount.set(0);
+    private void validateListenerFunctionality() {
         for (int i = 0; i < EVENT_COUNT; i++) {
             produceEvent();
         }
@@ -436,7 +424,7 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
                 assertTrue("Received event count is " + count + " but it is expected to be at least " + EVENT_COUNT,
                         count >= EVENT_COUNT);
             }
-        }, 5);
+        });
 
         assertTrueAllTheTime(new AssertTask() {
             @Override
@@ -449,27 +437,18 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
         }, 3);
     }
 
-    @Test
-    public void testClusterReconnectMultipleServersDueToHeartbeatSmartRouting()
-            throws InterruptedException {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersForHeartbeat();
+    private void terminateRandomNode() {
+        int clusterSize = factory.getAllHazelcastInstances().size();
+        HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+        factory.getAllHazelcastInstances().toArray(instances);
+        int randNode = new Random().nextInt(clusterSize);
+        instances[randNode].getLifecycleService().terminate();
     }
 
-    @Test
-    @Ignore(value = "https://github.com/hazelcast/hazelcast/issues/8244")
-    public void testClusterReconnectDueToHeartbeatNonSmartRouting()
-            throws InterruptedException {
-        factory.newHazelcastInstance();
-
-        ClientConfig clientConfig = getNonSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersForHeartbeat();
+    private Collection<ClientEventRegistration> getClientEventRegistrations(HazelcastInstance client, String id) {
+        HazelcastClientInstanceImpl clientImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
+        ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) clientImpl.getListenerService();
+        return listenerService.getActiveRegistrations(id);
     }
 
     private ClientConfig getNonSmartClientConfig() {
@@ -479,59 +458,15 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     private ClientConfig getSmartClientConfig() {
-        ClientConfig clientConfig = createClientConfig();
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(20).setConnectionAttemptPeriod(2000).setConnectionTimeout(5000);
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getNetworkConfig().setRedoOperation(true);
         clientConfig.setProperty(ClientProperty.HEARTBEAT_TIMEOUT.getName(), "4000");
         clientConfig.setProperty(ClientProperty.HEARTBEAT_INTERVAL.getName(), "1000");
         return clientConfig;
     }
 
-    @Test
-    public void testClusterReconnectMultipleServerDueToHeartbeatNonSmartRouting()
-            throws InterruptedException {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = getNonSmartClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-
-        testListenersForHeartbeat();
-    }
-
-    @Test
-    public void testListenersSmartRoutingMultipleServer()
-            throws InterruptedException {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = createClientConfig();
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersInternal();
-    }
-
-    @Test
-    public void testListenersNonSmartRoutingMultipleServer()
-            throws InterruptedException {
-        factory.newInstances(null, 3);
-
-        ClientConfig clientConfig = createClientConfig();
-        clientConfig.getNetworkConfig().setSmartRouting(false);
-        client = factory.newHazelcastClient(clientConfig);
-        testListenersInternal();
-    }
-
-    private ClientConfig createClientConfig() {
-        ClientConfig clientConfig = new ClientConfig();
-        clientConfig.getNetworkConfig().setRedoOperation(true);
-        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
-        return clientConfig;
-    }
-
-    private Collection<ClientEventRegistration> getClientEventRegistrations(HazelcastInstance client, String id) {
-        HazelcastClientInstanceImpl clientImpl = ClientTestUtil.getHazelcastClientInstanceImpl(client);
-        ClientListenerServiceImpl listenerService = (ClientListenerServiceImpl) clientImpl.getListenerService();
-        return listenerService.getActiveRegistrations(id);
-    }
-
-    protected abstract String addListener(final AtomicInteger eventCount);
+    protected abstract String addListener();
 
     protected abstract void produceEvent();
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTe
     private IMap<String, String> iMap;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         iMap = client.getMap(randomString());
 
         final EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnec
     private IList<String> iList;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         iList = client.getList(randomString());
 
         ItemListener<String> listener = new ItemListener<String>() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
@@ -9,8 +9,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -18,7 +16,7 @@ public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnRec
     private MultiMap<String, String> multiMap;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         multiMap = client.getMultiMap(randomString());
 
         EntryAdapter<String, String> listener = new EntryAdapter<String, String>() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconne
     private IQueue<String> iQueue;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         iQueue = client.getQueue(randomString());
 
         ItemListener<String> listener = new ItemListener<String>() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
     private ReplicatedMap<String, String> replicatedMap;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         replicatedMap = client.getReplicatedMap(randomString());
         final EntryAdapter<String, String> listener = new EntryAdapter<String, String>() {
             @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class SetItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -34,7 +32,7 @@ public class SetItemListenerOnReconnectTest extends AbstractListenersOnReconnect
     private ISet<String> iSet;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         iSet = client.getSet(randomString());
 
         ItemListener<String> listener = new ItemListener<String>() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
@@ -9,8 +9,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class TopicOnReconnectTest extends AbstractListenersOnReconnectTest {
@@ -18,7 +16,7 @@ public class TopicOnReconnectTest extends AbstractListenersOnReconnectTest {
     private ITopic<String> topic;
 
     @Override
-    protected String addListener(final AtomicInteger eventCount) {
+    protected String addListener() {
         topic = client.getTopic(randomString());
 
         MessageListener<String> listener = new MessageListener<String>() {


### PR DESCRIPTION
Remove ignore from testClusterReconnectDueToHeartbeatNonSmartRouting
This test failure caused by a timing problem. Test not fails because
of listeners but not able to connect to cluster in time after heartbeat
problem.

All latch usages changed to use assertOpenEventually

sleep in testListenersTerminateRandomNodeInternal is removed.
Justification: since validation is done by assertTrueEventually, there is no need to sleep.

Tests using same internal method is grouped so that it easy to follow.

testListenersTerminateRandomNodeInternal tests were with single node,
changed them so that they open 3 nodes.
Justification: Terminating random node when there is only one node was not making any sense

Some renamings to make it more clear what is going on in the test.
testListenersInternal -> testListenersTerminateOwnerNode
testListenersForHeartbeat -> testListenersHeartbeatTimeoutToOwner

fixes #9280
fixes #9224
fixes #9276
fixes #8244
fixes #9488