### PR TITLE
[BACKPORT] Apply join mechanism fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -103,7 +103,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                 logger.fine("Joining over target member " + targetAddress);
             }
             if (targetAddress.equals(node.getThisAddress()) || isLocalAddress(targetAddress)) {
-                node.setAsMaster();
+                clusterJoinManager.setAsMaster();
                 return;
             }
             long joinStartTime = Clock.currentTimeMillis();
@@ -137,7 +137,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             boolean foundConnection = tryInitialConnection(possibleAddresses);
             if (!foundConnection) {
                 logger.fine("This node will assume master role since no possible member where connected to.");
-                node.setAsMaster();
+                clusterJoinManager.setAsMaster();
                 return;
             }
 
@@ -155,7 +155,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                 if (isAllBlacklisted(possibleAddresses)) {
                     logger.fine(
                             "This node will assume master role since none of the possible members accepted join request.");
-                    node.setAsMaster();
+                    clusterJoinManager.setAsMaster();
                     return;
                 }
 
@@ -169,7 +169,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                             logger.fine("Setting myself as master after consensus!"
                                     + " Voting endpoints: " + votingEndpoints);
                         }
-                        node.setAsMaster();
+                        clusterJoinManager.setAsMaster();
                         claimingMaster = false;
                         return;
                     }
@@ -316,7 +316,7 @@ public class TcpIpJoiner extends AbstractJoiner {
             if (logger.isFineEnabled()) {
                 logger.fine("Setting myself as master! No possible addresses remaining to connect...");
             }
-            node.setAsMaster();
+            clusterJoinManager.setAsMaster();
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -34,6 +34,7 @@ import com.hazelcast.core.MembershipListener;
 import com.hazelcast.core.MigrationListener;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.ascii.TextCommandServiceImpl;
+import com.hazelcast.internal.cluster.impl.ClusterJoinManager;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ConfigCheck;
 import com.hazelcast.internal.cluster.impl.DiscoveryJoiner;
@@ -43,6 +44,7 @@ import com.hazelcast.internal.cluster.impl.MulticastJoiner;
 import com.hazelcast.internal.cluster.impl.MulticastService;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.partition.impl.InternalMigrationListener;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
@@ -52,7 +54,6 @@ import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.partition.PartitionLostListener;
-import com.hazelcast.internal.partition.impl.InternalMigrationListener;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.annotation.PrivateApi;
@@ -69,7 +70,6 @@ import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.PhoneHome;
-import com.hazelcast.util.UuidUtil;
 
 import java.lang.reflect.Constructor;
 import java.nio.channels.ServerSocketChannel;
@@ -641,7 +641,8 @@ public class Node {
         }
         if (joiner == null) {
             logger.warning("No join method is enabled! Starting standalone.");
-            setAsMaster();
+            ClusterJoinManager clusterJoinManager = clusterService.getClusterJoinManager();
+            clusterJoinManager.setAsMaster();
             return;
         }
 
@@ -691,14 +692,6 @@ public class Node {
             }
         }
         return null;
-    }
-
-    public void setAsMaster() {
-        logger.finest("This node is being set as the master");
-        masterAddress = address;
-        setJoined();
-        getClusterService().getClusterClock().setClusterStartTime(Clock.currentTimeMillis());
-        getClusterService().setClusterId(UuidUtil.createClusterUuid());
     }
 
     public Config getConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -147,7 +147,7 @@ public abstract class AbstractJoiner implements Joiner {
         }
         if (tryCount.incrementAndGet() == JOIN_TRY_COUNT) {
             logger.warning("Join try count exceed limit, setting this node as master!");
-            node.setAsMaster();
+            clusterJoinManager.setAsMaster();
         }
 
         if (node.joined()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -350,45 +350,105 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         return memberInfos;
     }
 
-    public void updateMembers(Collection<MemberInfo> members) {
+    public boolean finalizeJoin(Collection<MemberInfo> members, Address callerAddress, String clusterId,
+                                ClusterState clusterState, long clusterStartTime, long masterTime) {
         lock.lock();
         try {
-            Map<Address, MemberImpl> currentMemberMap = membersMapRef.get();
-
-            if (!shouldProcessMemberUpdate(currentMemberMap, members)) {
-                return;
-            }
-
-            String scopeId = thisAddress.getScopeId();
-            Collection<MemberImpl> newMembers = new LinkedList<MemberImpl>();
-            MemberImpl[] updatedMembers = new MemberImpl[members.size()];
-            int memberIndex = 0;
-            for (MemberInfo memberInfo : members) {
-                MemberImpl member = currentMemberMap.get(memberInfo.getAddress());
-                if (member == null) {
-                    member = createMember(memberInfo, scopeId);
-                    newMembers.add(member);
-                    long now = clusterClock.getClusterTime();
-                    clusterHeartbeatManager.onHeartbeat(member, now);
-                    clusterHeartbeatManager.acceptMasterConfirmation(member, now);
-
-                    Map<Address, MemberImpl> membersRemovedInNotActiveState
-                            = new LinkedHashMap<Address, MemberImpl>(membersRemovedInNotActiveStateRef.get());
-                    membersRemovedInNotActiveState.remove(member.getAddress());
-                    membersRemovedInNotActiveStateRef.set(Collections.unmodifiableMap(membersRemovedInNotActiveState));
+            if (!checkValidMaster(callerAddress)) {
+                if (logger.isFineEnabled()) {
+                    logger.fine("Not finalizing join because caller: " + callerAddress + " is not known master: "
+                            + getMasterAddress());
                 }
-                updatedMembers[memberIndex++] = member;
+                return false;
             }
 
-            setMembers(updatedMembers);
-            sendMembershipEvents(currentMemberMap.values(), newMembers);
+            if (node.joined()) {
+                if (logger.isFineEnabled()) {
+                    logger.fine("Node is already joined... No need to finalize join...");
+                }
+
+                return false;
+            }
+
+            initialClusterState(clusterState);
+            setClusterId(clusterId);
+            ClusterClockImpl clusterClock = getClusterClock();
+            clusterClock.setClusterStartTime(clusterStartTime);
+            clusterClock.setMasterTime(masterTime);
+            doUpdateMembers(members);
+            clusterHeartbeatManager.heartbeat();
 
             node.setJoined();
-            clusterHeartbeatManager.heartbeat();
-            logger.info(membersString());
+
+            return true;
         } finally {
             lock.unlock();
         }
+    }
+
+
+    public boolean updateMembers(Collection<MemberInfo> members, Address callerAddress) {
+        lock.lock();
+        try {
+            if (!checkValidMaster(callerAddress)) {
+                logger.warning("Not updating members because caller: " + callerAddress  + " is not known master: "
+                        + getMasterAddress());
+                return false;
+            }
+
+            if (!node.joined()) {
+                logger.warning("Not updating members received from caller: " + callerAddress +  " because node is not joined! ");
+                return false;
+            }
+
+            if (!shouldProcessMemberUpdate(membersMapRef.get(), members)) {
+                return false;
+            }
+
+            doUpdateMembers(members);
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean checkValidMaster(Address callerAddress) {
+        return (callerAddress != null && callerAddress.equals(getMasterAddress()));
+    }
+
+    private void doUpdateMembers(Collection<MemberInfo> members) {
+        Map<Address, MemberImpl> currentMemberMap = membersMapRef.get();
+
+        if (!shouldProcessMemberUpdate(currentMemberMap, members)) {
+            return;
+        }
+
+        String scopeId = thisAddress.getScopeId();
+        Collection<MemberImpl> newMembers = new LinkedList<MemberImpl>();
+        MemberImpl[] updatedMembers = new MemberImpl[members.size()];
+        int memberIndex = 0;
+        for (MemberInfo memberInfo : members) {
+            MemberImpl member = currentMemberMap.get(memberInfo.getAddress());
+            if (member == null) {
+                member = createMember(memberInfo, scopeId);
+                newMembers.add(member);
+                long now = clusterClock.getClusterTime();
+                clusterHeartbeatManager.onHeartbeat(member, now);
+                clusterHeartbeatManager.acceptMasterConfirmation(member, now);
+
+                Map<Address, MemberImpl> membersRemovedInNotActiveState
+                        = new LinkedHashMap<Address, MemberImpl>(membersRemovedInNotActiveStateRef.get());
+                membersRemovedInNotActiveState.remove(member.getAddress());
+                membersRemovedInNotActiveStateRef.set(Collections.unmodifiableMap(membersRemovedInNotActiveState));
+            }
+            updatedMembers[memberIndex++] = member;
+        }
+
+        setMembers(updatedMembers);
+        sendMembershipEvents(currentMemberMap.values(), newMembers);
+
+        clusterHeartbeatManager.heartbeat();
+        logger.info(membersString());
     }
 
     private boolean shouldProcessMemberUpdate(Map<Address, MemberImpl> currentMembers,
@@ -483,7 +543,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         if (!node.joined()) {
             Address masterAddress = node.getMasterAddress();
             if (masterAddress != null && masterAddress.equals(connection.getEndPoint())) {
-                node.setMasterAddress(null);
+                clusterJoinManager.setMasterAddress(null);
             }
         }
     }
@@ -929,7 +989,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         hazelcastInstance.getLifecycleService().shutdown();
     }
 
-    public void initialClusterState(ClusterState clusterState) {
+    void initialClusterState(ClusterState clusterState) {
         if (node.joined()) {
             throw new IllegalStateException("Cannot set initial state after node joined! -> " + clusterState);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -55,16 +55,16 @@ public class MulticastJoiner extends AbstractJoiner {
                 && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
 
             // clear master node
-            node.setMasterAddress(null);
+            clusterJoinManager.setMasterAddress(null);
 
             Address masterAddress = getTargetAddress();
             if (masterAddress == null) {
                 masterAddress = findMasterWithMulticast();
             }
-            node.setMasterAddress(masterAddress);
+            clusterJoinManager.setMasterAddress(masterAddress);
 
             if (masterAddress == null || thisAddress.equals(masterAddress)) {
-                node.setAsMaster();
+                clusterJoinManager.setAsMaster();
                 return;
             }
 
@@ -97,7 +97,7 @@ public class MulticastJoiner extends AbstractJoiner {
             }
 
             if (isBlacklisted(master)) {
-                node.setMasterAddress(null);
+                clusterJoinManager.setMasterAddress(null);
                 return;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -101,9 +101,10 @@ public class NodeMulticastListener implements MulticastListener {
             if (!node.joined() && node.getMasterAddress() == null) {
                 String masterHost = joinMessage.getAddress().getHost();
                 if (trustedInterfaces.isEmpty() || matchAnyInterface(masterHost, trustedInterfaces)) {
+                    ClusterJoinManager clusterJoinManager = node.getClusterService().getClusterJoinManager();
                     //todo: why are we making a copy here of address?
                     Address masterAddress = new Address(joinMessage.getAddress());
-                    node.setMasterAddress(masterAddress);
+                    clusterJoinManager.setMasterAddress(masterAddress);
                 } else {
                     logJoinMessageDropped(masterHost);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOperation.java
@@ -20,11 +20,10 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.MemberInfo;
-import com.hazelcast.internal.cluster.impl.ClusterClockImpl;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
-import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
@@ -78,38 +77,20 @@ public class FinalizeJoinOperation extends MemberInfoUpdateOperation implements 
 
     @Override
     public void run() throws Exception {
-        if (!checkValid()) {
+        ClusterServiceImpl clusterService = getService();
+        Address callerAddress = getConnectionEndpointOrThisAddress();
+
+        boolean finalized = clusterService.finalizeJoin(memberInfos, callerAddress, clusterId, clusterState,
+                                                        clusterStartTime, masterTime);
+        if (!finalized) {
             return;
         }
-
-        final ClusterServiceImpl clusterService = getService();
-        final NodeEngineImpl nodeEngine = clusterService.getNodeEngine();
-
-        if (nodeEngine.getNode().joined()) {
-            ILogger logger = getLogger();
-            if (logger.isFineEnabled()) {
-                logger.fine("Node is already joined... No need to finalize join...");
-            }
-            return;
-        }
-
-        initClusterStates(clusterService);
-
-        processMemberUpdate();
 
         processPartitionState();
 
         sendPostJoinOperations();
 
         runPostJoinOp();
-    }
-
-    private void initClusterStates(ClusterServiceImpl clusterService) {
-        clusterService.initialClusterState(clusterState);
-        clusterService.setClusterId(clusterId);
-        ClusterClockImpl clusterClock = clusterService.getClusterClock();
-        clusterClock.setClusterStartTime(clusterStartTime);
-        clusterClock.setMasterTime(masterTime);
     }
 
     private void processPartitionState() {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberListTest.java
@@ -169,7 +169,7 @@ public class MemberListTest {
         members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections.<String, Object>emptyMap()));
         members.add(new MemberInfo(m3.getAddress(), m3.getUuid(), Collections.<String, Object>emptyMap()));
         members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections.<String, Object>emptyMap()));
-        n2.clusterService.updateMembers(members);
+        n2.clusterService.updateMembers(members, n2.getMasterAddress());
         n2.setMasterAddress(m2.getAddress());
 
         // Give the cluster some time to figure things out. The merge and heartbeat code should have kicked in by this point
@@ -212,7 +212,7 @@ public class MemberListTest {
         List<MemberInfo> members = new ArrayList<MemberInfo>();
         members.add(new MemberInfo(m1.getAddress(), m1.getUuid(), Collections.<String, Object>emptyMap()));
         members.add(new MemberInfo(m2.getAddress(), m2.getUuid(), Collections.<String, Object>emptyMap()));
-        n2.clusterService.updateMembers(members);
+        n2.clusterService.updateMembers(members, n2.getMasterAddress());
 
         // Give the cluster some time to figure things out. The merge and heartbeat code should have kicked in by this point
         sleepSeconds(30);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -55,15 +55,14 @@ class MockJoiner extends AbstractJoiner {
 
                     if (node.getThisAddress().equals(joinAddress)) {
                         logger.fine("This node is found as master, no need to join.");
-                        node.setJoined();
-                        node.setAsMaster();
+                        clusterJoinManager.setAsMaster();
                         break;
                     }
 
                     logger.fine("Sending join request to " + joinAddress);
                     if (!clusterJoinManager.sendJoinRequest(joinAddress, true)) {
                         logger.fine("Could not send join request to " + joinAddress);
-                        node.setMasterAddress(null);
+                        clusterJoinManager.setMasterAddress(null);
                     }
 
                     Thread.sleep(500);
@@ -86,6 +85,9 @@ class MockJoiner extends AbstractJoiner {
         logger.fine("Known master address is: " + joinAddress);
         if (joinAddress == null) {
             joinAddress = lookupJoinAddress();
+            if (!node.getThisAddress().equals(joinAddress)) {
+                clusterJoinManager.sendMasterQuestion(joinAddress);
+            }
         }
         return joinAddress;
     }


### PR DESCRIPTION
* Update joined flag and master address within cluster service lock so that master address cannot be reset in racy cases after the node is already joined.
* Verify master address within cluster service lock to eliminate races when there are in-flight member list update operations and master change.

Backport of #9534 