### PR TITLE
Improvements of Near Cache pre-loader

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -298,14 +298,14 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
     private NearCachePreloaderConfig getNearCachePreloaderConfig(Node node) {
         NearCachePreloaderConfig preloaderConfig = new NearCachePreloaderConfig();
         String enabled = getAttribute(node, "enabled");
-        String fileName = getAttribute(node, "file-name");
+        String filename = getAttribute(node, "filename");
         String storeInitialDelaySeconds = getAttribute(node, "store-initial-delay-seconds");
         String storeIntervalSeconds = getAttribute(node, "store-interval-seconds");
         if (enabled != null) {
             preloaderConfig.setEnabled(getBooleanValue(enabled));
         }
-        if (fileName != null) {
-            preloaderConfig.setFileName(fileName);
+        if (filename != null) {
+            preloaderConfig.setFilename(filename);
         }
         if (storeInitialDelaySeconds != null) {
             preloaderConfig.setStoreInitialDelaySeconds(getIntegerValue("storage-initial-delay-seconds",

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.8.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.8.xsd
@@ -406,7 +406,7 @@
 
     <xs:complexType name="preloader">
         <xs:attribute name="enabled" type="xs:boolean" default="false" use="optional"/>
-        <xs:attribute name="file-name" type="xs:string" use="optional"/>
+        <xs:attribute name="filename" type="xs:string" use="optional"/>
         <xs:attribute name="store-initial-delay-seconds" type="xs:positiveInteger" default="600" use="optional"/>
         <xs:attribute name="store-interval-seconds" type="xs:positiveInteger" default="600" use="optional"/>
     </xs:complexType>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
@@ -16,6 +16,7 @@ import com.hazelcast.internal.adapter.ICacheDataStructureAdapter;
 import com.hazelcast.internal.nearcache.AbstractNearCachePreloaderTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
@@ -70,47 +71,67 @@ public class ClientCacheNearCachePreloaderTest extends AbstractNearCachePreloade
     }
 
     @Override
-    protected <K, V> com.hazelcast.internal.nearcache.NearCacheTestContext<K, V, Data, String> createContext() {
-        ClientConfig clientConfig = getClientConfig()
-                .addNearCacheConfig(nearCacheConfig);
-
+    protected <K, V> com.hazelcast.internal.nearcache.NearCacheTestContext<K, V, Data, String> createContext(
+            boolean createClient) {
         CacheConfig<K, V> cacheConfig = createCacheConfig(nearCacheConfig);
 
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance(getConfig());
-        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
-
         CachingProvider memberProvider = HazelcastServerCachingProvider.createCachingProvider(member);
         HazelcastServerCacheManager memberCacheManager = (HazelcastServerCacheManager) memberProvider.getCacheManager();
-
-        NearCacheManager nearCacheManager = client.client.getNearCacheManager();
-        CachingProvider provider = HazelcastClientCachingProvider.createCachingProvider(client);
-        HazelcastClientCacheManager cacheManager = (HazelcastClientCacheManager) provider.getCacheManager();
-        String cacheNameWithPrefix = cacheManager.getCacheNameWithPrefix(DEFAULT_NEAR_CACHE_NAME);
-
-        ICache<K, V> clientCache = cacheManager.createCache(DEFAULT_NEAR_CACHE_NAME, cacheConfig);
         ICache<K, V> memberCache = memberCacheManager.createCache(DEFAULT_NEAR_CACHE_NAME, cacheConfig);
 
-        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(cacheNameWithPrefix);
+        if (!createClient) {
+            return new NearCacheTestContext<K, V, Data, String>(
+                    getSerializationService(member),
+                    member,
+                    new ICacheDataStructureAdapter<K, V>(memberCache),
+                    false,
+                    null,
+                    null);
+        }
 
+        NearCacheTestContext<K, V, Data, String> clientContext = createClientContext(cacheConfig);
         return new com.hazelcast.internal.nearcache.NearCacheTestContext<K, V, Data, String>(
-                client.getSerializationService(),
-                client,
+                clientContext.serializationService,
+                clientContext.nearCacheInstance,
                 member,
-                new ICacheDataStructureAdapter<K, V>(clientCache),
+                clientContext.nearCacheAdapter,
                 new ICacheDataStructureAdapter<K, V>(memberCache),
                 false,
-                nearCache,
-                nearCacheManager,
-                cacheManager,
+                clientContext.nearCache,
+                clientContext.nearCacheManager,
+                clientContext.cacheManager,
                 memberCacheManager);
     }
 
     @Override
     protected <K, V> com.hazelcast.internal.nearcache.NearCacheTestContext<K, V, Data, String> createClientContext() {
+        CacheConfig<K, V> cacheConfig = createCacheConfig(nearCacheConfig);
+        return createClientContext(cacheConfig);
+    }
+
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
+    }
+
+    private <K, V> CacheConfig<K, V> createCacheConfig(NearCacheConfig nearCacheConfig) {
+        CacheConfig<K, V> cacheConfig = new CacheConfig<K, V>()
+                .setName(DEFAULT_NEAR_CACHE_NAME)
+                .setInMemoryFormat(nearCacheConfig.getInMemoryFormat());
+
+        if (nearCacheConfig.getInMemoryFormat() == NATIVE) {
+            cacheConfig.getEvictionConfig()
+                    .setEvictionPolicy(LRU)
+                    .setMaximumSizePolicy(USED_NATIVE_MEMORY_PERCENTAGE)
+                    .setSize(90);
+        }
+
+        return cacheConfig;
+    }
+
+    private <K, V> NearCacheTestContext<K, V, Data, String> createClientContext(CacheConfig<K, V> cacheConfig) {
         ClientConfig clientConfig = getClientConfig()
                 .addNearCacheConfig(nearCacheConfig);
-
-        CacheConfig<K, V> cacheConfig = createCacheConfig(nearCacheConfig);
 
         HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
 
@@ -134,24 +155,5 @@ public class ClientCacheNearCachePreloaderTest extends AbstractNearCachePreloade
                 nearCacheManager,
                 cacheManager,
                 null);
-    }
-
-    protected ClientConfig getClientConfig() {
-        return new ClientConfig();
-    }
-
-    private <K, V> CacheConfig<K, V> createCacheConfig(NearCacheConfig nearCacheConfig) {
-        CacheConfig<K, V> cacheConfig = new CacheConfig<K, V>()
-                .setName(DEFAULT_NEAR_CACHE_NAME)
-                .setInMemoryFormat(nearCacheConfig.getInMemoryFormat());
-
-        if (nearCacheConfig.getInMemoryFormat() == NATIVE) {
-            cacheConfig.getEvictionConfig()
-                    .setEvictionPolicy(LRU)
-                    .setMaximumSizePolicy(USED_NATIVE_MEMORY_PERCENTAGE)
-                    .setSize(90);
-        }
-
-        return cacheConfig;
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -262,7 +262,7 @@ public class XmlClientConfigBuilderTest {
 
         assertNotNull(nearCacheConfig.getPreloaderConfig());
         assertTrue(nearCacheConfig.getPreloaderConfig().isEnabled());
-        assertEquals("myNearCache.store", nearCacheConfig.getPreloaderConfig().getFileName());
+        assertEquals("myNearCache.store", nearCacheConfig.getPreloaderConfig().getFilename());
         assertEquals(2342, nearCacheConfig.getPreloaderConfig().getStoreInitialDelaySeconds());
         assertEquals(4223, nearCacheConfig.getPreloaderConfig().getStoreIntervalSeconds());
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
@@ -60,28 +60,30 @@ public class ClientMapNearCachePreloaderTest extends AbstractNearCachePreloaderT
     }
 
     @Override
-    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
-        ClientConfig clientConfig = getClientConfig()
-                .addNearCacheConfig(nearCacheConfig);
-
+    protected <K, V> NearCacheTestContext<K, V, Data, String> createContext(boolean createClient) {
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance(getConfig());
-        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
-
         IMap<K, V> memberMap = member.getMap(DEFAULT_NEAR_CACHE_NAME);
-        IMap<K, V> clientMap = client.getMap(DEFAULT_NEAR_CACHE_NAME);
 
-        NearCacheManager nearCacheManager = client.client.getNearCacheManager();
-        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+        if (!createClient) {
+            return new NearCacheTestContext<K, V, Data, String>(
+                    getSerializationService(member),
+                    member,
+                    new IMapDataStructureAdapter<K, V>(memberMap),
+                    false,
+                    null,
+                    null);
+        }
 
+        NearCacheTestContext<K, V, Data, String> clientContext = createClientContext();
         return new NearCacheTestContext<K, V, Data, String>(
-                client.getSerializationService(),
-                client,
+                clientContext.serializationService,
+                clientContext.nearCacheInstance,
                 member,
-                new IMapDataStructureAdapter<K, V>(clientMap),
+                clientContext.nearCacheAdapter,
                 new IMapDataStructureAdapter<K, V>(memberMap),
                 false,
-                nearCache,
-                nearCacheManager);
+                clientContext.nearCache,
+                clientContext.nearCacheManager);
     }
 
     @Override
@@ -90,7 +92,6 @@ public class ClientMapNearCachePreloaderTest extends AbstractNearCachePreloaderT
                 .addNearCacheConfig(nearCacheConfig);
 
         HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
-
         IMap<K, V> clientMap = client.getMap(DEFAULT_NEAR_CACHE_NAME);
 
         NearCacheManager nearCacheManager = client.client.getNearCacheManager();

--- a/hazelcast-client/src/test/resources/hazelcast-client-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-test.xml
@@ -28,7 +28,7 @@
         <in-memory-format>OBJECT</in-memory-format>
         <cache-local-entries>true</cache-local-entries>
         <eviction size="100" max-size-policy="ENTRY_COUNT" eviction-policy="LFU"/>
-        <preloader enabled="true" file-name="myNearCache.store"
+        <preloader enabled="true" filename="myNearCache.store"
                    store-initial-delay-seconds="2342" store-interval-seconds="4223"/>
     </near-cache>
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
@@ -48,7 +48,7 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
     public static final int DEFAULT_STORE_INTERVAL_SECONDS = 600;
 
     private boolean enabled;
-    private String fileName = "";
+    private String filename = "";
     private int storeInitialDelaySeconds = DEFAULT_STORE_INITIAL_DELAY_SECONDS;
     private int storeIntervalSeconds = DEFAULT_STORE_INTERVAL_SECONDS;
 
@@ -65,10 +65,10 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
          * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
          */
 
-        this(nearCachePreloaderConfig.enabled, nearCachePreloaderConfig.fileName);
+        this(nearCachePreloaderConfig.enabled, nearCachePreloaderConfig.filename);
     }
 
-    public NearCachePreloaderConfig(String fileName) {
+    public NearCachePreloaderConfig(String filename) {
         /**
          * ===== NOTE =====
          *
@@ -76,10 +76,10 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
          * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
          */
 
-        this(true, fileName);
+        this(true, filename);
     }
 
-    public NearCachePreloaderConfig(boolean enabled, String fileName) {
+    public NearCachePreloaderConfig(boolean enabled, String filename) {
         /**
          * ===== NOTE =====
          *
@@ -88,7 +88,7 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
          */
 
         this.enabled = enabled;
-        this.fileName = checkNotNull(fileName, "fileName cannot be null!");
+        this.filename = checkNotNull(filename, "filename cannot be null!");
     }
 
     NearCachePreloaderConfig getAsReadOnly() {
@@ -107,13 +107,13 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
         return this;
     }
 
-    public NearCachePreloaderConfig setFileName(String fileName) {
-        this.fileName = checkNotNull(fileName, "fileName cannot be null!");
+    public NearCachePreloaderConfig setFilename(String filename) {
+        this.filename = checkNotNull(filename, "filename cannot be null!");
         return this;
     }
 
-    public String getFileName() {
-        return fileName;
+    public String getFilename() {
+        return filename;
     }
 
     public int getStoreInitialDelaySeconds() {
@@ -139,7 +139,7 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(enabled);
-        out.writeUTF(fileName);
+        out.writeUTF(filename);
         out.writeInt(storeInitialDelaySeconds);
         out.writeInt(storeIntervalSeconds);
     }
@@ -147,7 +147,7 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         enabled = in.readBoolean();
-        fileName = in.readUTF();
+        filename = in.readUTF();
         storeInitialDelaySeconds = in.readInt();
         storeIntervalSeconds = in.readInt();
     }
@@ -156,7 +156,7 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
     public String toString() {
         return "NearCachePreloaderConfig{"
                 + "enabled=" + enabled
-                + ", fileName=" + fileName
+                + ", filename=" + filename
                 + ", storeInitialDelaySeconds=" + storeInitialDelaySeconds
                 + ", storeIntervalSeconds=" + storeIntervalSeconds
                 + '}';
@@ -180,7 +180,7 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
         }
 
         @Override
-        public NearCachePreloaderConfig setFileName(String fileName) {
+        public NearCachePreloaderConfig setFilename(String filename) {
             throw new UnsupportedOperationException();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -93,6 +93,7 @@ public class NearCachePreloader<KS> {
     private final NearCacheStatsImpl nearCacheStats;
     private final SerializationService serializationService;
 
+    private final NearCachePreloaderLock lock;
     private final File storeFile;
     private final File tmpStoreFile;
 
@@ -105,9 +106,14 @@ public class NearCachePreloader<KS> {
         this.nearCacheStats = nearCacheStats;
         this.serializationService = serializationService;
 
-        String fileName = getFileName(preloaderConfig.getFileName(), nearCacheName);
-        this.storeFile = new File(fileName);
-        this.tmpStoreFile = new File(fileName + "~");
+        String filename = getFileName(preloaderConfig.getFilename(), nearCacheName);
+        this.lock = new NearCachePreloaderLock(logger, filename + ".lock");
+        this.storeFile = new File(filename);
+        this.tmpStoreFile = new File(filename + "~");
+    }
+
+    public void destroy() {
+        lock.release();
     }
 
     /**
@@ -197,6 +203,8 @@ public class NearCachePreloader<KS> {
             updatePersistenceStats(startedNanos);
         } catch (Exception e) {
             logger.warning(format("Could not store keys of Near Cache %s (%s)", nearCacheName, storeFile.getAbsolutePath()), e);
+
+            nearCacheStats.addPersistenceFailure(e);
         } finally {
             deleteQuietly(tmpStoreFile);
             closeResource(fos);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloaderLock.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.nearcache.impl.preloader;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+
+import static com.hazelcast.nio.IOUtil.closeResource;
+
+class NearCachePreloaderLock {
+
+    private final ILogger logger;
+
+    private final File lockFile;
+    private final FileChannel channel;
+    private final FileLock lock;
+
+    NearCachePreloaderLock(ILogger logger, String lockFileName) {
+        this.logger = logger;
+
+        this.lockFile = new File(lockFileName);
+        this.channel = openChannel(lockFile);
+        this.lock = acquireLock(lockFile);
+    }
+
+    private FileLock acquireLock(File lockFile) {
+        FileLock fileLock = null;
+        try {
+            fileLock = channel.tryLock();
+            if (fileLock == null) {
+                throw new HazelcastException("Cannot acquire lock on " + lockFile.getAbsolutePath()
+                        + ". File is already being used by another Hazelcast instance.");
+            }
+            return fileLock;
+        } catch (OverlappingFileLockException e) {
+            throw new HazelcastException("Cannot acquire lock on " + lockFile.getAbsolutePath()
+                    + ". File is already being used by another Hazelcast instance.", e);
+        } catch (IOException e) {
+            throw new HazelcastException("Unknown failure while acquiring lock on " + lockFile.getAbsolutePath(), e);
+        } finally {
+            if (fileLock == null) {
+                closeResource(channel);
+            }
+        }
+    }
+
+    private FileChannel openChannel(File lockFile) {
+        try {
+            return new RandomAccessFile(lockFile, "rw").getChannel();
+        } catch (IOException e) {
+            throw new HazelcastException("Cannot create lock file " + lockFile.getAbsolutePath(), e);
+        }
+    }
+
+    void release() {
+        try {
+            lock.release();
+            channel.close();
+        } catch (IOException e) {
+            logger.severe("Problem while releasing the lock and closing channel on " + lockFile, e);
+        } finally {
+            lockFile.deleteOnExit();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -125,4 +125,12 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
             nearCachePreloader.storeKeys(records);
         }
     }
+
+    @Override
+    public void destroy() {
+        super.destroy();
+        if (nearCachePreloader != null) {
+            nearCachePreloader.destroy();
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/NearCacheStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/NearCacheStats.java
@@ -109,4 +109,11 @@ public interface NearCacheStats extends LocalInstanceStats {
      * @return the number of persisted keys of the last Near Cache key persistence
      */
     long getLastPersistenceKeyCount();
+
+    /**
+     * Returns the failure reason of the last Near Cache persistence (when the pre-load feature is enabled).
+     *
+     * @return the failure reason of the last Near Cache persistence
+     */
+    String getLastPersistenceFailure();
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCachePreloaderConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCachePreloaderConfigReadOnlyTest.java
@@ -22,7 +22,7 @@ public class NearCachePreloaderConfigReadOnlyTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void setFilenameOnReadOnlyNearCachePreloaderConfigShouldFail() {
-        getReadOnlyConfig().setFileName("myFileName");
+        getReadOnlyConfig().setFilename("myFileName");
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCachePreloaderConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCachePreloaderConfigTest.java
@@ -24,19 +24,19 @@ public class NearCachePreloaderConfigTest {
         config = new NearCachePreloaderConfig("myStorage.store");
 
         assertTrue(config.isEnabled());
-        assertEquals("myStorage.store", config.getFileName());
+        assertEquals("myStorage.store", config.getFilename());
     }
 
     @Test
     public void testFileName() {
-        config.setFileName("myStorage.store");
+        config.setFilename("myStorage.store");
 
-        assertEquals("myStorage.store", config.getFileName());
+        assertEquals("myStorage.store", config.getFilename());
     }
 
     @Test(expected = NullPointerException.class)
     public void testFileName_withNull() {
-        config.setFileName(null);
+        config.setFilename(null);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class NearCachePreloaderConfigTest {
     @Test
     public void testSerialization() {
         config.setEnabled(true);
-        config.setFileName("foobar");
+        config.setFilename("foobar");
         config.setStoreInitialDelaySeconds(23);
         config.setStoreIntervalSeconds(42);
 
@@ -81,7 +81,7 @@ public class NearCachePreloaderConfigTest {
         NearCachePreloaderConfig deserialized = serializationService.toObject(serialized);
 
         assertEquals(config.isEnabled(), deserialized.isEnabled());
-        assertEquals(config.getFileName(), deserialized.getFileName());
+        assertEquals(config.getFilename(), deserialized.getFilename());
         assertEquals(config.getStoreInitialDelaySeconds(), deserialized.getStoreInitialDelaySeconds());
         assertEquals(config.getStoreIntervalSeconds(), deserialized.getStoreIntervalSeconds());
         assertEquals(config.toString(), deserialized.toString());

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
@@ -81,7 +81,7 @@ public class NearCacheTestContext<K, V, NK, NV> {
         this.hasLocalData = hasLocalData;
 
         this.nearCache = nearCache;
-        this.stats = nearCache.getNearCacheStats();
+        this.stats = (nearCache == null) ? null : nearCache.getNearCacheStats();
         this.nearCacheManager = nearCacheManager;
         this.cacheManager = cacheManager;
         this.memberCacheManager = memberCacheManager;

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/NearCacheStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/NearCacheStatsImplTest.java
@@ -9,7 +9,10 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.FileNotFoundException;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -53,40 +56,28 @@ public class NearCacheStatsImplTest {
 
     @Test
     public void testDefaultConstructor() {
-        assertTrue(nearCacheStats.getCreationTime() > 0);
-        assertEquals(500, nearCacheStats.getOwnedEntryCount());
-        assertEquals(1280, nearCacheStats.getOwnedEntryMemoryCost());
-        assertEquals(602, nearCacheStats.getHits());
-        assertEquals(305, nearCacheStats.getMisses());
-        assertEquals(4, nearCacheStats.getEvictions());
-        assertEquals(3, nearCacheStats.getExpirations());
-        assertEquals(1, nearCacheStats.getPersistenceCount());
-        assertTrue(nearCacheStats.getLastPersistenceTime() > 0);
-        assertEquals(200, nearCacheStats.getLastPersistenceDuration());
-        assertEquals(300, nearCacheStats.getLastPersistenceWrittenBytes());
-        assertEquals(400, nearCacheStats.getLastPersistenceKeyCount());
-        assertNotNull(nearCacheStats.toString());
+        assertNearCacheStats(nearCacheStats, 1, 200, 300, 400, false);
     }
 
     @Test
     public void testSerialization() {
-        JsonObject serialized = nearCacheStats.toJson();
-        NearCacheStatsImpl deserialized = new NearCacheStatsImpl();
-        deserialized.fromJson(serialized);
+        NearCacheStatsImpl deserialized = serializeAndDeserializeNearCacheStats(nearCacheStats);
 
-        assertTrue(deserialized.getCreationTime() > 0);
-        assertEquals(500, deserialized.getOwnedEntryCount());
-        assertEquals(1280, deserialized.getOwnedEntryMemoryCost());
-        assertEquals(602, deserialized.getHits());
-        assertEquals(305, deserialized.getMisses());
-        assertEquals(4, deserialized.getEvictions());
-        assertEquals(3, deserialized.getExpirations());
-        assertEquals(1, deserialized.getPersistenceCount());
-        assertTrue(deserialized.getLastPersistenceTime() > 0);
-        assertEquals(200, deserialized.getLastPersistenceDuration());
-        assertEquals(300, deserialized.getLastPersistenceWrittenBytes());
-        assertEquals(400, deserialized.getLastPersistenceKeyCount());
-        assertNotNull(deserialized.toString());
+        assertNearCacheStats(deserialized, 1, 200, 300, 400, false);
+    }
+
+    @Test
+    public void testSerialization_withPersistenceFailure() {
+        Throwable throwable = new FileNotFoundException("expected exception");
+        nearCacheStats.addPersistenceFailure(throwable);
+
+        NearCacheStatsImpl deserialized = serializeAndDeserializeNearCacheStats(nearCacheStats);
+
+        assertNearCacheStats(deserialized, 2, 0, 0, 0, true);
+
+        String lastPersistenceFailure = deserialized.getLastPersistenceFailure();
+        assertTrue(lastPersistenceFailure.contains(throwable.getClass().getSimpleName()));
+        assertTrue(lastPersistenceFailure.contains("expected exception"));
     }
 
     @Test
@@ -108,5 +99,35 @@ public class NearCacheStatsImplTest {
         nearCacheStats.setHits(1);
         nearCacheStats.setMisses(1);
         assertEquals(100d, nearCacheStats.getRatio(), 0.0001);
+    }
+
+    private static NearCacheStatsImpl serializeAndDeserializeNearCacheStats(NearCacheStatsImpl original) {
+        JsonObject serialized = original.toJson();
+
+        NearCacheStatsImpl deserialized = new NearCacheStatsImpl();
+        deserialized.fromJson(serialized);
+        return deserialized;
+    }
+
+    private static void assertNearCacheStats(NearCacheStatsImpl stats, long expectedPersistenceCount, long expectedDuration,
+                                             long expectedWrittenBytes, long expectedKeyCount, boolean expectedFailure) {
+        assertTrue(stats.getCreationTime() > 0);
+        assertEquals(500, stats.getOwnedEntryCount());
+        assertEquals(1280, stats.getOwnedEntryMemoryCost());
+        assertEquals(602, stats.getHits());
+        assertEquals(305, stats.getMisses());
+        assertEquals(4, stats.getEvictions());
+        assertEquals(3, stats.getExpirations());
+        assertEquals(expectedPersistenceCount, stats.getPersistenceCount());
+        assertTrue(stats.getLastPersistenceTime() > 0);
+        assertEquals(expectedDuration, stats.getLastPersistenceDuration());
+        assertEquals(expectedWrittenBytes, stats.getLastPersistenceWrittenBytes());
+        assertEquals(expectedKeyCount, stats.getLastPersistenceKeyCount());
+        if (expectedFailure) {
+            assertFalse(stats.getLastPersistenceFailure().isEmpty());
+        } else {
+            assertTrue(stats.getLastPersistenceFailure().isEmpty());
+        }
+        assertNotNull(stats.toString());
     }
 }


### PR DESCRIPTION
* Added `NearCachePreloaderLock` to ensure that only one client writes to the same storage file.
* Added test with two clients and same storage file.
* Added `lastPersistenceFailure` to `NearCacheStats` to ease debugging.
* Changed configuration parameter name from `file-name` to `filename`.

This fix prevents obscure exceptions like this one:
```
Could not store keys of Near Cache /hz/defaultNearCache (/home/donnerbart/IdeaProjects/hazelcast/nearCache-defaultNearCache.store)
com.hazelcast.core.HazelcastException: Failed to rename /home/donnerbart/IdeaProjects/hazelcast/nearCache-defaultNearCache.store~ to /home/donnerbart/IdeaProjects/hazelcast/nearCache-defaultNearCache.store because /home/donnerbart/IdeaProjects/hazelcast/nearCache-defaultNearCache.store~ doesn't exist.
```