### PR TITLE
Fix BasicClientReplicatedMapNearCacheTest failures

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -88,7 +88,7 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
                 long ownedEntryCount = context.stats.getOwnedEntryCount();
                 assertTrue(format("Near Cache owned entry count didn't reach the desired value (%d vs. %d) (%s)",
                         ownedEntryCount, nearCacheSize, context.stats),
-                        ownedEntryCount >= nearCacheSize);
+                        ownedEntryCount == nearCacheSize);
             }
         });
     }


### PR DESCRIPTION
The tests would fail because the assertion passed if the owned count was > 0 and later the cost was asserted to be equal to 0.
Fixes:https://github.com/hazelcast/hazelcast/issues/9333