### PR TITLE
Fix semaphore & lock dead member cleanup mechanisms

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreDataSerializerHook.java
@@ -27,8 +27,8 @@ import com.hazelcast.concurrent.semaphore.operations.ReduceBackupOperation;
 import com.hazelcast.concurrent.semaphore.operations.ReduceOperation;
 import com.hazelcast.concurrent.semaphore.operations.ReleaseBackupOperation;
 import com.hazelcast.concurrent.semaphore.operations.ReleaseOperation;
-import com.hazelcast.concurrent.semaphore.operations.SemaphoreDeadMemberBackupOperation;
-import com.hazelcast.concurrent.semaphore.operations.SemaphoreDeadMemberOperation;
+import com.hazelcast.concurrent.semaphore.operations.SemaphoreDetachMemberBackupOperation;
+import com.hazelcast.concurrent.semaphore.operations.SemaphoreDetachMemberOperation;
 import com.hazelcast.concurrent.semaphore.operations.SemaphoreReplicationOperation;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
@@ -46,7 +46,7 @@ public class SemaphoreDataSerializerHook implements DataSerializerHook {
     public static final int ACQUIRE_BACKUP_OPERATION = 1;
     public static final int ACQUIRE_OPERATION = 2;
     public static final int AVAILABLE_OPERATION = 3;
-    public static final int DEAD_MEMBER_BACKUP_OPERATION = 4;
+    public static final int DETACH_MEMBER_BACKUP_OPERATION = 4;
     public static final int DRAIN_BACKUP_OPERATION = 5;
     public static final int DRAIN_OPERATION = 6;
     public static final int INIT_BACKUP_OPERATION = 7;
@@ -55,7 +55,7 @@ public class SemaphoreDataSerializerHook implements DataSerializerHook {
     public static final int REDUCE_OPERATION = 10;
     public static final int RELEASE_BACKUP_OPERATION = 11;
     public static final int RELEASE_OPERATION = 12;
-    public static final int DEAD_MEMBER_OPERATION = 13;
+    public static final int DETACH_MEMBER_OPERATION = 13;
     public static final int SEMAPHORE_REPLICATION_OPERATION = 14;
 
     @Override
@@ -77,8 +77,8 @@ public class SemaphoreDataSerializerHook implements DataSerializerHook {
                         return new AcquireOperation();
                     case AVAILABLE_OPERATION:
                         return new AvailableOperation();
-                    case DEAD_MEMBER_BACKUP_OPERATION:
-                        return new SemaphoreDeadMemberBackupOperation();
+                    case DETACH_MEMBER_BACKUP_OPERATION:
+                        return new SemaphoreDetachMemberBackupOperation();
                     case DRAIN_BACKUP_OPERATION:
                         return new DrainBackupOperation();
                     case DRAIN_OPERATION:
@@ -95,8 +95,8 @@ public class SemaphoreDataSerializerHook implements DataSerializerHook {
                         return new ReleaseBackupOperation();
                     case RELEASE_OPERATION:
                         return new ReleaseOperation();
-                    case DEAD_MEMBER_OPERATION:
-                        return new SemaphoreDeadMemberOperation();
+                    case DETACH_MEMBER_OPERATION:
+                        return new SemaphoreDetachMemberOperation();
                     case SEMAPHORE_REPLICATION_OPERATION:
                         return new SemaphoreReplicationOperation();
                     default:

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.concurrent.semaphore;
 
-import com.hazelcast.concurrent.semaphore.operations.SemaphoreDeadMemberOperation;
+import com.hazelcast.concurrent.semaphore.operations.SemaphoreDetachMemberOperation;
 import com.hazelcast.concurrent.semaphore.operations.SemaphoreReplicationOperation;
 import com.hazelcast.config.SemaphoreConfig;
 import com.hazelcast.spi.ClientAwareService;
@@ -43,7 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getPartitionKey;
-import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 
 public class SemaphoreService implements ManagedService, MigrationAwareService, MembershipAwareService, RemoteService,
@@ -97,28 +96,30 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
 
     @Override
     public void memberRemoved(MembershipServiceEvent event) {
-        String caller = event.getMember().getUuid();
-        onOwnerDisconnected(caller);
+        onOwnerDisconnected(event.getMember().getUuid());
     }
 
     @Override
     public void memberAttributeChanged(MemberAttributeServiceEvent event) {
     }
 
-    private void onOwnerDisconnected(final String caller) {
-        IPartitionService partitionService = nodeEngine.getPartitionService();
+    private void onOwnerDisconnected(final String owner) {
         OperationService operationService = nodeEngine.getOperationService();
 
-        for (String name : containers.keySet()) {
-            int partitionId = partitionService.getPartitionId(getPartitionKey(name));
-            Operation op = new SemaphoreDeadMemberOperation(name, caller)
-                    .setPartitionId(partitionId)
+        for (Map.Entry<String, SemaphoreContainer> entry : containers.entrySet()) {
+            String name = entry.getKey();
+            SemaphoreContainer container = entry.getValue();
+
+            Operation op = new SemaphoreDetachMemberOperation(name, owner)
+                    .setPartitionId(container.getPartitionId())
                     .setValidateTarget(false)
-                    .setOperationResponseHandler(createEmptyResponseHandler())
                     .setService(this)
                     .setNodeEngine(nodeEngine)
                     .setServiceName(SERVICE_NAME);
-            operationService.execute(op);
+
+            // op will be executed on partition thread locally.
+            // Invocation is to handle retries (if partition is being migrated).
+            operationService.invokeOnTarget(SERVICE_NAME, op, nodeEngine.getThisAddress());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireBackupOperation.java
@@ -31,7 +31,7 @@ public class AcquireBackupOperation extends SemaphoreBackupOperation {
     @Override
     public void run() throws Exception {
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
-        semaphoreContainer.acquire(permitCount, firstCaller);
+        semaphoreContainer.acquire(firstCaller, permitCount);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/AcquireOperation.java
@@ -38,7 +38,7 @@ public class AcquireOperation extends SemaphoreBackupAwareOperation implements B
     @Override
     public void run() throws Exception {
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
-        response = semaphoreContainer.acquire(permitCount, getCallerUuid());
+        response = semaphoreContainer.acquire(getCallerUuid(), permitCount);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseBackupOperation.java
@@ -31,7 +31,7 @@ public class ReleaseBackupOperation extends SemaphoreBackupOperation {
     @Override
     public void run() throws Exception {
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
-        semaphoreContainer.release(permitCount, firstCaller);
+        semaphoreContainer.release(firstCaller, permitCount);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/ReleaseOperation.java
@@ -35,7 +35,7 @@ public class ReleaseOperation extends SemaphoreBackupAwareOperation implements N
     @Override
     public void run() throws Exception {
         SemaphoreContainer semaphoreContainer = getSemaphoreContainer();
-        semaphoreContainer.release(permitCount, getCallerUuid());
+        semaphoreContainer.release(getCallerUuid(), permitCount);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDetachMemberBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/operations/SemaphoreDetachMemberBackupOperation.java
@@ -20,12 +20,12 @@ import com.hazelcast.concurrent.semaphore.SemaphoreContainer;
 import com.hazelcast.concurrent.semaphore.SemaphoreDataSerializerHook;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 
-public class SemaphoreDeadMemberBackupOperation extends SemaphoreBackupOperation {
+public class SemaphoreDetachMemberBackupOperation extends SemaphoreBackupOperation {
 
-    public SemaphoreDeadMemberBackupOperation() {
+    public SemaphoreDetachMemberBackupOperation() {
     }
 
-    public SemaphoreDeadMemberBackupOperation(String name, String firstCaller) {
+    public SemaphoreDetachMemberBackupOperation(String name, String firstCaller) {
         super(name, -1, firstCaller);
     }
 
@@ -34,12 +34,12 @@ public class SemaphoreDeadMemberBackupOperation extends SemaphoreBackupOperation
         SemaphoreService service = getService();
         if (service.containsSemaphore(name)) {
             SemaphoreContainer semaphoreContainer = service.getSemaphoreContainer(name);
-            response = semaphoreContainer.memberRemoved(firstCaller);
+            response = semaphoreContainer.detachAll(firstCaller);
         }
     }
 
     @Override
     public int getId() {
-        return SemaphoreDataSerializerHook.DEAD_MEMBER_BACKUP_OPERATION;
+        return SemaphoreDataSerializerHook.DETACH_MEMBER_BACKUP_OPERATION;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
@@ -1,124 +1,74 @@
 package com.hazelcast.concurrent.countdownlatch;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICountDownLatch;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.SlowTest;
-import org.junit.After;
-import org.junit.Before;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CountDownLatchSplitBrainTest extends HazelcastTestSupport {
-
-    @Before
-    @After
-    public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.shutdownAll();
-    }
 
     @Test
     public void testCountDownLatchSplitBrain() throws InterruptedException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         Config config = newConfig();
-        HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
-        HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
-        HazelcastInstance h3 = Hazelcast.newHazelcastInstance(config);
-        final String name = generateKeyOwnedBy(h3);
-        ICountDownLatch countDownLatch = h3.getCountDownLatch(name);
-        countDownLatch.trySetCount(5);
 
-        TestMemberShipListener memberShipListener = new TestMemberShipListener(2);
-        h3.getCluster().addMembershipListener(memberShipListener);
-        TestLifeCycleListener lifeCycleListener = new TestLifeCycleListener(1);
-        h3.getLifecycleService().addLifecycleListener(lifeCycleListener);
+        HazelcastInstance h1 = factory.newHazelcastInstance(config);
+        HazelcastInstance h2 = factory.newHazelcastInstance(config);
+        HazelcastInstance h3 = factory.newHazelcastInstance(config);
+        warmUpPartitions(h1, h2, h3);
 
-        countDownLatch.countDown();
+        String name = generateKeyOwnedBy(h3);
+        ICountDownLatch countDownLatch1 = h1.getCountDownLatch(name);
+        ICountDownLatch countDownLatch3 = h3.getCountDownLatch(name);
+        countDownLatch3.trySetCount(5);
 
+        waitAllForSafeState(h1, h2, h3);
+
+        // create split: [h1, h2] & [h3]
         closeConnectionBetween(h1, h3);
         closeConnectionBetween(h2, h3);
 
-        assertOpenEventually(memberShipListener.latch);
         assertClusterSizeEventually(2, h1);
         assertClusterSizeEventually(2, h2);
         assertClusterSizeEventually(1, h3);
 
-        ICountDownLatch countDownLatch1 = h1.getCountDownLatch(name);
+        // modify both latches after split with different counts
+
+        // count of h1 & h2 = 4
         countDownLatch1.countDown();
 
-        countDownLatch.countDown();
-        countDownLatch.countDown();
+        // count of h3 = 0
+        while (countDownLatch3.getCount() > 0) {
+            countDownLatch3.countDown();
+        }
 
-        assertOpenEventually(lifeCycleListener.latch);
+        // merge back
+        getNode(h3).getClusterService().merge(getAddress(h1));
+
         assertClusterSizeEventually(3, h1);
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        ICountDownLatch countDownLatchTest = h3.getCountDownLatch(name);
-        assertEquals(3, countDownLatchTest.getCount());
+        // latch count should be equal to the count of larger cluster
+        assertEquals(4, countDownLatch3.getCount());
     }
 
     private Config newConfig() {
         Config config = new Config();
-        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "30");
-        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "3");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "600");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "600");
         return config;
-    }
-
-    private class TestLifeCycleListener implements LifecycleListener {
-
-        CountDownLatch latch;
-
-        TestLifeCycleListener(int countdown) {
-            latch = new CountDownLatch(countdown);
-        }
-
-        @Override
-        public void stateChanged(LifecycleEvent event) {
-            if (event.getState() == LifecycleEvent.LifecycleState.MERGED) {
-                latch.countDown();
-            }
-        }
-    }
-
-    private class TestMemberShipListener implements MembershipListener {
-
-        final CountDownLatch latch;
-
-        TestMemberShipListener(int countdown) {
-            latch = new CountDownLatch(countdown);
-        }
-
-        @Override
-        public void memberAdded(MembershipEvent membershipEvent) {
-
-        }
-
-        @Override
-        public void memberRemoved(MembershipEvent membershipEvent) {
-            latch.countDown();
-        }
-
-        @Override
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockSplitBrainTest.java
@@ -1,130 +1,71 @@
 package com.hazelcast.concurrent.lock;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ILock;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.NightlyTest;
-import org.junit.After;
-import org.junit.Before;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class LockSplitBrainTest extends HazelcastTestSupport {
-
-    @Before
-    @After
-    public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.shutdownAll();
-    }
 
     @Test
     public void testLockSplitBrain_acquireSameLock() throws InterruptedException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         Config config = newConfig();
-        HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
-        HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance h3 = Hazelcast.newHazelcastInstance(config);
-        final String key = generateKeyOwnedBy(h3);
-        ILock lock = h3.getLock(key);
-        lock.lock();
 
-        TestMemberShipListener memberShipListener = new TestMemberShipListener(2);
-        h3.getCluster().addMembershipListener(memberShipListener);
-        TestLifeCycleListener lifeCycleListener = new TestLifeCycleListener(1);
-        h3.getLifecycleService().addLifecycleListener(lifeCycleListener);
+        HazelcastInstance h1 = factory.newHazelcastInstance(config);
+        HazelcastInstance h2 = factory.newHazelcastInstance(config);
+        HazelcastInstance h3 = factory.newHazelcastInstance(config);
+        warmUpPartitions(h1, h2, h3);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertTrue(h3.getPartitionService().isLocalMemberSafe());
-            }
-        });
+        String key = generateKeyOwnedBy(h3);
+        ILock lock1 = h1.getLock(key);
+        ILock lock3 = h3.getLock(key);
+        lock3.lock();
 
+        waitAllForSafeState(h1, h2, h3);
+
+        // create split: [h1, h2] & [h3]
         closeConnectionBetween(h1, h3);
         closeConnectionBetween(h2, h3);
 
-        assertOpenEventually(memberShipListener.latch);
         assertClusterSizeEventually(2, h1);
         assertClusterSizeEventually(2, h2);
         assertClusterSizeEventually(1, h3);
 
-        ILock h1Lock = h1.getLock(key);
-        h1Lock.lock();
+        // acquire lock on [h1, h2] side
+        lock1.lock();
 
-        lock.forceUnlock();
+        // release lock on h3 side
+        lock3.forceUnlock();
 
-        assertOpenEventually(lifeCycleListener.latch);
+        // merge back
+        getNode(h3).getClusterService().merge(getAddress(h1));
+
         assertClusterSizeEventually(3, h1);
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        ILock testLock = h3.getLock(key);
-        assertTrue(testLock.isLocked());
+        // h3 observes lock as acquired
+        assertTrue(lock3.isLocked());
     }
 
 
     private Config newConfig() {
         Config config = new Config();
-        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "3");
-        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "1");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "600");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "600");
         return config;
-    }
-
-    private class TestLifeCycleListener implements LifecycleListener {
-
-        CountDownLatch latch;
-
-        TestLifeCycleListener(int countdown) {
-            latch = new CountDownLatch(countdown);
-        }
-
-        @Override
-        public void stateChanged(LifecycleEvent event) {
-            if (event.getState() == LifecycleEvent.LifecycleState.MERGED) {
-                latch.countDown();
-            }
-        }
-    }
-
-    private class TestMemberShipListener implements MembershipListener {
-
-        final CountDownLatch latch;
-
-        TestMemberShipListener(int countdown) {
-            latch = new CountDownLatch(countdown);
-        }
-
-        @Override
-        public void memberAdded(MembershipEvent membershipEvent) {
-
-        }
-
-        @Override
-        public void memberRemoved(MembershipEvent membershipEvent) {
-            latch.countDown();
-        }
-
-        @Override
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreSplitBrainTest.java
@@ -1,75 +1,52 @@
 package com.hazelcast.concurrent.semaphore;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ISemaphore;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.core.MemberAttributeEvent;
-import com.hazelcast.core.MembershipEvent;
-import com.hazelcast.core.MembershipListener;
-import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.SlowTest;
-import org.junit.After;
-import org.junit.Before;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class SemaphoreSplitBrainTest extends HazelcastTestSupport {
-
-    @Before
-    @After
-    public void killAllHazelcastInstances() throws IOException {
-        HazelcastInstanceFactory.terminateAll();
-    }
 
     @Test
     public void testSemaphoreSplitBrain() throws InterruptedException {
         Config config = newConfig();
-        HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
-        HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance h3 = Hazelcast.newHazelcastInstance(config);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        final HazelcastInstance h1 = factory.newHazelcastInstance(config);
+        HazelcastInstance h2 = factory.newHazelcastInstance(config);
+        HazelcastInstance h3 = factory.newHazelcastInstance(config);
+        warmUpPartitions(h1, h2, h3);
+
         final String key = generateKeyOwnedBy(h3);
-        ISemaphore semaphore = h3.getSemaphore(key);
-        semaphore.init(5);
-        semaphore.acquire(3);
-        assertEquals(2, semaphore.availablePermits());
+        final ISemaphore semaphore1 = h1.getSemaphore(key);
+        final ISemaphore semaphore3 = h3.getSemaphore(key);
+        semaphore1.init(5);
+        semaphore3.acquire(3);
+        assertEquals(2, semaphore3.availablePermits());
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertTrue(h3.getPartitionService().isLocalMemberSafe());
-            }
-        });
+        waitAllForSafeState(h1, h2, h3);
 
-        TestMemberShipListener memberShipListener = new TestMemberShipListener(2);
-        h3.getCluster().addMembershipListener(memberShipListener);
-        TestLifeCycleListener lifeCycleListener = new TestLifeCycleListener(1);
-        h3.getLifecycleService().addLifecycleListener(lifeCycleListener);
-
+        // create split: [h1, h2] & [h3]
         closeConnectionBetween(h1, h3);
         closeConnectionBetween(h2, h3);
 
-        assertOpenEventually(memberShipListener.latch);
         assertClusterSizeEventually(2, h1);
         assertClusterSizeEventually(2, h2);
         assertClusterSizeEventually(1, h3);
 
-        final ISemaphore semaphore1 = h1.getSemaphore(key);
         // when member is down, permits are released.
         // since releasing the permits is async, we use assert eventually
         assertTrueEventually(new AssertTask() {
@@ -78,62 +55,23 @@ public class SemaphoreSplitBrainTest extends HazelcastTestSupport {
                 assertEquals(5, semaphore1.availablePermits());
             }
         });
+
         semaphore1.acquire(4);
 
-        assertOpenEventually(lifeCycleListener.latch);
+        // merge back
+        getNode(h3).getClusterService().merge(getAddress(h1));
+
         assertClusterSizeEventually(3, h1);
         assertClusterSizeEventually(3, h2);
         assertClusterSizeEventually(3, h3);
 
-        ISemaphore testSemaphore = h3.getSemaphore(key);
-        assertEquals(1, testSemaphore.availablePermits());
+        assertEquals(1, semaphore3.availablePermits());
     }
-
 
     private Config newConfig() {
         Config config = new Config();
-        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "3");
-        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "1");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "600");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "600");
         return config;
-    }
-
-    private static class TestLifeCycleListener implements LifecycleListener {
-
-        CountDownLatch latch;
-
-        TestLifeCycleListener(int countdown) {
-            latch = new CountDownLatch(countdown);
-        }
-
-        @Override
-        public void stateChanged(LifecycleEvent event) {
-            if (event.getState() == LifecycleEvent.LifecycleState.MERGED) {
-                latch.countDown();
-            }
-        }
-    }
-
-    private static class TestMemberShipListener implements MembershipListener {
-
-        final CountDownLatch latch;
-
-        TestMemberShipListener(int countdown) {
-            latch = new CountDownLatch(countdown);
-        }
-
-        @Override
-        public void memberAdded(MembershipEvent membershipEvent) {
-
-        }
-
-        @Override
-        public void memberRemoved(MembershipEvent membershipEvent) {
-            latch.countDown();
-        }
-
-        @Override
-        public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
-
-        }
     }
 }


### PR DESCRIPTION
Cleanup operations which are executed after a member is removed
should handle retry cases too. A partition can be promoted and/or migrated
when a member is removed. As a result of that, cleanup operation can be
rejected with a retry response.

With this change, cleanup operations are submitted to local member
via invocation mechanism.

Also simplified Semaphore, ILock and CountDownLatch split brain tests.

Fixes #7958 
