### PR TITLE
Client listener reconnect tests fix 

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -34,7 +34,6 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.test.AssertTask;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -66,7 +65,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
     //-------------------------- testListenersTerminateRandomNode --------------------- //
     @Test
-    @Ignore
     public void testListenersNonSmartRoutingTerminateRandomNode() {
         factory.newInstances(null, 3);
         ClientConfig clientConfig = getNonSmartClientConfig();
@@ -75,7 +73,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testListenersSmartRoutingTerminateRandomNode() {
         factory.newInstances(null, 3);
         ClientConfig clientConfig = getSmartClientConfig();
@@ -114,7 +111,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersWaitMemberDestroy --------------------- //
 
     @Test
-    @Ignore
     public void testListenersWaitMemberDestroySmartRouting() {
         factory.newInstances(null, 3);
 
@@ -167,7 +163,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersTemporaryNetworkBlockage --------------------- //
 
     @Test
-    @Ignore
     public void testTemporaryBlockedNoDisconnectionSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -178,7 +173,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testTemporaryBlockedNoDisconnectionNonSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -189,7 +183,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testTemporaryBlockedNoDisconnectionMultipleServerSmartRouting() {
         factory.newInstances(null, 3);
 
@@ -200,7 +193,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testTemporaryBlockedNoDisconnectionMultipleServerNonSmartRouting() {
         factory.newInstances(null, 3);
 
@@ -237,7 +229,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersHeartbeatTimeoutToOwner --------------------- //
 
     @Test
-    @Ignore
     public void testClusterReconnectDueToHeartbeatSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -248,7 +239,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testClusterReconnectMultipleServersDueToHeartbeatSmartRouting() {
         factory.newInstances(null, 3);
 
@@ -259,7 +249,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testClusterReconnectDueToHeartbeatNonSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -270,7 +259,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testClusterReconnectMultipleServerDueToHeartbeatNonSmartRouting() {
         factory.newInstances(null, 3);
 
@@ -314,7 +302,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersTerminateOwnerNode --------------------- //
 
     @Test
-    @Ignore
     public void testListenersSmartRoutingMultipleServer() {
         factory.newInstances(null, 3);
 
@@ -324,7 +311,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testListenersNonSmartRoutingMultipleServer() {
         factory.newInstances(null, 3);
 
@@ -334,7 +320,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testListenersSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -344,7 +329,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testListenersNonSmartRouting() {
         factory.newHazelcastInstance();
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
@@ -23,23 +23,46 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastTestSupport;
 
-/**
- * Created by ihsan on 05/09/16.
- */
 public class ClientTestSupport extends HazelcastTestSupport {
 
+    /**
+     * Blocks incoming messages to client from given instance
+     */
     protected void blockMessagesFromInstance(HazelcastInstance instance, HazelcastInstance client) {
         HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
         ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
         Address address = instance.getCluster().getLocalMember().getAddress();
-        ((TestClientRegistry.MockClientConnectionManager) connectionManager).block(address);
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).blockFrom(address);
     }
 
+    /**
+     * Unblocks incoming messages to client from given instance
+     */
     protected void unblockMessagesFromInstance(HazelcastInstance instance, HazelcastInstance client) {
         HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
         ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
         Address address = instance.getCluster().getLocalMember().getAddress();
-        ((TestClientRegistry.MockClientConnectionManager) connectionManager).unblock(address);
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).unblockFrom(address);
+    }
+
+    /**
+     * Blocks outgoing messages from client to given instance
+     */
+    protected void blockMessagesToInstance(HazelcastInstance instance, HazelcastInstance client) {
+        HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
+        ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
+        Address address = instance.getCluster().getLocalMember().getAddress();
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).blockTo(address);
+    }
+
+    /**
+     * Unblocks outgoing messages from client to given instance
+     */
+    protected void unblockMessagesToInstance(HazelcastInstance instance, HazelcastInstance client) {
+        HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
+        ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
+        Address address = instance.getCluster().getLocalMember().getAddress();
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).unblockTo(address);
     }
 
     protected HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TwoWayBlockableExecutor.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TwoWayBlockableExecutor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.test;
+
+import com.hazelcast.logging.Logger;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+/**
+ * Utility class to help mitigate temporary unresponsive node or client
+ * <p>
+ * TwoWayBlockableExecutor acts like network between client and network
+ * <p>
+ * IncomingMessages is carrying messages coming from server to   client
+ * OutgoingMessages is carrying messages going  to   server from client
+ * <p>
+ * with block* and unblock* methods one can stop/continue all messages from outside at any moment
+ */
+class TwoWayBlockableExecutor {
+
+    static class LockPair {
+        ReadWriteLock incomingLock;
+        ReadWriteLock outgoingLock;
+
+        LockPair(ReadWriteLock incomingLock, ReadWriteLock outgoingLock) {
+            this.incomingLock = incomingLock;
+            this.outgoingLock = outgoingLock;
+        }
+
+        void blockIncoming() {
+            incomingLock.writeLock().lock();
+        }
+
+        void unblockIncoming() {
+            incomingLock.writeLock().unlock();
+        }
+
+        void blockOutgoing() {
+            outgoingLock.writeLock().lock();
+        }
+
+        void unblockOutgoing() {
+            outgoingLock.writeLock().unlock();
+        }
+
+    }
+
+    private final ExecutorService incomingMessages = Executors.newSingleThreadExecutor();
+    private final ExecutorService outgoingMessages = Executors.newSingleThreadExecutor();
+    private final LockPair lockPair;
+
+    TwoWayBlockableExecutor(LockPair lockPair) {
+        this.lockPair = lockPair;
+    }
+
+    void shutdownIncoming() {
+        incomingMessages.shutdown();
+    }
+
+    void shutdownOutgoing() {
+        outgoingMessages.shutdown();
+    }
+
+    class BlockableRunnable implements Runnable {
+
+        private final Runnable runnable;
+        private final Lock lock;
+
+        BlockableRunnable(Runnable runnable, Lock lock) {
+            this.runnable = runnable;
+            this.lock = lock;
+        }
+
+        @Override
+        public void run() {
+            lock.lock();
+            try {
+                runnable.run();
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    void executeIncoming(Runnable runnable) {
+        try {
+            incomingMessages.execute(new BlockableRunnable(runnable, lockPair.incomingLock.readLock()));
+        } catch (RejectedExecutionException rejected) {
+            Logger.getLogger(this.getClass()).warning("Dropping incoming runnable since other end closed " + runnable);
+        }
+    }
+
+    void executeOutgoing(Runnable runnable) {
+        try {
+            outgoingMessages.execute(new BlockableRunnable(runnable, lockPair.outgoingLock.readLock()));
+        } catch (RejectedExecutionException rejected) {
+            Logger.getLogger(this.getClass()).warning("Dropping outgoing runnable since other end closed " + runnable);
+        }
+    }
+
+}


### PR DESCRIPTION
Test failures are caused by bug in logic to mitigate heartbeat
failures between nodes and clients. Two problems I found,

1) Unblock only frees the `activeConnections`. `activeConnections`
are authenticated ones. The ones in progress of authentication
never be freed. This was causing client to never able to conenct back
the related address.

2) We are blocking messages but not blocking close signal EOF.

Block/unblock infrastructure is rewritten to address these issues.
We were only able to block incoming messages to client. Blocking
outgoing messages also added in this pr.

Ignore's on ClientListenerReconnect tests are removed.