### PR TITLE
Client listener reconnect tests fix 

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -34,7 +34,6 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.test.AssertTask;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -66,7 +65,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
     //-------------------------- testListenersTerminateRandomNode --------------------- //
     @Test
-    @Ignore
     public void testListenersNonSmartRoutingTerminateRandomNode() {
         factory.newInstances(null, 3);
         ClientConfig clientConfig = getNonSmartClientConfig();
@@ -75,7 +73,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testListenersSmartRoutingTerminateRandomNode() {
         factory.newInstances(null, 3);
         ClientConfig clientConfig = getSmartClientConfig();
@@ -114,7 +111,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersWaitMemberDestroy --------------------- //
 
     @Test
-    @Ignore
     public void testListenersWaitMemberDestroySmartRouting() {
         factory.newInstances(null, 3);
 
@@ -167,7 +163,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersTemporaryNetworkBlockage --------------------- //
 
     @Test
-    @Ignore
     public void testTemporaryBlockedNoDisconnectionSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -178,7 +173,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testTemporaryBlockedNoDisconnectionNonSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -189,7 +183,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testTemporaryBlockedNoDisconnectionMultipleServerSmartRouting() {
         factory.newInstances(null, 3);
 
@@ -200,7 +193,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testTemporaryBlockedNoDisconnectionMultipleServerNonSmartRouting() {
         factory.newInstances(null, 3);
 
@@ -237,7 +229,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersHeartbeatTimeoutToOwner --------------------- //
 
     @Test
-    @Ignore
     public void testClusterReconnectDueToHeartbeatSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -248,7 +239,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testClusterReconnectMultipleServersDueToHeartbeatSmartRouting() {
         factory.newInstances(null, 3);
 
@@ -259,7 +249,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testClusterReconnectDueToHeartbeatNonSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -270,7 +259,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testClusterReconnectMultipleServerDueToHeartbeatNonSmartRouting() {
         factory.newInstances(null, 3);
 
@@ -314,7 +302,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     //-------------------------- testListenersTerminateOwnerNode --------------------- //
 
     @Test
-    @Ignore
     public void testListenersSmartRoutingMultipleServer() {
         factory.newInstances(null, 3);
 
@@ -324,7 +311,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testListenersNonSmartRoutingMultipleServer() {
         factory.newInstances(null, 3);
 
@@ -334,7 +320,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testListenersSmartRouting() {
         factory.newHazelcastInstance();
 
@@ -344,7 +329,6 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     @Test
-    @Ignore
     public void testListenersNonSmartRouting() {
         factory.newHazelcastInstance();
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/ClientTestSupport.java
@@ -23,23 +23,46 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastTestSupport;
 
-/**
- * Created by ihsan on 05/09/16.
- */
 public class ClientTestSupport extends HazelcastTestSupport {
 
+    /**
+     * Blocks incoming messages to client from given instance
+     */
     protected void blockMessagesFromInstance(HazelcastInstance instance, HazelcastInstance client) {
         HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
         ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
         Address address = instance.getCluster().getLocalMember().getAddress();
-        ((TestClientRegistry.MockClientConnectionManager) connectionManager).block(address);
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).blockFrom(address);
     }
 
+    /**
+     * Unblocks incoming messages to client from given instance
+     */
     protected void unblockMessagesFromInstance(HazelcastInstance instance, HazelcastInstance client) {
         HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
         ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
         Address address = instance.getCluster().getLocalMember().getAddress();
-        ((TestClientRegistry.MockClientConnectionManager) connectionManager).unblock(address);
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).unblockFrom(address);
+    }
+
+    /**
+     * Blocks outgoing messages from client to given instance
+     */
+    protected void blockMessagesToInstance(HazelcastInstance instance, HazelcastInstance client) {
+        HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
+        ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
+        Address address = instance.getCluster().getLocalMember().getAddress();
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).blockTo(address);
+    }
+
+    /**
+     * Unblocks outgoing messages from client to given instance
+     */
+    protected void unblockMessagesToInstance(HazelcastInstance instance, HazelcastInstance client) {
+        HazelcastClientInstanceImpl clientImpl = getHazelcastClientInstanceImpl(client);
+        ClientConnectionManager connectionManager = clientImpl.getConnectionManager();
+        Address address = instance.getCluster().getLocalMember().getAddress();
+        ((TestClientRegistry.MockClientConnectionManager) connectionManager).unblockTo(address);
     }
 
     protected HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -46,20 +46,20 @@ import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.mocknetwork.MockConnection;
 import com.hazelcast.test.mocknetwork.TestNodeRegistry;
+import com.hazelcast.util.ConcurrencyUtil;
+import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.Map;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 
-public class TestClientRegistry {
+class TestClientRegistry {
 
     private static final ILogger LOGGER = Logger.getLogger(HazelcastClient.class);
     private final TestNodeRegistry nodeRegistry;
@@ -110,10 +110,10 @@ public class TestClientRegistry {
         private final String host;
         private final AtomicInteger ports;
         private final HazelcastClientInstanceImpl client;
-        private final Map<Address, State> stateMap = new ConcurrentHashMap<Address, State>();
+        private final ConcurrentHashMap<Address, TwoWayBlockableExecutor.LockPair> addressBlockMap = new ConcurrentHashMap<Address, TwoWayBlockableExecutor.LockPair>();
 
-        public MockClientConnectionManager(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
-                                           String host, AtomicInteger ports) {
+        MockClientConnectionManager(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
+                                    String host, AtomicInteger ports) {
             super(client, addressTranslator);
             this.client = client;
             this.host = host;
@@ -147,8 +147,16 @@ public class TestClientRegistry {
                 }
                 Node node = TestUtil.getNode(instance);
                 Address localAddress = new Address(host, ports.incrementAndGet());
+                TwoWayBlockableExecutor.LockPair lockPair = ConcurrencyUtil.getOrPutIfAbsent(addressBlockMap, address,
+                        new ConstructorFunction<Address, TwoWayBlockableExecutor.LockPair>() {
+                            @Override
+                            public TwoWayBlockableExecutor.LockPair createNew(Address arg) {
+                                return new TwoWayBlockableExecutor.LockPair(new ReentrantReadWriteLock(), new ReentrantReadWriteLock());
+                            }
+                        });
+
                 MockedClientConnection connection = new MockedClientConnection(client,
-                        connectionIdGen.incrementAndGet(), node.nodeEngine, address, localAddress, stateMap);
+                        connectionIdGen.incrementAndGet(), node.nodeEngine, address, localAddress, lockPair);
                 LOGGER.info("Created connection to endpoint: " + address + ", connection: " + connection);
                 return connection;
             } catch (Exception e) {
@@ -157,59 +165,62 @@ public class TestClientRegistry {
         }
 
         /**
-         * Stores incoming messages from address to a temporary queue
-         * When unblocked first this queue will be processed after that new messages will be consumed
+         * Blocks incoming messages to client from given address
          */
-        public void block(Address address) {
-            stateMap.put(address, State.BLOCKING);
+        void blockFrom(Address address) {
             LOGGER.info("Blocked messages from " + address);
+            TwoWayBlockableExecutor.LockPair executor = addressBlockMap.get(address);
+            executor.blockIncoming();
         }
 
         /**
-         * Removes the filter that is put by either block or drop
-         * Consumes from the temporary queue if there is anything then continues to normal behaviour
+         * Unblocks incoming messages to client from given address
          */
-        public void unblock(Address address) {
-            stateMap.remove(address);
+        void unblockFrom(Address address) {
             LOGGER.info("Unblocked messages from " + address);
-            ClientConnection connection = getConnection(address);
-            if (null != connection) {
-                MockedClientConnection clientConnection = (MockedClientConnection) connection;
-                clientConnection.onUnblock();
-            }
+            TwoWayBlockableExecutor.LockPair lockPair = addressBlockMap.get(address);
+            lockPair.unblockIncoming();
         }
 
         /**
-         * Drops incoming messages from address
+         * Blocks outgoing messages from client to given address
          */
-        public void drop(Address address) {
-            stateMap.put(address, State.DROPPING);
-            LOGGER.info("Dropping messages from " + address);
+        void blockTo(Address address) {
+            LOGGER.info("Blocked messages to " + address);
+            TwoWayBlockableExecutor.LockPair lockPair = addressBlockMap.get(address);
+            lockPair.blockOutgoing();
         }
+
+        /**
+         * Unblocks outgoing messages from client to given address
+         */
+        void unblockTo(Address address) {
+            LOGGER.info("Unblocked messages to " + address);
+            TwoWayBlockableExecutor.LockPair lockPair = addressBlockMap.get(address);
+            lockPair.unblockOutgoing();
+        }
+
     }
 
-    enum State {
-        BLOCKING, DROPPING
-    }
-
-    public class MockedClientConnection extends ClientConnection {
+    private class MockedClientConnection extends ClientConnection {
         private volatile long lastReadTime;
         private volatile long lastWriteTime;
         private final NodeEngineImpl serverNodeEngine;
         private final Address remoteAddress;
         private final Address localAddress;
         private final Connection serverSideConnection;
+        private final TwoWayBlockableExecutor executor;
 
-        private final Queue<ClientMessage> incomingMessages = new ConcurrentLinkedQueue<ClientMessage>();
-        private final Map<Address, State> stateMap;
+        MockedClientConnection(HazelcastClientInstanceImpl client,
+                               int connectionId, NodeEngineImpl serverNodeEngine,
+                               Address address, Address localAddress,
+                               TwoWayBlockableExecutor.LockPair lockPair) throws IOException {
 
-        public MockedClientConnection(HazelcastClientInstanceImpl client, int connectionId, NodeEngineImpl serverNodeEngine,
-                                      Address address, Address localAddress, Map<Address, State> stateMap) throws IOException {
             super(client, connectionId);
             this.serverNodeEngine = serverNodeEngine;
             this.remoteAddress = address;
             this.localAddress = localAddress;
-            this.stateMap = stateMap;
+            this.executor = new TwoWayBlockableExecutor(lockPair);
             this.serverSideConnection = new MockedNodeConnection(connectionId, remoteAddress,
                     localAddress, serverNodeEngine, this);
         }
@@ -219,41 +230,42 @@ public class TestClientRegistry {
             //No init for mock connections
         }
 
-        void handleClientMessage(ClientMessage clientMessage) {
-            if (getState() == State.DROPPING) {
-                return;
-            }
+        void handleClientMessage(final ClientMessage clientMessage) {
+            executor.executeIncoming(new Runnable() {
+                @Override
+                public void run() {
+                    lastReadTime = System.currentTimeMillis();
+                    getConnectionManager().handleClientMessage(clientMessage, MockedClientConnection.this);
+                }
 
-            if (getState() == State.BLOCKING) {
-                incomingMessages.add(clientMessage);
-                return;
-            }
-            processBufferedIncomingMessages();
-            lastReadTime = System.currentTimeMillis();
-            getConnectionManager().handleClientMessage(clientMessage, this);
-        }
-
-        private void processBufferedIncomingMessages() {
-            ClientMessage message;
-            while ((message = incomingMessages.poll()) != null) {
-                lastReadTime = System.currentTimeMillis();
-                getConnectionManager().handleClientMessage(message, this);
-            }
-        }
-
-        private State getState() {
-            return stateMap.get(remoteAddress);
+                @Override
+                public String toString() {
+                    return "Runnable message " + clientMessage;
+                }
+            });
         }
 
         @Override
-        public boolean write(OutboundFrame frame) {
-            Node node = serverNodeEngine.getNode();
+        public boolean write(final OutboundFrame frame) {
+            final Node node = serverNodeEngine.getNode();
             if (node.getState() == NodeState.SHUT_DOWN) {
                 return false;
             }
-            ClientMessage newPacket = readFromPacket((ClientMessage) frame);
-            lastWriteTime = System.currentTimeMillis();
-            node.clientEngine.handleClientMessage(newPacket, serverSideConnection);
+            executor.executeOutgoing(new Runnable() {
+                @Override
+                public String toString() {
+                    return "Runnable message " + frame;
+                }
+
+                @Override
+                public void run() {
+                    ClientMessage newPacket = readFromPacket((ClientMessage) frame);
+                    lastWriteTime = System.currentTimeMillis();
+                    node.clientEngine.handleClientMessage(newPacket, serverSideConnection);
+
+
+                }
+            });
             return true;
         }
 
@@ -308,12 +320,37 @@ public class TestClientRegistry {
 
         @Override
         protected void innerClose() throws IOException {
-            serverSideConnection.close(null, null);
+            executor.executeOutgoing((new Runnable() {
+                @Override
+                public void run() {
+                    serverSideConnection.close(null, null);
+
+                }
+
+                @Override
+                public String toString() {
+                    return "Client Closed EOF";
+                }
+            }));
+            executor.shutdownIncoming();
+
         }
 
-        public void onUnblock() {
-            processBufferedIncomingMessages();
+        void onServerClose(final String reason) {
+            executor.executeIncoming(new Runnable() {
+                @Override
+                public String toString() {
+                    return "Server Closed EOF";
+                }
+
+                @Override
+                public void run() {
+                    MockedClientConnection.this.close(reason, new TargetDisconnectedException("Mocked Remote socket closed"));
+                }
+            });
+            executor.shutdownOutgoing();
         }
+
     }
 
     private class MockedNodeConnection extends MockConnection {
@@ -370,9 +407,7 @@ public class TestClientRegistry {
         @Override
         public void close(String reason, Throwable cause) {
             super.close(reason, cause);
-            ClientConnectionManager connectionManager = responseConnection.getConnectionManager();
-            connectionManager.destroyConnection(responseConnection, reason,
-                    new TargetDisconnectedException("Mocked Remote socket closed"));
+            responseConnection.onServerClose(reason);
         }
 
         @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TwoWayBlockableExecutor.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TwoWayBlockableExecutor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.test;
+
+import com.hazelcast.logging.Logger;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+/**
+ * Utility class to help mitigate temporary unresponsive node or client
+ * <p>
+ * TwoWayBlockableExecutor acts like network between client and network
+ * <p>
+ * IncomingMessages is carrying messages coming from server to   client
+ * OutgoingMessages is carrying messages going  to   server from client
+ * <p>
+ * with block* and unblock* methods one can stop/continue all messages from outside at any moment
+ */
+class TwoWayBlockableExecutor {
+
+    static class LockPair {
+        ReadWriteLock incomingLock;
+        ReadWriteLock outgoingLock;
+
+        LockPair(ReadWriteLock incomingLock, ReadWriteLock outgoingLock) {
+            this.incomingLock = incomingLock;
+            this.outgoingLock = outgoingLock;
+        }
+
+        void blockIncoming() {
+            incomingLock.writeLock().lock();
+        }
+
+        void unblockIncoming() {
+            incomingLock.writeLock().unlock();
+        }
+
+        void blockOutgoing() {
+            outgoingLock.writeLock().lock();
+        }
+
+        void unblockOutgoing() {
+            outgoingLock.writeLock().unlock();
+        }
+
+    }
+
+    private final ExecutorService incomingMessages = Executors.newSingleThreadExecutor();
+    private final ExecutorService outgoingMessages = Executors.newSingleThreadExecutor();
+    private final LockPair lockPair;
+
+    TwoWayBlockableExecutor(LockPair lockPair) {
+        this.lockPair = lockPair;
+    }
+
+    void shutdownIncoming() {
+        incomingMessages.shutdown();
+    }
+
+    void shutdownOutgoing() {
+        outgoingMessages.shutdown();
+    }
+
+    class BlockableRunnable implements Runnable {
+
+        private final Runnable runnable;
+        private final Lock lock;
+
+        BlockableRunnable(Runnable runnable, Lock lock) {
+            this.runnable = runnable;
+            this.lock = lock;
+        }
+
+        @Override
+        public void run() {
+            lock.lock();
+            try {
+                runnable.run();
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    void executeIncoming(Runnable runnable) {
+        try {
+            incomingMessages.execute(new BlockableRunnable(runnable, lockPair.incomingLock.readLock()));
+        } catch (RejectedExecutionException rejected) {
+            Logger.getLogger(this.getClass()).warning("Dropping incoming runnable since other end closed " + runnable);
+        }
+    }
+
+    void executeOutgoing(Runnable runnable) {
+        try {
+            outgoingMessages.execute(new BlockableRunnable(runnable, lockPair.outgoingLock.readLock()));
+        } catch (RejectedExecutionException rejected) {
+            Logger.getLogger(this.getClass()).warning("Dropping outgoing runnable since other end closed " + runnable);
+        }
+    }
+
+}


### PR DESCRIPTION
Test failures are caused by bug in logic to mitigate heartbeat
failures between nodes and clients. Two problems I found,

1) Unblock only frees the `activeConnections`. `activeConnections`
are authenticated ones. The ones in progress of authentication
never be freed. This was causing client to never able to connect back
the related address.

2) We are blocking messages but not blocking close signal EOF.

Block/unblock infrastructure is rewritten to address these issues.
We were only able to block incoming messages to client. Blocking
outgoing messages also added in this pr.

Ignore's on ClientListenerReconnect tests are removed.

backport of https://github.com/hazelcast/hazelcast/pull/9560