### PR TITLE
Fixed JVM crash in Near Cache preloader for NATIVE in-memory-format.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -18,8 +18,6 @@ package com.hazelcast.internal.nearcache.impl.preloader;
 
 import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
-import com.hazelcast.internal.nearcache.NearCacheRecord;
-import com.hazelcast.internal.nearcache.impl.NearCacheRecordMap;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.util.BufferingInputStream;
 import com.hazelcast.logging.ILogger;
@@ -37,7 +35,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.util.Set;
+import java.util.Iterator;
 
 import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.readIntB;
@@ -55,7 +53,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 /**
  * Loads and stores the keys from a Near Cache into a file.
  *
- * @param <KS> type of the {@link NearCacheRecord} keys
+ * @param <KS> type of the {@link com.hazelcast.internal.nearcache.NearCacheRecord} keys
  */
 public class NearCachePreloader<KS> {
 
@@ -163,16 +161,11 @@ public class NearCachePreloader<KS> {
     }
 
     /**
-     * Stores the keys from the supplied {@link NearCacheRecordMap} instances.
+     * Stores the Near Cache keys from the supplied iterator.
      *
-     * We need to support multiple records maps here, since Hazelcast Enterprise has a segmented
-     * {@link com.hazelcast.internal.nearcache.NearCacheRecordStore} which contains multiple records maps.
-     *
-     * @param records the {@link NearCacheRecordMap} instances to retrieve the keys from
-     * @param <R>     the {@link NearCacheRecord} type
-     * @param <NCRM>  the {@link NearCacheRecordMap} type
+     * @param keySetIterator the key set to store
      */
-    public <R extends NearCacheRecord, NCRM extends NearCacheRecordMap<KS, R>> void storeKeys(NCRM... records) {
+    public void storeKeys(Iterator<KS> keySetIterator) {
         long startedNanos = System.nanoTime();
         FileOutputStream fos = null;
         try {
@@ -181,14 +174,10 @@ public class NearCachePreloader<KS> {
 
             fos = new FileOutputStream(tmpStoreFile, false);
 
-            // writer header
+            // write header and keys
             writeInt(fos, MAGIC_BYTES);
             writeInt(fos, FileFormat.INTERLEAVED_LENGTH_FIELD.ordinal());
-
-            // writer keys
-            for (NCRM record : records) {
-                writeKeySet(fos, fos.getChannel(), record.keySet());
-            }
+            writeKeySet(fos, fos.getChannel(), keySetIterator);
 
             // cleanup if no keys have been written
             if (lastKeyCount == 0) {
@@ -242,9 +231,9 @@ public class NearCachePreloader<KS> {
         return loadedKeys;
     }
 
-    private void writeKeySet(FileOutputStream fos, FileChannel outChannel, Set<KS> keySet) throws IOException {
-        for (KS key : keySet) {
-            Data dataKey = serializationService.toData(key);
+    private void writeKeySet(FileOutputStream fos, FileChannel outChannel, Iterator<KS> keySetIterator) throws IOException {
+        while (keySetIterator.hasNext()) {
+            Data dataKey = serializationService.toData(keySetIterator.next());
             if (dataKey != null) {
                 int dataSize = dataKey.totalSize();
                 writeInt(fos, dataSize);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -119,10 +119,9 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void storeKeys() {
         if (nearCachePreloader != null) {
-            nearCachePreloader.storeKeys(records);
+            nearCachePreloader.storeKeys(records.keySet().iterator());
         }
     }
 


### PR DESCRIPTION
Changed the `NearCachePreloader` to accept an key-set `Iterator` instead of a number of `NearCacheRecordMap` instances. So the `NearCachePreloader` doesn't know anymore from how many sources the keys are coming from, which makes it an implementation detail of EE to deal with the segmented `NearCacheRecordStore`.

The actual fix is in the Enterprise PR, not in this one.