### PR TITLE
Fix lock destroy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.partition.MigrationEndpoint;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.ClientAwareService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MemberAttributeServiceEvent;
@@ -293,11 +294,23 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
 
     @Override
     public void destroyDistributedObject(String objectId) {
-        Data key = nodeEngine.getSerializationService().toData(objectId);
-        for (LockStoreContainer container : containers) {
-            InternalLockNamespace namespace = new InternalLockNamespace(objectId);
-            LockStoreImpl lockStore = container.getOrCreateLockStore(namespace);
-            lockStore.forceUnlock(key);
+        final Data key = nodeEngine.getSerializationService().toData(objectId, StringPartitioningStrategy.INSTANCE);
+        final int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
+        final LockStoreImpl lockStore = containers[partitionId].getLockStore(new InternalLockNamespace(objectId));
+
+        if (lockStore != null) {
+            InternalOperationService operationService = (InternalOperationService) nodeEngine.getOperationService();
+            operationService.execute(new PartitionSpecificRunnable() {
+                @Override
+                public void run() {
+                    lockStore.forceUnlock(key);
+                }
+
+                @Override
+                public int getPartitionId() {
+                    return partitionId;
+                }
+            });
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
@@ -492,6 +492,39 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void test_whenLockDestroyed_thenUnlocked() {
+        lock.lock();
+        lock.destroy();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse("Lock should have been unlocked by destroy.", lock.isLocked());
+            }
+        });
+    }
+
+    @Test
+    public void test_whenLockDestroyedFromAnotherThread_thenUnlocked() {
+        lock.lock();
+
+        Thread thread = new Thread() {
+            public void run() {
+                lock.destroy();
+            }
+        };
+        thread.start();
+        assertJoinable(thread);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse("Lock should have been unlocked by destroy.", lock.isLocked());
+            }
+        });
+    }
+
+    @Test
     public void testLockCount() throws Exception {
         lock.lock();
         assertEquals(1, lock.getLockCount());


### PR DESCRIPTION
Lock destroy was unlocking lock resource out of partition operation thread.
This doesn't conform threading model and is illegal.

Fixes #9562

Backport of https://github.com/hazelcast/hazelcast/pull/9565