### PR TITLE
Change local member uuid while merging after a cluster split

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -754,18 +754,14 @@ public class Node {
         if (joined()) {
             logger.severe("Cannot set new local member when joined.");
             return;
-        } else if (nodeExtension.isStartCompleted()) {
-            logger.severe("Cannot set new local member since start completed.");
-            return;
-        } else if (!nodeExtension.getInternalHotRestartService().isMemberExcluded(getThisAddress(), getThisUuid())) {
-            logger.severe("Cannot set new local member since this member is not excluded.");
-            return;
         }
 
         String newUuid = UuidUtil.createMemberUuid(address);
         logger.warning("Setting new local member. old uuid: " + localMember.getUuid() + " new uuid: " + newUuid);
         Map<String, Object> memberAttributes = localMember.getAttributes();
         localMember = new MemberImpl(address, version, true, newUuid, hazelcastInstance, memberAttributes, liteMember);
+
+        assert !joined() : "Node should not join concurrently while setting member uuid!";
     }
 
     public Config getConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
@@ -107,6 +107,8 @@ class ClusterMergeTask implements Runnable {
     }
 
     private void rejoin() {
+        // set new member uuid
+        node.setNewLocalMember();
         // start connection-manager to setup and accept new connections
         node.connectionManager.start();
         // re-join to the target cluster

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -520,7 +520,7 @@ public abstract class Invocation implements OperationResponseHandler {
 
     private void doInvokeLocal(boolean isAsync) {
         if (op.getCallerUuid() == null) {
-            op.setCallerUuid(context.localMemberUuid);
+            op.setCallerUuid(context.node.getThisUuid());
         }
 
         responseReceived = FALSE;
@@ -733,7 +733,6 @@ public abstract class Invocation implements OperationResponseHandler {
         final long defaultCallTimeoutMillis;
         final InvocationRegistry invocationRegistry;
         final InvocationMonitor invocationMonitor;
-        final String localMemberUuid;
         final ILogger logger;
         final Node node;
         final NodeEngine nodeEngine;
@@ -753,7 +752,6 @@ public abstract class Invocation implements OperationResponseHandler {
                        long defaultCallTimeoutMillis,
                        InvocationRegistry invocationRegistry,
                        InvocationMonitor invocationMonitor,
-                       String localMemberUuid,
                        ILogger logger,
                        Node node,
                        NodeEngine nodeEngine,
@@ -771,7 +769,6 @@ public abstract class Invocation implements OperationResponseHandler {
             this.defaultCallTimeoutMillis = defaultCallTimeoutMillis;
             this.invocationRegistry = invocationRegistry;
             this.invocationMonitor = invocationMonitor;
-            this.localMemberUuid = localMemberUuid;
             this.logger = logger;
             this.node = node;
             this.nodeEngine = nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -443,19 +443,10 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         slowOperationDetector.start();
     }
 
-    /**
-     * Initializes the invocation context to use most recent uuid of the local member. We have this method because the local
-     * member can change its uuid when the cluster has performed partial start and invocations should be done with the new uuid.
-     */
-    public void initInvocationContext() {
-        ManagedExecutorService asyncExecutor;
-        if (this.invocationContext != null) {
-            asyncExecutor = this.invocationContext.asyncExecutor;
-        } else {
-            asyncExecutor = nodeEngine.getExecutionService().register(
+    private void initInvocationContext() {
+        ManagedExecutorService asyncExecutor = nodeEngine.getExecutionService().register(
                     ExecutionService.ASYNC_EXECUTOR, Runtime.getRuntime().availableProcessors(),
                     ASYNC_QUEUE_CAPACITY, ExecutorType.CONCRETE);
-        }
 
         this.invocationContext = new Invocation.Context(
                 asyncExecutor,
@@ -466,7 +457,6 @@ public final class OperationServiceImpl implements InternalOperationService, Met
                 nodeEngine.getProperties().getMillis(OPERATION_CALL_TIMEOUT_MILLIS),
                 invocationRegistry,
                 invocationMonitor,
-                node.getThisUuid(),
                 nodeEngine.getLogger(Invocation.class),
                 node,
                 nodeEngine,

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -43,7 +43,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
 
     private Invocation newInvocation(Operation op) {
         Invocation.Context context = new Context(null, null, null, null, null,
-                1000, invocationRegistry, null, "", logger, null, null, null, null, null, null, null, null);
+                1000, invocationRegistry, null, logger, null, null, null, null, null, null, null, null);
         return new PartitionInvocation(context, op, 0, 0, 0, false);
     }
 


### PR DESCRIPTION
Hazelcast don't support recovering a member after failure,
so once a member is split then it should come back as a completely new member.

Currently this is not a much problem since a member cannot join back
until it's completely removed from partition table.

Additionally, removed  re-initialization step of invocation context when member uuid changes. Instead, local member uuid is retrieved over Node/NodeEngine when required.