### PR TITLE
Allow invokeAllPartitions from generic operation thread.

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapWithIndexCreationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapWithIndexCreationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.client.util.StaticLB;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Member;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMapWithIndexCreationTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        factory.shutdownAll();
+    }
+
+    /**
+     * Given a two members (A, B) cluster, a non-smart client connected to B attempts to create a map proxy targeting member A.
+     */
+    @Test
+    public void test_createMapWithIndexes_whenProxyCreatedOnMemberOtherThanClientOwner() {
+        Config config = new XmlConfigBuilder().build();
+
+        MapConfig mapConfig = config.getMapConfig("test");
+        List<MapIndexConfig> mapIndexConfigs = mapConfig.getMapIndexConfigs();
+
+        MapIndexConfig mapIndexConfig = new MapIndexConfig();
+        mapIndexConfig.setAttribute("name");
+        mapIndexConfig.setOrdered(true);
+        mapIndexConfigs.add(mapIndexConfig);
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+
+        ClientConfig clientConfig = new ClientConfig();
+        // ProxyManager#findNextAddressToSendCreateRequest uses the configured load balancer to find the next address
+        // to which proxy creation request will be sent. We want this to be member hz1.
+        clientConfig.setLoadBalancer(new StaticLB((Member) hz1.getLocalEndpoint()));
+        clientConfig.getNetworkConfig().setSmartRouting(false);
+        // the client only connects to member hz2.
+        clientConfig.getNetworkConfig().addAddress(
+                        hz2.getCluster().getLocalMember().getAddress().getHost() + ":" +
+                        hz2.getCluster().getLocalMember().getAddress().getPort());
+
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+
+        IMap<String, SampleObjects.Employee> test = client.getMap("test");
+        test.put("foo", new SampleObjects.Employee(1, "name", "age", 32, true, 230));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -66,8 +66,14 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
     public static final int UNMODIFIABLE_LAZY_LIST = 18;
     public static final int OPERATION_CONTROL = 19;
 
+    private static final DataSerializableFactory FACTORY = createFactoryInternal();
+
     @Override
     public DataSerializableFactory createFactory() {
+        return FACTORY;
+    }
+
+    private static DataSerializableFactory createFactoryInternal() {
         return new DataSerializableFactory() {
             @Override
             public IdentifiedDataSerializable create(int typeId) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation.PartitionResponse;
@@ -63,7 +64,7 @@ final class InvokeOnPartitions {
      * Executes all the operations on the partitions.
      */
     Map<Integer, Object> invoke() throws Exception {
-        ensureNotCallingFromOperationThread();
+        ensureNotCallingFromPartitionOperationThread();
 
         invokeOnAllPartitions();
 
@@ -74,8 +75,8 @@ final class InvokeOnPartitions {
         return partitionResults;
     }
 
-    private void ensureNotCallingFromOperationThread() {
-        if (operationService.operationExecutor.isOperationThread()) {
+    private void ensureNotCallingFromPartitionOperationThread() {
+        if (Thread.currentThread() instanceof PartitionOperationThread) {
             throw new IllegalThreadStateException(Thread.currentThread() + " cannot make invocation on multiple partitions!");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -176,7 +176,9 @@ public final class ProxyRegistry {
                 try {
                     ((InitializingObject) proxy).initialize();
                 } catch (Exception e) {
+                    // log and throw exception to be handled in outer catch block
                     proxyService.logger.warning("Error while initializing proxy: " + proxy, e);
+                    throw e;
                 }
             }
             proxyFuture.set(proxy);


### PR DESCRIPTION
Since #4889 `PartitionIteratingOperation` is non blocking, so
generic operation threads should be able to invoke on all partitions.

Fixes #8492 in which map proxy creation would fail when
client targets proxy creation on member other than client
connection owner member.