### PR TITLE
Improved query cache accumulators

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/Accumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/Accumulator.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.querycache.accumulator;
 
-import com.hazelcast.map.impl.querycache.event.sequence.PartitionSequencer;
 import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 
 import java.util.Iterator;
@@ -39,19 +38,9 @@ public interface Accumulator<E extends Sequenced> extends Iterable<E> {
     void accumulate(E event);
 
     /**
-     * Reads all items starting from the supplied {@code sequence}. This method does not advance
-     * head of this accumulator.
-     *
-     * @param handler  handler to process this accumulator.
-     * @param sequence read this accumulator by starting inclusively from this sequence.
-     * @return the number of elements read.
-     */
-    int peek(AccumulatorHandler<E> handler, long sequence);
-
-    /**
      * Reads this accumulator if it contains at least {@code maxItems}, otherwise
      * do not read anything. If this method adds items to the supplied handler, head of this accumulator advances.
-     * <p/>
+     *
      * Used for batching purposes.
      *
      * @param handler  handler to process this accumulator.
@@ -70,13 +59,6 @@ public interface Accumulator<E extends Sequenced> extends Iterable<E> {
      * @return the number of elements polled.
      */
     int poll(AccumulatorHandler<E> handler, long delay, TimeUnit unit);
-
-    /**
-     * Returns the {@link PartitionSequencer} of this accumulator.
-     *
-     * @return {@link PartitionSequencer} of this accumulator.
-     */
-    PartitionSequencer getPartitionSequencer();
 
     /**
      * Returns an iterator over the items in this accumulator in proper sequence.
@@ -119,6 +101,7 @@ public interface Accumulator<E extends Sequenced> extends Iterable<E> {
 
     /**
      * Resets this accumulator.
+     *
      * After return of this call, accumulator will be in its initial state.
      */
     void reset();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/CoalescingPublisherAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/CoalescingPublisherAccumulator.java
@@ -34,17 +34,16 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * {@link com.hazelcast.map.impl.querycache.accumulator.Accumulator Accumulator} which coalesces
- * keys during accumulation.
+ * An {@link com.hazelcast.map.impl.querycache.accumulator.Accumulator} which coalesces keys during accumulation.
  */
-public class CoalescingPublisherAccumulator extends BasicAccumulator<QueryCacheEventData> {
+class CoalescingPublisherAccumulator extends BasicAccumulator<QueryCacheEventData> {
 
     /**
      * Index map to hold last unpublished event sequence per key.
      */
     private final Map<Data, Long> index = new HashMap<Data, Long>();
 
-    public CoalescingPublisherAccumulator(QueryCacheContext context, AccumulatorInfo info) {
+    CoalescingPublisherAccumulator(QueryCacheContext context, AccumulatorInfo info) {
         super(context, info);
     }
 
@@ -74,15 +73,14 @@ public class CoalescingPublisherAccumulator extends BasicAccumulator<QueryCacheE
         }
 
         if (logger.isFinestEnabled()) {
-            if (logger.isFinestEnabled()) {
-                logger.finest(format("Added to index key=%s, sequence=%d, indexSize=%d",
-                        eventData.getKey(), eventData.getSequence(), index.size()));
-            }
+            logger.finest(format("Added to index key=%s, sequence=%d, indexSize=%d",
+                    eventData.getKey(), eventData.getSequence(), index.size()));
         }
     }
 
     @Override
-    protected AccumulatorProcessor createAccumulatorProcessor(AccumulatorInfo info, QueryCacheEventService eventService) {
+    protected AccumulatorProcessor<Sequenced> createAccumulatorProcessor(AccumulatorInfo info,
+                                                                         QueryCacheEventService eventService) {
         return new CoalescedEventAccumulatorProcessor(info, eventService);
     }
 
@@ -91,7 +89,7 @@ public class CoalescingPublisherAccumulator extends BasicAccumulator<QueryCacheE
      */
     private class CoalescedEventAccumulatorProcessor extends EventPublisherAccumulatorProcessor {
 
-        public CoalescedEventAccumulatorProcessor(AccumulatorInfo info, QueryCacheEventService eventService) {
+        CoalescedEventAccumulatorProcessor(AccumulatorInfo info, QueryCacheEventService eventService) {
             super(info, eventService);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/NonStopPublisherAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/NonStopPublisherAccumulator.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * This accumulator immediately publishes incoming events by only giving a sequence number to them.
- * <p/>
+ *
  * An instance of this class is called by at most one thread at a time.
  */
 class NonStopPublisherAccumulator extends BasicAccumulator<Sequenced> {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
@@ -37,24 +37,24 @@ import static java.util.logging.Level.WARNING;
  * If all incoming events are in the correct sequence order, this accumulator applies those events to
  * {@link com.hazelcast.map.QueryCache QueryCache}.
  * Otherwise, it informs registered callback if there is any.
- * <p/>
+ *
  * This class can be accessed by multiple-threads at a time.
  */
 public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData> {
 
-    private final AccumulatorHandler handler;
-    private final SubscriberSequencerProvider sequenceProvider;
     /**
      * When a partition's sequence order is broken, it will be registered here.
      */
-    private final ConcurrentMap<Integer, Long> brokenSequences;
+    private final ConcurrentMap<Integer, Long> brokenSequences = new ConcurrentHashMap<Integer, Long>();
 
-    public SubscriberAccumulator(QueryCacheContext context, AccumulatorInfo info) {
+    private final AccumulatorHandler handler;
+    private final SubscriberSequencerProvider sequenceProvider;
+
+    protected SubscriberAccumulator(QueryCacheContext context, AccumulatorInfo info) {
         super(context, info);
 
         this.handler = createAccumulatorHandler();
         this.sequenceProvider = createSequencerProvider();
-        this.brokenSequences = new ConcurrentHashMap<Integer, Long>();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheCoalescingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheCoalescingTest.java
@@ -1,7 +1,6 @@
 package com.hazelcast.map.impl.querycache;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
@@ -15,6 +14,8 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -31,6 +32,17 @@ public class QueryCacheCoalescingTest extends HazelcastTestSupport {
 
     @SuppressWarnings("unchecked")
     private static final Predicate<Integer, Integer> TRUE_PREDICATE = TruePredicate.INSTANCE;
+
+    @Before
+    public void setUp() {
+        setLoggingLog4j();
+        setLogLevel(org.apache.log4j.Level.DEBUG);
+    }
+
+    @After
+    public void tearDown() {
+        resetLogLevel();
+    }
 
     @Test
     public void testCoalescingModeWorks() {
@@ -69,15 +81,18 @@ public class QueryCacheCoalescingTest extends HazelcastTestSupport {
     }
 
     private Config getConfig(String mapName, String cacheName) {
-        Config config = new Config();
-        config.setProperty(PARTITION_COUNT.getName(), "1");
-        MapConfig mapConfig = config.getMapConfig(mapName);
-        QueryCacheConfig cacheConfig = new QueryCacheConfig(cacheName);
-        cacheConfig.setCoalesce(true);
-        cacheConfig.setBatchSize(64);
-        cacheConfig.setBufferSize(64);
-        cacheConfig.setDelaySeconds(3);
-        mapConfig.addQueryCacheConfig(cacheConfig);
+        QueryCacheConfig cacheConfig = new QueryCacheConfig(cacheName)
+                .setCoalesce(true)
+                .setBatchSize(64)
+                .setBufferSize(64)
+                .setDelaySeconds(3);
+
+        Config config = new Config()
+                .setProperty(PARTITION_COUNT.getName(), "1");
+
+        config.getMapConfig(mapName)
+                .addQueryCacheConfig(cacheConfig);
+
         return config;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/accumulator/ReadOnlyIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/accumulator/ReadOnlyIteratorTest.java
@@ -1,0 +1,50 @@
+package com.hazelcast.map.impl.querycache.accumulator;
+
+import com.hazelcast.map.impl.querycache.accumulator.BasicAccumulator.ReadOnlyIterator;
+import com.hazelcast.map.impl.querycache.event.DefaultQueryCacheEventData;
+import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ReadOnlyIteratorTest {
+
+    private Sequenced sequenced = new DefaultQueryCacheEventData();
+
+    private ReadOnlyIterator<Sequenced> iterator;
+
+    @Before
+    public void setUp() {
+        CyclicBuffer<Sequenced> buffer = new DefaultCyclicBuffer<Sequenced>(1);
+        buffer.add(sequenced);
+
+        iterator = new ReadOnlyIterator<Sequenced>(buffer);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testConstructor_whenBufferIsNull_thenThrowException() {
+        iterator = new ReadOnlyIterator<Sequenced>(null);
+    }
+
+    @Test
+    public void testIteration() {
+        assertTrue(iterator.hasNext());
+        assertEquals(sequenced, iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemove() {
+        iterator.remove();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/TestSubscriberContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/TestSubscriberContext.java
@@ -31,7 +31,7 @@ public class TestSubscriberContext extends NodeSubscriberContext {
 
     private class TestMapSubscriberRegistry extends MapSubscriberRegistry {
 
-        public TestMapSubscriberRegistry(QueryCacheContext context) {
+        TestMapSubscriberRegistry(QueryCacheContext context) {
             super(context);
         }
 
@@ -43,7 +43,7 @@ public class TestSubscriberContext extends NodeSubscriberContext {
 
     private class TestSubscriberRegistry extends SubscriberRegistry {
 
-        public TestSubscriberRegistry(QueryCacheContext context, String mapName) {
+        TestSubscriberRegistry(QueryCacheContext context, String mapName) {
             super(context, mapName);
         }
 
@@ -55,7 +55,7 @@ public class TestSubscriberContext extends NodeSubscriberContext {
 
     private class TestSubscriberAccumulatorFactory extends SubscriberAccumulatorFactory {
 
-        public TestSubscriberAccumulatorFactory(QueryCacheContext context) {
+        TestSubscriberAccumulatorFactory(QueryCacheContext context) {
             super(context);
         }
 
@@ -69,7 +69,7 @@ public class TestSubscriberContext extends NodeSubscriberContext {
 
         private final Set<Long> lostSequenceNumber = Collections.newSetFromMap(new ConcurrentHashMap<Long, Boolean>());
 
-        public TestSubscriberAccumulator(QueryCacheContext context, AccumulatorInfo info) {
+        TestSubscriberAccumulator(QueryCacheContext context, AccumulatorInfo info) {
             super(context, info);
 
             if (enableEventLoss) {
@@ -82,7 +82,6 @@ public class TestSubscriberContext extends NodeSubscriberContext {
         protected boolean isNextEvent(Sequenced event) {
             DefaultQueryCacheEventData eventData = (DefaultQueryCacheEventData) event;
             if (lostSequenceNumber.remove(event.getSequence())) {
-
                 // create an out of order event by changing actual sequence
                 DefaultQueryCacheEventData copy = new DefaultQueryCacheEventData(eventData);
                 copy.setSequence(eventData.getSequence() * 2);


### PR DESCRIPTION
* Removed unused methods from Accumulator interface and implementations.
* Improved some generics to reduce warnings.
* Fixed a duplicated logger.isFinestEnabled() in CoalescingPublisherAccumulator.
* Made classes and constructors package private where ever possible.