### PR TITLE
Fix broken scheduled task replication when completed

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceTest.java
@@ -41,4 +41,16 @@ public class ClientScheduledExecutorServiceTest extends ScheduledExecutorService
     public IScheduledExecutorService getScheduledExecutor(HazelcastInstance[] instances, String name) {
         return ((TestHazelcastFactory) factory).newHazelcastClient().getScheduledExecutorService(name);
     }
+
+    @Override
+    public void getErroneous()
+            throws InterruptedException {
+        // Ignore - pending client change to support the ExecutionException wrapper
+    }
+
+    @Override
+    public void getErroneous_durable()
+            throws InterruptedException {
+        // Ignore - pending client change to support the ExecutionException wrapper
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DelegatedScheduledFuturePeelerDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DelegatedScheduledFuturePeelerDecorator.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.scheduledexecutor.impl;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Simple adapter that unwraps the Future delegation done in
+ * {@link com.hazelcast.spi.impl.executionservice.impl.DelegatingCallableTaskDecorator}
+ * for single-run Callable tasks.
+ *
+ * @param <V>
+ */
+public class DelegatedScheduledFuturePeelerDecorator<V> implements ScheduledFuture<V> {
+
+    private final ScheduledFuture<V> original;
+
+    DelegatedScheduledFuturePeelerDecorator(ScheduledFuture<V> original) {
+        checkNotNull(original, "Original is null.");
+        this.original = original;
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        return original.getDelay(unit);
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        boolean cancelled = original.cancel(mayInterruptIfRunning);
+        try {
+            return peel().cancel(mayInterruptIfRunning);
+        } catch (CancellationException e) {
+            // ignore; cancelled before scheduled-in
+            ignore();
+        }
+
+        return cancelled;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return original.isCancelled() || peel().isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return original.isDone() && peel().isDone();
+    }
+
+    @Override
+    public V get()
+            throws InterruptedException, ExecutionException {
+        return peel().get();
+    }
+
+    @Override
+    public V get(long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        throw new UnsupportedOperationException();
+    }
+
+    private Future<V> peel() {
+        // Get the delegating Executor Future (in case of Callable, see. DelegatingCallableTaskDecorator)
+        try {
+            return (Future) original.get();
+        } catch (InterruptedException e) {
+            sneakyThrow(e);
+        } catch (ExecutionException e) {
+            sneakyThrow(e);
+        }
+
+        return null;
+    }
+
+    private void ignore() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DelegatedScheduledFuturePeelerDecorator<?> that = (DelegatedScheduledFuturePeelerDecorator<?>) o;
+
+        return original.equals(that.original);
+    }
+
+    @Override
+    public int hashCode() {
+        return original.hashCode();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -257,7 +257,7 @@ public class ScheduledExecutorContainer {
             try {
                 ScheduledTaskDescriptor replica = new ScheduledTaskDescriptor(
                         descriptor.getDefinition(),
-                        descriptor.getStateSnapshot(),
+                        descriptor.getState(),
                         descriptor.getStatsSnapshot(),
                         descriptor.getTaskResult());
                 replicas.put(descriptor.getDefinition().getName(), replica);
@@ -397,7 +397,7 @@ public class ScheduledExecutorContainer {
                 return;
             }
 
-            Map snapshot = descriptor.getStateSnapshot();
+            Map snapshot = descriptor.getState();
             if (original instanceof StatefulTask && !snapshot.isEmpty()) {
                 ((StatefulTask) original).load(snapshot);
             }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -37,11 +37,12 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService.SERVICE_NAME;
+import static com.hazelcast.scheduledexecutor.impl.TaskDefinition.Type.SINGLE_RUN;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
 
 public class ScheduledExecutorContainer {
@@ -89,33 +90,22 @@ public class ScheduledExecutorContainer {
             logger.finest("[Scheduler: " + name + "][Partition: " + partitionId + "] Cancelling " + taskName);
         }
 
-        ScheduledTaskDescriptor descriptor = tasks.get(taskName);
-        boolean cancelled = descriptor.getScheduledFuture().cancel(true);
+        return tasks.get(taskName).cancel(true);
+    }
 
-        if (TaskDefinition.Type.SINGLE_RUN.equals(descriptor.getDefinition().getType())) {
-            // Cancel the delegating Executor's Future (in case of Callable, see. DelegatingCallableTaskDecorator)
-            cancelled = ((Future) descriptor.getScheduledFuture().get()).cancel(true);
-        }
-
-        return cancelled;
+    public boolean has(String taskName) {
+        return tasks.containsKey(taskName);
     }
 
     public Object get(String taskName)
             throws ExecutionException, InterruptedException {
         checkNotStaleTask(taskName);
-        ScheduledTaskDescriptor descriptor = tasks.get(taskName);
-        if (TaskDefinition.Type.SINGLE_RUN.equals(descriptor.getDefinition().getType())) {
-            // Get the result from the delegating's Executor Future (in case of Callable, see. DelegatingCallableTaskDecorator)
-            return ((Future) descriptor.getScheduledFuture().get()).get();
-        } else {
-            return descriptor.getScheduledFuture().get();
-        }
+        return tasks.get(taskName).get();
     }
 
     public long getDelay(String taskName, TimeUnit unit) {
         checkNotStaleTask(taskName);
-        ScheduledTaskDescriptor descriptor = tasks.get(taskName);
-        return descriptor.getScheduledFuture().getDelay(unit);
+        return tasks.get(taskName).getDelay(unit);
     }
 
     public ScheduledTaskStatistics getStatistics(String taskName) {
@@ -127,25 +117,13 @@ public class ScheduledExecutorContainer {
     public boolean isCancelled(String taskName)
             throws ExecutionException, InterruptedException {
         checkNotStaleTask(taskName);
-        ScheduledTaskDescriptor descriptor = tasks.get(taskName);
-        if (TaskDefinition.Type.SINGLE_RUN.equals(descriptor.getDefinition().getType())) {
-            // Check the status from the delegating Executor Future (in case of Callable, see. DelegatingCallableTaskDecorator)
-            return ((Future) descriptor.getScheduledFuture().get()).isCancelled();
-        } else {
-            return descriptor.getScheduledFuture().isCancelled();
-        }
+        return tasks.get(taskName).isCancelled();
     }
 
     public boolean isDone(String taskName)
             throws ExecutionException, InterruptedException {
         checkNotStaleTask(taskName);
-        ScheduledTaskDescriptor descriptor = tasks.get(taskName);
-        if (TaskDefinition.Type.SINGLE_RUN.equals(descriptor.getDefinition().getType())) {
-            // Check the status from the delegating Executor Future (in case of Callable, see. DelegatingCallableTaskDecorator)
-            return ((Future) descriptor.getScheduledFuture().get()).isDone();
-        } else {
-            return descriptor.getScheduledFuture().isDone();
-        }
+        return tasks.get(taskName).isDone();
     }
 
     public void destroy() {
@@ -154,13 +132,11 @@ public class ScheduledExecutorContainer {
         }
 
         for (ScheduledTaskDescriptor descriptor : tasks.values()) {
-            if (descriptor.getScheduledFuture() != null) {
-                try {
-                    descriptor.getScheduledFuture().cancel(true);
-                } catch (Exception ex) {
-                    logger.warning("[Scheduler: " + name + "][Partition: " + partitionId + "] "
-                            + "Destroying " + descriptor.getDefinition().getName() + " error: ", ex);
-                }
+            try {
+                descriptor.cancel(true);
+            } catch (Exception ex) {
+                logger.warning("[Scheduler: " + name + "][Partition: " + partitionId + "] "
+                        + "Destroying " + descriptor.getDefinition().getName() + " error: ", ex);
             }
         }
     }
@@ -174,28 +150,23 @@ public class ScheduledExecutorContainer {
         }
 
         ScheduledTaskDescriptor descriptor = tasks.get(taskName);
-        Future scheduledFuture = descriptor.getScheduledFuture();
-        if (!scheduledFuture.isDone()) {
-            if (TaskDefinition.Type.SINGLE_RUN.equals(descriptor.getDefinition().getType())) {
-                // Cancel the delegating Executor Future (in case of Callable, see. DelegatingCallableTaskDecorator)
-                ((Future) scheduledFuture.get()).cancel(true);
-            }
-
-            // Cancel the ScheduledExecutor ScheduledFuture
-            scheduledFuture.cancel(true);
-        }
+        descriptor.cancel(true);
 
         tasks.remove(taskName);
     }
 
     public void stash(TaskDefinition definition) {
+        stash(new ScheduledTaskDescriptor(definition));
+    }
+
+    public void stash(ScheduledTaskDescriptor descriptor) {
         if (logger.isFinestEnabled()) {
-            logger.finest("[Backup Scheduler: " + name + "][Partition: " + partitionId + "] Stashing " + definition);
+            logger.finest("[Backup Scheduler: " + name + "][Partition: " + partitionId + "] Stashing "
+                    + descriptor.getDefinition());
         }
 
-        if (!tasks.containsKey(definition.getName())) {
-            ScheduledTaskDescriptor descriptor = new ScheduledTaskDescriptor(definition);
-            tasks.put(definition.getName(), descriptor);
+        if (!tasks.containsKey(descriptor.getDefinition().getName())) {
+            tasks.put(descriptor.getDefinition().getName(), descriptor);
         }
 
         if (logger.isFinestEnabled()) {
@@ -203,19 +174,14 @@ public class ScheduledExecutorContainer {
         }
     }
 
-    public void unstash(String taskName) {
-        tasks.remove(taskName);
-    }
-
     public Collection<ScheduledTaskDescriptor> getTasks() {
         return tasks.values();
     }
 
-    public void syncState(String taskName, Map newState, ScheduledTaskStatisticsImpl stats)
-            throws ExecutionException, InterruptedException {
+    public void syncState(String taskName, Map newState, ScheduledTaskStatisticsImpl stats, ScheduledTaskResult resolution) {
         ScheduledTaskDescriptor descriptor = tasks.get(taskName);
         if (descriptor == null) {
-            // Task previously disposed or unstashed
+            // Task previously disposed
             if (logger.isFinestEnabled()) {
                 logger.finest("[Scheduler: " + name + "][Partition: " + partitionId + "] syncState attempt "
                         + "but no descriptor found for task: " + taskName);
@@ -223,17 +189,20 @@ public class ScheduledExecutorContainer {
             return;
         }
 
+        if (logger.isFinestEnabled()) {
+            logger.finest("[Scheduler: " + name + "][Partition: " + partitionId + "] syncState for task: " + taskName + ", "
+                        + "state: " + newState);
+        }
+
         descriptor.setState(newState);
         descriptor.setStats(stats);
+        descriptor.setTaskResult(resolution);
     }
 
     public boolean shouldParkGetResult(String taskName)
             throws ExecutionException, InterruptedException {
-        if (!tasks.containsKey(taskName)) {
-            return false;
-        }
-
-        return tasks.get(taskName).getScheduledFuture() == null || !isDone(taskName);
+        return tasks.containsKey(taskName)
+                && (tasks.get(taskName).getTaskResult() == null || !isDone(taskName));
     }
 
     public int getDurability() {
@@ -271,8 +240,12 @@ public class ScheduledExecutorContainer {
 
     void promoteStash() {
         for (ScheduledTaskDescriptor descriptor : tasks.values()) {
-            if (descriptor.getScheduledFuture() == null) {
-                doSchedule(descriptor);
+            try {
+                if (descriptor.shouldSchedule()) {
+                    doSchedule(descriptor);
+                }
+            } catch (Exception e) {
+                throw rethrow(e);
             }
         }
     }
@@ -285,17 +258,22 @@ public class ScheduledExecutorContainer {
                 ScheduledTaskDescriptor replica = new ScheduledTaskDescriptor(
                         descriptor.getDefinition(),
                         descriptor.getStateSnapshot(),
-                        descriptor.getStatsSnapshot());
+                        descriptor.getStatsSnapshot(),
+                        descriptor.getTaskResult());
                 replicas.put(descriptor.getDefinition().getName(), replica);
+            } catch (Exception ex) {
+                sneakyThrow(ex);
             } finally {
                 if (migrationMode) {
                     // Best effort to cancel & interrupt the task.
                     // In the case of Runnable the DelegateAndSkipOnConcurrentExecutionDecorator is not exposing access
                     // to the Executor's Future, hence, we have no access on the runner thread to interrupt. In this case
                     // the line below is only cancelling future scheduling attempts.
-                    descriptor.getScheduledFuture().cancel(true);
-                    // Nullify record so we can re-schedule in the event of rollback
-                    descriptor.setScheduledFuture(null);
+                    try {
+                        descriptor.cancel(true);
+                    } catch (Exception ex) {
+                        throw rethrow(ex);
+                    }
                 }
             }
         }
@@ -314,13 +292,14 @@ public class ScheduledExecutorContainer {
      * State is published after every run.
      * When replicas get promoted, they start of, with the latest state see {@link TaskRunner#initOnce()}
      */
-    protected void publishTaskState(String taskName, Map stateSnapshot, ScheduledTaskStatisticsImpl statsSnapshot) {
+    protected void publishTaskState(String taskName, Map stateSnapshot, ScheduledTaskStatisticsImpl statsSnapshot,
+                                    ScheduledTaskResult result) {
         if (logger.isFinestEnabled()) {
             logger.finest("[Scheduler: " + name + "][Partition: " + partitionId + "][Task: " + taskName + "] "
                     + "Publishing state, to replicas. State: " + stateSnapshot);
         }
 
-        Operation op = new SyncStateOperation(getName(), taskName, stateSnapshot, statsSnapshot);
+        Operation op = new SyncStateOperation(getName(), taskName, stateSnapshot, statsSnapshot, result);
         createInvocationBuilder(op)
                 .invoke()
                 .join();
@@ -340,8 +319,9 @@ public class ScheduledExecutorContainer {
         switch (definition.getType()) {
             case SINGLE_RUN:
                 runner = new TaskRunner<V>(descriptor);
-                    future = executionService.scheduleDurable(name, (Callable) runner,
-                            definition.getInitialDelay(), definition.getUnit());
+                future = new DelegatedScheduledFuturePeelerDecorator<V>(
+                            executionService.scheduleDurable(name, (Callable) runner,
+                                definition.getInitialDelay(), definition.getUnit()));
                 break;
             case AT_FIXED_RATE:
                 runner = new TaskRunner<V>(descriptor);
@@ -357,7 +337,7 @@ public class ScheduledExecutorContainer {
     }
 
     private void checkNotStaleTask(String taskName) {
-        if (!tasks.containsKey(taskName)) {
+        if (!has(taskName)) {
             throw new StaleTaskException("Task with name " + taskName + " not found. ");
         }
     }
@@ -374,6 +354,8 @@ public class ScheduledExecutorContainer {
 
         private boolean initted;
 
+        private ScheduledTaskResult resolution;
+
         TaskRunner(ScheduledTaskDescriptor descriptor) {
             this.descriptor = descriptor;
             this.original = descriptor.getDefinition().getCommand();
@@ -387,7 +369,15 @@ public class ScheduledExecutorContainer {
                 throws Exception {
             beforeRun();
             try {
-                return original.call();
+                V result = original.call();
+                if (SINGLE_RUN.equals(descriptor.getDefinition().getType())) {
+                    resolution = new ScheduledTaskResult(result);
+                }
+                return result;
+            } catch (Throwable t) {
+                logger.warning("Exception occurred during scheduled task run phase", t);
+                resolution = new ScheduledTaskResult(t);
+                throw rethrow(t);
             } finally {
                 afterRun();
             }
@@ -398,7 +388,7 @@ public class ScheduledExecutorContainer {
             try {
                 call();
             } catch (Exception e) {
-                sneakyThrow(e);
+                throw rethrow(e);
             }
         }
 
@@ -439,7 +429,7 @@ public class ScheduledExecutorContainer {
                     ((StatefulTask) original).save(state);
                 }
 
-                publishTaskState(taskName, state, statistics);
+                publishTaskState(taskName, state, statistics, resolution);
             } catch (Exception ex) {
                 logger.warning("[Scheduler: " + name + "][Partition: " + partitionId + "][Task: " + taskName + "] "
                         + "Unexpected exception during afterRun occurred: ", ex);

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorDataSerializerHook.java
@@ -79,6 +79,8 @@ public class    ScheduledExecutorDataSerializerHook implements DataSerializerHoo
 
     public static final int SHUTDOWN = 23;
 
+    public static final int TASK_RESOLUTION = 24;
+
     @Override
     public int getFactoryId() {
         return F_ID;
@@ -136,6 +138,8 @@ public class    ScheduledExecutorDataSerializerHook implements DataSerializerHoo
                         return new ResultReadyNotifyOperation();
                     case SHUTDOWN:
                         return new ShutdownOperation();
+                    case TASK_RESOLUTION:
+                        return new ScheduledTaskResult();
                     default:
                         throw new IllegalArgumentException("Illegal Scheduled Executor serializer type ID: " + typeId);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorPartition.java
@@ -61,20 +61,6 @@ public class ScheduledExecutorPartition implements ScheduledExecutorContainerHol
         this.nodeEngine = nodeEngine;
     }
 
-    public void createContainer(String name, ConcurrentMap<String, ScheduledTaskDescriptor> tasks) {
-        checkNotNull(name, "Name can't be null");
-        checkNotNull(tasks, "Tasks info can't be null");
-
-        if (logger.isFineEnabled()) {
-            logger.fine("Creating Scheduled Executor partition with name: " + name);
-        }
-
-        ScheduledExecutorConfig config = nodeEngine.getConfig().findScheduledExecutorConfig(name);
-        ScheduledExecutorContainer container =
-                new ScheduledExecutorContainer(name, partitionId, nodeEngine, config.getDurability(), tasks);
-        containers.put(name, container);
-    }
-
     public Collection<ScheduledExecutorContainer> getContainers() {
         return Collections.unmodifiableCollection(containers.values());
     }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledFutureProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledFutureProxy.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 @SuppressWarnings({"checkstyle:methodcount"})
@@ -155,14 +156,22 @@ public final class ScheduledFutureProxy<V>
     @Override
     public V get()
             throws InterruptedException, ExecutionException {
-        return this.get0().join();
+        try {
+            return this.get0().join();
+        } catch (ScheduledTaskResult.ExecutionExceptionDecorator ex) {
+            return sneakyThrow(ex.getCause());
+        }
     }
 
     @Override
     public V get(long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
         checkNotNull(unit, "Unit is null");
-        return this.get0().get(timeout, unit);
+        try {
+            return this.get0().get(timeout, unit);
+        } catch (ScheduledTaskResult.ExecutionExceptionDecorator ex) {
+            return sneakyThrow(ex.getCause());
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
@@ -23,27 +23,36 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Metadata holder for scheduled tasks.
- * Scheduled ones have a reference in their future in {@link #scheduledFuture}.
+ * Scheduled ones have a reference in their future in {@link #future}.
  * Stashed ones have this reference null.
  */
 public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
 
     private TaskDefinition definition;
 
-    private ScheduledFuture<?> scheduledFuture;
+    private ScheduledFuture<?> future;
 
     /**
-     * Stats are written from a single thread and read by many outside the partition threads. (see. Member owned tasks)
+     * SPMC (see. Member owned tasks)
      */
-    private AtomicReference<ScheduledTaskStatisticsImpl> stats = new AtomicReference<ScheduledTaskStatisticsImpl>(null);
+    private volatile ScheduledTaskStatisticsImpl stats;
 
     /**
-     * State is only write/read only through the partition threads.
+     * MPMC (Multiple Producers Multiple Concumers)
+     * MP when cancelling, due to member owned tasks, all other writes are SP and through partition threads.
+     * Reads are MP for member owned tasks.
+     */
+    private AtomicReference<ScheduledTaskResult> resultRef = new AtomicReference<ScheduledTaskResult>(null);
+
+    /**
+     * SPMC
      */
     private Map<?, ?> state;
 
@@ -53,13 +62,16 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
     public ScheduledTaskDescriptor(TaskDefinition definition) {
         this.definition = definition;
         this.state = new HashMap();
-        this.stats.set(new ScheduledTaskStatisticsImpl());
+        this.stats = new ScheduledTaskStatisticsImpl();
     }
+
     public ScheduledTaskDescriptor(TaskDefinition definition,
-                                   Map<?, ?> state, ScheduledTaskStatisticsImpl stats) {
+                                   Map<?, ?> state, ScheduledTaskStatisticsImpl stats,
+                                   ScheduledTaskResult result) {
         this.definition = definition;
-        this.stats.set(stats);
+        this.stats = stats;
         this.state = state;
+        this.resultRef.set(result);
     }
 
     public TaskDefinition getDefinition() {
@@ -67,15 +79,19 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
     }
 
     ScheduledTaskStatisticsImpl getStatsSnapshot() {
-        return stats.get().snapshot();
-    }
-
-    void setStats(ScheduledTaskStatisticsImpl stats) {
-        this.stats.set(stats);
+        return stats.snapshot();
     }
 
     Map<?, ?> getStateSnapshot() {
-        return new HashMap(state);
+        return state;
+    }
+
+    ScheduledTaskResult getTaskResult() {
+        return resultRef.get();
+    }
+
+    void setStats(ScheduledTaskStatisticsImpl stats) {
+        this.stats = stats;
     }
 
     void setState(Map<?, ?> snapshot) {
@@ -83,11 +99,63 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
     }
 
     ScheduledFuture<?> getScheduledFuture() {
-        return scheduledFuture;
+        return future;
     }
 
     void setScheduledFuture(ScheduledFuture<?> future) {
-        this.scheduledFuture = future;
+        this.future = future;
+    }
+
+    void setTaskResult(ScheduledTaskResult result) {
+        this.resultRef.set(result);
+    }
+
+    Object get()
+            throws ExecutionException, InterruptedException {
+
+        ScheduledTaskResult result = resultRef.get();
+        if (result != null) {
+            result.checkErroneousState();
+        }
+
+        return future.get();
+    }
+
+    boolean cancel(boolean mayInterrupt)
+            throws ExecutionException, InterruptedException {
+
+        if (!resultRef.compareAndSet(null, new ScheduledTaskResult(true)) || future == null) {
+            return false;
+        }
+
+        return future.cancel(mayInterrupt);
+    }
+
+    long getDelay(TimeUnit unit) {
+        boolean wasDoneOrCancelled = resultRef.get() != null;
+        if (wasDoneOrCancelled) {
+            return 0;
+        }
+
+        return future.getDelay(unit);
+    }
+
+    boolean isCancelled()
+            throws ExecutionException, InterruptedException {
+        ScheduledTaskResult result = resultRef.get();
+        boolean wasCancelled = result != null && result.isCancelled();
+        return wasCancelled || (future != null && future.isCancelled());
+    }
+
+    boolean isDone()
+            throws ExecutionException, InterruptedException {
+        boolean wasDone = resultRef.get() != null;
+        return wasDone || (future != null && future.isDone());
+    }
+
+    boolean shouldSchedule() {
+        // Stashed tasks that never got scheduled, and weren't cancelled in-between
+        return future == null && this.resultRef.get() == null;
     }
 
     @Override
@@ -105,7 +173,8 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
             throws IOException {
         out.writeObject(definition);
         out.writeObject(state);
-        out.writeObject(stats.get());
+        out.writeObject(stats);
+        out.writeObject(resultRef.get());
     }
 
     @Override
@@ -113,13 +182,19 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
             throws IOException {
         definition = in.readObject();
         state = in.readObject();
-        stats.set((ScheduledTaskStatisticsImpl) in.readObject());
+        stats = in.readObject();
+        resultRef.set((ScheduledTaskResult) in.readObject());
     }
 
     @Override
     public String toString() {
-        return "ScheduledTaskDescriptor{" + "definition=" + definition + ", scheduledFuture=" + scheduledFuture + ", stats="
-                + stats + ", state=" + state + '}';
+        return "ScheduledTaskDescriptor{"
+                + "definition=" + definition + ", "
+                + "future=" + future + ", "
+                + "stats=" + stats + ", "
+                + "state=" + state + ", "
+                + "result=" + resultRef.get()
+                + '}';
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
@@ -82,7 +82,7 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
         return stats.snapshot();
     }
 
-    Map<?, ?> getStateSnapshot() {
+    Map<?, ?> getState() {
         return state;
     }
 
@@ -116,6 +116,7 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
         ScheduledTaskResult result = resultRef.get();
         if (result != null) {
             result.checkErroneousState();
+            return result.getReturnValue();
         }
 
         return future.get();

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.scheduledexecutor.impl;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+
+public class ScheduledTaskResult
+        implements IdentifiedDataSerializable {
+
+    private boolean done;
+
+    private Object result;
+
+    private Throwable exception;
+
+    private boolean cancelled;
+
+    ScheduledTaskResult() {
+    }
+
+    ScheduledTaskResult(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    ScheduledTaskResult(Throwable exception) {
+        this.exception = exception;
+    }
+
+    ScheduledTaskResult(Object result) {
+        this.result = result;
+        this.done = true;
+    }
+
+    public Object getResult() {
+        return result;
+    }
+
+    public Throwable getException() {
+        return exception;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public boolean isDone() {
+        return done || cancelled || exception != null;
+    }
+
+    public void checkErroneousState()
+            throws ExecutionException {
+
+        if (isCancelled()) {
+            throw new CancellationException();
+        } else if (exception != null) {
+            throw new ExecutionExceptionDecorator(new ExecutionException(exception));
+        }
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ScheduledExecutorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ScheduledExecutorDataSerializerHook.TASK_RESOLUTION;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out)
+            throws IOException {
+        out.writeObject(result);
+        out.writeBoolean(done);
+        out.writeBoolean(cancelled);
+        out.writeObject(exception);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in)
+            throws IOException {
+        result = in.readObject();
+        done = in.readBoolean();
+        cancelled = in.readBoolean();
+        exception = in.readObject();
+    }
+
+    @Override
+    public String
+    toString() {
+        return "ScheduledTaskResult{"
+                + "result=" + result + ", "
+                + "exception=" + exception + ", "
+                + "cancelled=" + cancelled
+                + '}';
+    }
+
+    // ExecutionExceptions get peeled away during Operation response, this wrapper
+    // helps identifying them on the proxy and re-construct them.
+    public static class ExecutionExceptionDecorator
+            extends RuntimeException {
+
+        public ExecutionExceptionDecorator(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
@@ -51,7 +51,7 @@ public class ScheduledTaskResult
         this.done = true;
     }
 
-    public Object getResult() {
+    public Object getReturnValue() {
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/CancelTaskBackupOperation.java
@@ -39,7 +39,7 @@ public class CancelTaskBackupOperation
     @Override
     public void run()
             throws Exception {
-        getContainer().unstash(taskName);
+        getContainer().cancel(taskName);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeBackupTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/DisposeBackupTaskOperation.java
@@ -38,7 +38,7 @@ public class DisposeBackupTaskOperation
     @Override
     public void run()
             throws Exception {
-        getContainer().unstash(taskName);
+        getContainer().dispose(taskName);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetResultOperation.java
@@ -37,7 +37,7 @@ public class GetResultOperation<V>
 
     private ScheduledTaskHandler handler;
 
-    private V result;
+    private Object result;
 
     public GetResultOperation() {
     }
@@ -51,11 +51,11 @@ public class GetResultOperation<V>
     @Override
     public void run()
             throws Exception {
-        result = (V) getContainer().get(taskName);
+        result = getContainer().get(taskName);
     }
 
     @Override
-    public V getResponse() {
+    public Object getResponse() {
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncBackupStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncBackupStateOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.scheduledexecutor.impl.ScheduledExecutorDataSerializerHook;
 import com.hazelcast.scheduledexecutor.impl.ScheduledTaskStatisticsImpl;
+import com.hazelcast.scheduledexecutor.impl.ScheduledTaskResult;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -34,20 +35,24 @@ public class SyncBackupStateOperation
 
     private ScheduledTaskStatisticsImpl stats;
 
+    private ScheduledTaskResult result;
+
     public SyncBackupStateOperation() {
     }
 
-    public SyncBackupStateOperation(String schedulerName, String taskName, Map state, ScheduledTaskStatisticsImpl stats) {
+    public SyncBackupStateOperation(String schedulerName, String taskName, Map state,
+                                    ScheduledTaskStatisticsImpl stats, ScheduledTaskResult result) {
         super(schedulerName);
         this.taskName = taskName;
         this.state = state;
         this.stats = stats;
+        this.result = result;
     }
 
     @Override
     public void run()
             throws Exception {
-        getContainer().syncState(taskName, state, stats);
+        getContainer().syncState(taskName, state, stats, result);
     }
 
     @Override
@@ -66,6 +71,7 @@ public class SyncBackupStateOperation
             out.writeObject(entry.getValue());
         }
         out.writeObject(stats);
+        out.writeObject(result);
     }
 
     @Override
@@ -79,5 +85,6 @@ public class SyncBackupStateOperation
             this.state.put(in.readObject(), in.readObject());
         }
         this.stats = in.readObject();
+        this.result = in.readObject();
     }
 }


### PR DESCRIPTION
When cancelling a task, the replication algorithm is still promoting the task in the new node causing further scheduling. This misbehaviour was noted during tests, where after cancelling, the node is shutting down, and before asserting the stats the new owner already restarts the task and increments the counters.

This should fix all tests failing with counters greater than the expected value, eg. expected 5 actual 6.