### PR TITLE
Throttling of queries executed from a HZ client. 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -33,6 +33,7 @@ import com.hazelcast.client.impl.protocol.task.AuthenticationMessageTask;
 import com.hazelcast.client.impl.protocol.task.GetPartitionsMessageTask;
 import com.hazelcast.client.impl.protocol.task.MessageTask;
 import com.hazelcast.client.impl.protocol.task.PingMessageTask;
+import com.hazelcast.client.impl.protocol.task.map.AbstractMapQueryMessageTask;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientListener;
@@ -104,6 +105,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
 
     private static final int EXECUTOR_QUEUE_CAPACITY_PER_CORE = 100000;
     private static final int THREADS_PER_CORE = 20;
+    private static final int QUERY_THREADS_PER_CORE = 1;
     private static final ConstructorFunction<String, AtomicLong> LAST_AUTH_CORRELATION_ID_CONSTRUCTOR_FUNC =
             new ConstructorFunction<String, AtomicLong>() {
                 @Override
@@ -114,6 +116,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     private final Node node;
     private final NodeEngineImpl nodeEngine;
     private final Executor executor;
+    private final Executor queryExecutor;
 
     private final SerializationService serializationService;
     // client uuid -> member uuid
@@ -135,7 +138,8 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         this.serializationService = node.getSerializationService();
         this.nodeEngine = node.nodeEngine;
         this.endpointManager = new ClientEndpointManagerImpl(this, nodeEngine);
-        this.executor = newExecutor();
+        this.executor = newClientExecutor();
+        this.queryExecutor = newClientQueryExecutor();
         this.messageTaskFactory = new CompositeMessageTaskFactory(this.nodeEngine);
         this.clientExceptionFactory = initClientExceptionFactory();
 
@@ -149,7 +153,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         return new ClientExceptionFactory(jcacheAvailable);
     }
 
-    private Executor newExecutor() {
+    private Executor newClientExecutor() {
         final ExecutionService executionService = nodeEngine.getExecutionService();
         int coreSize = Runtime.getRuntime().availableProcessors();
 
@@ -157,8 +161,24 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         if (threadCount <= 0) {
             threadCount = coreSize * THREADS_PER_CORE;
         }
+        logger.finest("Creating new client executor with threadCount=" + threadCount);
 
         return executionService.register(ExecutionService.CLIENT_EXECUTOR,
+                threadCount, coreSize * EXECUTOR_QUEUE_CAPACITY_PER_CORE,
+                ExecutorType.CONCRETE);
+    }
+
+    private Executor newClientQueryExecutor() {
+        final ExecutionService executionService = nodeEngine.getExecutionService();
+        int coreSize = Runtime.getRuntime().availableProcessors();
+
+        int threadCount = node.getProperties().getInteger(GroupProperty.CLIENT_ENGINE_QUERY_THREAD_COUNT);
+        if (threadCount <= 0) {
+            threadCount = coreSize * QUERY_THREADS_PER_CORE;
+        }
+        logger.finest("Creating new client query executor with threadCount=" + threadCount);
+
+        return executionService.register(ExecutionService.CLIENT_QUERY_EXECUTOR,
                 threadCount, coreSize * EXECUTOR_QUEUE_CAPACITY_PER_CORE,
                 ExecutorType.CONCRETE);
     }
@@ -185,6 +205,8 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         if (partitionId < 0) {
             if (isUrgent(messageTask)) {
                 operationService.execute(new PriorityPartitionSpecificRunnable(messageTask));
+            } else if (isQuery(messageTask)) {
+                queryExecutor.execute(messageTask);
             } else {
                 executor.execute(messageTask);
             }
@@ -200,6 +222,10 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
                 || clazz == AuthenticationMessageTask.class
                 || clazz == AuthenticationCustomCredentialsMessageTask.class
                 ;
+    }
+
+    private boolean isQuery(MessageTask messageTask) {
+        return messageTask instanceof AbstractMapQueryMessageTask;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -53,6 +53,11 @@ public interface ExecutionService {
     String CLIENT_EXECUTOR = "hz:client";
 
     /**
+     * Name of the client executor.
+     */
+    String CLIENT_QUERY_EXECUTOR = "hz:client-query";
+
+    /**
      * Name of the query executor.
      */
     String QUERY_EXECUTOR = "hz:query";

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -100,6 +100,9 @@ public final class GroupProperty {
     public static final HazelcastProperty CLIENT_ENGINE_THREAD_COUNT
             = new HazelcastProperty("hazelcast.clientengine.thread.count", -1);
 
+    public static final HazelcastProperty CLIENT_ENGINE_QUERY_THREAD_COUNT
+            = new HazelcastProperty("hazelcast.clientengine.query.thread.count", -1);
+
     public static final HazelcastProperty EVENT_THREAD_COUNT
             = new HazelcastProperty("hazelcast.event.thread.count", 5);
     public static final HazelcastProperty EVENT_QUEUE_CAPACITY


### PR DESCRIPTION
The number of thread in the client executor is too big for full-table scan queries. If there's too many of them executed at once the client executor holds to much data and throws OOME eventually.

Fixes #9568