### PR TITLE
Fixes testClientConnectionEvents

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -250,9 +250,10 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
         list.offer(LifecycleState.SHUTTING_DOWN);
         list.offer(LifecycleState.SHUTDOWN);
 
-        final HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
+        hazelcastFactory.newHazelcastInstance();
         final CountDownLatch latch = new CountDownLatch(list.size());
         final CountDownLatch connectedLatch = new CountDownLatch(2);
+        final CountDownLatch disconnectedLatch = new CountDownLatch(2);
         LifecycleListener listener = new LifecycleListener() {
             public void stateChanged(LifecycleEvent event) {
                 Logger.getLogger(getClass()).info("stateChanged: " + event);
@@ -263,6 +264,9 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
                 }
                 if (LifecycleState.CLIENT_CONNECTED.equals(eventState)) {
                     connectedLatch.countDown();
+                }
+                if (LifecycleState.CLIENT_DISCONNECTED.equals(eventState)) {
+                    disconnectedLatch.countDown();
                 }
             }
         };
@@ -276,13 +280,16 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
 
         hazelcastFactory.newHazelcastInstance();
 
-        assertTrue("LifecycleState failed. Expected two CLIENT_CONNECTED events!" , connectedLatch.await(60, TimeUnit.SECONDS));
+        assertOpenEventually("LifecycleState failed. Expected two CLIENT_CONNECTED events!", connectedLatch);
 
         hazelcastFactory.shutdownAllMembers();
 
+        //wait for disconnect then call client.shutdown(). Otherwise shutdown could prevent firing DISCONNECTED event
+        assertOpenEventually("LifecycleState failed. Expected two CLIENT_DISCONNECTED events!", disconnectedLatch);
+
         hazelcastClient.shutdown();
 
-        assertTrue("LifecycleState failed" , latch.await(60, TimeUnit.SECONDS));
+        assertOpenEventually("LifecycleState failed", latch);
     }
 
 


### PR DESCRIPTION
Issue seen in pr https://github.com/hazelcast/hazelcast/pull/9561
with following error message

	java.lang.AssertionError: LifecycleState failed
		at org.junit.Assert.fail(Assert.java:88)
		at org.junit.Assert.assertTrue(Assert.java:41)
		at com.hazelcast.client.ClientRegressionWithMockNetworkTest.testClientConnectionEvents(ClientRegressionWithMockNetworkTest.java:285)

Since client shutdown can happen before detecting cluster gone,
we need to wait disconected state before shutting down client.

bakcport of https://github.com/hazelcast/hazelcast/pull/9587