### PR TITLE
Increased code coverage of ClearWanQueuesOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ClearWanQueuesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ClearWanQueuesOperation.java
@@ -28,9 +28,6 @@ public class ClearWanQueuesOperation extends AbstractLocalOperation {
     private String schemeName;
     private String publisherName;
 
-    public ClearWanQueuesOperation() {
-    }
-
     public ClearWanQueuesOperation(String schemeName, String publisherName) {
         this.schemeName = schemeName;
         this.publisherName = publisherName;


### PR DESCRIPTION
`ClearWanQueuesOperation` is a local operation (the abstract base class
enforces this). So the default constructor is never used.