### PR TITLE
WIP Further fix related to #9273 and #9271

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -108,9 +108,4 @@ public interface ClientEndpoint extends Client {
      */
     void setClientVersion(String version);
 
-    /**
-     *
-     * @return true if any listeners are registered or transactions exist for the endpoint
-     */
-    boolean resourcesExist();
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
@@ -88,28 +88,7 @@ public interface ClientEndpointManager {
      * @param endpoint the endpoint to remove.
      * @param reason The reason why the endpoint is being removed
      * @throws java.lang.NullPointerException if endpoint is null.
-     * @see #removeEndpoint(ClientEndpoint, boolean, String)
      */
     void removeEndpoint(ClientEndpoint endpoint, String reason);
 
-    /**
-     * Removes an endpoint and optionally closes it immediately.
-     *
-     * todo: what happens when the endpoint already is removed
-     * todo: what happens when the endpoint was never registered
-     *
-     * @param ce the endpoint to remove.
-     * @param closeImmediately if the endpoint is immediately closed.
-     * @param reason The reason why the endpoint is being removed.
-     * @throws java.lang.NullPointerException if endpoint is null.
-     * @see #removeEndpoint(ClientEndpoint, String)
-     */
-    void removeEndpoint(ClientEndpoint ce, boolean closeImmediately, String reason);
-
-    /**
-     *
-     * @param clientUuid The uuid of the desired client conection
-     * @return Any connection with the provided client uuid which is live
-     */
-    Connection findLiveConnectionFor(String clientUuid);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -84,15 +84,7 @@ public final class ClientEndpointImpl implements ClientEndpoint {
 
     @Override
     public boolean isAlive() {
-        if (conn.isAlive()) {
-            return true;
-        }
-        String clientUuid = getUuid();
-        if (null != clientUuid) {
-            Connection connection = clientEngine.getEndpointManager().findLiveConnectionFor(clientUuid);
-            return null != connection;
-        }
-        return false;
+        return conn.isAlive();
     }
 
     @Override
@@ -235,11 +227,6 @@ public final class ClientEndpointImpl implements ClientEndpoint {
             }
         }
         removeListenerActions.clear();
-    }
-
-    @Override
-    public boolean resourcesExist() {
-        return !removeListenerActions.isEmpty() || !transactionContextMap.isEmpty();
     }
 
     public void destroy() throws LoginException {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -92,12 +92,7 @@ public class ClientHeartbeatMonitor implements Runnable {
                 String message = "Client heartbeat is timed out, closing connection to " + connection
                         + ". Now: " + timeToString(currentTimeMillis)
                         + ". LastTimePacketReceived: " + timeToString(lastTimePacketReceived);
-                connection.close(message, null);
-                if (clientEndpoint.resourcesExist()) {
-                    return;
-                }
-
-                clientEndpointManager.removeEndpoint(clientEndpoint, true, message);
+                clientEndpointManager.removeEndpoint(clientEndpoint, message);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/ClientDisconnectionOperation.java
@@ -51,7 +51,7 @@ public class ClientDisconnectionOperation extends AbstractClientOperation implem
             Set<ClientEndpoint> endpoints = endpointManager.getEndpoints(clientUuid);
             for (ClientEndpoint endpoint : endpoints) {
                 endpointManager
-                        .removeEndpoint(endpoint, true, "ClientDisconnectionOperation: Cleanup of disconnected client resources");
+                        .removeEndpoint(endpoint, "ClientDisconnectionOperation: Cleanup of disconnected client resources");
             }
 
             NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -203,28 +203,8 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
         resultClientMessage.setCorrelationId(clientMessage.getCorrelationId());
         resultClientMessage.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
         resultClientMessage.setVersion(ClientMessage.VERSION);
-        final Connection endpointConnection = findSendConnection();
         //TODO framing not implemented yet, should be split into frames before writing to connection
-        endpointConnection.write(resultClientMessage);
-    }
-
-    protected Connection findSendConnection() {
-        if (connection.isAlive()) {
-            return connection;
-        }
-
-        String clientUuid = endpoint.getUuid();
-        // The connection may have changed for listener tasks, hence try find a connection to the client
-        if (null != clientUuid) {
-            Connection conn = endpointManager.findLiveConnectionFor(clientUuid);
-            if (null != conn) {
-                // update the connection for this task so that the new messages will use this new live connection
-                connection = conn;
-                return conn;
-            }
-        }
-
-        return connection;
+        connection.write(resultClientMessage);
     }
 
     protected void sendClientMessage(Object key, ClientMessage resultClientMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -96,21 +96,12 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMultiTarg
 
     @Override
     protected ClientEndpointImpl getEndpoint() {
-        if (connection.isAlive()) {
-            return new ClientEndpointImpl(clientEngine, connection);
-        } else {
-            handleEndpointNotCreatedConnectionNotAlive();
-        }
-        return null;
+        return new ClientEndpointImpl(clientEngine, connection);
     }
 
     @Override
     protected boolean isAuthenticationMessage() {
         return true;
-    }
-
-    private void handleEndpointNotCreatedConnectionNotAlive() {
-        logger.warning("Dropped: " + clientMessage + " -> endpoint not created for AuthenticationRequest, connection not alive");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/PingMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/PingMessageTask.java
@@ -69,8 +69,4 @@ public class PingMessageTask extends AbstractCallableMessageTask<ClientPingCodec
         return null;
     }
 
-    @Override
-    protected Connection findSendConnection() {
-        return connection;
-    }
 }


### PR DESCRIPTION
 Related pull requests
 https://github.com/hazelcast/hazelcast/pull/9271
 https://github.com/hazelcast/hazelcast/pull/9273

In #9271, connections with resources are destroyed. I have converted
it so that every endpoint is removed. The purpose of heartbeat
was to clean resources of a client when heartbeat is timeout in the
first place.

With the fix above, the addition of findLiveConnection is not necessary 
any more. . When endpoint destroyed listeners
are removed. This means there can not be any listener task that its connection
is not live but it is trying to send events to client.