### PR TITLE
WIP Further fix related to #9273 and #9271

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpointManager.java
@@ -88,23 +88,8 @@ public interface ClientEndpointManager {
      * @param endpoint the endpoint to remove.
      * @param reason The reason why the endpoint is being removed
      * @throws java.lang.NullPointerException if endpoint is null.
-     * @see #removeEndpoint(ClientEndpoint, boolean, String)
      */
     void removeEndpoint(ClientEndpoint endpoint, String reason);
-
-    /**
-     * Removes an endpoint and optionally closes it immediately.
-     *
-     * todo: what happens when the endpoint already is removed
-     * todo: what happens when the endpoint was never registered
-     *
-     * @param ce the endpoint to remove.
-     * @param closeImmediately if the endpoint is immediately closed.
-     * @param reason The reason why the endpoint is being removed.
-     * @throws java.lang.NullPointerException if endpoint is null.
-     * @see #removeEndpoint(ClientEndpoint, String)
-     */
-    void removeEndpoint(ClientEndpoint ce, boolean closeImmediately, String reason);
 
     /**
      *

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -349,11 +349,11 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
     }
 
     public void removeClient(String clientUuid) {
-         ownershipMappings.remove(clientUuid);
+        ownershipMappings.remove(clientUuid);
 
         Set<ClientEndpoint> endpoints = endpointManager.getEndpoints(clientUuid);
         for (ClientEndpoint endpoint : endpoints) {
-            endpointManager.removeEndpoint(endpoint, true, "Resources are being cleaned up for client " + clientUuid);
+            endpointManager.removeEndpoint(endpoint, "Resources are being cleaned up for client " + clientUuid);
         }
 
         NodeEngineImpl nodeEngine = node.getNodeEngine();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -97,7 +97,7 @@ public class ClientHeartbeatMonitor implements Runnable {
                     return;
                 }
 
-                clientEndpointManager.removeEndpoint(clientEndpoint, true, message);
+                clientEndpointManager.removeEndpoint(clientEndpoint, message);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -61,21 +61,12 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractCallableM
 
     @Override
     protected ClientEndpointImpl getEndpoint() {
-        if (connection.isAlive()) {
-            return new ClientEndpointImpl(clientEngine, connection);
-        } else {
-            handleEndpointNotCreatedConnectionNotAlive();
-        }
-        return null;
+        return new ClientEndpointImpl(clientEngine, connection);
     }
 
     @Override
     protected boolean isAuthenticationMessage() {
         return true;
-    }
-
-    private void handleEndpointNotCreatedConnectionNotAlive() {
-        logger.warning("Dropped: " + clientMessage + " -> endpoint not created for AuthenticationRequest, connection not alive");
     }
 
     @Override
@@ -205,7 +196,7 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractCallableM
                 op.setCallerUuid(localMember.getUuid());
                 try {
                     InvocationBuilder invocationBuilder = nodeEngine.getOperationService()
-                                                                    .createInvocationBuilder(null, op, member.getAddress());
+                            .createInvocationBuilder(null, op, member.getAddress());
                     invocationBuilder.setTryCount(1);
                     operationInfos.add(new OperationInfo(invocationBuilder.invoke(), member));
                 } catch (Exception e) {
@@ -259,7 +250,6 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractCallableM
     }
 
     /**
-     *
      * @return true if client resources does not exist on this member, false otherwise
      */
     private boolean reAuthLocal() {


### PR DESCRIPTION
 Related pull requests
 https://github.com/hazelcast/hazelcast/pull/9271
 https://github.com/hazelcast/hazelcast/pull/9273

In #9271, connections with resources are destroyed. I have converted
it so that every that endpoints are removed. The purpose of heartbeat
was to clean resources of a client when heartbeat is timeout in the
first place.

With the fix above, the addition of findLiveConnection which added in
if and only if its endpoint destroyed. When enpoint destroyed listeners
are removed. This means there can not be any listener task that its connection
is not live but it is trying to send events to client.