### PR TITLE
Fix wrong estimation due to wrong encoding engine.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
@@ -60,7 +60,6 @@ public class HyperLogLogImpl implements HyperLogLog {
     @Override
     public long estimate() {
         if (cachedEstimate == null) {
-            convertToDenseIfNeeded();
             cachedEstimate = encoder.estimate();
         }
 
@@ -69,6 +68,7 @@ public class HyperLogLogImpl implements HyperLogLog {
 
     @Override
     public void add(long hash) {
+        convertToDenseIfNeeded();
         boolean changed = encoder.add(hash);
         if (changed) {
             cachedEstimate = null;
@@ -103,7 +103,7 @@ public class HyperLogLogImpl implements HyperLogLog {
     }
 
     private void convertToDenseIfNeeded() {
-        boolean shouldConvertToDense = encoder.getEncodingType() == SPARSE
+        boolean shouldConvertToDense = SPARSE.equals(encoder.getEncodingType())
                 && encoder.getMemoryFootprint() >= m;
         if (shouldConvertToDense) {
             encoder = ((SparseHyperLogLogEncoder) encoder).asDense();

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorStressTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cardinality;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class CardinalityEstimatorStressTest extends HazelcastTestSupport {
+
+    private CardinalityEstimator estimator;
+
+    @Before
+    public void setup() {
+        estimator = createHazelcastInstance().getCardinalityEstimator("StressTest_Estimator");
+    }
+
+    @Test(timeout = 4 * 60000)
+    public void addBigRange_checkErrorMargin_completeWithinFourMins() {
+        // Sparse encoding would have taken much longer to complete, thus
+        // timeout helps to make sure the encoding engine used is the correct one.
+        long expected = 10000000;
+
+        float tolerancePct = .3f;
+        long acceptableDelta = (long) ((tolerancePct / 100) * expected);
+
+        for (int i = 0; i < expected; i++) {
+            estimator.add(i);
+        }
+
+        long actual = estimator.estimate();
+        assertEquals(expected, actual, acceptableDelta);
+    }
+
+}


### PR DESCRIPTION
When using an estimator to constantly add new elements and not checking the estimate
then encoding engine is not upgraded to the Dense, which leads to two problems.
a. the default engine keeps consuming more and more resources and it is fundamentally very hungry and slow
b. upon calling estimate at the very end, the conversion gives very wrong results

The problem with the delayed conversion, between the encoders, is that the actual condition check, whether to upgrade, takes place during the `estimate()` call, rather than the `add()`.

This patch, moves the check to the `add()` instead.

Credit goes to @pveentjer for reporting the issue.