### PR TITLE
Partition initialization fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
@@ -57,7 +57,7 @@ public class PartitionServiceMBean extends HazelcastMBean<InternalPartitionServi
     @ManagedDescription("Number of active partitions")
     public int getActivePartitionCount() {
         InetSocketAddress address = hazelcastInstance.getCluster().getLocalMember().getSocketAddress();
-        return managedObject.getMemberPartitions(new Address(address)).size();
+        return managedObject.getMemberPartitionsIfAssigned(new Address(address)).size();
     }
 
     @ManagedAnnotation("isClusterSafe")

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PartitionServiceBeanDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/PartitionServiceBeanDTO.java
@@ -39,7 +39,7 @@ public class PartitionServiceBeanDTO implements JsonSerializable {
                                    HazelcastInstanceImpl hazelcastInstance) {
         Address address = hazelcastInstance.getCluster().getLocalMember().getAddress();
         this.partitionCount = partitionService.getPartitionCount();
-        this.activePartitionCount = partitionService.getMemberPartitions(address).size();
+        this.activePartitionCount = partitionService.getMemberPartitionsIfAssigned(address).size();
     }
 
     public int getPartitionCount() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -20,6 +20,7 @@ import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.partition.IPartitionService;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public interface InternalPartitionService extends IPartitionService {
@@ -98,4 +99,12 @@ public interface InternalPartitionService extends IPartitionService {
     long[] incrementPartitionReplicaVersions(int partitionId, int totalBackupCount);
 
     PartitionTableView createPartitionTableView();
+
+    /**
+     * Returns partition id list assigned to given target if partitions are assigned when method is called.
+     * Does not trigger partition assignment otherwise.
+     *
+     * @return partition id list assigned to given target if partitions are assigned already
+     */
+    List<Integer> getMemberPartitionsIfAssigned(Address target);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -67,6 +67,7 @@ import com.hazelcast.util.scheduler.ScheduledEntry;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -914,6 +915,14 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             }
         }
         return ownedPartitions;
+    }
+
+    @Override
+    public List<Integer> getMemberPartitionsIfAssigned(Address target) {
+        if (!partitionStateManager.isInitialized()) {
+            return Collections.emptyList();
+        }
+        return getMemberPartitions(target);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionService.java
@@ -103,6 +103,12 @@ public interface IPartitionService extends CoreService {
      */
     int getPartitionCount();
 
+    /**
+     * Returns partition id list assigned to given target.
+     * Triggers partition assignment if partitions are not assigned yet.
+     *
+     * @return partition id list assigned to given target
+     */
     List<Integer> getMemberPartitions(Address target);
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/PartitionServiceBeanDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/PartitionServiceBeanDTOTest.java
@@ -1,14 +1,13 @@
 package com.hazelcast.internal.management;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.management.dto.PartitionServiceBeanDTO;
 import com.hazelcast.monitor.impl.MemberStateImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -16,13 +15,8 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class PartitionServiceBeanDTOTest extends HazelcastTestSupport {
-
-    @After
-    public void tearDown() {
-        Hazelcast.shutdownAll();
-    }
 
     /**
      * https://github.com/hazelcast/hazelcast/issues/8463
@@ -31,7 +25,8 @@ public class PartitionServiceBeanDTOTest extends HazelcastTestSupport {
     public void testJMXStatsWithPublicAddressHostName() {
         Config config = new Config();
         config.getNetworkConfig().setPublicAddress("hazelcast.org");
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = createHazelcastInstance(config);
+        warmUpPartitions(instance);
         MemberStateImpl memberState = new MemberStateImpl();
         TimedMemberStateFactoryHelper.registerJMXBeans(getNode(instance).hazelcastInstance, memberState);
         PartitionServiceBeanDTO partitionServiceDTO = memberState.getMXBeans().getPartitionServiceBean();

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImplTest.java
@@ -40,12 +40,15 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.internal.partition.InternalPartition.MAX_REPLICA_COUNT;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -162,6 +165,33 @@ public class InternalPartitionServiceImplTest extends HazelcastTestSupport {
 
         partitionService.setInitialState(new PartitionTableView(addresses, 0));
         assertEquals(0, listener.eventCount);
+    }
+
+    @Test
+    public void test_getMemberPartitions_whenNotInitialized() {
+        List<Integer> partitions = partitionService.getMemberPartitions(getAddress(instance));
+        assertTrue(partitionService.getPartitionStateManager().isInitialized());
+        assertEquals(partitionCount, partitions.size());
+    }
+
+    @Test
+    public void test_getMemberPartitions_whenInitialized() {
+        partitionService.firstArrangement();
+        List<Integer> partitions = partitionService.getMemberPartitions(getAddress(instance));
+        assertEquals(partitionCount, partitions.size());
+    }
+
+    @Test
+    public void test_getMemberPartitionsIfAssigned_whenNotInitialized() {
+        List<Integer> partitions = partitionService.getMemberPartitionsIfAssigned(getAddress(instance));
+        assertThat(partitions, empty());
+    }
+
+    @Test
+    public void test_getMemberPartitionsIfAssigned_whenInitialized() {
+        partitionService.firstArrangement();
+        List<Integer> partitions = partitionService.getMemberPartitionsIfAssigned(getAddress(instance));
+        assertEquals(partitionCount, partitions.size());
     }
 
     private static class TestPartitionListener implements PartitionListener {


### PR DESCRIPTION
- Partitions should not be initialized until startup is completed
- Add a new variant of getMemberPartitions() which is not triggering initialization