### PR TITLE
Fixed CachedExecutorServiceDelegate shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
@@ -22,6 +22,8 @@ import com.hazelcast.util.EmptyStatement;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
@@ -33,6 +35,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -53,6 +56,7 @@ public final class CachedExecutorServiceDelegate implements ExecutorService, Man
     private final NodeEngine nodeEngine;
     private final BlockingQueue<Runnable> taskQ;
     private final Lock lock = new ReentrantLock();
+    private final AtomicBoolean shutdown = new AtomicBoolean(false);
     private volatile int size;
 
     public CachedExecutorServiceDelegate(NodeEngine nodeEngine, String name, ExecutorService cachedExecutor,
@@ -103,6 +107,9 @@ public final class CachedExecutorServiceDelegate implements ExecutorService, Man
 
     @Override
     public void execute(Runnable command) {
+        if (shutdown.get()) {
+            throw new RejectedExecutionException();
+        }
         if (!taskQ.offer(command)) {
             throw new RejectedExecutionException("Executor[" + name + "] is overloaded!");
         }
@@ -150,28 +157,37 @@ public final class CachedExecutorServiceDelegate implements ExecutorService, Man
 
     @Override
     public void shutdown() {
-        taskQ.clear();
+        shutdown.set(true);
     }
 
     @Override
     public List<Runnable> shutdownNow() {
-        shutdown();
-        return null;
+        if (!shutdown.compareAndSet(false, true)) {
+            return Collections.emptyList();
+        }
+        List<Runnable> tasks = new LinkedList<Runnable>();
+        taskQ.drainTo(tasks);
+        for (Runnable task : tasks) {
+            if (task instanceof RunnableFuture) {
+                ((RunnableFuture) task).cancel(false);
+            }
+        }
+        return tasks;
     }
 
     @Override
     public boolean isShutdown() {
-        return false;
+        return shutdown.get();
     }
 
     @Override
     public boolean isTerminated() {
-        return false;
+        return shutdown.get() && taskQ.isEmpty();
     }
 
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        return false;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCreateDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCreateDestroyTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.executor;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.Member;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ExecutorServiceCreateDestroyTest extends HazelcastTestSupport {
+
+    private static final int INSTANCE_COUNT = 3;
+
+    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+    private HazelcastInstance[] instances = new HazelcastInstance[INSTANCE_COUNT];
+
+    @Before
+    public void setup() {
+        for (int i = 0; i < instances.length; i++) {
+            instances[i] = factory.newHazelcastInstance();
+        }
+        warmUpPartitions(instances);
+    }
+
+    @Test
+    public void test_createSubmit_thenDestroy() throws Exception {
+        test_createUse_thenDestroy(new ExecutorServiceCommand() {
+            @Override
+            Collection<Future> submit(IExecutorService ex, Callable task) {
+                return Collections.singleton(ex.submit(task));
+            }
+        });
+    }
+
+    @Test
+    public void test_createSubmitAllMembers_thenDestroy() throws Exception {
+        test_createUse_thenDestroy(new ExecutorServiceCommand() {
+            @Override
+            Collection<Future> submit(IExecutorService ex, Callable task) {
+                Map<Member, Future> futures = ex.submitToAllMembers(task);
+                return futures.values();
+            }
+        });
+    }
+
+    private void test_createUse_thenDestroy(final ExecutorServiceCommand command) throws Exception {
+        Future[] futures = new Future[INSTANCE_COUNT];
+        for (int i = 0; i < INSTANCE_COUNT; i++) {
+            final HazelcastInstance instance = instances[i];
+
+            futures[i] = spawn(new Callable() {
+                @Override
+                public Object call() throws Exception {
+                    Random rand = new Random();
+                    for (int i = 0; i < 1000; i++) {
+                        LockSupport.parkNanos(1 + rand.nextInt(100));
+                        IExecutorService ex = instance.getExecutorService("executor");
+                        command.run(ex);
+                        ex.destroy();
+                    }
+                    return null;
+                }
+            });
+        }
+
+        for (Future future : futures) {
+            future.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS);
+        }
+    }
+
+    private static abstract class ExecutorServiceCommand {
+        final void run(IExecutorService ex) throws Exception {
+            try {
+                Collection<Future> futures = submit(ex, new VoidCallableTask());
+                for (Future future : futures) {
+                    future.get();
+                }
+            } catch (RejectedExecutionException ignored) {
+            } catch (ExecutionException e) {
+                // This looks like an unexpected behaviour!
+                // When a task is rejected, it's wrapped in ExecutionException.
+                if (!(e.getCause() instanceof RejectedExecutionException)) {
+                    throw e;
+                }
+            }
+        }
+
+        abstract Collection<Future> submit(IExecutorService ex, Callable task);
+    }
+
+    private static class VoidCallableTask implements Callable<Void>, Serializable {
+        @Override
+        public Void call() throws Exception {
+            return null;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/CachedExecutorServiceDelegateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/CachedExecutorServiceDelegateTest.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.executor;
+
+import com.hazelcast.spi.ExecutionService;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.randomString;
+import static com.hazelcast.util.FutureUtil.checkAllDone;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CachedExecutorServiceDelegateTest {
+
+    private static final String NAME = "test-executor";
+
+    private ManagedExecutorService cachedExecutorService;
+    private NodeEngine nodeEngine;
+
+    @Before
+    public void setup() {
+        cachedExecutorService = new NamedThreadPoolExecutor("test", 0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>(), Executors.defaultThreadFactory());
+
+        ExecutionService executionService = mock(ExecutionService.class);
+        when(executionService.getExecutor(ExecutionService.ASYNC_EXECUTOR))
+                .thenReturn(cachedExecutorService);
+
+        nodeEngine = mock(NodeEngine.class);
+        when(nodeEngine.getExecutionService()).thenReturn(executionService);
+    }
+
+    @After
+    public void cleanup() {
+        cachedExecutorService.shutdown();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nonPositiveMaxPoolSize() {
+        newManagedExecutorService(-1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nonPositiveQueueCapacity() {
+        newManagedExecutorService(1, -1);
+    }
+
+    @Test
+    public void getName() throws Exception {
+        ManagedExecutorService executor = newManagedExecutorService();
+        assertEquals(NAME, executor.getName());
+    }
+
+    @Test
+    public void getMaximumPoolSize() throws Exception {
+        int maxPoolSize = 123;
+        assertEquals(maxPoolSize, newManagedExecutorService(maxPoolSize, 1).getMaximumPoolSize());
+    }
+
+    @Test
+    public void getPoolSize_whenNoTasksSubmitted() throws Exception {
+        assertEquals(0, newManagedExecutorService().getPoolSize());
+    }
+
+    @Test
+    public void getPoolSize_whenTaskSubmitted() throws Exception {
+        int maxPoolSize = 3;
+        ManagedExecutorService executorService = newManagedExecutorService(maxPoolSize, 100);
+
+        for (int i = 0; i < maxPoolSize * 2; i++) {
+            executeInfinitelyRunningTask(executorService);
+        }
+
+        assertEquals(maxPoolSize, executorService.getPoolSize());
+    }
+
+    @Test
+    public void getQueueSize_whenNoTasksSubmitted() throws Exception {
+        assertEquals(0, newManagedExecutorService().getQueueSize());
+    }
+
+    @Test
+    public void getQueueSize_whenTaskSubmitted() throws Exception {
+        int queueSize = 10;
+        ManagedExecutorService executorService = newManagedExecutorService(1, queueSize);
+
+        startInfinitelyRunningTask(executorService);
+        executeNopTask(executorService);
+
+        assertEquals(1, executorService.getQueueSize());
+        assertEquals(1, executorService.getQueueSize());
+    }
+
+    @Test
+    public void getRemainingQueueCapacity_whenNoTasksSubmitted() throws Exception {
+        int queueSize = 123;
+        assertEquals(queueSize, newManagedExecutorService(1, queueSize).getRemainingQueueCapacity());
+    }
+
+    @Test
+    public void getRemainingQueueCapacity_whenTaskSubmitted() throws Exception {
+        int queueSize = 10;
+        ManagedExecutorService executorService = newManagedExecutorService(1, queueSize);
+
+        startInfinitelyRunningTask(executorService);
+        executeNopTask(executorService);
+
+        assertEquals(queueSize - 1, executorService.getRemainingQueueCapacity());
+    }
+
+    @Test
+    public void getCompletedTaskCount_whenNoTasksSubmitted() throws Exception {
+        assertEquals(0, newManagedExecutorService().getCompletedTaskCount());
+    }
+
+    @Test
+    public void getCompletedTaskCount_whenTasksSubmitted() throws Exception {
+        final int taskCount = 10;
+        final ManagedExecutorService executorService = newManagedExecutorService();
+
+        for (int i = 0; i < taskCount; i++) {
+            executeNopTask(executorService);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(taskCount, executorService.getCompletedTaskCount());
+            }
+        });
+    }
+
+    @Test
+    public void execute() throws Exception {
+        final int taskCount = 10;
+        ManagedExecutorService executorService = newManagedExecutorService(1, taskCount);
+
+        final CountDownLatch latch = new CountDownLatch(taskCount);
+        for (int i = 0; i < taskCount; i++) {
+            executorService.execute(new Runnable() {
+                @Override
+                public void run() {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertOpenEventually(latch);
+    }
+
+    @Test(expected = RejectedExecutionException.class)
+    public void execute_rejected_whenShutdown() throws Exception {
+        ManagedExecutorService executorService = newManagedExecutorService();
+        executorService.shutdown();
+
+        executeNopTask(executorService);
+    }
+
+    @Test
+    public void submitRunnable() throws Exception {
+        final int taskCount = 10;
+        ManagedExecutorService executorService = newManagedExecutorService(1, taskCount);
+
+        Future[] futures = new Future[taskCount];
+        for (int i = 0; i < taskCount; i++) {
+            futures[i] = executorService.submit(new Runnable() {
+                @Override
+                public void run() {
+                }
+            });
+        }
+
+        checkAllDone(Arrays.asList(futures));
+    }
+
+    @Test
+    public void submitCallable() throws Exception {
+        final int taskCount = 10;
+        ManagedExecutorService executorService = newManagedExecutorService(1, taskCount);
+
+        final String result = randomString();
+        Future[] futures = new Future[taskCount];
+        for (int i = 0; i < taskCount; i++) {
+            futures[i] = executorService.submit(new Callable() {
+                @Override
+                public Object call() throws Exception {
+                    return result;
+                }
+            });
+        }
+
+        checkAllDone(Arrays.asList(futures));
+        for (Future future : futures) {
+            assertEquals(result, future.get());
+        }
+    }
+
+    @Test
+    public void submitRunnable_withResult() throws Exception {
+        final int taskCount = 10;
+        ManagedExecutorService executorService = newManagedExecutorService(1, taskCount);
+
+        final String result = randomString();
+        Future[] futures = new Future[taskCount];
+        for (int i = 0; i < taskCount; i++) {
+            futures[i] = executorService.submit(new Runnable() {
+                @Override
+                public void run() {
+                }
+            }, result);
+        }
+
+        checkAllDone(Arrays.asList(futures));
+        for (Future future : futures) {
+            assertEquals(result, future.get());
+        }
+    }
+
+    @Test
+    public void shutdown() throws Exception {
+        ManagedExecutorService executorService = newManagedExecutorService();
+        Future<Object> future = executorService.submit(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(1));
+                return null;
+            }
+        });
+
+        executorService.shutdown();
+        assertTrue(executorService.isShutdown());
+        future.get();
+    }
+
+    @Test
+    public void shutdownNow() throws Exception {
+        ManagedExecutorService executorService = newManagedExecutorService();
+        startInfinitelyRunningTask(executorService);
+
+        Future<Object> future = executorService.submit(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return null;
+            }
+        });
+
+        List<Runnable> tasks = executorService.shutdownNow();
+        assertTrue(executorService.isShutdown());
+
+        assertEquals(1, tasks.size());
+        try {
+            future.get();
+        } catch (CancellationException expected) {
+        }
+    }
+
+    public void isShutdown_whenRunning() throws Exception {
+        assertFalse(newManagedExecutorService().isShutdown());
+    }
+
+    @Test
+    public void isShutdown() throws Exception {
+        ManagedExecutorService executorService = newManagedExecutorService();
+        executorService.shutdown();
+        assertTrue(executorService.isShutdown());
+    }
+
+    @Test
+    public void isTerminated() throws Exception {
+        ManagedExecutorService executorService = newManagedExecutorService();
+        executorService.shutdown();
+        assertTrue(executorService.isTerminated());
+    }
+
+    @Test
+    public void isTerminated_whenRunning() throws Exception {
+        assertFalse(newManagedExecutorService().isTerminated());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void awaitTermination() throws Exception {
+        newManagedExecutorService().awaitTermination(1, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void invokeAll() throws Exception {
+        newManagedExecutorService().invokeAll(Collections.singleton(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return null;
+            }
+        }));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void invokeAll_withTimeout() throws Exception {
+        newManagedExecutorService().invokeAll(Collections.singleton(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return null;
+            }
+        }), 1, TimeUnit.SECONDS);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void invokeAny() throws Exception {
+        newManagedExecutorService().invokeAny(Collections.singleton(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return null;
+            }
+        }));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void invokeAny_withTimeout() throws Exception {
+        newManagedExecutorService().invokeAny(Collections.singleton(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return null;
+            }
+        }), 1, TimeUnit.SECONDS);
+    }
+
+    private void executeInfinitelyRunningTask(ExecutorService executorService) {
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                LockSupport.park();
+            }
+        });
+    }
+
+    private void startInfinitelyRunningTask(ExecutorService executorService) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                latch.countDown();
+                LockSupport.park();
+            }
+        });
+
+        assertOpenEventually(latch);
+    }
+
+    private void executeNopTask(ExecutorService executorService) {
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+            }
+        });
+    }
+
+    private ManagedExecutorService newManagedExecutorService() {
+        return newManagedExecutorService(1, 10);
+    }
+
+    private ManagedExecutorService newManagedExecutorService(int maxPoolSize, int queueCapacity) {
+        return new CachedExecutorServiceDelegate(nodeEngine, NAME, cachedExecutorService, maxPoolSize, queueCapacity);
+    }
+}


### PR DESCRIPTION
`IExecutorService` shutdown/destroy relies on `CachedExecutorServiceDelegate.shutdown()`.

Fixes #9586