### PR TITLE
Fixes ClientDisconnectionOperation removes the client endpoint twice

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnection;
-import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.ClientTestUtil;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.impl.ClusterListenerSupport;
@@ -54,7 +53,6 @@ import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
@@ -218,8 +216,8 @@ public class ClientServiceTest extends HazelcastTestSupport {
         client1.getLifecycleService().shutdown();
         client2.getLifecycleService().shutdown();
 
-        assertTrue(latchAdd.await(2 * ClientEngineImpl.ENDPOINT_REMOVE_DELAY_SECONDS, TimeUnit.SECONDS));
-        assertTrue(latchRemove.await(2 * ClientEngineImpl.ENDPOINT_REMOVE_DELAY_SECONDS, TimeUnit.SECONDS));
+        assertOpenEventually(latchAdd);
+        assertOpenEventually(latchRemove);
 
         assertTrue(clientService.removeClientListener(id));
 
@@ -227,7 +225,7 @@ public class ClientServiceTest extends HazelcastTestSupport {
 
         assertEquals(0, clientService.getConnectedClients().size());
 
-        final HazelcastInstance client3 = hazelcastFactory.newHazelcastClient();
+        hazelcastFactory.newHazelcastClient();
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnDisconnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnDisconnectionTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.txn;
 
-import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
@@ -40,7 +39,6 @@ import java.util.concurrent.Callable;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
-import static com.hazelcast.test.HazelcastTestSupport.sleepSeconds;
 import static com.hazelcast.test.HazelcastTestSupport.spawn;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -127,6 +125,6 @@ public class ClientTxnDisconnectionTest {
             public void run() throws Exception {
                 Assert.assertEquals(count, waitNotifyService.getTotalValidWaitingOperationCount());
             }
-        }, 2 * ClientEngineImpl.ENDPOINT_REMOVE_DELAY_SECONDS);
+        });
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/ClientEndpoint.java
@@ -85,7 +85,8 @@ public interface ClientEndpoint extends Client {
 
     void setLoginContext(LoginContext lc);
 
-    void authenticated(ClientPrincipal principal, Credentials credentials, boolean firstConnection, String clientVersion);
+    void authenticated(ClientPrincipal principal, Credentials credentials, boolean firstConnection,
+                       String clientVersion, long authCorrelationId);
 
     void authenticated(ClientPrincipal principal);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointImpl.java
@@ -58,6 +58,7 @@ public final class ClientEndpointImpl implements ClientEndpoint {
     private volatile boolean authenticated;
     private int clientVersion;
     private String clientVersionString;
+    private long authenticationCorrelationId;
 
     public ClientEndpointImpl(ClientEngineImpl clientEngine, Connection conn) {
         this.clientEngine = clientEngine;
@@ -110,11 +111,13 @@ public final class ClientEndpointImpl implements ClientEndpoint {
     }
 
     @Override
-    public void authenticated(ClientPrincipal principal, Credentials credentials, boolean firstConnection, String clientVersion) {
+    public void authenticated(ClientPrincipal principal, Credentials credentials, boolean firstConnection,
+                              String clientVersion, long authCorrelationId) {
         this.principal = principal;
         this.firstConnection = firstConnection;
         this.credentials = credentials;
         this.authenticated = true;
+        this.authenticationCorrelationId = authCorrelationId;
         this.setClientVersion(clientVersion);
     }
 
@@ -277,5 +280,9 @@ public final class ClientEndpointImpl implements ClientEndpoint {
                 + ", authenticated=" + authenticated
                 + ", clientVersion=" + clientVersionString
                 + '}';
+    }
+
+    public long getAuthenticationCorrelationId() {
+        return authenticationCorrelationId;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -222,7 +222,7 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMultiTarg
         Connection connection = endpoint.getConnection();
         ILogger logger = clientEngine.getLogger(getClass());
 
-        endpoint.authenticated(principal, credentials, isOwnerConnection(), clientVersion);
+        endpoint.authenticated(principal, credentials, isOwnerConnection(), clientVersion, clientMessage.getCorrelationId());
         setConnectionType();
         logger.info("Received auth from " + connection + ", successfully authenticated" + ", principal : " + principal
                 + ", owner connection : " + isOwnerConnection() + ", client version : " + clientVersion);

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -102,6 +102,13 @@ public final class GroupProperty {
 
     public static final HazelcastProperty CLIENT_ENGINE_QUERY_THREAD_COUNT
             = new HazelcastProperty("hazelcast.clientengine.query.thread.count", -1);
+    /**
+     *  Client connection is removed or owner node of a client is removed from cluster
+     *  ClientDisconnectedOperation runs and clean all resources of client(listeners are removed, locks/txn are released)
+     *  With this property, client has a window to connect back and prevent cleaning up its resources.
+     */
+    public static final HazelcastProperty CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS
+            = new HazelcastProperty("hazelcast.client.endpoint.remove.delay.seconds", 10);
 
     public static final HazelcastProperty EVENT_THREAD_COUNT
             = new HazelcastProperty("hazelcast.event.thread.count", 5);


### PR DESCRIPTION
ClientDisconnectionOperation removes the client endpoint twice when
client reconnected to same node. Reason was only check we had was client
and member uuid not changed. In this scenario, both of them do not
change. We are addinitially checking last authentication correlation
id of client to prevent second endpoint destroy.

A group property is added to make similar tests to take less time.
"hazelcast.client.endpoint.remove.delay.seconds". This value was
hardcoded as 10 seconds and causing all related tests to wait for
at least 10 seconds.