### PR TITLE
Use different property file for Hazelcast Enterprise build info

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
@@ -39,6 +39,7 @@ import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTDOWN;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTING;
+import static com.hazelcast.util.StringUtil.isNullOrEmpty;
 
 /**
  * Default {@link com.hazelcast.core.LifecycleService} implementation for the client.
@@ -92,7 +93,19 @@ public final class LifecycleServiceImpl implements LifecycleService {
     public void fireLifecycleEvent(LifecycleEvent.LifecycleState lifecycleState) {
         final LifecycleEvent lifecycleEvent = new LifecycleEvent(lifecycleState);
         String revision = buildInfo.getRevision();
-        revision = revision == null || revision.isEmpty() ? "" : " - " + revision;
+        if (isNullOrEmpty(revision)) {
+            revision = "";
+        } else {
+            revision = " - " + revision;
+            BuildInfo upstreamInfo = buildInfo.getUpstreamBuildInfo();
+            if (upstreamInfo != null) {
+                String upstreamRevision = upstreamInfo.getRevision();
+                if (!isNullOrEmpty(upstreamRevision)) {
+                    revision += ", " + upstreamRevision;
+                }
+            }
+        }
+
         getLogger().info("HazelcastClient " + buildInfo.getVersion() + " ("
                 + buildInfo.getBuild() + revision + ") is "
                 + lifecycleEvent.getState());

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
@@ -34,15 +34,22 @@ public class BuildInfo {
     private final int buildNumber;
     private final boolean enterprise;
     private final byte serializationVersion;
+    private final BuildInfo upstreamBuildInfo;
 
     public BuildInfo(String version, String build, String revision, int buildNumber, boolean enterprise,
                      byte serializationVersion) {
+        this(version, build, revision, buildNumber, enterprise, serializationVersion, null);
+    }
+
+    public BuildInfo(String version, String build, String revision, int buildNumber, boolean enterprise,
+                     byte serializationVersion, BuildInfo upstreamBuildInfo) {
         this.version = version;
         this.build = build;
         this.revision = revision;
         this.buildNumber = buildNumber;
         this.enterprise = enterprise;
         this.serializationVersion = serializationVersion;
+        this.upstreamBuildInfo = upstreamBuildInfo;
     }
 
     public String getRevision() {
@@ -67,6 +74,10 @@ public class BuildInfo {
 
     public byte getSerializationVersion() {
         return serializationVersion;
+    }
+
+    public BuildInfo getUpstreamBuildInfo() {
+        return upstreamBuildInfo;
     }
 
     public static int calculateVersion(String version) {
@@ -105,6 +116,7 @@ public class BuildInfo {
                 + ", revision=" + revision
                 + ", enterprise=" + enterprise
                 + ", serializationVersion=" + serializationVersion
+                + (upstreamBuildInfo == null ? "" : ", upstream=" + upstreamBuildInfo)
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -56,19 +56,18 @@ public final class BuildInfoProvider {
      * @return the parsed BuildInfo
      */
     public static BuildInfo getBuildInfo() {
-        final InputStream inRuntimeProperties =
-                BuildInfoProvider.class.getClassLoader().getResourceAsStream("hazelcast-runtime.properties");
-        Properties runtimeProperties = new Properties();
-        try {
-            if (inRuntimeProperties != null) {
-                runtimeProperties.load(inRuntimeProperties);
-            }
-        } catch (Exception ignored) {
-            EmptyStatement.ignore(ignored);
-        } finally {
-            closeResource(inRuntimeProperties);
-        }
+        Properties properties = loadPropertiesFromResource("hazelcast-runtime.properties");
+        Properties enterpriseProperties = loadPropertiesFromResource("hazelcast-enterprise-runtime.properties");
 
+        BuildInfo buildInfo = readBuildInfoProperties(properties, null);
+        if (enterpriseProperties.isEmpty()) {
+            return buildInfo;
+        } else {
+            return readBuildInfoProperties(enterpriseProperties, buildInfo);
+        }
+    }
+
+    private static BuildInfo readBuildInfoProperties(Properties runtimeProperties, BuildInfo upstreamBuildInfo) {
         String version = runtimeProperties.getProperty("hazelcast.version");
         String distribution = runtimeProperties.getProperty("hazelcast.distribution");
         String revision = runtimeProperties.getProperty("hazelcast.git.revision", "");
@@ -86,7 +85,6 @@ public final class BuildInfoProvider {
             build = String.valueOf(hazelcastBuild);
         }
         int buildNumber = Integer.parseInt(build);
-
         // override version with a system property
         String overridingVersion = System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
         if (overridingVersion != null) {
@@ -96,7 +94,23 @@ public final class BuildInfoProvider {
 
         String sv = runtimeProperties.getProperty("hazelcast.serialization.version");
         byte serialVersion = Byte.parseByte(sv);
-        return new BuildInfo(version, build, revision, buildNumber, enterprise, serialVersion);
+        return new BuildInfo(version, build, revision, buildNumber, enterprise, serialVersion, upstreamBuildInfo);
+    }
+
+    private static Properties loadPropertiesFromResource(String resourceName) {
+        final InputStream properties =
+                BuildInfoProvider.class.getClassLoader().getResourceAsStream(resourceName);
+        Properties runtimeProperties = new Properties();
+        try {
+            if (properties != null) {
+                runtimeProperties.load(properties);
+            }
+        } catch (Exception ignored) {
+            EmptyStatement.ignore(ignored);
+        } finally {
+            closeResource(properties);
+        }
+        return runtimeProperties;
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/BuildInfoPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/BuildInfoPlugin.java
@@ -48,6 +48,10 @@ public class BuildInfoPlugin extends DiagnosticsPlugin {
         // we convert to string to prevent formatting the number
         writer.writeKeyValueEntry("BuildNumber", "" + buildInfo.getBuildNumber());
         writer.writeKeyValueEntry("Revision", buildInfo.getRevision());
+        BuildInfo upstreamBuildInfo = buildInfo.getUpstreamBuildInfo();
+        if (upstreamBuildInfo != null) {
+            writer.writeKeyValueEntry("UpstreamRevision", upstreamBuildInfo.getRevision());
+        }
         writer.writeKeyValueEntry("Version", buildInfo.getVersion());
         writer.writeKeyValueEntry("SerialVersion", buildInfo.getSerializationVersion());
         writer.writeKeyValueEntry("Enterprise", buildInfo.isEnterprise());


### PR DESCRIPTION
When hazelcast-enterprise-runtime.properties are found then
we treat hazelcast-runtime.properties as an upstream source.

Hazelcast Enterprise can see what (Open Source) Hazelcast
was used  to build that particular version of Enterprise.