### PR TITLE
Make TextReadHandler command buffer expandable

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -39,17 +39,17 @@ public class HTTPCommunicator {
         this.address = "http:/" + instance.getCluster().getLocalMember().getSocketAddress().toString() + "/hazelcast/rest/";
     }
 
-    public String poll(String queueName, long timeout) throws IOException {
+    public String queuePoll(String queueName, long timeout) throws IOException {
         String url = address + "queues/" + queueName + "/" + String.valueOf(timeout);
         return doGet(url);
     }
 
-    public int size(String queueName) throws IOException {
+    public int queueSize(String queueName) throws IOException {
         String url = address + "queues/" + queueName + "/size";
         return Integer.parseInt(doGet(url));
     }
 
-    public int offer(String queueName, String data) throws IOException {
+    public int queueOffer(String queueName, String data) throws IOException {
         final String url = address + "queues/" + queueName;
         final HttpURLConnection urlConnection = setupConnection(url, "POST");
 
@@ -63,7 +63,7 @@ public class HTTPCommunicator {
         return urlConnection.getResponseCode();
     }
 
-    public String get(String mapName, String key) throws IOException {
+    public String mapGet(String mapName, String key) throws IOException {
         String url = address + "maps/" + mapName + "/" + key;
         return doGet(url);
     }
@@ -79,7 +79,7 @@ public class HTTPCommunicator {
         return doGet(url);
     }
 
-    public int put(String mapName, String key, String value) throws IOException {
+    public int mapPut(String mapName, String key, String value) throws IOException {
         final String url = address + "maps/" + mapName + "/" + key;
         final HttpURLConnection urlConnection = setupConnection(url, "POST");
 
@@ -93,12 +93,12 @@ public class HTTPCommunicator {
         return urlConnection.getResponseCode();
     }
 
-    public int deleteAll(String mapName) throws IOException {
+    public int mapDeleteAll(String mapName) throws IOException {
         String url = address + "maps/" + mapName;
         return setupConnection(url, "DELETE").getResponseCode();
     }
 
-    public int delete(String mapName, String key) throws IOException {
+    public int mapDelete(String mapName, String key) throws IOException {
         String url = address + "maps/" + mapName + "/" + key;
         return setupConnection(url, "DELETE").getResponseCode();
     }
@@ -209,9 +209,13 @@ public class HTTPCommunicator {
         HttpURLConnection httpUrlConnection = (HttpURLConnection) (new URL(url)).openConnection();
         try {
             InputStream inputStream = httpUrlConnection.getInputStream();
-            byte[] buffer = new byte[4096];
-            int readBytes = inputStream.read(buffer);
-            return readBytes == -1 ? "" : new String(buffer, 0, readBytes);
+            StringBuilder builder = new StringBuilder();
+            byte[] buffer = new byte[1024];
+            int readBytes;
+            while ((readBytes = inputStream.read(buffer)) > -1) {
+                builder.append(new String(buffer, 0, readBytes));
+            }
+            return builder.toString();
         } finally {
             httpUrlConnection.disconnect();
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.SocketException;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class RestClusterTest extends HazelcastTestSupport {
+
+    private static final String STATUS_FORBIDDEN = "{\"status\":\"forbidden\"}";
+
+    private Config config = new Config();
+
+    @Before
+    public void setup() {
+        config.setProperty(GroupProperty.REST_ENABLED.getName(), "true");
+        config.setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "true");
+
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(true).clear().addMember("127.0.0.1");
+    }
+
+    @After
+    public void tearDown() {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testDisabledRest() throws Exception {
+        // REST should be disabled by default
+        Config config = new Config();
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+
+        try {
+            communicator.getClusterInfo();
+            fail("Rest is disabled. Not expected to reach here!");
+        } catch (SocketException ignored) {
+        }
+    }
+
+    @Test
+    public void testClusterShutdown() throws Exception {
+        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
+        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance2);
+
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.shutdownCluster("dev", "dev-pass"));
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertFalse(instance1.getLifecycleService().isRunning());
+                assertFalse(instance2.getLifecycleService().isRunning());
+            }
+        });
+    }
+
+    @Test
+    public void testGetClusterState() throws Exception {
+        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
+
+        HTTPCommunicator communicator1 = new HTTPCommunicator(instance1);
+        HTTPCommunicator communicator2 = new HTTPCommunicator(instance2);
+
+        instance1.getCluster().changeClusterState(ClusterState.FROZEN);
+        assertEquals("{\"status\":\"success\",\"state\":\"frozen\"}",
+                communicator1.getClusterState("dev", "dev-pass"));
+
+        instance1.getCluster().changeClusterState(ClusterState.PASSIVE);
+        assertEquals("{\"status\":\"success\",\"state\":\"passive\"}",
+                communicator2.getClusterState("dev", "dev-pass"));
+    }
+
+    @Test
+    public void testChangeClusterState() throws Exception {
+        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
+        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance1);
+
+        assertEquals(STATUS_FORBIDDEN, communicator.changeClusterState("dev1", "dev-pass", "frozen").response);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterState("dev", "dev-pass", "frozen").responseCode);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertEquals(ClusterState.FROZEN, instance1.getCluster().getClusterState());
+                assertEquals(ClusterState.FROZEN, instance2.getCluster().getClusterState());
+            }
+        });
+    }
+
+    @Test
+    public void testGetClusterVersion() throws IOException {
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        final String expected = "{\"status\":\"success\","
+                + "\"version\":\"" + instance.getCluster().getClusterVersion().toString() + "\"}";
+        assertEquals(expected, communicator.getClusterVersion());
+    }
+
+    @Test
+    public void testChangeClusterVersion() throws IOException {
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterVersion("dev", "dev-pass",
+                instance.getCluster().getClusterVersion().toString()).responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.changeClusterVersion("dev1", "dev-pass", "1.2.3").response);
+    }
+
+    @Test
+    public void testHotBackup() throws IOException {
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.hotBackup("dev", "dev-pass").responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.hotBackup("dev1", "dev-pass").response);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.hotBackupInterrupt("dev", "dev-pass").responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.hotBackupInterrupt("dev1", "dev-pass").response);
+    }
+
+    @Test
+    public void testForceAndPartialStart() throws IOException {
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
+
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.forceStart("dev", "dev-pass").responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.forceStart("dev1", "dev-pass").response);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.partialStart("dev", "dev-pass").responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.partialStart("dev1", "dev-pass").response);
+    }
+
+    @Test
+    public void testManagementCenterUrlChange() throws IOException {
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        assertEquals(HttpURLConnection.HTTP_NO_CONTENT,
+                communicator.changeManagementCenterUrl("dev", "dev-pass", "http://bla").responseCode);
+    }
+
+    @Test
+    public void testListNodes() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        HazelcastTestSupport.waitInstanceForSafeState(instance);
+        String result = String.format("{\"status\":\"success\",\"response\":\"[%s]\n%s\n%s\"}",
+                instance.getCluster().getLocalMember().toString(),
+                BuildInfoProvider.getBuildInfo().getVersion(),
+                System.getProperty("java.version"));
+        assertEquals(result, communicator.listClusterNodes("dev", "dev-pass"));
+    }
+
+    @Test
+    public void testListNodesWithWrongCredentials() throws Exception {
+        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance1);
+        HazelcastTestSupport.waitInstanceForSafeState(instance1);
+        assertEquals(STATUS_FORBIDDEN, communicator.listClusterNodes("dev1", "dev-pass"));
+    }
+
+    @Test
+    public void testShutdownNode() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+
+        final CountDownLatch shutdownLatch = new CountDownLatch(1);
+        instance.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                if (event.getState() == LifecycleEvent.LifecycleState.SHUTDOWN) {
+                    shutdownLatch.countDown();
+                }
+            }
+        });
+
+        try {
+            assertEquals("{\"status\":\"success\"}", communicator.shutdownMember("dev", "dev-pass"));
+        } catch (ConnectException ignored) {
+            // if node shuts down before response is received, `java.net.ConnectException: Connection refused` is expected
+        }
+
+        assertOpenEventually(shutdownLatch);
+        assertFalse(instance.getLifecycleService().isRunning());
+    }
+
+    @Test
+    public void testShutdownNodeWithWrongCredentials() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+
+        assertEquals(STATUS_FORBIDDEN, communicator.shutdownMember("dev1", "dev-pass"));
+    }
+
+    @Test
+    public void simpleHealthCheck() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        String result = communicator.getClusterHealth();
+
+        assertEquals("Hazelcast::NodeState=ACTIVE\n" +
+                "Hazelcast::ClusterState=ACTIVE\n" +
+                "Hazelcast::ClusterSafe=TRUE\n" +
+                "Hazelcast::MigrationQueueSize=0\n" +
+                "Hazelcast::ClusterSize=1\n", result);
+    }
+
+    @Test(expected = SocketException.class)
+    public void fail_with_deactivatedHealthCheck() throws Exception {
+        // Healthcheck REST URL is deactivated by default - no passed config on purpose
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance();
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        communicator.getClusterHealth();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -16,68 +16,106 @@
 
 package com.hazelcast.internal.ascii;
 
-import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EntryListenerConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.WanReplicationConfig;
-import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 import com.hazelcast.core.IQueue;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.management.dto.WanReplicationConfigDTO;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-import java.net.ConnectException;
-import java.net.HttpURLConnection;
-import java.net.SocketException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+// intentionally not in ParallelTest category,
+// test is starting standalone HazelcastInstances.
 public class RestTest extends HazelcastTestSupport {
 
-    private final static Config config = new XmlConfigBuilder().build();
-    public static final String STATUS_FORBIDDEN = "{\"status\":\"forbidden\"}";
+    private Config config = new Config();
+    private HazelcastInstance instance;
+    private HTTPCommunicator communicator;
 
     @Before
     public void setup() {
         config.setProperty(GroupProperty.REST_ENABLED.getName(), "true");
-        config.setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "true");
-        final JoinConfig join = config.getNetworkConfig().getJoin();
+
+        // Join is disabled intentionally. will start standalone HazelcastInstances.
+        JoinConfig join = config.getNetworkConfig().getJoin();
         join.getMulticastConfig().setEnabled(false);
-        join.getTcpIpConfig().setEnabled(true).addMember("127.0.0.1").setConnectionTimeoutSeconds(3000);
+        join.getTcpIpConfig().setEnabled(false);
+
+        instance = Hazelcast.newHazelcastInstance(config);
+        communicator = new HTTPCommunicator(instance);
     }
 
     @After
     public void tearDown() {
-        Hazelcast.shutdownAll();
+        instance.getLifecycleService().terminate();
     }
 
     @Test
-    public void testTtl_issue1783() throws Exception {
+    public void testMapPutGet() throws Exception {
+        String name = randomMapName();
+
+        String key = "key";
+        String value = "value";
+
+        assertEquals(HTTP_OK, communicator.mapPut(name, key, value));
+        assertEquals(value, communicator.mapGet(name, key));
+        assertTrue(instance.getMap(name).containsKey(key));
+    }
+
+    @Test
+    public void testMapPutDelete() throws Exception {
+        String name = randomMapName();
+
+        String key = "key";
+        String value = "value";
+
+        assertEquals(HTTP_OK, communicator.mapPut(name, key, value));
+        assertEquals(HTTP_OK, communicator.mapDelete(name, key));
+        assertFalse(instance.getMap(name).containsKey(key));
+    }
+
+    @Test
+    public void testMapDeleteAll() throws Exception {
+        String name = randomMapName();
+
+        int count = 10;
+        for (int i = 0; i < count; i++) {
+            assertEquals(HTTP_OK, communicator.mapPut(name, "key" + i, "value"));
+        }
+
+        IMap<Object, Object> map = instance.getMap(name);
+        assertEquals(10, map.size());
+
+        assertEquals(HTTP_OK, communicator.mapDeleteAll(name));
+        assertTrue(map.isEmpty());
+    }
+
+    // issue #1783
+    @Test
+    public void testMapTtl() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         EntryListenerConfig listenerConfig = new EntryListenerConfig().setImplementation(new EntryAdapter() {
             @Override
@@ -86,320 +124,102 @@ public class RestTest extends HazelcastTestSupport {
             }
         });
 
-        String name = "map";
+        String name = randomMapName();
         config.getMapConfig(name)
                 .setTimeToLiveSeconds(3)
                 .addEntryListenerConfig(listenerConfig);
 
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        String key = "key";
+        communicator.mapPut(name, key, "value");
 
-        communicator.put(name, "key", "value");
-        String value = communicator.get(name, "key");
-
-        assertNotNull(value);
-        assertEquals("value", value);
-
-        assertTrue(latch.await(30, TimeUnit.SECONDS));
-        value = communicator.get(name, "key");
+        assertOpenEventually(latch);
+        String value = communicator.mapGet(name, key);
         assertTrue(value.isEmpty());
     }
 
     @Test
-    public void testRestSimple() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        String name = "testRestSimple";
+    public void testQueueOfferPoll() throws Exception {
+        String name = randomName();
 
-        for (int i = 0; i < 100; i++) {
-            assertEquals(HttpURLConnection.HTTP_OK, communicator.put(name, String.valueOf(i), String.valueOf(i * 10)));
-        }
-        for (int i = 0; i < 100; i++) {
-            String actual = communicator.get(name, String.valueOf(i));
-            assertEquals(String.valueOf(i * 10), actual);
-        }
+        String item = communicator.queuePoll(name, 1);
+        assertTrue(item.isEmpty());
 
-        communicator.deleteAll(name);
-        for (int i = 0; i < 100; i++) {
-            String actual = communicator.get(name, String.valueOf(i));
-            assertEquals("", actual);
-        }
+        String value = "value";
+        assertEquals(HTTP_OK, communicator.queueOffer(name, value));
 
-        for (int i = 0; i < 100; i++) {
-            assertEquals(HttpURLConnection.HTTP_OK, communicator.put(name, String.valueOf(i), String.valueOf(i * 10)));
-        }
-        for (int i = 0; i < 100; i++) {
-            assertEquals(String.valueOf(i * 10), communicator.get(name, String.valueOf(i)));
-        }
+        IQueue<Object> queue = instance.getQueue(name);
+        assertEquals(1, queue.size());
 
-        for (int i = 0; i < 100; i++) {
-            assertEquals(HttpURLConnection.HTTP_OK, communicator.delete(name, String.valueOf(i)));
-        }
-        for (int i = 0; i < 100; i++) {
-            assertEquals("", communicator.get(name, String.valueOf(i)));
-        }
-
-        for (int i = 0; i < 100; i++) {
-            assertEquals(HttpURLConnection.HTTP_OK, communicator.offer(name, String.valueOf(i)));
-        }
-        for (int i = 0; i < 100; i++) {
-            assertEquals(String.valueOf(i), communicator.poll(name, 2));
-        }
+        assertEquals(value, communicator.queuePoll(name, 10));
+        assertTrue(queue.isEmpty());
     }
 
     @Test
-    public void testQueueSizeEmpty() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        String name = "testQueueSizeEmpty";
-
-        IQueue queue = instance.getQueue(name);
-        Assert.assertEquals(queue.size(), communicator.size(name));
-    }
-
-    @Test
-    public void testQueueSizeNonEmpty() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        String name = "testQueueSizeNotEmpty";
-        int num_items = 100;
-
+    public void testQueueSize() throws Exception {
+        String name = randomName();
         IQueue<Integer> queue = instance.getQueue(name);
-
-        for (int i = 0; i < num_items; i++) {
+        for (int i = 0; i < 10; i++) {
             queue.add(i);
         }
 
-        Assert.assertEquals(queue.size(), communicator.size(name));
-    }
-
-    @Test
-    public void testDisabledRest() throws Exception {
-        // REST should be disabled by default
-        Config config = new XmlConfigBuilder().build();
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        String mapName = "testMap";
-
-        try {
-            communicator.put("testMap", "1", "1");
-        } catch (SocketException ignore) {
-        }
-
-        assertEquals(0, instance.getMap(mapName).size());
-    }
-
-    @Test
-    public void testClusterShutdown() throws Exception {
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance instance3 = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance1);
-
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.shutdownCluster("dev", "dev-pass"));
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertFalse(instance1.getLifecycleService().isRunning());
-                assertFalse(instance2.getLifecycleService().isRunning());
-                assertFalse(instance3.getLifecycleService().isRunning());
-            }
-        });
-    }
-
-    @Test
-    public void testGetClusterState() throws Exception {
-        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
-
-        HTTPCommunicator communicator1 = new HTTPCommunicator(instance1);
-        HTTPCommunicator communicator2 = new HTTPCommunicator(instance2);
-
-        instance1.getCluster().changeClusterState(ClusterState.FROZEN);
-        assertEquals("{\"status\":\"success\",\"state\":\"frozen\"}",
-                communicator1.getClusterState("dev", "dev-pass"));
-
-        instance1.getCluster().changeClusterState(ClusterState.PASSIVE);
-        assertEquals("{\"status\":\"success\",\"state\":\"passive\"}",
-                communicator2.getClusterState("dev", "dev-pass"));
-    }
-
-    @Test
-    public void testChangeClusterState() throws Exception {
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance1);
-
-        assertEquals(STATUS_FORBIDDEN, communicator.changeClusterState("dev1", "dev-pass", "frozen").response);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterState("dev", "dev-pass", "frozen").responseCode);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(ClusterState.FROZEN, instance1.getCluster().getClusterState());
-                assertEquals(ClusterState.FROZEN, instance2.getCluster().getClusterState());
-            }
-        });
-    }
-
-    @Test
-    public void testGetClusterVersion() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        final String expected = "{\"status\":\"success\","
-                + "\"version\":\"" + instance.getCluster().getClusterVersion().toString() + "\"}";
-        assertEquals(expected, communicator.getClusterVersion());
-    }
-
-    @Test
-    public void testChangeClusterVersion() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterVersion("dev", "dev-pass",
-                instance.getCluster().getClusterVersion().toString()).responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.changeClusterVersion("dev1", "dev-pass", "1.2.3").response);
-    }
-
-    @Test
-    public void testHotBackup() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.hotBackup("dev", "dev-pass").responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.hotBackup("dev1", "dev-pass").response);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.hotBackupInterrupt("dev", "dev-pass").responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.hotBackupInterrupt("dev1", "dev-pass").response);
-    }
-
-    @Test
-    public void testForceAndPartialStart() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.forceStart("dev", "dev-pass").responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.forceStart("dev1", "dev-pass").response);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.partialStart("dev", "dev-pass").responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.partialStart("dev1", "dev-pass").response);
-    }
-
-    @Test
-    public void testManagementCenterUrlChange() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        assertEquals(HttpURLConnection.HTTP_NO_CONTENT,
-                communicator.changeManagementCenterUrl("dev", "dev-pass", "http://bla").responseCode);
-    }
-
-    @Test
-    public void testListNodes() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        HazelcastTestSupport.waitInstanceForSafeState(instance);
-        String result = String.format("{\"status\":\"success\",\"response\":\"[%s]\n%s\n%s\"}",
-                instance.getCluster().getLocalMember().toString(),
-                BuildInfoProvider.getBuildInfo().getVersion(),
-                System.getProperty("java.version"));
-        assertEquals(result, communicator.listClusterNodes("dev", "dev-pass"));
-    }
-
-    @Test
-    public void testListNodesWithWrongCredentials() throws Exception {
-        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance1);
-        HazelcastTestSupport.waitInstanceForSafeState(instance1);
-        assertEquals(STATUS_FORBIDDEN, communicator.listClusterNodes("dev1", "dev-pass"));
-    }
-
-    @Test
-    public void testShutdownNode() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-
-        final CountDownLatch shutdownLatch = new CountDownLatch(1);
-        instance.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (event.getState() == LifecycleEvent.LifecycleState.SHUTDOWN) {
-                    shutdownLatch.countDown();
-                }
-            }
-        });
-
-        try {
-            assertEquals("{\"status\":\"success\"}", communicator.shutdownMember("dev", "dev-pass"));
-        } catch (ConnectException ignored) {
-            // if node shuts down before response is received, `java.net.ConnectException: Connection refused` is expected
-        }
-
-        assertOpenEventually(shutdownLatch);
-        assertFalse(instance.getLifecycleService().isRunning());
-    }
-
-    @Test
-    public void testShutdownNodeWithWrongCredentials() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-
-        assertEquals(STATUS_FORBIDDEN, communicator.shutdownMember("dev1", "dev-pass"));
+        assertEquals(queue.size(), communicator.queueSize(name));
     }
 
     @Test
     public void syncMapOverWAN() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
         String result = communicator.syncMapOverWAN("atob", "b", "default");
-
         assertEquals("{\"status\":\"fail\",\"message\":\"WAN sync for map is not supported.\"}", result);
     }
 
     @Test
     public void syncAllMapsOverWAN() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
         String result = communicator.syncMapsOverWAN("atob", "b");
-
         assertEquals("{\"status\":\"fail\",\"message\":\"WAN sync is not supported.\"}", result);
     }
 
     @Test
     public void wanClearQueues() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
         String result = communicator.wanClearQueues("atob", "b");
-
         assertEquals("{\"status\":\"fail\",\"message\":\"Clearing WAN replication queues is not supported.\"}", result);
     }
 
     @Test
     public void addWanConfig() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
         WanReplicationConfig wanConfig = new WanReplicationConfig();
         wanConfig.setName("test");
         WanReplicationConfigDTO dto = new WanReplicationConfigDTO(wanConfig);
         String result = communicator.addWanConfig(dto.toJson().toString());
-
         assertEquals("{\"status\":\"fail\",\"message\":\"java.lang.UnsupportedOperationException: Adding new WAN config is not supported.\"}", result);
     }
 
     @Test
-    public void simpleHealthCheck() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        String result = communicator.getClusterHealth();
+    public void testMap_PutGet_withLargeValue() throws IOException {
+        String mapName = randomMapName();
+        String key = "key";
+        int capacity = 10000;
+        StringBuilder value = new StringBuilder(capacity);
+        while (value.length() < capacity) {
+            value.append(randomString());
+        }
 
-        assertEquals("Hazelcast::NodeState=ACTIVE\n" +
-                "Hazelcast::ClusterState=ACTIVE\n" +
-                "Hazelcast::ClusterSafe=TRUE\n" +
-                "Hazelcast::MigrationQueueSize=0\n" +
-                "Hazelcast::ClusterSize=1\n", result);
+        int response = communicator.mapPut(mapName, key, value.toString());
+        assertEquals(HTTP_OK, response);
+
+        assertEquals(value.toString(), communicator.mapGet(mapName, key));
     }
 
-    @Test(expected = SocketException.class)
-    public void fail_with_deactivatedHealthCheck() throws Exception {
-        // Healthcheck REST URL is deactivated by default - no passed config on purpose
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance();
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        communicator.getClusterHealth();
+    @Test
+    public void testMap_PutGet_withLargeKey() throws IOException {
+        String mapName = randomMapName();
+        int capacity = 5000;
+        StringBuilder key = new StringBuilder(capacity);
+        while (key.length() < capacity) {
+            key.append(randomString());
+        }
+
+        String value = "value";
+        int response = communicator.mapPut(mapName, key.toString(), value);
+        assertEquals(HTTP_OK, response);
+        assertEquals(value, communicator.mapGet(mapName, key.toString()));
     }
 }


### PR DESCRIPTION
TextReadHandler command buffer had a fixed capacity of 500 bytes.
When
- REST request is sent with a URL longer than that
- Memcached request is sent with a very long key
- Memcached bulk read request is sent with a many keys

this buffer can overflow and requests fail.

This buffer is made on-demand expandable up to 65536 bytes.

Improved REST and Memcached integration tests.

Fixes #9355