### PR TITLE
Clearer message logged when cluster version initially set or changed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -255,7 +255,7 @@ public class DefaultNodeExtension implements NodeExtension {
 
     @Override
     public void onClusterVersionChange(ClusterVersion newVersion) {
-        systemLogger.info("Cluster version changed to " + newVersion);
+        systemLogger.info("Cluster version set to " + newVersion);
         ServiceManager serviceManager = node.getNodeEngine().getServiceManager();
         List<ClusterVersionListener> listeners = serviceManager.getServices(ClusterVersionListener.class);
         for (ClusterVersionListener listener : listeners) {


### PR DESCRIPTION
Since the same log message appears both when cluster version is initially set and when it is explicitly changed, log `Cluster version set to X.Y` instead of `Cluster version changed to X.Y`