### PR TITLE
Add option for InMemoryFormat of object to skip defensive copies.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
@@ -182,7 +182,7 @@ abstract class AbstractCacheProxy<K, V>
             Map<Integer, Object> responses = operationService.invokeOnPartitions(getServiceName(), factory, partitions);
             for (Object response : responses.values()) {
                 MapEntries mapEntries = serializationService.toObject(response);
-                mapEntries.putAllToMap(serializationService, result);
+                mapEntries.putAllToMapDeserialized(serializationService, result);
             }
         } catch (Throwable e) {
             throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -156,7 +156,8 @@ public class MapConfig {
     // and #setCacheDeserializedValues()
     private boolean optimizeQueryExplicitlyInvoked;
     private boolean setCacheDeserializedValuesExplicitlyInvoked;
-
+    
+    private boolean forceDefensiveCopy = true;
 
     public MapConfig(String name) {
         this.name = name;
@@ -180,6 +181,7 @@ public class MapConfig {
         this.mapStoreConfig = config.mapStoreConfig != null ? new MapStoreConfig(config.mapStoreConfig) : null;
         this.nearCacheConfig = config.nearCacheConfig != null ? new NearCacheConfig(config.nearCacheConfig) : null;
         this.readBackupData = config.readBackupData;
+        this.forceDefensiveCopy = config.forceDefensiveCopy;
         this.cacheDeserializedValues = config.cacheDeserializedValues;
         this.statisticsEnabled = config.statisticsEnabled;
         this.mergePolicy = config.mergePolicy;
@@ -869,6 +871,21 @@ public class MapConfig {
         this.quorumName = quorumName;
     }
 
+    /**
+     * @return the forceDefensiveCopy
+     */
+    public boolean isForceDefensiveCopy() {
+        return this.forceDefensiveCopy;
+    }
+
+    /**
+     * @param forceDefensiveCopy the forceDefensiveCopy to set
+     */
+    public MapConfig setForceDefensiveCopy(boolean forceDefensiveCopy) {
+        this.forceDefensiveCopy = forceDefensiveCopy;
+        return this;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -903,6 +920,7 @@ public class MapConfig {
         result = prime * result + this.timeToLiveSeconds;
         result = prime * result + cacheDeserializedValues.hashCode();
         result = prime * result + (this.readBackupData ? 1231 : 1237);
+        result = prime * result + (this.forceDefensiveCopy ? 1231 : 1237);
         return result;
     }
 
@@ -925,6 +943,7 @@ public class MapConfig {
                         && this.maxSizeConfig.getSize() == other.maxSizeConfig.getSize()
                         && this.timeToLiveSeconds == other.timeToLiveSeconds
                         && this.readBackupData == other.readBackupData
+                        && this.forceDefensiveCopy == other.forceDefensiveCopy
                         && (this.cacheDeserializedValues == other.cacheDeserializedValues)
                         && (this.mergePolicy != null ? this.mergePolicy.equals(other.mergePolicy) : other.mergePolicy == null)
                         && (this.inMemoryFormat != null ? this.inMemoryFormat.equals(other.inMemoryFormat)
@@ -954,6 +973,7 @@ public class MapConfig {
                 + ", minEvictionCheckMillis=" + minEvictionCheckMillis
                 + ", maxSizeConfig=" + maxSizeConfig
                 + ", readBackupData=" + readBackupData
+                + ", forceDefensiveCopy=" + forceDefensiveCopy
                 + ", hotRestart=" + hotRestartConfig
                 + ", nearCacheConfig=" + nearCacheConfig
                 + ", mapStoreConfig=" + mapStoreConfig

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -1179,6 +1179,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 mapConfig.setHotRestartConfig(createHotRestartConfig(node));
             } else if ("read-backup-data".equals(nodeName)) {
                 mapConfig.setReadBackupData(getBooleanValue(value));
+            } else if ("force-defensive-copy".equals(nodeName)) {
+                mapConfig.setForceDefensiveCopy(getBooleanValue(value));
             } else if ("statistics-enabled".equals(nodeName)) {
                 mapConfig.setStatisticsEnabled(getBooleanValue(value));
             } else if ("optimize-queries".equals(nodeName)) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -245,6 +245,17 @@ abstract class AbstractMultipleEntryOperation extends MapOperation implements Mu
         return toData(result);
     }
 
+    protected void processToEntries(Data key, Map.Entry entry, MapEntries mapEntries) {
+        final Object result = entryProcessor.process(entry);
+        if (result != null) {
+            if (this.mapContainer.getMapConfig().isForceDefensiveCopy()) {
+                mapEntries.add(key, toData(result));
+            } else {
+                mapEntries.add(key, result, this.mapServiceContext.getNodeEngine().getSerializationService());
+            }
+        }
+    }
+
     protected void processBackup(Map.Entry entry) {
         backupProcessor.processBackup(entry);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -30,7 +30,7 @@ import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
 
 public abstract class BasePutOperation extends LockAwareOperation implements BackupAwareOperation {
 
-    protected transient Data dataOldValue;
+    protected transient Object oldValue;
     protected transient EntryEventType eventType;
     protected transient boolean putTransient;
 
@@ -50,7 +50,7 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
         mapServiceContext.interceptAfterPut(name, dataValue);
         Object value = isPostProcessing(recordStore) ? recordStore.getRecord(dataKey).getValue() : dataValue;
 
-        mapEventPublisher.publishEvent(getCallerAddress(), name, getEventType(), dataKey, dataOldValue, value);
+        mapEventPublisher.publishEvent(getCallerAddress(), name, getEventType(), dataKey, oldValue, value);
         invalidateNearCache(dataKey);
         publishWANReplicationEvent(mapEventPublisher, value);
         evict(dataKey);
@@ -72,7 +72,7 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
 
     private EntryEventType getEventType() {
         if (eventType == null) {
-            eventType = dataOldValue == null ? EntryEventType.ADDED : EntryEventType.UPDATED;
+            eventType = oldValue == null ? EntryEventType.ADDED : EntryEventType.UPDATED;
         }
         return eventType;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.spi.WaitNotifyKey;
 
 public final class GetOperation extends ReadonlyKeyBasedMapOperation implements BlockingOperation {
 
-    private Data result;
+    private Object result;
 
     public GetOperation() {
     }
@@ -40,7 +40,8 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
 
     @Override
     public void run() {
-        result = mapServiceContext.toData(recordStore.get(dataKey, false));
+        final Object storeData = recordStore.get(dataKey, false);
+        result = this.mapContainer.getMapConfig().isForceDefensiveCopy() ? mapServiceContext.toData(storeData) : storeData;
     }
 
     @Override
@@ -67,7 +68,7 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
     }
 
     @Override
-    public Data getResponse() {
+    public Object getResponse() {
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -58,7 +58,9 @@ public class MergeOperation extends BasePutOperation {
     public void run() {
         Record oldRecord = recordStore.getRecord(dataKey);
         if (oldRecord != null) {
-            dataOldValue = mapServiceContext.toData(oldRecord.getValue());
+            final Object putResult = oldRecord.getValue();
+            this.oldValue = this.mapContainer.getMapConfig().isForceDefensiveCopy() ? mapServiceContext.toData(putResult)
+                    : putResult;
         }
         merged = recordStore.merge(dataKey, mergingEntry, mergePolicy);
         if (merged) {
@@ -84,8 +86,8 @@ public class MergeOperation extends BasePutOperation {
     public void afterRun() {
         if (merged) {
             mapServiceContext.interceptAfterPut(name, dataValue);
-            mapEventPublisher.publishEvent(getCallerAddress(), name, EntryEventType.MERGED, dataKey, dataOldValue,
-                    dataValue, mergingValue);
+            mapEventPublisher.publishEvent(getCallerAddress(), name, EntryEventType.MERGED, dataKey, oldValue, dataValue,
+                    mergingValue);
             invalidateNearCache(dataKey);
             evict(dataKey);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -70,10 +70,7 @@ public class MultipleEntryOperation extends AbstractMultipleEntryOperation imple
                 continue;
             }
 
-            Data response = process(entry);
-            if (response != null) {
-                responses.add(key, response);
-            }
+            processToEntries(key, entry, responses);
 
             // first call noOp, other if checks below depends on it.
             if (noOp(entry, value, now)) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -74,10 +74,7 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
             }
 
             Map.Entry entry = createMapEntry(dataKey, oldValue);
-            Data response = process(entry);
-            if (response != null) {
-                responses.add(dataKey, response);
-            }
+            processToEntries(dataKey, entry, responses);
 
             // first call noOp, other if checks below depends on it.
             if (noOp(entry, oldValue, now)) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
@@ -32,9 +32,9 @@ public class PutIfAbsentOperation extends BasePutOperation {
 
     @Override
     public void run() {
-        final Object oldValue = recordStore.putIfAbsent(dataKey, dataValue, ttl);
-        dataOldValue = mapServiceContext.toData(oldValue);
-        successful = dataOldValue == null;
+        final Object prevValue = recordStore.putIfAbsent(dataKey, dataValue, ttl);
+        oldValue = this.mapContainer.getMapConfig().isForceDefensiveCopy() ?  mapServiceContext.toData(prevValue) : prevValue;
+        successful = oldValue == null;
     }
 
     @Override
@@ -46,7 +46,7 @@ public class PutIfAbsentOperation extends BasePutOperation {
 
     @Override
     public Object getResponse() {
-        return dataOldValue;
+        return oldValue;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
@@ -30,12 +30,13 @@ public class PutOperation extends BasePutOperation {
 
     @Override
     public void run() {
-        dataOldValue = mapServiceContext.toData(recordStore.put(dataKey, dataValue, ttl));
+        final Object putResult = recordStore.put(dataKey, dataValue, ttl);
+        oldValue = this.mapContainer.getMapConfig().isForceDefensiveCopy() ? mapServiceContext.toData(putResult) : putResult;
     }
 
     @Override
     public Object getResponse() {
-        return dataOldValue;
+        return oldValue;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceIfSameOperation.java
@@ -40,7 +40,7 @@ public class ReplaceIfSameOperation extends BasePutOperation {
     public void run() {
         successful = recordStore.replace(dataKey, expect, dataValue);
         if (successful) {
-            dataOldValue = expect;
+            oldValue = expect;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ReplaceOperation.java
@@ -32,8 +32,8 @@ public class ReplaceOperation extends BasePutOperation {
 
     @Override
     public void run() {
-        Object oldValue = recordStore.replace(dataKey, dataValue);
-        dataOldValue = mapServiceContext.toData(oldValue);
+        Object prevValue = recordStore.replace(dataKey, dataValue);
+        oldValue = this.mapContainer.getMapConfig().isForceDefensiveCopy() ? mapServiceContext.toData(prevValue) : prevValue;
         successful = oldValue != null;
     }
 
@@ -52,7 +52,7 @@ public class ReplaceOperation extends BasePutOperation {
 
     @Override
     public Object getResponse() {
-        return dataOldValue;
+        return oldValue;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -743,13 +743,13 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public Map<K, Object> executeOnEntries(EntryProcessor entryProcessor, Predicate predicate) {
-        final Map<Data, Object> results = executeOnEntriesInternalToMap(entryProcessor, predicate);
+        final List<Object> results = executeOnEntriesInternalToMixedList(entryProcessor, predicate);
 
-        final Map<K, Object> resultingMap = MapUtil.createHashMap(results.size());
-        for (Map.Entry<Data, Object> entry : results.entrySet()) {
-            final K key = toObject(entry.getKey());
-            resultingMap.put(key, toObject(entry.getValue()));
-
+        final Map<K, Object> resultingMap = MapUtil.createHashMap(results.size() / 2);
+        for (int i=0, j=results.size(); i<j; ++i) {
+            final K key = toObject(results.get(i));
+            ++i;
+            resultingMap.put(key, toObject(results.get(i)));
         }
         return resultingMap;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -743,19 +743,12 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
     @Override
     public Map<K, Object> executeOnEntries(EntryProcessor entryProcessor, Predicate predicate) {
-        List<Data> result = new ArrayList<Data>();
+        final Map<Data, Object> results = executeOnEntriesInternalToMap(entryProcessor, predicate);
 
-        executeOnEntriesInternal(entryProcessor, predicate, result);
-        if (result.isEmpty()) {
-            return emptyMap();
-        }
-
-        Map<K, Object> resultingMap = MapUtil.createHashMap(result.size() / 2);
-        for (int i = 0; i < result.size(); ) {
-            Data key = result.get(i++);
-            Data value = result.get(i++);
-
-            resultingMap.put((K) toObject(key), toObject(value));
+        final Map<K, Object> resultingMap = MapUtil.createHashMap(results.size());
+        for (Map.Entry<Data, Object> entry : results.entrySet()) {
+            final K key = toObject(entry.getKey());
+            resultingMap.put(key, toObject(entry.getValue()));
 
         }
         return resultingMap;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -126,7 +126,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
         Data key = toData(k, partitionStrategy);
         Data value = toData(v);
-        Data result = putInternal(key, value, ttl, timeunit);
+        Object result = putInternal(key, value, ttl, timeunit);
         return toObject(result);
     }
 
@@ -152,7 +152,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
 
         Data key = toData(k, partitionStrategy);
         Data value = toData(v);
-        Data result = putIfAbsentInternal(key, value, ttl, timeunit);
+        Object result = putIfAbsentInternal(key, value, ttl, timeunit);
         return toObject(result);
     }
 
@@ -360,15 +360,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, I
             requestedKeys.add(dataKey);
         }
 
-        List<Object> resultingKeyValuePairs = new ArrayList<Object>(keys.size());
-        getAllObjectInternal(requestedKeys, resultingKeyValuePairs);
-
-        Map<K, V> result = MapUtil.createHashMap(keys.size());
-        for (int i = 0; i < resultingKeyValuePairs.size(); ) {
-            K key = toObject(resultingKeyValuePairs.get(i++));
-            V value = toObject(resultingKeyValuePairs.get(i++));
-            result.put(key, value);
-        }
+        final Map<K, V> result = MapUtil.createHashMap(keys.size());
+        getAllObjectInternal(requestedKeys, result);
+        
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -384,6 +384,16 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected Map<Data, Object> executeOnEntriesInternalToMap(EntryProcessor entryProcessor, Predicate predicate) {
+        final Map<Data, Object> results = super.executeOnEntriesInternalToMap(entryProcessor, predicate);
+        invalidateCache(results.keySet());
+        return results;
+    }
+
     @Override
     protected boolean preDestroy() {
         if (invalidateOnChange) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -388,9 +388,11 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
      * {@inheritDoc}
      */
     @Override
-    protected Map<Data, Object> executeOnEntriesInternalToMap(EntryProcessor entryProcessor, Predicate predicate) {
-        final Map<Data, Object> results = super.executeOnEntriesInternalToMap(entryProcessor, predicate);
-        invalidateCache(results.keySet());
+    protected List<Object> executeOnEntriesInternalToMixedList(EntryProcessor entryProcessor, Predicate predicate) {
+        final List<Object> results = super.executeOnEntriesInternalToMixedList(entryProcessor, predicate);
+        for (int i=0, j=results.size(); i<j; i+=2) {
+            invalidateCache((Data) results.get(i));
+        }
         return results;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -104,6 +104,19 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
      */
     Data readBackupData(Data key);
 
+    /**
+     * Called when {@link com.hazelcast.config.MapConfig#isReadBackupData} is <code>true</code> from
+     * {@link com.hazelcast.map.impl.proxy.MapProxySupport#getInternal}
+     * <p/>
+     * Returns corresponding value for key as {@link com.hazelcast.nio.serialization.Data}.
+     * This will only add an extra serialization step if {@link MapConfig#isForceDefensiveCopy()}. 
+     * For the reason of the potential needs for a defensive copy, please see issue 1292 on github.
+     *
+     * @param key key to be accessed
+     * @return value based on {@link com.hazelcast.config.InMemoryFormat}
+     */
+    Object readBackup(Data key);
+
     MapEntries getAll(Set<Data> keySet);
 
     boolean containsKey(Data dataKey);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -78,7 +78,12 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
         if (record == null || version == record.getVersion()) {
             EventService eventService = getNodeEngine().getEventService();
             if (eventService.hasEventRegistration(MapService.SERVICE_NAME, getName())) {
-                dataOldValue = record == null ? null : mapServiceContext.toData(record.getValue());
+                if (record == null) {
+                    oldValue = null;
+                } else {
+                    Object prevValue = record.getValue();
+                    oldValue = this.mapContainer.getMapConfig().isForceDefensiveCopy() ? mapServiceContext.toData(prevValue) : prevValue;
+                }
             }
             eventType = record == null ? EntryEventType.ADDED : EntryEventType.UPDATED;
             recordStore.set(dataKey, dataValue, ttl);

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -318,6 +318,7 @@
             <xs:element name="partition-strategy" type="xs:string" minOccurs="0" maxOccurs="1"/>
             <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1"/>
             <xs:element name="query-caches" type="query-caches" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="force-defensive-copy" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
         </xs:all>
         <xs:attribute name="name" use="required">
             <xs:annotation>

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -405,4 +405,18 @@ public class MapConfigTest {
         // then
         assertEquals(mapConfig, otherMapConfig);
     }
+
+    @Test
+    public void testDefaultTrueDefensiveCopy() {
+        MapConfig mapConfig = new MapConfig();
+
+        assertTrue(mapConfig.isForceDefensiveCopy());
+    }
+
+    @Test
+    public void testDefensiveCopyFalse() {
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setForceDefensiveCopy(false);
+        assertFalse(mapConfig.isForceDefensiveCopy());
+    }
 }


### PR DESCRIPTION
Allow skipping defensive copies when retrieving from an IMap and the InMemoryFormat.OBJECT is being used.