### PR TITLE
Add config for Cardinality Estimator

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.Duration
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
 import com.hazelcast.config.CacheSimpleEntryListenerConfig;
+import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.DurableExecutorConfig;
@@ -137,6 +138,7 @@ import static com.hazelcast.util.StringUtil.upperCaseInternal;
  * &lt;/hz:config&gt;
  * </pre>
  */
+@SuppressWarnings("checkstyle:executablestatementcount")
 public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDefinitionParser {
 
     protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
@@ -163,6 +165,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private ManagedMap<String, AbstractBeanDefinition> executorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> durableExecutorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> scheduledExecutorManagedMap;
+        private ManagedMap<String, AbstractBeanDefinition> cardinalityEstimatorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> wanReplicationManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> jobTrackerManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> replicatedMapManagedMap;
@@ -185,6 +188,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.executorManagedMap = createManagedMap("executorConfigs");
             this.durableExecutorManagedMap = createManagedMap("durableExecutorConfigs");
             this.scheduledExecutorManagedMap = createManagedMap("scheduledExecutorConfigs");
+            this.cardinalityEstimatorManagedMap = createManagedMap("cardinalityEstimatorConfigs");
             this.wanReplicationManagedMap = createManagedMap("wanReplicationConfigs");
             this.jobTrackerManagedMap = createManagedMap("jobTrackerConfigs");
             this.replicatedMapManagedMap = createManagedMap("replicatedMapConfigs");
@@ -218,6 +222,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleDurableExecutor(node);
                     } else if ("scheduled-executor-service".equals(nodeName)) {
                         handleScheduledExecutor(node);
+                    } else if ("cardinality-estimator".equals(nodeName)) {
+                        handleCardinalityEstimator(node);
                     } else if ("queue".equals(nodeName)) {
                         handleQueue(node);
                     } else if ("lock".equals(nodeName)) {
@@ -542,6 +548,10 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         public void handleScheduledExecutor(Node node) {
             createAndFillListedBean(node, ScheduledExecutorConfig.class, "name", scheduledExecutorManagedMap);
+        }
+
+        public void handleCardinalityEstimator(Node node) {
+            createAndFillListedBean(node, CardinalityEstimatorConfig.class, "name", cardinalityEstimatorManagedMap);
         }
 
         public void handleMulticast(Node node, BeanDefinitionBuilder joinConfigBuilder) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
@@ -93,7 +93,7 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
-                        <xs:element name="scheduled-executor-service" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="scheduled-executor" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
                                 <xs:sequence/>
                                 <xs:attribute name="name" use="required" type="xs:string"/>
@@ -108,6 +108,37 @@
                                     <xs:annotation>
                                         <xs:documentation>
                                             The durability of the scheduled executor.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="cardinality-estimator-service">
+                            <xs:complexType>
+                                <xs:all>
+                                    <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Number of synchronous backups. For example, if 1 is set as the backup-count,
+                                                then the cardinality estimation will be copied to one other JVM for
+                                                fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Number of asynchronous backups. For example, if 1 is set as the async-backup-count,
+                                                then cardinality estimation will be copied to one other JVM (asynchronously) for
+                                                fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:all>
+                                <xs:attribute name="name" type="xs:string" use="optional" default="default">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Name of the cardinality estimator.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
@@ -113,7 +113,7 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
-                        <xs:element name="cardinality-estimator-service">
+                        <xs:element name="cardinality-estimator" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
                                 <xs:all>
                                     <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
@@ -93,7 +93,7 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
-                        <xs:element name="scheduled-executor" minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="scheduled-executor-service" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
                                 <xs:sequence/>
                                 <xs:attribute name="name" use="required" type="xs:string"/>

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
@@ -24,21 +24,25 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
+import static com.hazelcast.config.CardinalityEstimatorConfig.DEFAULT_ASYNC_BACKUP_COUNT;
+import static com.hazelcast.config.CardinalityEstimatorConfig.DEFAULT_SYNC_BACKUP_COUNT;
+
 public class CardinalityEstimatorContainer implements IdentifiedDataSerializable {
 
-    private static final int DEFAULT_DURABILITY = 1;
+    private int backupCount;
 
-    private int durability;
+    private int asyncBackupCount;
 
     private HyperLogLog hll;
 
     public CardinalityEstimatorContainer() {
-        this(DEFAULT_DURABILITY);
+        this(DEFAULT_SYNC_BACKUP_COUNT, DEFAULT_ASYNC_BACKUP_COUNT);
     }
 
-    public CardinalityEstimatorContainer(int durability) {
+    public CardinalityEstimatorContainer(int backupCount, int asyncBackupCount) {
         this.hll = new HyperLogLogImpl();
-        this.durability = durability;
+        this.backupCount = backupCount;
+        this.asyncBackupCount = asyncBackupCount;
     }
 
     public void add(long hash) {
@@ -49,20 +53,30 @@ public class CardinalityEstimatorContainer implements IdentifiedDataSerializable
         return hll.estimate();
     }
 
-    public int getDurability() {
-        return durability;
+    public int getBackupCount() {
+        return backupCount;
+    }
+
+    public int getAsyncBackupCount() {
+        return asyncBackupCount;
+    }
+
+    public int getTotalBackupCount() {
+        return backupCount + asyncBackupCount;
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(hll);
-        out.writeInt(durability);
+        out.writeInt(backupCount);
+        out.writeInt(asyncBackupCount);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         hll = in.readObject();
-        durability = in.readInt();
+        backupCount = in.readInt();
+        asyncBackupCount = in.readInt();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
@@ -26,10 +26,17 @@ import java.io.IOException;
 
 public class CardinalityEstimatorContainer implements IdentifiedDataSerializable {
 
+    private int durability;
+
     private HyperLogLog hll;
 
     public CardinalityEstimatorContainer() {
         hll = new HyperLogLogImpl();
+    }
+
+    public CardinalityEstimatorContainer(int durability) {
+        this();
+        this.durability = durability;
     }
 
     public void add(long hash) {
@@ -40,14 +47,20 @@ public class CardinalityEstimatorContainer implements IdentifiedDataSerializable
         return hll.estimate();
     }
 
+    public int getDurability() {
+        return durability;
+    }
+
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeObject(hll);
+        out.writeInt(durability);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         hll = in.readObject();
+        durability = in.readInt();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainer.java
@@ -26,16 +26,18 @@ import java.io.IOException;
 
 public class CardinalityEstimatorContainer implements IdentifiedDataSerializable {
 
+    private static final int DEFAULT_DURABILITY = 1;
+
     private int durability;
 
     private HyperLogLog hll;
 
     public CardinalityEstimatorContainer() {
-        hll = new HyperLogLogImpl();
+        this(DEFAULT_DURABILITY);
     }
 
     public CardinalityEstimatorContainer(int durability) {
-        this();
+        this.hll = new HyperLogLogImpl();
         this.durability = durability;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -116,27 +116,25 @@ public class CardinalityEstimatorService
     @Override
     public void commitMigration(PartitionMigrationEvent event) {
         if (event.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
-            int thresholdReplicaIndex = event.getNewReplicaIndex();
-            clearPartitionReplica(event.getPartitionId(), thresholdReplicaIndex);
+            clearPartitionReplica(event.getPartitionId(), event.getNewReplicaIndex());
         }
     }
 
     @Override
     public void rollbackMigration(PartitionMigrationEvent event) {
         if (event.getMigrationEndpoint() == MigrationEndpoint.DESTINATION) {
-            int thresholdReplicaIndex = event.getCurrentReplicaIndex();
-            clearPartitionReplica(event.getPartitionId(), thresholdReplicaIndex);
+            clearPartitionReplica(event.getPartitionId(), event.getCurrentReplicaIndex());
         }
     }
 
-    private void clearPartitionReplica(int partitionId, int thresholdReplicaIndex) {
+    private void clearPartitionReplica(int partitionId, int durabilityThreshold) {
         final Iterator<String> iterator = containers.keySet().iterator();
         while (iterator.hasNext()) {
             String name = iterator.next();
             CardinalityEstimatorContainer container = containers.get(name);
 
             if (getPartitionId(name) == partitionId
-                    && (thresholdReplicaIndex == -1 || thresholdReplicaIndex > container.getDurability())) {
+                    && (durabilityThreshold == -1 || durabilityThreshold > container.getDurability())) {
                 iterator.remove();
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -128,13 +128,12 @@ public class CardinalityEstimatorService
     }
 
     private void clearPartitionReplica(int partitionId, int durabilityThreshold) {
-        final Iterator<String> iterator = containers.keySet().iterator();
+        final Iterator<Map.Entry<String, CardinalityEstimatorContainer>> iterator = containers.entrySet().iterator();
         while (iterator.hasNext()) {
-            String name = iterator.next();
-            CardinalityEstimatorContainer container = containers.get(name);
+            Map.Entry<String, CardinalityEstimatorContainer> entry = iterator.next();
 
-            if (getPartitionId(name) == partitionId
-                    && (durabilityThreshold == -1 || durabilityThreshold > container.getTotalBackupCount())) {
+            if (getPartitionId(entry.getKey()) == partitionId
+                    && (durabilityThreshold == -1 || durabilityThreshold > entry.getValue().getTotalBackupCount())) {
                 iterator.remove();
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -53,7 +53,7 @@ public class CardinalityEstimatorService
                 @Override
                 public CardinalityEstimatorContainer createNew(String name) {
                     CardinalityEstimatorConfig config = nodeEngine.getConfig().findCardinalityEstimatorConfig(name);
-                    return new CardinalityEstimatorContainer(config.getDurability());
+                    return new CardinalityEstimatorContainer(config.getBackupCount(), config.getAsyncBackupCount());
                 }
             };
 
@@ -105,7 +105,7 @@ public class CardinalityEstimatorService
             String name = containerEntry.getKey();
             CardinalityEstimatorContainer container = containerEntry.getValue();
 
-            if (partitionId == getPartitionId(name) && event.getReplicaIndex() <= container.getDurability()) {
+            if (partitionId == getPartitionId(name) && event.getReplicaIndex() <= container.getTotalBackupCount()) {
                 data.put(name, containerEntry.getValue());
             }
         }
@@ -134,7 +134,7 @@ public class CardinalityEstimatorService
             CardinalityEstimatorContainer container = containers.get(name);
 
             if (getPartitionId(name) == partitionId
-                    && (durabilityThreshold == -1 || durabilityThreshold > container.getDurability())) {
+                    && (durabilityThreshold == -1 || durabilityThreshold > container.getTotalBackupCount())) {
                 iterator.remove();
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
@@ -38,12 +38,12 @@ public abstract class CardinalityEstimatorBackupAwareOperation
 
     @Override
     public int getSyncBackupCount() {
-        return getCardinalityEstimatorContainer().getDurability();
+        return getCardinalityEstimatorContainer().getBackupCount();
     }
 
     @Override
     public int getAsyncBackupCount() {
-        return 0;
+        return getCardinalityEstimatorContainer().getAsyncBackupCount();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/operations/CardinalityEstimatorBackupAwareOperation.java
@@ -38,7 +38,7 @@ public abstract class CardinalityEstimatorBackupAwareOperation
 
     @Override
     public int getSyncBackupCount() {
-        return 1;
+        return getCardinalityEstimatorContainer().getDurability();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import static com.hazelcast.util.Preconditions.checkNotNegative;
+
+/**
+ * Configuration options for the {@link com.hazelcast.cardinality.CardinalityEstimator}
+ */
+public class CardinalityEstimatorConfig {
+
+    /**
+     * The number of replicas per estimator
+     */
+    private static final int DEFAULT_DURABILITY = 1;
+
+    private String name = "default";
+
+    private int durability = DEFAULT_DURABILITY;
+
+    private com.hazelcast.config.CardinalityEstimatorConfig.CardinalityEstimatorConfigReadOnly readOnly;
+
+    public CardinalityEstimatorConfig() {
+    }
+
+    public CardinalityEstimatorConfig(String name) {
+        this.name = name;
+    }
+
+    public CardinalityEstimatorConfig(String name, int durability) {
+        this.name = name;
+        this.durability = durability;
+    }
+
+    public CardinalityEstimatorConfig(com.hazelcast.config.CardinalityEstimatorConfig config) {
+        this(config.getName(), config.getDurability());
+    }
+
+    public com.hazelcast.config.CardinalityEstimatorConfig.CardinalityEstimatorConfigReadOnly getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new com.hazelcast.config.CardinalityEstimatorConfig.CardinalityEstimatorConfigReadOnly(this);
+        }
+        return readOnly;
+    }
+
+    /**
+     * Gets the name of the cardinality estimator.
+     *
+     * @return The name of the estimator.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the name of the cardinality estimator.
+     *
+     * @param name The name of the estimator.
+     * @return The cardinality estimator config instance.
+     */
+    public com.hazelcast.config.CardinalityEstimatorConfig setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Gets the durability of the estimator
+     *
+     * @return the durability of the estimator
+     */
+    public int getDurability() {
+        return durability;
+    }
+
+    /**
+     * Sets the durability of the cardinality estimator
+     * The durability represents the number of replicas that exist in a cluster for any given estimator.
+     * If this is set to 0 then there is only 1 copy of the estimator in the cluster, meaning that if the partition owning it,
+     * goes down then the estimation is lost.
+     *
+     * @param durability the durability of the estimator
+     * @return The cardinality estimator config instance.
+     */
+    public com.hazelcast.config.CardinalityEstimatorConfig setDurability(int durability) {
+        checkNotNegative(durability, "durability can't be smaller than 0");
+        this.durability = durability;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "CardinalityEstimatorConfig{" + "name='" + name + '\'' + ", durability=" + durability + '}';
+    }
+
+    private static class CardinalityEstimatorConfigReadOnly
+            extends com.hazelcast.config.CardinalityEstimatorConfig {
+
+        CardinalityEstimatorConfigReadOnly(com.hazelcast.config.CardinalityEstimatorConfig config) {
+            super(config);
+        }
+
+        @Override
+        public com.hazelcast.config.CardinalityEstimatorConfig setName(String name) {
+            throw new UnsupportedOperationException("This config is read-only cardinality estimator: " + getName());
+        }
+
+        @Override
+        public com.hazelcast.config.CardinalityEstimatorConfig setDurability(int durability) {
+            throw new UnsupportedOperationException("This config is read-only cardinality estimator: " + getName());
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -18,6 +18,7 @@ package com.hazelcast.config;
 
 import static com.hazelcast.util.Preconditions.checkAsyncBackupCount;
 import static com.hazelcast.util.Preconditions.checkBackupCount;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * Configuration options for the {@link com.hazelcast.cardinality.CardinalityEstimator}
@@ -40,7 +41,7 @@ public class CardinalityEstimatorConfig {
 
     private int asyncBackupCount = DEFAULT_ASYNC_BACKUP_COUNT;
 
-    private com.hazelcast.config.CardinalityEstimatorConfig.CardinalityEstimatorConfigReadOnly readOnly;
+    private CardinalityEstimatorConfigReadOnly readOnly;
 
     public CardinalityEstimatorConfig() {
     }
@@ -55,13 +56,13 @@ public class CardinalityEstimatorConfig {
         this.asyncBackupCount = asyncBackupCount;
     }
 
-    public CardinalityEstimatorConfig(com.hazelcast.config.CardinalityEstimatorConfig config) {
+    public CardinalityEstimatorConfig(CardinalityEstimatorConfig config) {
         this(config.getName(), config.getBackupCount(), config.getAsyncBackupCount());
     }
 
-    public com.hazelcast.config.CardinalityEstimatorConfig.CardinalityEstimatorConfigReadOnly getAsReadOnly() {
+    public CardinalityEstimatorConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
-            readOnly = new com.hazelcast.config.CardinalityEstimatorConfig.CardinalityEstimatorConfigReadOnly(this);
+            readOnly = new CardinalityEstimatorConfigReadOnly(this);
         }
         return readOnly;
     }
@@ -81,7 +82,8 @@ public class CardinalityEstimatorConfig {
      * @param name The name of the estimator.
      * @return The cardinality estimator config instance.
      */
-    public com.hazelcast.config.CardinalityEstimatorConfig setName(String name) {
+    public CardinalityEstimatorConfig setName(String name) {
+        checkNotNull(name);
         this.name = name;
         return this;
     }
@@ -152,24 +154,24 @@ public class CardinalityEstimatorConfig {
     }
 
     private static class CardinalityEstimatorConfigReadOnly
-            extends com.hazelcast.config.CardinalityEstimatorConfig {
+            extends CardinalityEstimatorConfig {
 
-        CardinalityEstimatorConfigReadOnly(com.hazelcast.config.CardinalityEstimatorConfig config) {
+        CardinalityEstimatorConfigReadOnly(CardinalityEstimatorConfig config) {
             super(config);
         }
 
         @Override
-        public com.hazelcast.config.CardinalityEstimatorConfig setName(String name) {
+        public CardinalityEstimatorConfig setName(String name) {
             throw new UnsupportedOperationException("This config is read-only cardinality estimator: " + getName());
         }
 
         @Override
-        public com.hazelcast.config.CardinalityEstimatorConfig setBackupCount(int backupCount) {
+        public CardinalityEstimatorConfig setBackupCount(int backupCount) {
             throw new UnsupportedOperationException("This config is read-only cardinality estimator: " + getName());
         }
 
         @Override
-        public com.hazelcast.config.CardinalityEstimatorConfig setAsyncBackupCount(int asyncBackupCount) {
+        public CardinalityEstimatorConfig setAsyncBackupCount(int asyncBackupCount) {
             throw new UnsupportedOperationException("This config is read-only cardinality estimator: " + getName());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -28,6 +28,8 @@ public class CardinalityEstimatorConfig {
      */
     private static final int DEFAULT_DURABILITY = 1;
 
+    private static final int MAX_DURABILITY = 8;
+
     private String name = "default";
 
     private int durability = DEFAULT_DURABILITY;

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -106,6 +106,9 @@ public class Config {
 
     private final Map<String, RingbufferConfig> ringbufferConfigs = new ConcurrentHashMap<String, RingbufferConfig>();
 
+    private final Map<String, CardinalityEstimatorConfig> cardinalityEstimatorConfigs =
+            new ConcurrentHashMap<String, CardinalityEstimatorConfig>();
+
     private ServicesConfig servicesConfig = new ServicesConfig();
 
     private SecurityConfig securityConfig = new SecurityConfig();
@@ -783,6 +786,15 @@ public class Config {
         }
         return getScheduledExecutorConfig("default").getAsReadOnly();
     }
+
+    public CardinalityEstimatorConfig findCardinalityEstimatorConfig(String name) {
+        String baseName = getBaseName(name);
+        CardinalityEstimatorConfig config = lookupByPattern(cardinalityEstimatorConfigs, baseName);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getCardinalityEstimatorConfig("default").getAsReadOnly();
+    }
     /**
      * Returns the ExecutorConfig for the given name
      *
@@ -856,6 +868,30 @@ public class Config {
     }
 
     /**
+     * Returns the CardinalityEstimatorConfig for the given name
+     *
+     * @param name name of the cardinality estimator config
+     * @return CardinalityEstimatorConfig
+     */
+    public CardinalityEstimatorConfig getCardinalityEstimatorConfig(String name) {
+        String baseName = getBaseName(name);
+        CardinalityEstimatorConfig config = lookupByPattern(cardinalityEstimatorConfigs, baseName);
+        if (config != null) {
+            return config;
+        }
+        CardinalityEstimatorConfig defConfig = cardinalityEstimatorConfigs.get("default");
+        if (defConfig == null) {
+            defConfig = new CardinalityEstimatorConfig();
+            defConfig.setName("default");
+            addCardinalityEstimatorConfig(defConfig);
+        }
+        config = new CardinalityEstimatorConfig(defConfig);
+        config.setName(name);
+        addCardinalityEstimatorConfig(config);
+        return config;
+    }
+
+    /**
      * Adds a new ExecutorConfig by name
      *
      * @param executorConfig executor config to add
@@ -885,6 +921,17 @@ public class Config {
      */
     public Config addScheduledExecutorConfig(ScheduledExecutorConfig scheduledExecutorConfig) {
         this.scheduledExecutorConfigs.put(scheduledExecutorConfig.getName(), scheduledExecutorConfig);
+        return this;
+    }
+
+    /**
+     * Adds a new CardinalityEstimatorConfig by name
+     *
+     * @param cardinalityEstimatorConfig estimator config to add
+     * @return this config instance
+     */
+    public Config addCardinalityEstimatorConfig(CardinalityEstimatorConfig cardinalityEstimatorConfig) {
+        this.cardinalityEstimatorConfigs.put(cardinalityEstimatorConfig.getName(), cardinalityEstimatorConfig);
         return this;
     }
 
@@ -922,6 +969,19 @@ public class Config {
         this.scheduledExecutorConfigs.clear();
         this.scheduledExecutorConfigs.putAll(scheduledExecutorConfigs);
         for (Entry<String, ScheduledExecutorConfig> entry : scheduledExecutorConfigs.entrySet()) {
+            entry.getValue().setName(entry.getKey());
+        }
+        return this;
+    }
+
+    public Map<String, CardinalityEstimatorConfig> getCardinalityEstimatorConfigs() {
+        return cardinalityEstimatorConfigs;
+    }
+
+    public Config setCardinalityEstimatorConfigs(Map<String, CardinalityEstimatorConfig> cardinalityEstimatorConfigs) {
+        this.cardinalityEstimatorConfigs.clear();
+        this.cardinalityEstimatorConfigs.putAll(cardinalityEstimatorConfigs);
+        for (Entry<String, CardinalityEstimatorConfig> entry : cardinalityEstimatorConfigs.entrySet()) {
             entry.getValue().setName(entry.getKey());
         }
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -126,6 +126,8 @@ public class ConfigXmlGenerator {
 
         scheduledExecutorXmlGenerator(xml, config);
 
+        cardinalityEstimatorXmlGenerator(xml, config);
+
         partitionGroupXmlGenerator(xml, config);
 
         listenerXmlGenerator(xml, config);
@@ -216,6 +218,15 @@ public class ConfigXmlGenerator {
             appendNode(xml, "pool-size", ex.getPoolSize());
             appendNode(xml, "durability", ex.getDurability());
             xml.append("</scheduled-executor-service>");
+        }
+    }
+
+    private void cardinalityEstimatorXmlGenerator(StringBuilder xml, Config config) {
+        for (CardinalityEstimatorConfig ex : config.getCardinalityEstimatorConfigs().values()) {
+            xml.append("<cardinality-estimator name=\"").append(ex.getName()).append("\">");
+            appendNode(xml, "backup-count", ex.getBackupCount());
+            appendNode(xml, "async-backup-count", ex.getAsyncBackupCount());
+            xml.append("</cardinality-estimator>");
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -61,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.MapStoreConfig.InitialLoadMode;
 import static com.hazelcast.config.XmlElements.CACHE;
+import static com.hazelcast.config.XmlElements.CARDINALITY_ESTIMATOR;
 import static com.hazelcast.config.XmlElements.DISTRIBUTED_CLASSLOADING;
 import static com.hazelcast.config.XmlElements.DURABLE_EXECUTOR_SERVICE;
 import static com.hazelcast.config.XmlElements.EXECUTOR_SERVICE;
@@ -359,6 +360,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleHotRestartPersistence(node);
         } else if (DISTRIBUTED_CLASSLOADING.isEqual(nodeName)) {
             handleDistributedClassLoading(node);
+        } else if (CARDINALITY_ESTIMATOR.isEqual(nodeName)) {
+            handleCardinalityEstimator(node);
         } else {
             return true;
         }
@@ -609,6 +612,11 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
     private void handleScheduledExecutor(Node node) throws Exception {
         ScheduledExecutorConfig scheduledExecutorConfig = new ScheduledExecutorConfig();
         handleViaReflection(node, config, scheduledExecutorConfig);
+    }
+
+    private void handleCardinalityEstimator(Node node) throws Exception {
+        CardinalityEstimatorConfig cardinalityEstimatorConfig = new CardinalityEstimatorConfig();
+        handleViaReflection(node, config, cardinalityEstimatorConfig);
     }
 
     private void handleGroup(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -53,6 +53,7 @@ enum XmlElements {
     LITE_MEMBER("lite-member", false),
     HOT_RESTART_PERSISTENCE("hot-restart-persistence", false),
     DISTRIBUTED_CLASSLOADING("distributed-classloading", false),
+    CARDINALITY_ESTIMATOR("cardinality-estimator", false),
     ;
 
     final String name;

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -65,7 +65,7 @@
                 <xs:element name="lite-member" type="lite-member" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="hot-restart-persistence" type="hot-restart-persistence" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="distributed-classloading" type="distributed-classloading" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="cardinality-estimator" type="cardinality-estimator-service" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="cardinality-estimator" type="cardinality-estimator" minOccurs="0" maxOccurs="unbounded"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -1722,7 +1722,7 @@
         </xs:attribute>
     </xs:complexType>
 
-    <xs:complexType name="cardinality-estimator-service">
+    <xs:complexType name="cardinality-estimator">
         <xs:all>
             <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
                 <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -65,6 +65,7 @@
                 <xs:element name="lite-member" type="lite-member" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="hot-restart-persistence" type="hot-restart-persistence" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="distributed-classloading" type="distributed-classloading" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="cardinality-estimator" type="cardinality-estimator-service" minOccurs="0" maxOccurs="unbounded"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -1716,6 +1717,25 @@
             <xs:annotation>
                 <xs:documentation>
                     Name of the scheduled executor.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="cardinality-estimator-service">
+        <xs:all>
+            <xs:element name="durability" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The durability of the cardinality estimator.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the cardinality estimator.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -1724,10 +1724,21 @@
 
     <xs:complexType name="cardinality-estimator-service">
         <xs:all>
-            <xs:element name="durability" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="1">
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
                 <xs:annotation>
                     <xs:documentation>
-                        The durability of the cardinality estimator.
+                        Number of synchronous backups. For example, if 1 is set as the backup-count,
+                        then the cardinality estimation will be copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if 1 is set as the async-backup-count,
+                        then cardinality estimation will be copied to one other JVM (asynchronously) for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -460,6 +460,26 @@ https://hazelcast.org/documentation/.
     </scheduled-executor-service>
 
 <!--
+===== HAZELCAST CARDINALITY ESTIMATOR SERVICE CONFIGURATION =====
+
+Configuration element's name is <cardinality-estimator-service>. It has the optional attribute "name" with which you
+can specify the name of your estimator. Its default value is "default".
+It has the following sub-elements:
+* <backup-count>:
+   Number of synchronous backups. For example, if 1 is set as the backup-count,
+   then the cardinality estimation will be copied to one other JVM for
+   fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+* <async-backup-count>:
+    Number of asynchronous backups. For example, if 1 is set as the backup-count,
+   then the cardinality estimation will be copied to one other JVM for
+   fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+-->
+    <cardinality-estimator name="default">
+        <backup-count>1</backup-count>
+        <async-backup-count>0</async-backup-count>
+    </cardinality-estimator>
+
+<!--
     ===== HAZELCAST QUEUE CONFIGURATION =====
     
     Configuration element's name is <queue>. It has the optional attribute "name" with which you 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1054,7 +1054,8 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     public void testCardinalityEstimatorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <cardinality-estimator name=\"foobar\">\n"
-                + "        <durability>4</durability>\n"
+                + "        <backup-count>2</backup-count>\n"
+                + "        <async-backup-count>3</async-backup-count>\n"
                 + "    </cardinality-estimator>\n"
                 + HAZELCAST_END_TAG;
 
@@ -1062,7 +1063,8 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         CardinalityEstimatorConfig cardinalityEstimatorConfig = config.getCardinalityEstimatorConfig("foobar");
 
         assertFalse(config.getCardinalityEstimatorConfigs().isEmpty());
-        assertEquals(4, cardinalityEstimatorConfig.getDurability());
+        assertEquals(2, cardinalityEstimatorConfig.getBackupCount());
+        assertEquals(3, cardinalityEstimatorConfig.getAsyncBackupCount());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1051,6 +1051,21 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testCardinalityEstimatorConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "    <cardinality-estimator name=\"foobar\">\n"
+                + "        <durability>4</durability>\n"
+                + "    </cardinality-estimator>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        CardinalityEstimatorConfig cardinalityEstimatorConfig = config.getCardinalityEstimatorConfig("foobar");
+
+        assertFalse(config.getCardinalityEstimatorConfigs().isEmpty());
+        assertEquals(4, cardinalityEstimatorConfig.getDurability());
+    }
+
+    @Test
     public void testIndexesConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <map name=\"people\">\n"


### PR DESCRIPTION
Durability for Cardinality Estimator is not configurable, having a hard coded value of 1.
Recent test failures due to total partition loss, are mainly the reason for this change. 
See. #9217 #9017 #9124 