### PR TITLE
Moved eviction calls to recordStore

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -53,7 +53,6 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
         mapEventPublisher.publishEvent(getCallerAddress(), name, getEventType(), dataKey, dataOldValue, value);
         invalidateNearCache(dataKey);
         publishWANReplicationEvent(mapEventPublisher, value);
-        evict(dataKey);
     }
 
     private void publishWANReplicationEvent(MapEventPublisher mapEventPublisher, Object value) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -53,7 +53,6 @@ public abstract class BaseRemoveOperation extends LockAwareOperation implements 
             // todo should evict operation replicated??
             mapEventPublisher.publishWanReplicationRemove(name, dataKey, Clock.currentTimeMillis());
         }
-        evict(dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryBackupOperation.java
@@ -100,11 +100,6 @@ public class EntryBackupOperation extends MutatingKeyBasedMapOperation implement
         }
     }
 
-    @Override
-    public void afterRun() throws Exception {
-        evict(dataKey);
-    }
-
     private boolean entryRemovedBackup(Map.Entry entry) {
         final Object value = entry.getValue();
         if (value == null) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -112,7 +112,6 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
         invalidateNearCache(dataKey);
         publishEntryEvent();
         publishWanReplicationEvent();
-        evict(dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -140,12 +140,6 @@ public abstract class MapOperation extends AbstractNamedOperation implements Ide
         return mapNearCacheManager.getInvalidator();
     }
 
-    protected void evict(Data excludedKey) {
-        assert recordStore != null : "Record-store cannot be null";
-
-        recordStore.evictEntries(excludedKey);
-    }
-
     private RecordStore getRecordStoreOrNull() {
         int partitionId = getPartitionId();
         if (partitionId == -1) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperation.java
@@ -87,7 +87,6 @@ public class MergeOperation extends BasePutOperation {
             mapEventPublisher.publishEvent(getCallerAddress(), name, EntryEventType.MERGED, dataKey, dataOldValue,
                     dataValue, mergingValue);
             invalidateNearCache(dataKey);
-            evict(dataKey);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -63,8 +63,6 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOpe
                 continue;
             }
             entryAddedOrUpdatedBackup(entry, key);
-
-            evict(key);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -84,8 +84,6 @@ public class MultipleEntryOperation extends AbstractMultipleEntryOperation imple
             }
 
             entryAddedOrUpdated(entry, key, value, now);
-
-            evict(key);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -63,8 +63,6 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryBack
                 continue;
             }
             entryAddedOrUpdatedBackup(entry, dataKey);
-
-            evict(dataKey);
         }
 
         publishWanReplicationEventBackups();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -87,8 +87,6 @@ public class PartitionWideEntryOperation extends AbstractMultipleEntryOperation 
                 continue;
             }
             entryAddedOrUpdated(entry, dataKey, oldValue, now);
-
-            evict(dataKey);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
@@ -62,8 +62,6 @@ public class PutAllBackupOperation extends MapOperation implements PartitionAwar
                 EntryView entryView = createSimpleEntryView(dataKey, dataValueAsData, record);
                 mapEventPublisher.publishWanReplicationUpdateBackup(name, entryView);
             }
-
-            evict(dataKey);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -113,7 +113,6 @@ public class PutAllOperation extends MapOperation implements PartitionAwareOpera
             backupRecordInfos.add(replicationInfo);
         }
 
-        evict(dataKey);
         if (hasInvalidation) {
             invalidationKeys.add(dataKey);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -80,9 +80,6 @@ public final class PutBackupOperation extends MutatingKeyBasedMapOperation imple
 
     @Override
     public void afterRun() throws Exception {
-        if (recordInfo != null) {
-            evict(dataKey);
-        }
         if (!disableWanReplicationEvent) {
             publishWANReplicationEventBackup(mapServiceContext, mapEventPublisher);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -64,13 +64,6 @@ public class PutFromLoadAllBackupOperation extends MapOperation implements Backu
         }
     }
 
-    @Override
-    public void afterRun() throws Exception {
-        evict(null);
-
-        super.afterRun();
-    }
-
     private void publishWanReplicationEvent(Data key, Data value, Record record) {
         if (record == null) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -116,7 +116,6 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
     @Override
     public void afterRun() throws Exception {
         invalidateNearCache(invalidationKeys);
-        evict(null);
 
         super.afterRun();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveBackupOperation.java
@@ -58,8 +58,6 @@ public class RemoveBackupOperation extends MutatingKeyBasedMapOperation implemen
 
     @Override
     public void afterRun() throws Exception {
-        evict(dataKey);
-
         if (!disableWanReplicationEvent && mapContainer.isWanReplicationEnabled()) {
             mapEventPublisher.publishWanReplicationRemoveBackup(name, dataKey, Clock.currentTimeMillis());
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -256,6 +256,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         } else {
             mapDataStore.addBackup(key, value, now);
         }
+        evictEntries(key);
         return record;
     }
 
@@ -778,14 +779,15 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
 
         saveIndex(record, oldValue);
+        evictEntries(key);
         return oldValue;
     }
 
     @Override
     public boolean merge(Data key, EntryView mergingEntry, MapMergePolicy mergePolicy) {
         checkIfLoaded();
-        final long now = getNow();
 
+        final long now = getNow();
         Record record = getRecordOrNull(key, now, false);
         mergingEntry = EntryViews.convertToLazyEntryView(mergingEntry, serializationService, mergePolicy);
         Object newValue;
@@ -827,6 +829,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             storage.updateRecordValue(key, record, newValue);
         }
         saveIndex(record, oldValue);
+        evictEntries(key);
         return newValue != null;
     }
 
@@ -834,8 +837,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public Object replace(Data key, Object update) {
         checkIfLoaded();
-        final long now = getNow();
 
+        final long now = getNow();
         final Record record = getRecordOrNull(key, now, false);
         if (record == null || record.getValue() == null) {
             return null;
@@ -846,14 +849,15 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         onStore(record);
         updateRecord(key, record, update, now);
         saveIndex(record, oldValue);
+        evictEntries(key);
         return oldValue;
     }
 
     @Override
     public boolean replace(Data key, Object expect, Object update) {
         checkIfLoaded();
-        final long now = getNow();
 
+        final long now = getNow();
         final Record record = getRecordOrNull(key, now, false);
         if (record == null) {
             return false;
@@ -869,12 +873,14 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         onStore(record);
         updateRecord(key, record, update, now);
         saveIndex(record, current);
+        evictEntries(key);
         return true;
     }
 
     @Override
     public void putTransient(Data key, Object value, long ttl) {
         checkIfLoaded();
+
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
@@ -892,6 +898,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
         saveIndex(record, oldValue);
         mapDataStore.addTransient(key, now);
+        evictEntries(key);
     }
 
     @Override
@@ -936,6 +943,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (!backup) {
             saveIndex(record, oldValue);
         }
+        evictEntries(key);
         return oldValue;
     }
 
@@ -962,6 +970,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public Object putIfAbsent(Data key, Object value, long ttl) {
         checkIfLoaded();
+
         final long now = getNow();
         markRecordStoreExpirable(ttl);
 
@@ -986,6 +995,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             updateExpiryTime(record, ttl, mapContainer.getMapConfig());
         }
         saveIndex(record, oldValue);
+        evictEntries(key);
         return oldValue;
     }
 


### PR DESCRIPTION
This refactoring is helpful to control/see all eviction calls from one place. And will be used for later fixes.