### PR TITLE
Make TextReadHandler command buffer expandable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
@@ -39,6 +39,7 @@ import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.StringUtil;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -62,7 +63,11 @@ public class TextReadHandler implements ReadHandler {
 
     private static final Map<String, CommandParser> MAP_COMMAND_PARSERS = new HashMap<String, CommandParser>();
 
-    private static final int CAPACITY = 500;
+    @SuppressWarnings("checkstyle:magicnumber")
+    private static final int INITIAL_CAPACITY = 1 << 8;
+    // 65536, no specific reason, similar to UDP packet size limit
+    @SuppressWarnings("checkstyle:magicnumber")
+    private static final int MAX_CAPACITY = 1 << 16;
 
     static {
         MAP_COMMAND_PARSERS.put("get", new GetCommandParser());
@@ -85,7 +90,7 @@ public class TextReadHandler implements ReadHandler {
         MAP_COMMAND_PARSERS.put("DELETE", new HttpDeleteCommandParser());
     }
 
-    private ByteBuffer commandLine = ByteBuffer.allocate(CAPACITY);
+    private ByteBuffer commandLineBuffer = ByteBuffer.allocate(INITIAL_CAPACITY);
     private boolean commandLineRead;
     private TextCommand command;
     private final TextCommandService textCommandService;
@@ -112,25 +117,25 @@ public class TextReadHandler implements ReadHandler {
     }
 
     @Override
-    public void onRead(ByteBuffer src) {
+    public void onRead(ByteBuffer src) throws Exception {
         while (src.hasRemaining()) {
             doRead(src);
         }
     }
 
-    private void doRead(ByteBuffer bb) {
+    private void doRead(ByteBuffer bb) throws IOException {
         while (!commandLineRead && bb.hasRemaining()) {
             byte b = bb.get();
             char c = (char) b;
             if (c == '\n') {
                 commandLineRead = true;
             } else if (c != '\r') {
-                commandLine.put(b);
+                appendToBuffer(b);
             }
         }
         if (commandLineRead) {
             if (command == null) {
-                processCmd(toStringAndClear(commandLine));
+                processCmd(toStringAndClear(commandLineBuffer));
             }
             if (command != null) {
                 boolean complete = command.readFrom(bb);
@@ -144,13 +149,36 @@ public class TextReadHandler implements ReadHandler {
         }
     }
 
-    void reset() {
+    private void appendToBuffer(byte b) throws IOException {
+        if (!commandLineBuffer.hasRemaining()) {
+            expandBuffer();
+        }
+        commandLineBuffer.put(b);
+    }
+
+    private void expandBuffer() throws IOException {
+        if (commandLineBuffer.capacity() == MAX_CAPACITY) {
+            throw new IOException("Max command size capacity [" + MAX_CAPACITY + "] has been reached!");
+        }
+
+        int capacity = commandLineBuffer.capacity() << 1;
+        if (logger.isFineEnabled()) {
+            logger.fine("Expanding buffer capacity to " + capacity);
+        }
+
+        ByteBuffer newBuffer = ByteBuffer.allocate(capacity);
+        commandLineBuffer.flip();
+        newBuffer.put(commandLineBuffer);
+        commandLineBuffer = newBuffer;
+    }
+
+    private void reset() {
         command = null;
-        commandLine.clear();
+        commandLineBuffer.clear();
         commandLineRead = false;
     }
 
-    public static String toStringAndClear(ByteBuffer bb) {
+    private static String toStringAndClear(ByteBuffer bb) {
         if (bb == null) {
             return "";
         }
@@ -190,7 +218,7 @@ public class TextReadHandler implements ReadHandler {
         textCommandService.processRequest(command);
     }
 
-    void processCmd(String cmd) {
+    private void processCmd(String cmd) {
         try {
             int space = cmd.indexOf(' ');
             String operation = (space == -1) ? cmd : cmd.substring(0, space);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -37,19 +37,19 @@ public class HTTPCommunicator {
         this.address = "http:/" + instance.getCluster().getLocalMember().getSocketAddress().toString() + "/hazelcast/rest/";
     }
 
-    public String poll(String queueName, long timeout) throws IOException {
+    public String queuePoll(String queueName, long timeout) throws IOException {
         String url = address + "queues/" + queueName + "/" + String.valueOf(timeout);
         String result = doGet(url);
         return result;
     }
 
-    public int size(String queueName) throws IOException {
+    public int queueSize(String queueName) throws IOException {
         String url = address + "queues/" + queueName + "/size";
         Integer result = Integer.parseInt(doGet(url));
         return result;
     }
 
-    public int offer(String queueName, String data) throws IOException {
+    public int queueOffer(String queueName, String data) throws IOException {
         String url = address + "queues/" + queueName;
         /** set up the http connection parameters */
         HttpURLConnection urlConnection = (HttpURLConnection) (new URL(url)).openConnection();
@@ -72,7 +72,7 @@ public class HTTPCommunicator {
         return urlConnection.getResponseCode();
     }
 
-    public String get(String mapName, String key) throws IOException {
+    public String mapGet(String mapName, String key) throws IOException {
         String url = address + "maps/" + mapName + "/" + key;
         String result = doGet(url);
         return result;
@@ -84,7 +84,7 @@ public class HTTPCommunicator {
 
     }
 
-    public int put(String mapName, String key, String value) throws IOException {
+    public int mapPut(String mapName, String key, String value) throws IOException {
 
         String url = address + "maps/" + mapName + "/" + key;
         /** set up the http connection parameters */
@@ -106,7 +106,7 @@ public class HTTPCommunicator {
         return urlConnection.getResponseCode();
     }
 
-    public int deleteAll(String mapName) throws IOException {
+    public int mapDeleteAll(String mapName) throws IOException {
 
         String url = address + "maps/" + mapName;
         /** set up the http connection parameters */
@@ -121,7 +121,7 @@ public class HTTPCommunicator {
         return urlConnection.getResponseCode();
     }
 
-    public int delete(String mapName, String key) throws IOException {
+    public int mapDelete(String mapName, String key) throws IOException {
 
         String url = address + "maps/" + mapName + "/" + key;
         /** set up the http connection parameters */
@@ -211,9 +211,13 @@ public class HTTPCommunicator {
         HttpURLConnection httpUrlConnection = (HttpURLConnection) (new URL(url)).openConnection();
         try {
             InputStream inputStream = httpUrlConnection.getInputStream();
-            byte[] buffer = new byte[4096];
-            int readBytes = inputStream.read(buffer);
-            return readBytes == -1 ? "" : new String(buffer, 0, readBytes);
+            StringBuilder builder = new StringBuilder();
+            byte[] buffer = new byte[1024];
+            int readBytes;
+            while ((readBytes = inputStream.read(buffer)) > -1) {
+                builder.append(new String(buffer, 0, readBytes));
+            }
+            return builder.toString();
         } finally {
             httpUrlConnection.disconnect();
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcacheTest.java
@@ -17,248 +17,368 @@
 package com.hazelcast.internal.ascii;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.internal.ascii.memcache.MemcacheCommandProcessor;
 import com.hazelcast.internal.ascii.memcache.MemcacheEntry;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.FailureMode;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.internal.OperationFuture;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.LinkedList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-/**
- * User: sancar
- * Date: 3/7/13
- * Time: 2:48 PM
- */
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+// intentionally not in ParallelTest category,
+// test is starting standalone HazelcastInstances.
 public class MemcacheTest extends HazelcastTestSupport {
 
-    final static Config config = new XmlConfigBuilder().build();
+    private Config config = new Config();
+    private HazelcastInstance instance;
+    private MemcachedClient client;
 
-    @BeforeClass
-    public static void setup() throws IOException {
+    @Before
+    public void setup() throws Exception {
         config.setProperty(GroupProperty.MEMCACHE_ENABLED.getName(), "true");
+
+        // Join is disabled intentionally. will start standalone HazelcastInstances.
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(false);
+
+        instance = Hazelcast.newHazelcastInstance(config);
+        client = getMemcacheClient(instance);
     }
 
-    @AfterClass
-    public static void tearDown() throws IOException {
-        Hazelcast.shutdownAll();
-    }
-
-    public MemcachedClient getMemcacheClient(HazelcastInstance instance) throws IOException {
-        final LinkedList<InetSocketAddress> addresses = new LinkedList<InetSocketAddress>();
-        addresses.add(instance.getCluster().getLocalMember().getSocketAddress());
-        final ConnectionFactory factory = new ConnectionFactoryBuilder().setOpTimeout(60 * 60 * 60).setDaemon(true).setFailureMode(FailureMode.Retry).build();
-        return new MemcachedClient(factory, addresses);
-    }
-
-    @Test
-    public void testMemcacheSimple() throws IOException, ExecutionException, InterruptedException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        MemcachedClient client = getMemcacheClient(instance);
+    @After
+    public void tearDown() {
         try {
-            for (int i = 0; i < 100; i++) {
-                final OperationFuture<Boolean> future = client.set(String.valueOf(i), 0, i);
-                assertEquals(Boolean.TRUE, future.get());
+            if (client != null) {
+                client.shutdown();
             }
-            for (int i = 0; i < 100; i++) {
-                assertEquals(i, client.get(String.valueOf(i)));
-            }
-            for (int i = 0; i < 100; i++) {
-                final OperationFuture<Boolean> future = client.add(String.valueOf(i), 0, i * 100);
-                assertEquals(Boolean.FALSE, future.get());
-            }
-            for (int i = 0; i < 100; i++) {
-                assertEquals(i, client.get(String.valueOf(i)));
-            }
-            for (int i = 100; i < 200; i++) {
-                final OperationFuture<Boolean> future = client.add(String.valueOf(i), 0, i);
-                assertEquals(Boolean.TRUE, future.get());
-            }
-            for (int i = 0; i < 200; i++) {
-                assertEquals(i, client.get(String.valueOf(i)));
-            }
-            for (int i = 0; i < 200; i++) {
-                final OperationFuture<Boolean> future = client.replace(String.valueOf(i), 0, i * 10);
-                assertEquals(Boolean.TRUE, future.get());
-            }
-            for (int i = 0; i < 200; i++) {
-                assertEquals(i * 10, client.get(String.valueOf(i)));
-            }
-            for (int i = 200; i < 400; i++) {
-                final OperationFuture<Boolean> future = client.replace(String.valueOf(i), 0, i);
-                assertEquals(Boolean.FALSE, future.get());
-            }
-            for (int i = 200; i < 400; i++) {
-                assertEquals(null, client.get(String.valueOf(i)));
-            }
-            for (int i = 100; i < 200; i++) {
-                final OperationFuture<Boolean> future = client.delete(String.valueOf(i));
-                assertEquals(Boolean.TRUE, future.get());
-            }
-            for (int i = 100; i < 200; i++) {
-                assertEquals(null, client.get(String.valueOf(100)));
-            }
-            for (int i = 100; i < 200; i++) {
-                final OperationFuture<Boolean> future = client.delete(String.valueOf(i));
-                assertEquals(Boolean.FALSE, future.get());
-            }
-
-            final LinkedList<String> keys = new LinkedList<String>();
-            for (int i = 0; i < 100; i++) {
-                keys.add(String.valueOf(i));
-            }
-            final Map<String, Object> bulk = client.getBulk(keys);
-            for (int i = 0; i < 100; i++) {
-                assertEquals(i * 10, bulk.get(String.valueOf(i)));
-            }
-            // STATS
-            final Map<String, String> stats = client.getStats().get(instance.getCluster().getLocalMember().getSocketAddress());
-            assertEquals("700", stats.get("cmd_set"));
-            assertEquals("1000", stats.get("cmd_get"));
-            assertEquals("700", stats.get("get_hits"));
-            assertEquals("300", stats.get("get_misses"));
-            assertEquals("100", stats.get("delete_hits"));
-            assertEquals("100", stats.get("delete_misses"));
         } finally {
-            client.shutdown();
+            if (instance != null) {
+                instance.getLifecycleService().terminate();
+            }
         }
     }
 
     @Test
-    public void testMemcacheWithIMap() throws IOException, InterruptedException, ExecutionException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        MemcachedClient client = getMemcacheClient(instance);
-        final String prefix = "testMemcacheWithIMap:";
-        try {
-            final IMap<String, Object> map = instance.getMap("hz_memcache_testMemcacheWithIMap");
-            for (int i = 0; i < 100; i++) {
-                map.put(String.valueOf(i), String.valueOf(i));
-            }
-            for (int i = 0; i < 100; i++) {
-                assertEquals(String.valueOf(i), client.get(prefix + String.valueOf(i)));
-                final OperationFuture<Boolean> future = client.set(prefix + String.valueOf(i), 0, String.valueOf(i * 10));
-                future.get();
-            }
-            for (int i = 0; i < 100; i++) {
-                final MemcacheEntry memcacheEntry = (MemcacheEntry) map.get(String.valueOf(i));
-                final MemcacheEntry expected = new MemcacheEntry(prefix + String.valueOf(i), String.valueOf(i * 10).getBytes(), 0);
-                assertEquals(expected, memcacheEntry);
-            }
-            final OperationFuture<Boolean> future = client.delete(prefix);
-            future.get();
-            for (int i = 0; i < 100; i++) {
-                assertEquals(null, client.get(prefix + String.valueOf(i)));
-            }
-        } finally {
-            client.shutdown();
+    public void testSetAndGet() throws Exception {
+        String key = "key";
+        String value = "value";
+
+        OperationFuture<Boolean> future = client.set(key, 0, value);
+        assertEquals(Boolean.TRUE, future.get());
+
+        assertEquals(value, client.get(key));
+
+        checkStats(1, 1, 1, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    @Test
+    public void testAddAndGet() throws Exception {
+        String key = "key";
+        String value = "value";
+        String key2 = "key2";
+        String value2 = "value2";
+
+        OperationFuture<Boolean> future = client.set(key, 0, value);
+        assertEquals(Boolean.TRUE, future.get());
+
+        future = client.add(key, 0, value2);
+        assertEquals(Boolean.FALSE, future.get());
+        assertEquals(value, client.get(key));
+
+        future = client.add(key2, 0, value2);
+        assertEquals(Boolean.TRUE, future.get());
+        assertEquals(value2, client.get(key2));
+
+        checkStats(3, 2, 2, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    @Test
+    public void testReplace() throws Exception {
+        String key = "key";
+        String value = "value";
+        String value2 = "value2";
+
+        OperationFuture<Boolean> future = client.replace(key, 0, value2);
+        assertEquals(Boolean.FALSE, future.get());
+        assertNull(client.get(key));
+
+        future = client.set(key, 0, value);
+        assertEquals(Boolean.TRUE, future.get());
+
+        future = client.replace(key, 0, value2);
+        assertEquals(Boolean.TRUE, future.get());
+        assertEquals(value2, client.get(key));
+
+        checkStats(3, 2, 1, 1, 0, 0, 0, 0, 0, 0);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        String key = "key";
+        String value = "value";
+
+        OperationFuture<Boolean> future = client.delete(key);
+        assertEquals(Boolean.FALSE, future.get());
+
+        future = client.set(key, 0, value);
+        assertEquals(Boolean.TRUE, future.get());
+
+        future = client.delete(key);
+        assertEquals(Boolean.TRUE, future.get());
+        assertNull(client.get(key));
+
+        checkStats(1, 1, 0, 1, 1, 1, 0, 0, 0, 0);
+    }
+
+    @Test
+    public void testBulkGet() throws Exception {
+        List<String> keys = new ArrayList<String>();
+        for (int i = 0; i < 10; i++) {
+            keys.add("key" + i);
         }
-    }
 
-    @Test
-    public void testIncrementAndDecrement() throws IOException, ExecutionException, InterruptedException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        MemcachedClient client = getMemcacheClient(instance);
-        try {
-            for (int i = 0; i < 100; i++) {
-                final OperationFuture<Boolean> future = client.set(String.valueOf(i), 0, i);
-                future.get();
-            }
-            for (int i = 0; i < 100; i++) {
-                assertEquals(i * 2, client.incr(String.valueOf(i), i));
-            }
-            for (int i = 100; i < 120; i++) {
-                assertEquals(-1, client.incr(String.valueOf(i), i));
-            }
-            for (int i = 0; i < 100; i++) {
-                assertEquals(i, client.decr(String.valueOf(i), i));
-            }
-            for (int i = 100; i < 130; i++) {
-                assertEquals(-1, client.decr(String.valueOf(i), i));
-            }
-            for (int i = 0; i < 100; i++) {
-                assertEquals(i, client.get(String.valueOf(i)));
-            }
-            final Map<String, String> stats = client.getStats().get(instance.getCluster().getLocalMember().getSocketAddress());
-            assertEquals("100", stats.get("cmd_set"));
-            assertEquals("100", stats.get("cmd_get"));
-            assertEquals("100", stats.get("incr_hits"));
-            assertEquals("20", stats.get("incr_misses"));
-            assertEquals("100", stats.get("decr_hits"));
-            assertEquals("30", stats.get("decr_misses"));
-        } finally {
-            client.shutdown();
+        Map<String, Object> result = client.getBulk(keys);
+        assertEquals(0, result.size());
+
+        String value = "value";
+        for (String key : keys) {
+            OperationFuture<Boolean> future = client.set(key, 0, value);
         }
-    }
 
-    @Test
-    public void testMemcacheAppendPrepend() throws IOException, ExecutionException, InterruptedException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        MemcachedClient client = getMemcacheClient(instance);
-        try {
-            for (int i = 0; i < 100; i++) {
-                final OperationFuture<Boolean> future = client.set(String.valueOf(i), 0, String.valueOf(i));
-                future.get();
-            }
-            for (int i = 0; i < 100; i++) {
-                final OperationFuture<Boolean> future = client.append(0, String.valueOf(i), "append");
-                assertEquals(Boolean.TRUE, future.get());
-            }
-            for (int i = 0; i < 100; i++) {
-                final OperationFuture<Boolean> future = client.prepend(0, String.valueOf(i), "prepend");
-                assertEquals(Boolean.TRUE, future.get());
-            }
-            for (int i = 1; i < 100; i++) {
-                assertEquals("prepend" + String.valueOf(i) + "append", client.get(String.valueOf(i)));
-            }
-        } finally {
-            client.shutdown();
+        result = client.getBulk(keys);
+        assertEquals(keys.size(), result.size());
+        for (String key : keys) {
+            assertEquals(value, result.get(key));
         }
+
+        checkStats(keys.size(), keys.size() * 2, keys.size(), keys.size(), 0, 0, 0, 0, 0, 0);
     }
 
     @Test
-    public void testQuit() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        MemcachedClient client = getMemcacheClient(instance);
-        client.shutdown();
+    public void testSetGetDelete_WithDefaultIMap() throws Exception {
+        testSetGetDelete_WithIMap(MemcacheCommandProcessor.DEFAULT_MAP_NAME, "");
     }
 
     @Test
-    public void testMemcacheTTL() throws IOException, ExecutionException, InterruptedException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final MemcachedClient client = getMemcacheClient(instance);
-        try {
-            client.set(String.valueOf(0), 5, 10).get();
-            assertTrueEventually(new AssertTask() {
+    public void testSetGetDelete_WithCustomIMap() throws Exception {
+        String mapName = randomMapName();
+        testSetGetDelete_WithIMap(MemcacheCommandProcessor.MAP_NAME_PRECEDER + mapName, mapName + ":");
+    }
+
+    private void testSetGetDelete_WithIMap(String mapName, String prefix) throws Exception {
+        String key = "key";
+        String value = "value";
+        String value2 = "value2";
+
+        IMap<String, Object> map = instance.getMap(mapName);
+        map.put(key, value);
+        assertEquals(value, client.get(prefix + key));
+
+        client.set(prefix + key, 0, value2).get();
+
+        MemcacheEntry memcacheEntry = (MemcacheEntry) map.get(key);
+        MemcacheEntry expectedEntry = new MemcacheEntry(prefix + key, value2.getBytes(), 0);
+        assertEquals(expectedEntry, memcacheEntry);
+
+        client.delete(prefix + key).get();
+        assertNull(client.get(prefix + key));
+        assertNull(map.get(key));
+    }
+
+    @Test
+    public void testDeleteAll_withIMapPrefix() throws Exception {
+        String mapName = randomMapName();
+        String prefix = mapName + ":";
+        IMap<String, Object> map = instance.getMap(MemcacheCommandProcessor.MAP_NAME_PRECEDER + mapName);
+
+        for (int i = 0; i < 100; i++) {
+            map.put(String.valueOf(i), i);
+        }
+
+        OperationFuture<Boolean> future = client.delete(prefix);
+        future.get();
+
+        for (int i = 0; i < 100; i++) {
+            assertNull(client.get(prefix + String.valueOf(i)));
+        }
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    public void testIncrement() throws Exception {
+        String key = "key";
+
+        long value = client.incr(key, 1);
+        assertEquals(-1, value);
+        assertNull(client.get(key));
+
+        OperationFuture<Boolean> future = client.set(key, 0, 1);
+        future.get();
+
+        value = client.incr(key, 10);
+        assertEquals(11, value);
+
+        value = client.incr(key, -5);
+        assertEquals(6, value);
+
+        checkStats(1, 1, 0, 1, 0, 0, 2, 1, 0, 0);
+    }
+
+    @Test
+    public void testDecrement() throws Exception {
+        String key = "key";
+
+        long value = client.decr(key, 1);
+        assertEquals(-1, value);
+        assertNull(client.get(key));
+
+        OperationFuture<Boolean> future = client.set(key, 0, 5);
+        future.get();
+
+        value = client.decr(key, 2);
+        assertEquals(3, value);
+
+        value = client.decr(key, -2);
+        assertEquals(5, value);
+
+        checkStats(1, 1, 0, 1, 0, 0, 0, 0, 2, 1);
+    }
+
+    @Test
+    public void testAppend() throws Exception {
+        String key = "key";
+        String value = "value";
+        String append = "123";
+
+        OperationFuture<Boolean> future = client.append(key, append);
+        assertEquals(Boolean.FALSE, future.get());
+
+        future = client.set(key, 0, value);
+        future.get();
+
+        future = client.append(key, append);
+        assertEquals(Boolean.TRUE, future.get());
+
+        assertEquals(value + append, client.get(key));
+    }
+
+    @Test
+    public void testPrepend() throws Exception {
+        String key = "key";
+        String value = "value";
+        String prepend = "123";
+
+        OperationFuture<Boolean> future = client.prepend(key, prepend);
+        assertEquals(Boolean.FALSE, future.get());
+
+        future = client.set(key, 0, value);
+        future.get();
+
+        future = client.prepend(key, prepend);
+        assertEquals(Boolean.TRUE, future.get());
+
+        assertEquals(prepend + value, client.get(key));
+    }
+
+    @Test
+    public void testExpiration() throws Exception {
+        final String key = "key";
+        client.set(key, 3, "value").get();
+        assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    assertEquals(null, client.get(String.valueOf(0)));
+                    assertEquals(null, client.get(key));
                 }
             });
-        } finally {
-            client.shutdown();
+    }
+
+    @Test
+    public void testSetGet_withLargeValue() throws Exception {
+        String key = "key";
+        int capacity = 10000;
+        StringBuilder value = new StringBuilder(capacity);
+        while (value.length() < capacity) {
+            value.append(randomString());
         }
+
+        OperationFuture<Boolean> future = client.set(key, 0, value.toString());
+        future.get();
+
+        Object result = client.get(key);
+        assertEquals(value.toString(), result);
+    }
+
+    @Test
+    public void testBulkSetGet_withManyKeys() throws Exception {
+        int numberOfKeys = 1000;
+        Collection<String> keys = new HashSet<String>(numberOfKeys);
+
+        for (int i = 0; i < numberOfKeys; i++) {
+            String key = "key" + i;
+            OperationFuture<Boolean> future = client.set(key, 0, key);
+            future.get();
+            keys.add(key);
+        }
+
+        Map<String, Object> result = client.getBulk(keys);
+        for (String key : keys) {
+            assertEquals(key, result.get(key));
+        }
+    }
+
+    private void checkStats(int sets, int gets, int getHits, int getMisses, int deleteHits, int deleteMisses,
+            int incHits, int incMisses, int decHits, int decMisses) {
+        InetSocketAddress address = instance.getCluster().getLocalMember().getSocketAddress();
+        Map<String, String> stats = client.getStats().get(address);
+
+        assertEquals(String.valueOf(sets), stats.get("cmd_set"));
+        assertEquals(String.valueOf(gets), stats.get("cmd_get"));
+        assertEquals(String.valueOf(getHits), stats.get("get_hits"));
+        assertEquals(String.valueOf(getMisses), stats.get("get_misses"));
+        assertEquals(String.valueOf(deleteHits), stats.get("delete_hits"));
+        assertEquals(String.valueOf(deleteMisses), stats.get("delete_misses"));
+        assertEquals(String.valueOf(incHits), stats.get("incr_hits"));
+        assertEquals(String.valueOf(incMisses), stats.get("incr_misses"));
+        assertEquals(String.valueOf(decHits), stats.get("decr_hits"));
+        assertEquals(String.valueOf(decMisses), stats.get("decr_misses"));
+    }
+
+    private MemcachedClient getMemcacheClient(HazelcastInstance instance) throws Exception {
+        InetSocketAddress address = instance.getCluster().getLocalMember().getSocketAddress();
+        ConnectionFactory factory = new ConnectionFactoryBuilder()
+                .setOpTimeout(60 * 60 * 60)
+                .setDaemon(true)
+                .setFailureMode(FailureMode.Retry)
+                .build();
+        return new MemcachedClient(factory, Collections.singletonList(address));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -16,293 +16,187 @@
 
 package com.hazelcast.internal.ascii;
 
-import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EntryListenerConfig;
-import com.hazelcast.config.MapConfig;
-import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 import com.hazelcast.core.IQueue;
-import com.hazelcast.core.LifecycleEvent;
-import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
-import java.net.ConnectException;
-import java.net.HttpURLConnection;
-import java.net.SocketException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-/**
- * User: sancar
- * Date: 3/11/13
- * Time: 3:33 PM
- */
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+// intentionally not in ParallelTest category,
+// test is starting standalone HazelcastInstances.
 public class RestTest extends HazelcastTestSupport {
 
-    final static Config config = new XmlConfigBuilder().build();
+    private Config config = new Config();
+    private HazelcastInstance instance;
+    private HTTPCommunicator communicator;
 
     @Before
     public void setup() throws IOException {
         config.setProperty(GroupProperty.REST_ENABLED.getName(), "true");
+
+        // Join is disabled intentionally. will start standalone HazelcastInstances.
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(false);
+
+        instance = Hazelcast.newHazelcastInstance(config);
+        communicator = new HTTPCommunicator(instance);
     }
 
     @After
-    public void tearDown() throws IOException {
-        Hazelcast.shutdownAll();
+    public void tearDown() {
+        instance.getLifecycleService().terminate();
     }
 
     @Test
-    public void testTtl_issue1783() throws IOException, InterruptedException {
-        String name = "map";
+    public void testMapPutGet() throws Exception {
+        String name = randomMapName();
 
+        String key = "key";
+        String value = "value";
+
+        assertEquals(HTTP_OK, communicator.mapPut(name, key, value));
+        assertEquals(value, communicator.mapGet(name, key));
+        assertTrue(instance.getMap(name).containsKey(key));
+    }
+
+    @Test
+    public void testMapPutDelete() throws Exception {
+        String name = randomMapName();
+
+        String key = "key";
+        String value = "value";
+
+        assertEquals(HTTP_OK, communicator.mapPut(name, key, value));
+        assertEquals(HTTP_OK, communicator.mapDelete(name, key));
+        assertFalse(instance.getMap(name).containsKey(key));
+    }
+
+    @Test
+    public void testMapDeleteAll() throws Exception {
+        String name = randomMapName();
+
+        int count = 10;
+        for (int i = 0; i < count; i++) {
+            assertEquals(HTTP_OK, communicator.mapPut(name, "key" + i, "value"));
+        }
+
+        IMap<Object, Object> map = instance.getMap(name);
+        assertEquals(10, map.size());
+
+        assertEquals(HTTP_OK, communicator.mapDeleteAll(name));
+        assertTrue(map.isEmpty());
+    }
+
+    // issue #1783
+    @Test
+    public void testMapTtl() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        final MapConfig mapConfig = config.getMapConfig(name);
-        mapConfig.setTimeToLiveSeconds(3);
-        mapConfig.addEntryListenerConfig(new EntryListenerConfig()
-                .setImplementation(new EntryAdapter() {
-                    @Override
-                    public void entryEvicted(EntryEvent event) {
-                        latch.countDown();
-                    }
-                }));
+        EntryListenerConfig listenerConfig = new EntryListenerConfig().setImplementation(new EntryAdapter() {
+            @Override
+            public void entryEvicted(EntryEvent event) {
+                latch.countDown();
+            }
+        });
 
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        String name = randomMapName();
+        config.getMapConfig(name)
+                .setTimeToLiveSeconds(3)
+                .addEntryListenerConfig(listenerConfig);
 
-        communicator.put(name, "key", "value");
-        String value = communicator.get(name, "key");
+        String key = "key";
+        communicator.mapPut(name, key, "value");
 
-        assertNotNull(value);
-        assertEquals("value", value);
-
-        assertTrue(latch.await(30, TimeUnit.SECONDS));
-        value = communicator.get(name, "key");
+        assertOpenEventually(latch);
+        String value = communicator.mapGet(name, key);
         assertTrue(value.isEmpty());
     }
 
     @Test
-    public void testRestSimple() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        final String name = "testRestSimple";
-        for (int i = 0; i < 100; i++) {
-            assertEquals(HttpURLConnection.HTTP_OK, communicator.put(name, String.valueOf(i), String.valueOf(i * 10)));
-        }
+    public void testQueueOfferPoll() throws Exception {
+        String name = randomName();
 
-        for (int i = 0; i < 100; i++) {
-            String actual = communicator.get(name, String.valueOf(i));
-            assertEquals(String.valueOf(i * 10), actual);
-        }
+        String item = communicator.queuePoll(name, 1);
+        assertTrue(item.isEmpty());
 
-        communicator.deleteAll(name);
+        String value = "value";
+        assertEquals(HTTP_OK, communicator.queueOffer(name, value));
 
-        for (int i = 0; i < 100; i++) {
-            String actual = communicator.get(name, String.valueOf(i));
-            assertEquals("", actual);
-        }
+        IQueue<Object> queue = instance.getQueue(name);
+        assertEquals(1, queue.size());
 
-        for (int i = 0; i < 100; i++) {
-            assertEquals(HttpURLConnection.HTTP_OK, communicator.put(name, String.valueOf(i), String.valueOf(i * 10)));
-        }
-
-        for (int i = 0; i < 100; i++) {
-            assertEquals(String.valueOf(i * 10), communicator.get(name, String.valueOf(i)));
-        }
-
-        for (int i = 0; i < 100; i++) {
-            assertEquals(HttpURLConnection.HTTP_OK, communicator.delete(name, String.valueOf(i)));
-        }
-
-        for (int i = 0; i < 100; i++) {
-            assertEquals("", communicator.get(name, String.valueOf(i)));
-        }
-
-        for (int i = 0; i < 100; i++) {
-            assertEquals(HttpURLConnection.HTTP_OK, communicator.offer(name, String.valueOf(i)));
-        }
-
-        for (int i = 0; i < 100; i++) {
-            assertEquals(String.valueOf(i), communicator.poll(name, 2));
-        }
+        assertEquals(value, communicator.queuePoll(name, 10));
+        assertTrue(queue.isEmpty());
     }
 
     @Test
-    public void testQueueSizeEmpty() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        final String name = "testQueueSizeEmpty";
-
-        IQueue queue = instance.getQueue(name);
-        Assert.assertEquals(queue.size(), communicator.size(name));
-    }
-
-    @Test
-    public void testQueueSizeNonEmpty() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        final String name = "testQueueSizeNotEmpty";
-        final int num_items = 100;
-
-        IQueue queue = instance.getQueue(name);
-
-        for (int i = 0; i < num_items; i++) {
+    public void testQueueSize() throws Exception {
+        String name = randomName();
+        IQueue<Integer> queue = instance.getQueue(name);
+        for (int i = 0; i < 10; i++) {
             queue.add(i);
         }
 
-        Assert.assertEquals(queue.size(), communicator.size(name));
+        assertEquals(queue.size(), communicator.queueSize(name));
     }
 
     @Test
-    public void testDisabledRest() throws IOException {
-        Config config = new XmlConfigBuilder().build(); //REST should be disabled by default
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        String mapName = "testMap";
-
-        try {
-            communicator.put("testMap", "1", "1");
-        } catch (SocketException ignore) {
-        }
-
-        assertEquals(0, instance.getMap(mapName).size());
-    }
-
-    @Test
-    public void testClusterShutdown() throws IOException {
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance instance3 = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance1);
-
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.shutdownCluster("dev", "dev-pass"));
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertFalse(instance1.getLifecycleService().isRunning());
-                assertFalse(instance2.getLifecycleService().isRunning());
-                assertFalse(instance3.getLifecycleService().isRunning());
-            }
-        });
-    }
-
-    @Test
-    public void testGetClusterState() throws IOException {
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
-
-        HTTPCommunicator communicator1 = new HTTPCommunicator(instance1);
-        HTTPCommunicator communicator2 = new HTTPCommunicator(instance2);
-
-        instance1.getCluster().changeClusterState(ClusterState.FROZEN);
-        assertEquals("{\"status\":\"success\",\"state\":\"frozen\"}",
-                communicator1.getClusterState("dev", "dev-pass"));
-
-        instance1.getCluster().changeClusterState(ClusterState.PASSIVE);
-        assertEquals("{\"status\":\"success\",\"state\":\"passive\"}",
-                communicator2.getClusterState("dev", "dev-pass"));
-
-    }
-
-    @Test
-    public void testChangeClusterState() throws IOException {
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance1);
-
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterState("dev", "dev-pass", "frozen"));
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(ClusterState.FROZEN, instance1.getCluster().getClusterState());
-                assertEquals(ClusterState.FROZEN, instance2.getCluster().getClusterState());
-            }
-        });
-    }
-
-    @Test
-    public void testListNodes() throws IOException {
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance1);
-        HazelcastTestSupport.waitInstanceForSafeState(instance1);
-        String result = String.format("{\"status\":\"success\" \"response\":\"[%s]\n%s\n%s\"}",
-                instance1.getCluster().getLocalMember().toString(),
-                BuildInfoProvider.getBuildInfo().getVersion(),
-                System.getProperty("java.version"));
-        assertEquals(result, communicator.listClusterNodes("dev", "dev-pass"));
-    }
-
-    @Test
-    public void testListNodesWithWrongCredentials() throws IOException {
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance1);
-        HazelcastTestSupport.waitInstanceForSafeState(instance1);
-        assertEquals("{\"status\":\"forbidden\" \"response\":\"null\"}", communicator.listClusterNodes("dev1", "dev-pass"));
-    }
-
-    @Test
-    public void testShutdownNode() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-
-        final CountDownLatch shutdownLatch = new CountDownLatch(1);
-        instance.getLifecycleService().addLifecycleListener(new LifecycleListener() {
-            @Override
-            public void stateChanged(LifecycleEvent event) {
-                if (event.getState() == LifecycleEvent.LifecycleState.SHUTDOWN) {
-                    shutdownLatch.countDown();
-                }
-            }
-        });
-
-        try {
-            assertEquals("{\"status\":\"success\"}", communicator.shutdownMember("dev", "dev-pass"));
-        } catch (ConnectException ignored) {
-            // If node shuts down before response is received,
-            // `java.net.ConnectException: Connection refused` is expected.
-        }
-
-        assertOpenEventually(shutdownLatch);
-        assertFalse(instance.getLifecycleService().isRunning());
-    }
-
-    @Test
-    public void testShutdownNodeWithWrongCredentials() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
-
-        assertEquals("{\"status\":\"forbidden\"}", communicator.shutdownMember("dev1", "dev-pass"));
-    }
-
-    @Test
-    public void syncMapOverWAN() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+    public void syncMapOverWAN() throws Exception {
         String result = communicator.syncMapOverWAN("atob", "b", "default");
         assertEquals("{\"status\":\"fail\",\"message\":\"WAN sync for map is not supported.\"}", result);
+    }
+
+    @Test
+    public void testMap_PutGet_withLargeValue() throws IOException {
+        String mapName = randomMapName();
+        String key = "key";
+        int capacity = 10000;
+        StringBuilder value = new StringBuilder(capacity);
+        while (value.length() < capacity) {
+            value.append(randomString());
+        }
+
+        int response = communicator.mapPut(mapName, key, value.toString());
+        assertEquals(HTTP_OK, response);
+
+        assertEquals(value.toString(), communicator.mapGet(mapName, key));
+    }
+
+    @Test
+    public void testMap_PutGet_withLargeKey() throws IOException {
+        String mapName = randomMapName();
+        int capacity = 5000;
+        StringBuilder key = new StringBuilder(capacity);
+        while (key.length() < capacity) {
+            key.append(randomString());
+        }
+
+        String value = "value";
+        int response = communicator.mapPut(mapName, key.toString(), value);
+        assertEquals(HTTP_OK, response);
+        assertEquals(value, communicator.mapGet(mapName, key.toString()));
     }
 }


### PR DESCRIPTION
TextReadHandler command buffer had a fixed capacity of 500 bytes.
When
- REST request is sent with a URL longer than that
- Memcached request is sent with a very long key
- Memcached bulk read request is sent with a many keys

this buffer can overflow and requests fail.

This buffer is made on-demand expandable up to 65536 bytes.

Backport of #9615
Fixes #9355