### PR TITLE
Fixes disappering map stats

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/LocalMapStatsUnderOnGoingClientUpdateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/LocalMapStatsUnderOnGoingClientUpdateTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.spi.StatisticsAwareService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LocalMapStatsUnderOnGoingClientUpdateTest extends HazelcastTestSupport {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+    private HazelcastInstance member = factory.newHazelcastInstance();
+    private HazelcastInstance client = factory.newHazelcastClient();
+    private String mapName = "test";
+
+    @After
+    public void tearDown() throws Exception {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void stats_generated_when_member_restarted_under_ongoing_client_update() throws Exception {
+        IMap map = client.getMap(mapName);
+
+        member.shutdown();
+
+        member = factory.newHazelcastInstance();
+        map.put(1, 1);
+        map.put(2, 2);
+
+        // get internal StatisticsAwareService.
+        MapService mapService = getNodeEngineImpl(member).getService(SERVICE_NAME);
+        Map<String, LocalMapStats> stats = ((StatisticsAwareService) mapService).getStats();
+        LocalMapStats localMapStats = stats.get(mapName);
+
+        // StatisticsAwareService should give right stats.
+        assertNotNull("there should be 1 LocalMapStats object", localMapStats);
+        assertEquals("Owned entry count should be 2", 2, localMapStats.getOwnedEntryCount());
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -21,10 +21,10 @@ import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.nearcache.NearCacheProvider;
 import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.partition.IPartitionService;
@@ -32,6 +32,9 @@ import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -42,23 +45,26 @@ import java.util.concurrent.TimeUnit;
  */
 public class LocalMapStatsProvider {
 
-    protected static final int WAIT_PARTITION_TABLE_UPDATE_MILLIS = 100;
-    protected static final int RETRY_COUNT = 3;
+    public static final LocalMapStats EMPTY_LOCAL_MAP_STATS = new LocalMapStatsImpl();
 
-    protected final ConcurrentMap<String, LocalMapStatsImpl> statsMap
+    private static final int RETRY_COUNT = 3;
+    private static final int WAIT_PARTITION_TABLE_UPDATE_MILLIS = 100;
+
+    private final ConcurrentMap<String, LocalMapStatsImpl> statsMap
             = new ConcurrentHashMap<String, LocalMapStatsImpl>(1000);
-    protected final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction
+    private final ConstructorFunction<String, LocalMapStatsImpl> constructorFunction
             = new ConstructorFunction<String, LocalMapStatsImpl>() {
         public LocalMapStatsImpl createNew(String key) {
             return new LocalMapStatsImpl();
         }
     };
 
-    protected final MapServiceContext mapServiceContext;
-    protected final NearCacheProvider nearCacheProvider;
-    protected final ClusterService clusterService;
-    protected final IPartitionService partitionService;
-    protected final ILogger logger;
+    private final MapServiceContext mapServiceContext;
+    private final NearCacheProvider nearCacheProvider;
+    private final ClusterService clusterService;
+    private final IPartitionService partitionService;
+    private final Address localAddress;
+    private final ILogger logger;
 
     public LocalMapStatsProvider(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
@@ -67,6 +73,7 @@ public class LocalMapStatsProvider {
         this.nearCacheProvider = mapServiceContext.getNearCacheProvider();
         this.clusterService = nodeEngine.getClusterService();
         this.partitionService = nodeEngine.getPartitionService();
+        this.localAddress = clusterService.getThisAddress();
     }
 
     public LocalMapStatsImpl getLocalMapStatsImpl(String name) {
@@ -77,48 +84,82 @@ public class LocalMapStatsProvider {
         statsMap.remove(name);
     }
 
-    public LocalMapStatsImpl createLocalMapStats(String mapName) {
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+    public LocalMapStats createLocalMapStats(String mapName) {
         LocalMapStatsImpl stats = getLocalMapStatsImpl(mapName);
-        if (!mapContainer.getMapConfig().isStatisticsEnabled()) {
-            return stats;
-        }
-        int backupCount = mapContainer.getTotalBackupCount();
-        Address thisAddress = clusterService.getThisAddress();
-
         LocalMapOnDemandCalculatedStats onDemandStats = new LocalMapOnDemandCalculatedStats();
-        onDemandStats.setBackupCount(backupCount);
+        addNearCacheStats(mapName, stats, onDemandStats);
+        updateMapOnDemandStats(mapName, onDemandStats);
 
-        addNearCacheStats(stats, onDemandStats, mapContainer);
-
-        for (int partitionId = 0; partitionId < partitionService.getPartitionCount(); partitionId++) {
-            IPartition partition = partitionService.getPartition(partitionId);
-            Address owner = partition.getOwnerOrNull();
-            if (owner == null) {
-                //no-op because no owner is set yet. Therefore we don't know anything about the map
-                continue;
-            }
-
-            if (owner.equals(thisAddress)) {
-                addOwnerPartitionStats(stats, onDemandStats, mapName, partitionId);
-            } else {
-                addReplicaPartitionStats(onDemandStats, mapName, partitionId,
-                        partition, partitionService, backupCount, thisAddress);
-            }
-        }
-
-        onDemandStats.copyValuesTo(stats);
-
-        return stats;
+        return onDemandStats.updateAndGet(stats);
     }
 
-    /**
-     * Calculates and adds owner partition stats.
-     */
-    protected void addOwnerPartitionStats(LocalMapStatsImpl stats,
-                                          LocalMapOnDemandCalculatedStats onDemandStats,
-                                          String mapName, int partitionId) {
-        RecordStore recordStore = getRecordStoreOrNull(mapName, partitionId);
+    public Map<String, LocalMapStats> createAllLocalMapStats() {
+        Map statsPerMap = new HashMap();
+
+        PartitionContainer[] partitionContainers = mapServiceContext.getPartitionContainers();
+        for (PartitionContainer partitionContainer : partitionContainers) {
+            IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId());
+            Collection<RecordStore> allRecordStores = partitionContainer.getAllRecordStores();
+
+            for (RecordStore recordStore : allRecordStores) {
+                if (!isStatisticsCalculationEnabledFor(recordStore)) {
+                    continue;
+                }
+
+                if (partition.isLocal()) {
+                    addPrimaryStatsOf(recordStore, getOrCreateOnDemandStats(statsPerMap, recordStore));
+                } else {
+                    addReplicaStatsOf(recordStore, getOrCreateOnDemandStats(statsPerMap, recordStore));
+                }
+            }
+        }
+
+        // reuse same HashMap to return calculated LocalMapStats.
+        for (Object object : statsPerMap.entrySet()) {
+            Map.Entry entry = (Map.Entry) object;
+            String mapName = ((String) entry.getKey());
+            LocalMapOnDemandCalculatedStats onDemandStats = ((LocalMapOnDemandCalculatedStats) entry.getValue());
+
+            LocalMapStatsImpl existingStats = getLocalMapStatsImpl(mapName);
+            addNearCacheStats(mapName, existingStats, onDemandStats);
+
+            LocalMapStatsImpl updatedStats = onDemandStats.updateAndGet(existingStats);
+            entry.setValue(updatedStats);
+        }
+
+        return statsPerMap;
+    }
+
+    private static boolean isStatisticsCalculationEnabledFor(RecordStore recordStore) {
+        return recordStore.getMapContainer().getMapConfig().isStatisticsEnabled();
+    }
+
+    private static LocalMapOnDemandCalculatedStats getOrCreateOnDemandStats(Map<String, Object> onDemandStats,
+                                                                            RecordStore recordStore) {
+        String mapName = recordStore.getName();
+
+        Object stats = onDemandStats.get(mapName);
+        if (stats == null) {
+            stats = new LocalMapOnDemandCalculatedStats();
+            onDemandStats.put(mapName, stats);
+        }
+        return ((LocalMapOnDemandCalculatedStats) stats);
+    }
+
+    private void updateMapOnDemandStats(String mapName, LocalMapOnDemandCalculatedStats onDemandStats) {
+        PartitionContainer[] partitionContainers = mapServiceContext.getPartitionContainers();
+        for (PartitionContainer partitionContainer : partitionContainers) {
+            IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId());
+
+            if (partition.isLocal()) {
+                addPrimaryStatsOf(partitionContainer.getExistingRecordStore(mapName), onDemandStats);
+            } else {
+                addReplicaStatsOf(partitionContainer.getExistingRecordStore(mapName), onDemandStats);
+            }
+        }
+    }
+
+    private static void addPrimaryStatsOf(RecordStore recordStore, LocalMapOnDemandCalculatedStats onDemandStats) {
         if (!hasRecords(recordStore)) {
             return;
         }
@@ -129,70 +170,56 @@ public class LocalMapStatsProvider {
         onDemandStats.incrementOwnedEntryMemoryCost(recordStore.getHeapCost());
         onDemandStats.incrementHeapCost(recordStore.getHeapCost());
         onDemandStats.incrementOwnedEntryCount(recordStore.size());
-
-        stats.setLastAccessTime(recordStore.getLastAccessTime());
-        stats.setLastUpdateTime(recordStore.getLastUpdateTime());
-    }
-
-    /**
-     * Return 1 if locked, otherwise 0.
-     * Used to find {@link LocalMapStatsImpl#lockedEntryCount}.
-     */
-    protected int isLocked(Data key, RecordStore recordStore) {
-        if (recordStore.isLocked(key)) {
-            return 1;
-        }
-        return 0;
+        onDemandStats.setLastAccessTime(recordStore.getLastAccessTime());
+        onDemandStats.setLastUpdateTime(recordStore.getLastUpdateTime());
+        onDemandStats.setBackupCount(recordStore.getMapContainer().getMapConfig().getTotalBackupCount());
     }
 
     /**
      * Calculates and adds replica partition stats.
      */
-    protected void addReplicaPartitionStats(LocalMapOnDemandCalculatedStats onDemandStats,
-                                            String mapName, int partitionId, IPartition partition,
-                                            IPartitionService partitionService, int backupCount, Address thisAddress) {
+    private void addReplicaStatsOf(RecordStore recordStore, LocalMapOnDemandCalculatedStats onDemandStats) {
+        if (!hasRecords(recordStore)) {
+            return;
+        }
+
         long backupEntryCount = 0;
         long backupEntryMemoryCost = 0;
 
-        for (int replica = 1; replica <= backupCount; replica++) {
-            Address replicaAddress = getReplicaAddress(replica, partition, partitionService, backupCount);
-            if (!isReplicaAvailable(replicaAddress, partitionService, backupCount)) {
-                printWarning(partition, replica);
+        int totalBackupCount = recordStore.getMapContainer().getTotalBackupCount();
+        for (int replicaNumber = 1; replicaNumber <= totalBackupCount; replicaNumber++) {
+            int partitionId = recordStore.getPartitionId();
+            Address replicaAddress = getReplicaAddress(partitionId, replicaNumber, totalBackupCount);
+            if (!isReplicaAvailable(replicaAddress, totalBackupCount)) {
+                printWarning(partitionId, replicaNumber);
                 continue;
             }
-            if (isReplicaOnThisNode(replicaAddress, thisAddress)) {
-                RecordStore recordStore = getRecordStoreOrNull(mapName, partitionId);
-                if (hasRecords(recordStore)) {
-                    backupEntryMemoryCost += recordStore.getHeapCost();
-                    backupEntryCount += recordStore.size();
-                }
+            if (isReplicaOnThisNode(replicaAddress)) {
+                backupEntryMemoryCost += recordStore.getHeapCost();
+                backupEntryCount += recordStore.size();
             }
         }
+
         onDemandStats.incrementHeapCost(backupEntryMemoryCost);
         onDemandStats.incrementBackupEntryMemoryCost(backupEntryMemoryCost);
         onDemandStats.incrementBackupEntryCount(backupEntryCount);
+        onDemandStats.setBackupCount(recordStore.getMapContainer().getMapConfig().getTotalBackupCount());
     }
 
-    protected boolean hasRecords(RecordStore recordStore) {
+    private static boolean hasRecords(RecordStore recordStore) {
         return recordStore != null && recordStore.size() > 0;
     }
 
-    protected boolean isReplicaAvailable(Address replicaAddress, IPartitionService partitionService, int backupCount) {
+    private boolean isReplicaAvailable(Address replicaAddress, int backupCount) {
         return !(replicaAddress == null && partitionService.getMaxAllowedBackupCount() >= backupCount);
     }
 
-    protected boolean isReplicaOnThisNode(Address replicaAddress, Address thisAddress) {
-        return replicaAddress != null && replicaAddress.equals(thisAddress);
+    private boolean isReplicaOnThisNode(Address replicaAddress) {
+        return replicaAddress != null && localAddress.equals(replicaAddress);
     }
 
-    protected void printWarning(IPartition partition, int replica) {
-        logger.warning("Partition: " + partition + ", replica: " + replica + " has no owner!");
-    }
-
-
-    protected RecordStore getRecordStoreOrNull(String mapName, int partitionId) {
-        final PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(partitionId);
-        return partitionContainer.getExistingRecordStore(mapName);
+    private void printWarning(int partitionId, int replica) {
+        logger.warning("partitionId: " + partitionId + ", replica: " + replica + " has no owner!");
     }
 
     /**
@@ -200,11 +227,11 @@ public class LocalMapStatsProvider {
      *
      * @see #waitForReplicaAddress
      */
-    protected Address getReplicaAddress(int replica, IPartition partition, IPartitionService partitionService,
-                                        int backupCount) {
-        Address replicaAddress = partition.getReplicaAddress(replica);
+    private Address getReplicaAddress(int partitionId, int replicaNumber, int backupCount) {
+        IPartition partition = partitionService.getPartition(partitionId);
+        Address replicaAddress = partition.getReplicaAddress(replicaNumber);
         if (replicaAddress == null) {
-            replicaAddress = waitForReplicaAddress(replica, partition, partitionService, backupCount);
+            replicaAddress = waitForReplicaAddress(replicaNumber, partition, backupCount);
         }
         return replicaAddress;
     }
@@ -212,8 +239,7 @@ public class LocalMapStatsProvider {
     /**
      * Waits partition table update to get replica address if current replica address is null.
      */
-    protected Address waitForReplicaAddress(int replica, IPartition partition, IPartitionService partitionService,
-                                            int backupCount) {
+    private Address waitForReplicaAddress(int replica, IPartition partition, int backupCount) {
         int tryCount = RETRY_COUNT;
         Address replicaAddress = null;
         while (replicaAddress == null && partitionService.getMaxAllowedBackupCount() >= backupCount && tryCount-- > 0) {
@@ -223,7 +249,7 @@ public class LocalMapStatsProvider {
         return replicaAddress;
     }
 
-    protected void sleep() {
+    private static void sleep() {
         try {
             TimeUnit.MILLISECONDS.sleep(WAIT_PARTITION_TABLE_UPDATE_MILLIS);
         } catch (InterruptedException e) {
@@ -231,37 +257,34 @@ public class LocalMapStatsProvider {
         }
     }
 
-    /**
-     * Adds near cache stats.
-     */
-    protected void addNearCacheStats(LocalMapStatsImpl stats,
-                                     LocalMapOnDemandCalculatedStats onDemandStats, MapContainer mapContainer) {
-        if (!mapContainer.getMapConfig().isNearCacheEnabled()) {
+    private void addNearCacheStats(String mapName, LocalMapStatsImpl localMapStats,
+                                   LocalMapOnDemandCalculatedStats onDemandStats) {
+
+        NearCache nearCache = nearCacheProvider.getOrNullNearCache(mapName);
+        if (nearCache == null) {
             return;
         }
-        NearCache nearCache = nearCacheProvider.getOrCreateNearCache(mapContainer.getName());
-        NearCacheStats nearCacheStats = nearCache.getNearCacheStats();
-        long nearCacheHeapCost = mapContainer.getNearCacheSizeEstimator().getSize();
 
-        stats.setNearCacheStats(nearCacheStats);
-        onDemandStats.incrementHeapCost(nearCacheHeapCost);
+        NearCacheStats nearCacheStats = nearCache.getNearCacheStats();
+
+        localMapStats.setNearCacheStats(nearCacheStats);
+        onDemandStats.incrementHeapCost(nearCacheStats.getOwnedEntryMemoryCost());
     }
 
-    protected static class LocalMapOnDemandCalculatedStats {
+    private static class LocalMapOnDemandCalculatedStats {
 
-        protected long hits;
-
-        protected long ownedEntryCount;
-        protected long backupEntryCount;
-        protected long ownedEntryMemoryCost;
-        protected long backupEntryMemoryCost;
-        /**
-         * Holds total heap cost of map & near-cache & backups.
-         */
-        protected long heapCost;
-        protected long lockedEntryCount;
-        protected long dirtyEntryCount;
-        protected int backupCount;
+        private int backupCount;
+        private long hits;
+        private long ownedEntryCount;
+        private long backupEntryCount;
+        private long ownedEntryMemoryCost;
+        private long backupEntryMemoryCost;
+        // Holds total heap cost of map & Near Cache & backups
+        private long heapCost;
+        private long lockedEntryCount;
+        private long dirtyEntryCount;
+        private long lastAccessTime;
+        private long lastUpdateTime;
 
         public void setBackupCount(int backupCount) {
             this.backupCount = backupCount;
@@ -299,7 +322,7 @@ public class LocalMapStatsProvider {
             this.heapCost += heapCost;
         }
 
-        public void copyValuesTo(LocalMapStatsImpl stats) {
+        public LocalMapStatsImpl updateAndGet(LocalMapStatsImpl stats) {
             stats.setBackupCount(backupCount);
             stats.setHits(hits);
             stats.setOwnedEntryCount(ownedEntryCount);
@@ -309,8 +332,21 @@ public class LocalMapStatsProvider {
             stats.setHeapCost(heapCost);
             stats.setLockedEntryCount(lockedEntryCount);
             stats.setDirtyEntryCount(dirtyEntryCount);
+            stats.setLastAccessTime(lastAccessTime);
+            stats.setLastUpdateTime(lastUpdateTime);
+            return stats;
         }
 
-    }
+        public void setLastAccessTime(long lastAccessTime) {
+            if (lastAccessTime > this.lastAccessTime) {
+                this.lastAccessTime = lastAccessTime;
+            }
+        }
 
+        public void setLastUpdateTime(long lastUpdateTime) {
+            if (lastUpdateTime > this.lastUpdateTime) {
+                this.lastUpdateTime = lastUpdateTime;
+            }
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -149,4 +149,5 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     void removePartitioningStrategyFromCache(String mapName);
 
+    PartitionContainer[] getPartitionContainers();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -611,4 +611,9 @@ class MapServiceContextImpl implements MapServiceContext {
     public void removePartitioningStrategyFromCache(String mapName) {
         partitioningStrategyFactory.removePartitioningStrategyFromCache(mapName);
     }
+
+    @Override
+    public PartitionContainer[] getPartitionContainers() {
+        return partitionContainers;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapStatisticsAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapStatisticsAwareService.java
@@ -16,13 +16,9 @@
 
 package com.hazelcast.map.impl;
 
-import com.hazelcast.core.DistributedObject;
 import com.hazelcast.monitor.LocalMapStats;
-import com.hazelcast.spi.ProxyService;
 import com.hazelcast.spi.StatisticsAwareService;
-import com.hazelcast.util.MapUtil;
 
-import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -35,22 +31,14 @@ import java.util.Map;
 class MapStatisticsAwareService implements StatisticsAwareService {
 
     private final MapServiceContext mapServiceContext;
-    private final ProxyService proxyService;
 
     MapStatisticsAwareService(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
-        this.proxyService = mapServiceContext.getNodeEngine().getProxyService();
     }
 
     @Override
     public Map<String, LocalMapStats> getStats() {
-        MapServiceContext mapServiceContext = this.mapServiceContext;
-        Collection<DistributedObject> mapProxies = proxyService.getDistributedObjects(MapService.SERVICE_NAME);
-        Map<String, LocalMapStats> mapStats = MapUtil.createHashMap(mapProxies.size());
-        for (DistributedObject mapProxy : mapProxies) {
-            LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
-            mapStats.put(mapProxy.getName(), localMapStatsProvider.createLocalMapStats(mapProxy.getName()));
-        }
-        return mapStats;
+        LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
+        return localMapStatsProvider.createAllLocalMapStats();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/NearCacheProvider.java
@@ -81,7 +81,7 @@ public class NearCacheProvider {
         return ConcurrencyUtil.getOrPutIfAbsent(nearCacheMap, mapName, nearCacheConstructor);
     }
 
-    NearCache getOrNullNearCache(String mapName) {
+    public NearCache getOrNullNearCache(String mapName) {
         return nearCacheMap.get(mapName);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -107,6 +107,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.LITE_MEMBER_SELECTOR;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.NON_LOCAL_MEMBER_SELECTOR;
 import static com.hazelcast.config.MapIndexConfig.validateIndexAttribute;
+import static com.hazelcast.map.impl.LocalMapStatsProvider.EMPTY_LOCAL_MAP_STATS;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
@@ -1106,6 +1107,9 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     }
 
     public LocalMapStats getLocalMapStats() {
+        if (!mapConfig.isStatisticsEnabled()) {
+            return EMPTY_LOCAL_MAP_STATS;
+        }
         return mapServiceContext.getLocalMapStatsProvider().createLocalMapStats(name);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapStatisticsAwareServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapStatisticsAwareServiceTest.java
@@ -39,11 +39,11 @@ import static org.junit.Assert.assertNotNull;
 public class MapStatisticsAwareServiceTest extends HazelcastTestSupport {
 
     @Test
-    public void getStats() {
+    public void getStats_whenMapHasData() {
         HazelcastInstance hz = createHazelcastInstance();
         warmUpPartitions(hz);
         // when one map exists
-        hz.getMap("map");
+        hz.getMap("map").put(1, 1);
         MapService mapService = getNodeEngineImpl(hz).getService(MapService.SERVICE_NAME);
         Map<String, LocalMapStats> mapStats = mapService.getStats();
 


### PR DESCRIPTION
__problem:__ If there is no map proxy, stats are not generated. This can be happen if one restarts member and if there is an ongoing update from previously connected client. In this case, since client proxy is not re-created upon member restart, stats collection over map proxy cannot be done.

__fix:__ Stats are collected over recordStores instead of map proxy.

fixes #9590