### PR TITLE
Synchronize default config values and fix xml generator

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
@@ -261,7 +261,7 @@
                                             Number of items in the ringbuffer. If no time-to-live-seconds is set, the size will
                                             always
                                             be equal to capacity after the head completed the first loop around the ring. This is
-                                            because no items are getting retired.
+                                            because no items are getting retired. The default value is 10000.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -1206,7 +1206,7 @@
                                     <xs:annotation>
                                         <xs:documentation>
                                             The queue-size defines the maximum number of tasks are able to wait to be
-                                            processed. A value of 0 means unbounded queue.
+                                            processed. A value of 0 means number of partitions * 2.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -1376,7 +1376,8 @@
                             maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                            DataSerializableFactory class to be registered.
+                            Custom classes implementing com.hazelcast.nio.serialization.DataSerializableFactory to be registered.
+                            These can be used to speed up serialization/deserialization of objects.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -17,7 +17,6 @@
 package com.hazelcast.config;
 
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -25,20 +24,17 @@ import com.hazelcast.logging.Logger;
 import java.io.File;
 import java.net.URL;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static java.text.MessageFormat.format;
 
 /**
  * Contains all the configuration to start a {@link com.hazelcast.core.HazelcastInstance}. A Config
@@ -1346,7 +1342,7 @@ public class Config {
         return this;
     }
 
-    private <T> T lookupByPattern(Map<String, T> configPatterns, String itemName) {
+    <T> T lookupByPattern(Map<String, T> configPatterns, String itemName) {
         T candidate = configPatterns.get(itemName);
         if (candidate != null) {
             return candidate;
@@ -1359,44 +1355,6 @@ public class Config {
             LOGGER.finest("No configuration found for " + itemName + ", using default config!");
         }
         return null;
-    }
-
-    // TODO: This mechanism isn't used anymore to determine if 2 HZ configurations are compatible.
-    // See {@link ConfigCheck} for more information.
-
-    /**
-     * Checks if a {@link Config} matches the group configuration.
-     *
-     * @param config the {@link Config} to check
-     * @return {@code true} if config is compatible with this one, {@code false} if config belongs to another group
-     * @throws RuntimeException if map, queue, topic configs are incompatible
-     */
-    public boolean isCompatible(final Config config) {
-        if (config == null) {
-            throw new IllegalArgumentException("Expected not null config");
-        }
-        if (!this.groupConfig.getName().equals(config.getGroupConfig().getName())) {
-            return false;
-        }
-        if (!this.groupConfig.getPassword().equals(config.getGroupConfig().getPassword())) {
-            throw new HazelcastException("Incompatible group password");
-        }
-        checkMapConfigCompatible(config);
-        return true;
-    }
-
-    private void checkMapConfigCompatible(final Config config) {
-        Set<String> mapConfigNames = new HashSet<String>(mapConfigs.keySet());
-        mapConfigNames.addAll(config.mapConfigs.keySet());
-        for (final String name : mapConfigNames) {
-            final MapConfig thisMapConfig = lookupByPattern(mapConfigs, name);
-            final MapConfig thatMapConfig = lookupByPattern(config.mapConfigs, name);
-            if (thisMapConfig != null && thatMapConfig != null
-                    && !thisMapConfig.isCompatible(thatMapConfig)) {
-                throw new HazelcastException(format("Incompatible map config this:\n{0}\nanother:\n{1}",
-                        thisMapConfig, thatMapConfig));
-            }
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -842,25 +842,6 @@ public class MapConfig {
         return cacheDeserializedValues;
     }
 
-    public boolean isCompatible(MapConfig other) {
-        if (this == other) {
-            return true;
-        }
-        return other != null
-                && (this.name != null ? this.name.equals(other.name) : other.name == null)
-                && this.backupCount == other.backupCount
-                && this.asyncBackupCount == other.asyncBackupCount
-                && this.evictionPercentage == other.evictionPercentage
-                && this.minEvictionCheckMillis == other.minEvictionCheckMillis
-                && this.maxIdleSeconds == other.maxIdleSeconds
-                && (this.maxSizeConfig.getSize() == other.maxSizeConfig.getSize()
-                || (Math.min(maxSizeConfig.getSize(), other.maxSizeConfig.getSize()) == 0
-                && Math.max(maxSizeConfig.getSize(), other.maxSizeConfig.getSize()) == Integer.MAX_VALUE))
-                && this.timeToLiveSeconds == other.timeToLiveSeconds
-                && this.hotRestartConfig.isEnabled() == other.hotRestartConfig.isEnabled()
-                && this.readBackupData == other.readBackupData;
-    }
-
     public String getQuorumName() {
         return quorumName;
     }

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -1099,7 +1099,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         The maximum size of the queue; the maximum number of tasks that can wait to be processed. A
-                        value of 0 means an unbounded queue.
+                        value of 0 means number of partitions * 2.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -1228,7 +1228,7 @@
                     <xs:documentation>
                         Number of items in the ringbuffer. If no time-to-live-seconds is set, the size will always
                         be equal to capacity after the head completed the first loop around the ring. This is
-                        because no items are getting retired.
+                        because no items are getting retired. The default value is 10000.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -1489,7 +1489,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="loopbackModeEnabled" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="loopbackModeEnabled" type="xs:boolean" use="optional" default="false"/>
     </xs:complexType>
     <xs:complexType name="aws">
         <xs:all>
@@ -1690,7 +1690,7 @@
         <xs:attribute name="name" type="xs:string" use="optional" default="default">
             <xs:annotation>
                 <xs:documentation>
-                    Name of the executor task.
+                    Name of the durable executor.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -1712,7 +1712,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="capacity" type="xs:unsignedShort" default="100">
+            <xs:element name="capacity" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="100">
                 <xs:annotation>
                     <xs:documentation>
                         The maximum number of tasks that a scheduler can have at any given point
@@ -2581,7 +2581,8 @@
                                     maxOccurs="unbounded">
                             <xs:annotation>
                                 <xs:documentation>
-                                    PortableFactory class to be registered.
+                                    Custom classes implementing com.hazelcast.nio.serialization.DataSerializableFactory to be
+                                    registered. These can be used to speed up serialization/deserialization of objects.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:element>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -17,7 +17,7 @@
 
 <!--
     The default Hazelcast configuration. This is used when no hazelcast.xml is present.
-    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.7.xsd
+    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.8.xsd
     or the documentation at https://hazelcast.org/documentation/
 -->
 <hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.8.xsd"

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1273,7 +1273,7 @@ It has the following sub-elements:
     * <max-thread-size>: 
 	Maximum thread pool size of the JobTracker. Its default value is 0.
     * <queue-size>:
-    	Maximum number of tasks that can wait to be processed. A value of 0 means an unbounded queue. 
+    	Maximum number of tasks that can wait to be processed. A value of 0 means number of partitions * 2.
     	Very low numbers can prevent successful execution since job might not be correctly scheduled or intermediate 
     	chunks might be lost. Its default value is 0.
     * <retry-count>:
@@ -1372,7 +1372,7 @@ It has the following sub-elements:
 
     <ringbuffer name="default">
         <capacity>10000</capacity>
-        <time-to-live-seconds>30</time-to-live-seconds>
+        <time-to-live-seconds>0</time-to-live-seconds>
         <backup-count>1</backup-count>
         <async-backup-count>0</async-backup-count>
         <in-memory-format>BINARY</in-memory-format>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1,0 +1,861 @@
+package com.hazelcast.config;
+
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
+import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.util.CollectionUtil;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import static java.text.MessageFormat.format;
+
+class ConfigCompatibilityChecker {
+
+    /**
+     * Checks if two {@link Config}'s are compatible. This mostly means that the config values will have the same
+     * impact on the behaviour of the system but are not necessarily the same (e.g. null value is sometimes the same
+     * as an empty collection or a disabled config).
+     * NOTE : This method checks MOST but NOT ALL configuration. As such it is best used in test scenarios to cover
+     * as much config checks as possible automatically.
+     *
+     * @param c1 the {@link Config} to check
+     * @param c2 the {@link Config} to check
+     * @return {@code true} if the configs are compatible
+     * @throws HazelcastException       if configs are incompatible
+     * @throws IllegalArgumentException if one of the configs is {@code null}
+     */
+    static boolean isCompatible(final Config c1, final Config c2) {
+        if (c1 == c2) {
+            return true;
+        }
+        if (c1 == null || c2 == null) {
+            throw new IllegalArgumentException("One of the two configs is null");
+        }
+        if (!c1.getGroupConfig().getName().equals(c2.getGroupConfig().getName())) {
+            return false;
+        }
+        if (!c1.getGroupConfig().getPassword().equals(c2.getGroupConfig().getPassword())) {
+            throw new HazelcastException("Incompatible group password");
+        }
+        checkCompatibleConfigs("partition group", c1.getPartitionGroupConfig(), c2.getPartitionGroupConfig(), new PartitionGroupConfigChecker());
+        checkCompatibleConfigs("serialization", c1.getSerializationConfig(), c2.getSerializationConfig(), new SerializationConfigChecker());
+        checkCompatibleConfigs("services", c1.getServicesConfig(), c2.getServicesConfig(), new ServicesConfigChecker());
+        checkCompatibleConfigs("management center", c1.getManagementCenterConfig(), c2.getManagementCenterConfig(), new ManagementCenterConfigChecker());
+        checkCompatibleConfigs("hot restart", c1.getHotRestartPersistenceConfig(), c2.getHotRestartPersistenceConfig(), new HotRestartConfigChecker());
+        checkCompatibleConfigs("network", c1.getNetworkConfig(), c2.getNetworkConfig(), new NetworkConfigChecker());
+        checkCompatibleConfigs("map", c1, c2, c1.getMapConfigs(), c2.getMapConfigs(), new MapConfigChecker());
+        checkCompatibleConfigs("ringbuffer", c1, c2, c1.getRingbufferConfigs(), c2.getRingbufferConfigs(), new RingbufferConfigChecker());
+        checkCompatibleConfigs("queue", c1, c2, c1.getQueueConfigs(), c2.getQueueConfigs(), new QueueConfigChecker());
+        checkCompatibleConfigs("semaphore", c1, c2, getSemaphoreConfigsByName(c1), getSemaphoreConfigsByName(c2), new SemaphoreConfigChecker());
+        checkCompatibleConfigs("lock", c1, c2, c1.getLockConfigs(), c2.getLockConfigs(), new LockConfigChecker());
+        checkCompatibleConfigs("topic", c1, c2, c1.getTopicConfigs(), c2.getTopicConfigs(), new TopicConfigChecker());
+        checkCompatibleConfigs("reliable topic", c1, c2, c1.getReliableTopicConfigs(), c2.getReliableTopicConfigs(), new ReliableTopicConfigChecker());
+        checkCompatibleConfigs("cache", c1, c2, c1.getCacheConfigs(), c2.getCacheConfigs(), new CacheSimpleConfigChecker());
+        checkCompatibleConfigs("executor", c1, c2, c1.getExecutorConfigs(), c2.getExecutorConfigs(), new ExecutorConfigChecker());
+        checkCompatibleConfigs("durable executor", c1, c2, c1.getDurableExecutorConfigs(), c2.getDurableExecutorConfigs(), new DurableExecutorConfigChecker());
+        checkCompatibleConfigs("scheduled executor", c1, c2, c1.getScheduledExecutorConfigs(), c2.getScheduledExecutorConfigs(), new ScheduledExecutorConfigChecker());
+        checkCompatibleConfigs("multimap", c1, c2, c1.getMultiMapConfigs(), c2.getMultiMapConfigs(), new MultimapConfigChecker());
+        checkCompatibleConfigs("list", c1, c2, c1.getListConfigs(), c2.getListConfigs(), new ListConfigChecker());
+        checkCompatibleConfigs("set", c1, c2, c1.getSetConfigs(), c2.getSetConfigs(), new SetConfigChecker());
+        checkCompatibleConfigs("job tracker", c1, c2, c1.getJobTrackerConfigs(), c2.getJobTrackerConfigs(), new JobTrackerConfigChecker());
+
+        return true;
+    }
+
+    private static Map<String, SemaphoreConfig> getSemaphoreConfigsByName(Config c) {
+        final Collection<SemaphoreConfig> semaphoreConfigs = c.getSemaphoreConfigs();
+        final HashMap<String, SemaphoreConfig> configsByName = new HashMap<String, SemaphoreConfig>(semaphoreConfigs.size());
+        for (SemaphoreConfig config : semaphoreConfigs) {
+            configsByName.put(config.getName(), config);
+        }
+        return configsByName;
+    }
+
+    private static <T> void checkCompatibleConfigs(String type, T c1, T c2, ConfigChecker<T> checker) {
+        if (!checker.check(c1, c2)) {
+            throw new HazelcastException(format("Incompatible " + type + " config :\n{0}\n vs \n{1}", c1, c2));
+        }
+    }
+
+    private static <T> void checkCompatibleConfigs(
+            String type, Config c1, Config c2,
+            Map<String, T> configs1, Map<String, T> configs2, ConfigChecker<T> checker) {
+
+        final Set<String> configNames = new HashSet<String>(configs1.keySet());
+        configNames.addAll(configs2.keySet());
+
+        for (final String name : configNames) {
+            final T config1 = c1.lookupByPattern(configs1, name);
+            final T config2 = c2.lookupByPattern(configs2, name);
+            if (config1 != null && config2 != null && !checker.check(config1, config2)) {
+                throw new HazelcastException(format("Incompatible " + type + " config :\n{0}\n vs \n{1}",
+                        config1, config2));
+            }
+        }
+        final T config1 = checker.getDefault(c1);
+        final T config2 = checker.getDefault(c2);
+        if (!checker.check(config1, config2)) {
+            throw new HazelcastException(format("Incompatible default " + type + " config :\n{0}\n vs \n{1}",
+                    config1, config2));
+        }
+    }
+
+    private abstract static class ConfigChecker<T> {
+        abstract boolean check(T t1, T t2);
+
+        T getDefault(Config c) {
+            return null;
+        }
+    }
+
+    private static boolean nullSafeEqual(Object a, Object b) {
+        return (a == b) || (a != null && a.equals(b));
+    }
+
+    private static <T> boolean isCollectionCompatible(Collection<T> c1, Collection<T> c2, ConfigChecker<T> checker) {
+        if (c1 == c2) {
+            return true;
+        }
+        if (c1 == null || c2 == null || c1.size() != c2.size()) {
+            return false;
+        }
+
+        final Iterator<T> i1 = c1.iterator();
+        final Iterator<T> i2 = c2.iterator();
+        while (i1.hasNext() && i2.hasNext()) {
+            final T config1 = i1.next();
+            final T config2 = i2.next();
+            if (!checker.check(config1, config2)) {
+                return false;
+            }
+        }
+        return !(i1.hasNext() || i2.hasNext());
+    }
+
+    private static boolean isCompatible(HotRestartConfig c1, HotRestartConfig c2) {
+        final boolean c1Disabled = c1 == null || !c1.isEnabled();
+        final boolean c2Disabled = c2 == null || !c2.isEnabled();
+        return c1 == c2 || (c1Disabled && c2Disabled) ||
+                (c1 != null && c2 != null && nullSafeEqual(c1.isFsync(), c2.isFsync()));
+    }
+
+    // CONFIG CHECKERS
+    private static class RingbufferConfigChecker extends ConfigChecker<RingbufferConfig> {
+        @Override
+        boolean check(RingbufferConfig c1, RingbufferConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getBackupCount(), c2.getBackupCount())
+                    && nullSafeEqual(c1.getAsyncBackupCount(), c2.getAsyncBackupCount())
+                    && nullSafeEqual(c1.getCapacity(), c2.getCapacity())
+                    && nullSafeEqual(c1.getTimeToLiveSeconds(), c2.getTimeToLiveSeconds())
+                    && nullSafeEqual(c1.getInMemoryFormat(), c2.getInMemoryFormat())
+                    && isCompatible(c1.getRingbufferStoreConfig(), c2.getRingbufferStoreConfig());
+        }
+
+        private static boolean isCompatible(RingbufferStoreConfig c1, RingbufferStoreConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getClassName(), c2.getClassName())
+                            && nullSafeEqual(c1.getFactoryClassName(), c2.getFactoryClassName())
+                            && nullSafeEqual(c1.getProperties(), c2.getProperties()));
+        }
+
+        @Override
+        RingbufferConfig getDefault(Config c) {
+            return c.getRingbufferConfig("default");
+        }
+    }
+
+    private static class QueueConfigChecker extends ConfigChecker<QueueConfig> {
+        @Override
+        boolean check(QueueConfig c1, QueueConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getItemListenerConfigs(), c2.getItemListenerConfigs())
+                    && nullSafeEqual(c1.getBackupCount(), c2.getBackupCount())
+                    && nullSafeEqual(c1.getAsyncBackupCount(), c2.getAsyncBackupCount())
+                    && nullSafeEqual(c1.getMaxSize(), c2.getMaxSize())
+                    && nullSafeEqual(c1.getEmptyQueueTtl(), c2.getEmptyQueueTtl())
+                    && isCompatible(c1.getQueueStoreConfig(), c2.getQueueStoreConfig())
+                    && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
+                    && nullSafeEqual(c1.getQuorumName(), c2.getQuorumName());
+        }
+
+        private static boolean isCompatible(QueueStoreConfig c1, QueueStoreConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getClassName(), c2.getClassName())
+                            && nullSafeEqual(c1.getFactoryClassName(), c2.getFactoryClassName())
+                            && nullSafeEqual(c1.getProperties(), c2.getProperties()));
+        }
+
+        @Override
+        QueueConfig getDefault(Config c) {
+            return c.getQueueConfig("default");
+        }
+    }
+
+    private static class SemaphoreConfigChecker extends ConfigChecker<SemaphoreConfig> {
+        @Override
+        boolean check(SemaphoreConfig c1, SemaphoreConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getBackupCount(), c2.getBackupCount())
+                    && nullSafeEqual(c1.getAsyncBackupCount(), c2.getAsyncBackupCount())
+                    && nullSafeEqual(c1.getInitialPermits(), c2.getInitialPermits());
+        }
+
+        @Override
+        SemaphoreConfig getDefault(Config c) {
+            return c.getSemaphoreConfig("default");
+        }
+    }
+
+    private static class LockConfigChecker extends ConfigChecker<LockConfig> {
+        @Override
+        boolean check(LockConfig c1, LockConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getQuorumName(), c2.getQuorumName());
+        }
+
+        @Override
+        LockConfig getDefault(Config c) {
+            return c.getLockConfig("default");
+        }
+    }
+
+    private static class SetConfigChecker extends ConfigChecker<SetConfig> {
+        @Override
+        boolean check(SetConfig c1, SetConfig c2) {
+            return isCompatible(c1, c2);
+        }
+
+        @Override
+        SetConfig getDefault(Config c) {
+            return c.getSetConfig("default");
+        }
+    }
+
+    private static class ListConfigChecker extends ConfigChecker<ListConfig> {
+        @Override
+        boolean check(ListConfig c1, ListConfig c2) {
+            return isCompatible(c1, c2);
+        }
+
+        @Override
+        ListConfig getDefault(Config c) {
+            return c.getListConfig("default");
+        }
+    }
+
+    private static boolean isCompatible(CollectionConfig c1, CollectionConfig c2) {
+        return c1 == c2 || !(c1 == null || c2 == null)
+                && nullSafeEqual(c1.getName(), c2.getName())
+                && nullSafeEqual(c1.getItemListenerConfigs(), c2.getItemListenerConfigs())
+                && nullSafeEqual(c1.getBackupCount(), c2.getBackupCount())
+                && nullSafeEqual(c1.getAsyncBackupCount(), c2.getAsyncBackupCount())
+                && nullSafeEqual(c1.getMaxSize(), c2.getMaxSize())
+                && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled());
+    }
+
+    private static class TopicConfigChecker extends ConfigChecker<TopicConfig> {
+        @Override
+        boolean check(TopicConfig c1, TopicConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.isGlobalOrderingEnabled(), c2.isGlobalOrderingEnabled())
+                    && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
+                    && nullSafeEqual(c1.isMultiThreadingEnabled(), c2.isMultiThreadingEnabled())
+                    && nullSafeEqual(c1.getMessageListenerConfigs(), c2.getMessageListenerConfigs());
+        }
+
+        @Override
+        TopicConfig getDefault(Config c) {
+            return c.getTopicConfig("default");
+        }
+    }
+
+    private static class ReliableTopicConfigChecker extends ConfigChecker<ReliableTopicConfig> {
+        @Override
+        boolean check(ReliableTopicConfig c1, ReliableTopicConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getReadBatchSize(), c2.getReadBatchSize())
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
+                    && nullSafeEqual(c1.getMessageListenerConfigs(), c2.getMessageListenerConfigs())
+                    && nullSafeEqual(c1.getTopicOverloadPolicy(), c2.getTopicOverloadPolicy());
+        }
+
+        @Override
+        ReliableTopicConfig getDefault(Config c) {
+            return c.getReliableTopicConfig("default");
+        }
+    }
+
+    private static class ExecutorConfigChecker extends ConfigChecker<ExecutorConfig> {
+        @Override
+        boolean check(ExecutorConfig c1, ExecutorConfig c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null) {
+                return false;
+            }
+            final int cap1 = c1.getQueueCapacity();
+            final int cap2 = c2.getQueueCapacity();
+            return nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getPoolSize(), c2.getPoolSize())
+                    && (nullSafeEqual(cap1, cap2) || (Math.min(cap1, cap2) == 0 && Math.max(cap1, cap2) == Integer.MAX_VALUE))
+                    && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled());
+        }
+
+        @Override
+        ExecutorConfig getDefault(Config c) {
+            return c.getExecutorConfig("default");
+        }
+    }
+
+    private static class DurableExecutorConfigChecker extends ConfigChecker<DurableExecutorConfig> {
+        @Override
+        boolean check(DurableExecutorConfig c1, DurableExecutorConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getPoolSize(), c2.getPoolSize())
+                    && nullSafeEqual(c1.getDurability(), c2.getDurability())
+                    && nullSafeEqual(c1.getCapacity(), c2.getCapacity());
+        }
+
+        @Override
+        DurableExecutorConfig getDefault(Config c) {
+            return c.getDurableExecutorConfig("default");
+        }
+    }
+
+    private static class ScheduledExecutorConfigChecker extends ConfigChecker<ScheduledExecutorConfig> {
+        @Override
+        boolean check(ScheduledExecutorConfig c1, ScheduledExecutorConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getDurability(), c2.getDurability())
+                    && nullSafeEqual(c1.getPoolSize(), c2.getPoolSize());
+        }
+
+        @Override
+        ScheduledExecutorConfig getDefault(Config c) {
+            return c.getScheduledExecutorConfig("default");
+        }
+    }
+
+    private static class MultimapConfigChecker extends ConfigChecker<MultiMapConfig> {
+        @Override
+        boolean check(MultiMapConfig c1, MultiMapConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getValueCollectionType(), c2.getValueCollectionType())
+                    && nullSafeEqual(c1.getEntryListenerConfigs(), c2.getEntryListenerConfigs())
+                    && nullSafeEqual(c1.isBinary(), c2.isBinary())
+                    && nullSafeEqual(c1.getBackupCount(), c2.getBackupCount())
+                    && nullSafeEqual(c1.getAsyncBackupCount(), c2.getAsyncBackupCount())
+                    && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled());
+        }
+
+        @Override
+        MultiMapConfig getDefault(Config c) {
+            return c.getMultiMapConfig("default");
+        }
+    }
+
+    private static class JobTrackerConfigChecker extends ConfigChecker<JobTrackerConfig> {
+        @Override
+        boolean check(JobTrackerConfig c1, JobTrackerConfig c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null) {
+                return false;
+            }
+            final int max1 = c1.getMaxThreadSize();
+            final int max2 = c2.getMaxThreadSize();
+            return nullSafeEqual(c1.getName(), c2.getName())
+                    && (nullSafeEqual(max1, max2) || (Math.min(max1, max2) == 0 && Math.max(max1, max2) == Runtime.getRuntime().availableProcessors()))
+                    && nullSafeEqual(c1.getRetryCount(), c2.getRetryCount())
+                    && nullSafeEqual(c1.getChunkSize(), c2.getChunkSize())
+                    && nullSafeEqual(c1.getQueueSize(), c2.getQueueSize())
+                    && nullSafeEqual(c1.isCommunicateStats(), c2.isCommunicateStats())
+                    && nullSafeEqual(c1.getTopologyChangedStrategy(), c2.getTopologyChangedStrategy());
+        }
+
+        @Override
+        JobTrackerConfig getDefault(Config c) {
+            return c.getJobTrackerConfig("default");
+        }
+    }
+
+    private static class CacheSimpleConfigChecker extends ConfigChecker<CacheSimpleConfig> {
+        @Override
+        boolean check(CacheSimpleConfig c1, CacheSimpleConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getKeyType(), c2.getKeyType())
+                    && nullSafeEqual(c1.getValueType(), c2.getValueType())
+                    && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
+                    && nullSafeEqual(c1.isManagementEnabled(), c2.isManagementEnabled())
+                    && nullSafeEqual(c1.isReadThrough(), c2.isReadThrough())
+                    && nullSafeEqual(c1.isWriteThrough(), c2.isWriteThrough())
+                    && nullSafeEqual(c1.getCacheLoaderFactory(), c2.getCacheLoaderFactory())
+                    && nullSafeEqual(c1.getCacheWriterFactory(), c2.getCacheWriterFactory())
+                    && nullSafeEqual(c1.getCacheLoader(), c2.getCacheLoader())
+                    && nullSafeEqual(c1.getCacheWriter(), c2.getCacheWriter())
+                    && isCompatible(c1.getExpiryPolicyFactoryConfig(), c2.getExpiryPolicyFactoryConfig())
+                    && isCollectionCompatible(c1.getCacheEntryListeners(), c2.getCacheEntryListeners(), new CacheSimpleEntryListenerConfigChecker())
+                    && nullSafeEqual(c1.getAsyncBackupCount(), c2.getAsyncBackupCount())
+                    && nullSafeEqual(c1.getBackupCount(), c2.getBackupCount())
+                    && nullSafeEqual(c1.getInMemoryFormat(), c2.getInMemoryFormat())
+                    && isCompatible(c1.getEvictionConfig(), c2.getEvictionConfig())
+                    && isCompatible(c1.getWanReplicationRef(), c2.getWanReplicationRef())
+                    && nullSafeEqual(c1.getQuorumName(), c2.getQuorumName())
+                    && nullSafeEqual(c1.getPartitionLostListenerConfigs(), c2.getPartitionLostListenerConfigs())
+                    && nullSafeEqual(c1.getMergePolicy(), c2.getMergePolicy())
+                    && ConfigCompatibilityChecker.isCompatible(c1.getHotRestartConfig(), c2.getHotRestartConfig());
+        }
+
+        private static boolean isCompatible(ExpiryPolicyFactoryConfig c1, ExpiryPolicyFactoryConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getClassName(), c2.getClassName())
+                    && isCompatible(c1.getTimedExpiryPolicyFactoryConfig(), c2.getTimedExpiryPolicyFactoryConfig());
+        }
+
+        private static boolean isCompatible(TimedExpiryPolicyFactoryConfig c1, TimedExpiryPolicyFactoryConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getExpiryPolicyType(), c2.getExpiryPolicyType())
+                    && isCompatible(c1.getDurationConfig(), c2.getDurationConfig());
+        }
+
+        private static boolean isCompatible(DurationConfig c1, DurationConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getDurationAmount(), c2.getDurationAmount())
+                    && nullSafeEqual(c1.getTimeUnit(), c2.getTimeUnit());
+        }
+
+        private static boolean isCompatible(EvictionConfig c1, EvictionConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getSize(), c2.getSize())
+                    && nullSafeEqual(c1.getMaximumSizePolicy(), c2.getMaximumSizePolicy())
+                    && nullSafeEqual(c1.getEvictionPolicy(), c2.getEvictionPolicy())
+                    && nullSafeEqual(c1.getComparatorClassName(), c2.getComparatorClassName());
+        }
+
+        private static boolean isCompatible(WanReplicationRef c1, WanReplicationRef c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getMergePolicy(), c2.getMergePolicy())
+                    && nullSafeEqual(c1.getFilters(), c2.getFilters())
+                    && nullSafeEqual(c1.isRepublishingEnabled(), c2.isRepublishingEnabled());
+        }
+
+        @Override
+        CacheSimpleConfig getDefault(Config c) {
+            return c.getCacheConfig("default");
+        }
+    }
+
+    private static class MapConfigChecker extends ConfigChecker<MapConfig> {
+        @Override
+        boolean check(MapConfig c1, MapConfig c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null) {
+                return false;
+            }
+            final int maxSize1 = c1.getMaxSizeConfig().getSize();
+            final int maxSize2 = c2.getMaxSizeConfig().getSize();
+
+            return nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getInMemoryFormat(), c2.getInMemoryFormat())
+                    && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
+                    && nullSafeEqual(c1.isOptimizeQueries(), c2.isOptimizeQueries())
+                    && nullSafeEqual(c1.getCacheDeserializedValues(), c2.getCacheDeserializedValues())
+                    && nullSafeEqual(c1.getBackupCount(), c2.getBackupCount())
+                    && nullSafeEqual(c1.getAsyncBackupCount(), c2.getAsyncBackupCount())
+                    && nullSafeEqual(c1.getTimeToLiveSeconds(), c2.getTimeToLiveSeconds())
+                    && nullSafeEqual(c1.getMaxIdleSeconds(), c2.getMaxIdleSeconds())
+                    && nullSafeEqual(c1.getEvictionPolicy(), c2.getEvictionPolicy())
+                    && (nullSafeEqual(maxSize1, maxSize2) || (Math.min(maxSize1, maxSize2) == 0 && Math.max(maxSize1, maxSize2) == Integer.MAX_VALUE))
+                    && nullSafeEqual(c1.getEvictionPercentage(), c2.getEvictionPercentage())
+                    && nullSafeEqual(c1.getMinEvictionCheckMillis(), c2.getMinEvictionCheckMillis())
+                    && nullSafeEqual(c1.getMergePolicy(), c2.getMergePolicy())
+                    && nullSafeEqual(c1.isReadBackupData(), c2.isReadBackupData())
+                    && ConfigCompatibilityChecker.isCompatible(c1.getHotRestartConfig(), c2.getHotRestartConfig())
+                    && isCompatible(c1.getMapStoreConfig(), c2.getMapStoreConfig())
+                    && isCompatible(c1.getNearCacheConfig(), c2.getNearCacheConfig())
+                    && isCompatible(c1.getWanReplicationRef(), c2.getWanReplicationRef())
+                    && isCollectionCompatible(c1.getMapIndexConfigs(), c2.getMapIndexConfigs(), new MapIndexConfigChecker())
+                    && isCollectionCompatible(c1.getMapAttributeConfigs(), c2.getMapAttributeConfigs(), new MapAttributeConfigChecker())
+                    && isCollectionCompatible(c1.getEntryListenerConfigs(), c2.getEntryListenerConfigs(), new EntryListenerConfigChecker())
+                    && nullSafeEqual(c1.getPartitionLostListenerConfigs(), c2.getPartitionLostListenerConfigs())
+                    && nullSafeEqual(c1.getPartitioningStrategyConfig(), c2.getPartitioningStrategyConfig());
+        }
+
+        private static boolean isCompatible(WanReplicationRef c1, WanReplicationRef c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getMergePolicy(), c2.getMergePolicy())
+                    && nullSafeEqual(c1.getFilters(), c2.getFilters())
+                    && nullSafeEqual(c1.isRepublishingEnabled(), c2.isRepublishingEnabled());
+        }
+
+        private static boolean isCompatible(NearCacheConfig c1, NearCacheConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getTimeToLiveSeconds(), c2.getTimeToLiveSeconds())
+                    && nullSafeEqual(c1.getMaxSize(), c2.getMaxSize())
+                    && nullSafeEqual(c1.getEvictionPolicy(), c2.getEvictionPolicy())
+                    && isCompatible(c1.getEvictionConfig(), c2.getEvictionConfig());
+        }
+
+        private static boolean isCompatible(EvictionConfig c1, EvictionConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getSize(), c2.getSize())
+                    && nullSafeEqual(c1.getMaximumSizePolicy(), c2.getMaximumSizePolicy())
+                    && nullSafeEqual(c1.getEvictionPolicy(), c2.getEvictionPolicy())
+                    && nullSafeEqual(c1.getEvictionPolicyType(), c2.getEvictionPolicyType())
+                    && nullSafeEqual(c1.getEvictionStrategyType(), c2.getEvictionStrategyType())
+                    && nullSafeEqual(c1.getComparatorClassName(), c2.getComparatorClassName());
+        }
+
+        private static boolean isCompatible(MapStoreConfig c1, MapStoreConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getClassName(), c2.getClassName())
+                            && nullSafeEqual(c1.getFactoryClassName(), c2.getFactoryClassName())
+                            && nullSafeEqual(c1.getProperties(), c2.getProperties()));
+        }
+
+        @Override
+        MapConfig getDefault(Config c) {
+            return c.getMapConfig("default");
+        }
+    }
+
+    private static class MapIndexConfigChecker extends ConfigChecker<MapIndexConfig> {
+        @Override
+        boolean check(MapIndexConfig c1, MapIndexConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getAttribute(), c2.getAttribute())
+                    && nullSafeEqual(c1.isOrdered(), c2.isOrdered());
+        }
+    }
+
+    private static class CacheSimpleEntryListenerConfigChecker extends ConfigChecker<CacheSimpleEntryListenerConfig> {
+        @Override
+        boolean check(CacheSimpleEntryListenerConfig c1, CacheSimpleEntryListenerConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getCacheEntryListenerFactory(), c2.getCacheEntryListenerFactory())
+                    && nullSafeEqual(c1.getCacheEntryEventFilterFactory(), c2.getCacheEntryEventFilterFactory())
+                    && nullSafeEqual(c1.isOldValueRequired(), c2.isOldValueRequired())
+                    && nullSafeEqual(c1.isSynchronous(), c2.isSynchronous());
+        }
+    }
+
+    private static class EntryListenerConfigChecker extends ConfigChecker<EntryListenerConfig> {
+        @Override
+        boolean check(EntryListenerConfig c1, EntryListenerConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.isLocal(), c2.isLocal())
+                    && nullSafeEqual(c1.isIncludeValue(), c2.isIncludeValue())
+                    && nullSafeEqual(c1.getClassName(), c2.getClassName());
+        }
+    }
+
+    private static class MapAttributeConfigChecker extends ConfigChecker<MapAttributeConfig> {
+        @Override
+        boolean check(MapAttributeConfig c1, MapAttributeConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getName(), c2.getName())
+                    && nullSafeEqual(c1.getExtractor(), c2.getExtractor());
+        }
+    }
+
+    private static class DiscoveryStrategyConfigChecker extends ConfigChecker<DiscoveryStrategyConfig> {
+        @Override
+        boolean check(DiscoveryStrategyConfig c1, DiscoveryStrategyConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getClassName(), c2.getClassName())
+                    && nullSafeEqual(c1.getProperties(), c2.getProperties());
+        }
+    }
+
+    private static class MemberGroupConfigChecker extends ConfigChecker<MemberGroupConfig> {
+        @Override
+        boolean check(MemberGroupConfig c1, MemberGroupConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(new ArrayList<String>(c1.getInterfaces()),
+                    new ArrayList<String>(c2.getInterfaces()));
+        }
+    }
+
+    private static class SerializerConfigChecker extends ConfigChecker<SerializerConfig> {
+        @Override
+        boolean check(SerializerConfig c1, SerializerConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getClassName(), c2.getClassName())
+                    && nullSafeEqual(c1.getTypeClass(), c2.getTypeClass())
+                    && nullSafeEqual(c1.getTypeClassName(), c2.getTypeClassName());
+        }
+    }
+
+    private static class NetworkConfigChecker extends ConfigChecker<NetworkConfig> {
+        @Override
+        boolean check(NetworkConfig c1, NetworkConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getPort(), c2.getPort())
+                    && nullSafeEqual(c1.getPortCount(), c2.getPortCount())
+                    && nullSafeEqual(c1.isPortAutoIncrement(), c2.isPortAutoIncrement())
+                    && nullSafeEqual(c1.isReuseAddress(), c2.isReuseAddress())
+                    && nullSafeEqual(c1.getPublicAddress(), c2.getPublicAddress())
+                    && isCompatible(c1.getOutboundPortDefinitions(), c2.getOutboundPortDefinitions())
+                    && nullSafeEqual(c1.getOutboundPorts(), c2.getOutboundPorts())
+                    && isCompatible(c1.getInterfaces(), c2.getInterfaces())
+                    && isCompatible(c1.getJoin(), c2.getJoin())
+                    && isCompatible(c1.getSymmetricEncryptionConfig(), c2.getSymmetricEncryptionConfig())
+                    && isCompatible(c1.getSocketInterceptorConfig(), c2.getSocketInterceptorConfig())
+                    && isCompatible(c1.getSSLConfig(), c2.getSSLConfig());
+        }
+
+        private static boolean isCompatible(Collection<String> portDefinitions1, Collection<String> portDefinitions2) {
+            final String[] defaultValues = {"0", "*"};
+            final boolean defaultDefinition1 = CollectionUtil.isEmpty(portDefinitions1) ||
+                    (portDefinitions1.size() == 1 && ArrayUtils.contains(defaultValues, portDefinitions1.iterator().next()));
+            final boolean defaultDefinition2 = CollectionUtil.isEmpty(portDefinitions2) ||
+                    (portDefinitions2.size() == 1 && ArrayUtils.contains(defaultValues, portDefinitions2.iterator().next()));
+            return (defaultDefinition1 && defaultDefinition2) || nullSafeEqual(portDefinitions1, portDefinitions2);
+        }
+
+        private static boolean isCompatible(JoinConfig c1, JoinConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && isCompatible(c1.getMulticastConfig(), c2.getMulticastConfig())
+                    && isCompatible(c1.getTcpIpConfig(), c2.getTcpIpConfig())
+                    && isCompatible(c1.getAwsConfig(), c2.getAwsConfig())
+                    && isCompatible(c1.getDiscoveryConfig(), c2.getDiscoveryConfig());
+        }
+
+        private static boolean isCompatible(DiscoveryConfig c1, DiscoveryConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getNodeFilterClass(), c2.getNodeFilterClass())
+                            && isCollectionCompatible(c1.getDiscoveryStrategyConfigs(), c2.getDiscoveryStrategyConfigs(), new DiscoveryStrategyConfigChecker()));
+        }
+
+        private static boolean isCompatible(AwsConfig c1, AwsConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getAccessKey(), c2.getAccessKey())
+                            && nullSafeEqual(c1.getSecretKey(), c2.getSecretKey())
+                            && nullSafeEqual(c1.getRegion(), c2.getRegion())
+                            && nullSafeEqual(c1.getSecurityGroupName(), c2.getSecurityGroupName())
+                            && nullSafeEqual(c1.getTagKey(), c2.getTagKey())
+                            && nullSafeEqual(c1.getTagValue(), c2.getTagValue())
+                            && nullSafeEqual(c1.getHostHeader(), c2.getHostHeader())
+                            && nullSafeEqual(c1.getIamRole(), c2.getIamRole())
+                            && nullSafeEqual(c1.getConnectionTimeoutSeconds(), c2.getConnectionTimeoutSeconds()));
+        }
+
+        private static boolean isCompatible(TcpIpConfig c1, TcpIpConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getConnectionTimeoutSeconds(), c2.getConnectionTimeoutSeconds())
+                            && nullSafeEqual(c1.getMembers(), c2.getMembers()))
+                            && nullSafeEqual(c1.getRequiredMember(), c2.getRequiredMember());
+        }
+
+        private static boolean isCompatible(MulticastConfig c1, MulticastConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getMulticastGroup(), c2.getMulticastGroup())
+                            && nullSafeEqual(c1.getMulticastPort(), c2.getMulticastPort()))
+                            && nullSafeEqual(c1.getMulticastTimeoutSeconds(), c2.getMulticastTimeoutSeconds())
+                            && nullSafeEqual(c1.getMulticastTimeToLive(), c2.getMulticastTimeToLive())
+                            && nullSafeEqual(c1.getTrustedInterfaces(), c2.getTrustedInterfaces());
+        }
+
+        private static boolean isCompatible(InterfacesConfig c1, InterfacesConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(new ArrayList<String>(c1.getInterfaces()), new ArrayList<String>(c2.getInterfaces())));
+        }
+
+        private static boolean isCompatible(SymmetricEncryptionConfig c1, SymmetricEncryptionConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getSalt(), c2.getSalt())
+                            && nullSafeEqual(c1.getPassword(), c2.getPassword()))
+                            && nullSafeEqual(c1.getIterationCount(), c2.getIterationCount())
+                            && nullSafeEqual(c1.getAlgorithm(), c2.getAlgorithm())
+                            && nullSafeEqual(c1.getKey(), c2.getKey());
+        }
+
+        private static boolean isCompatible(SocketInterceptorConfig c1, SocketInterceptorConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getClassName(), c2.getClassName())
+                            && nullSafeEqual(c1.getImplementation(), c2.getImplementation()))
+                            && nullSafeEqual(c1.getProperties(), c2.getProperties());
+        }
+
+        private static boolean isCompatible(SSLConfig c1, SSLConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getFactoryClassName(), c2.getFactoryClassName())
+                            && nullSafeEqual(c1.getFactoryImplementation(), c2.getFactoryImplementation()))
+                            && nullSafeEqual(c1.getProperties(), c2.getProperties());
+        }
+    }
+
+    private static class PartitionGroupConfigChecker extends ConfigChecker<PartitionGroupConfig> {
+        @Override
+        boolean check(PartitionGroupConfig c1, PartitionGroupConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getGroupType(), c2.getGroupType())
+                            && isCollectionCompatible(c1.getMemberGroupConfigs(), c2.getMemberGroupConfigs(), new MemberGroupConfigChecker()));
+        }
+    }
+
+    private static class SerializationConfigChecker extends ConfigChecker<SerializationConfig> {
+        @Override
+        boolean check(SerializationConfig c1, SerializationConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getPortableVersion(), c2.getPortableVersion())
+                    && nullSafeEqual(c1.getDataSerializableFactoryClasses(), c2.getDataSerializableFactoryClasses())
+                    && nullSafeEqual(c1.getPortableFactoryClasses(), c2.getPortableFactoryClasses())
+                    && isCompatible(c1.getGlobalSerializerConfig(), c2.getGlobalSerializerConfig())
+                    && isCollectionCompatible(c1.getSerializerConfigs(), c2.getSerializerConfigs(), new SerializerConfigChecker())
+                    && nullSafeEqual(c1.isCheckClassDefErrors(), c2.isCheckClassDefErrors())
+                    && nullSafeEqual(c1.isUseNativeByteOrder(), c2.isUseNativeByteOrder())
+                    && nullSafeEqual(c1.getByteOrder(), c2.getByteOrder())
+                    && nullSafeEqual(c1.isEnableCompression(), c2.isEnableCompression())
+                    && nullSafeEqual(c1.isEnableSharedObject(), c2.isEnableSharedObject())
+                    && nullSafeEqual(c1.isAllowUnsafe(), c2.isAllowUnsafe());
+        }
+
+        private static boolean isCompatible(GlobalSerializerConfig c1, GlobalSerializerConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.getClassName(), c2.getClassName())
+                    && nullSafeEqual(c1.isOverrideJavaSerialization(), c2.isOverrideJavaSerialization());
+        }
+    }
+
+    private static class ServicesConfigChecker extends ConfigChecker<ServicesConfig> {
+        @Override
+        boolean check(ServicesConfig c1, ServicesConfig c2) {
+            return c1 == c2 || !(c1 == null || c2 == null)
+                    && nullSafeEqual(c1.isEnableDefaults(), c2.isEnableDefaults())
+                    && isCompatible(c1.getServiceConfigs(), c2.getServiceConfigs());
+        }
+
+        private static boolean isCompatible(Collection<ServiceConfig> c1, Collection<ServiceConfig> c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null || c1.size() != c2.size()) {
+                return false;
+            }
+
+            final HashMap<String, ServiceConfig> config1 = new HashMap<String, ServiceConfig>();
+            final HashMap<String, ServiceConfig> config2 = new HashMap<String, ServiceConfig>();
+
+            for (ServiceConfig serviceConfig : c1) {
+                config1.put(serviceConfig.getName(), serviceConfig);
+            }
+            for (ServiceConfig serviceConfig : c2) {
+                config2.put(serviceConfig.getName(), serviceConfig);
+            }
+
+            if (!config1.keySet().equals(config2.keySet())) {
+                return false;
+            }
+
+            for (ServiceConfig serviceConfig : c1) {
+                if (!isCompatible(serviceConfig, config2.get(serviceConfig.getName()))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static boolean isCompatible(ServiceConfig c1, ServiceConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getName(), c2.getName())
+                            && nullSafeEqual(c1.getClassName(), c2.getClassName())
+                            && nullSafeEqual(c1.getImplementation(), c2.getImplementation())
+                            && nullSafeEqual(c1.getProperties(), c2.getProperties())
+                            && nullSafeEqual(c1.getConfigObject(), c2.getConfigObject()));
+        }
+    }
+
+    private static class ManagementCenterConfigChecker extends ConfigChecker<ManagementCenterConfig> {
+        @Override
+        boolean check(ManagementCenterConfig c1, ManagementCenterConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getUrl(), c2.getUrl())
+                            && nullSafeEqual(c1.getUpdateInterval(), c2.getUpdateInterval()));
+        }
+    }
+
+    private static class HotRestartConfigChecker extends ConfigChecker<HotRestartPersistenceConfig> {
+        @Override
+        boolean check(HotRestartPersistenceConfig c1, HotRestartPersistenceConfig c2) {
+            final boolean c1Disabled = c1 == null || !c1.isEnabled();
+            final boolean c2Disabled = c2 == null || !c2.isEnabled();
+            return c1 == c2 || (c1Disabled && c2Disabled) ||
+                    (c1 != null && c2 != null
+                            && nullSafeEqual(c1.getBaseDir(), c2.getBaseDir())
+                            && nullSafeEqual(c1.getBackupDir(), c2.getBackupDir())
+                            && nullSafeEqual(c1.getParallelism(), c2.getParallelism())
+                            && nullSafeEqual(c1.getValidationTimeoutSeconds(), c2.getValidationTimeoutSeconds())
+                            && nullSafeEqual(c1.getDataLoadTimeoutSeconds(), c2.getDataLoadTimeoutSeconds())
+                            && nullSafeEqual(c1.getClusterDataRecoveryPolicy(), c2.getClusterDataRecoveryPolicy()));
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigDefaultsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigDefaultsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigDefaultsTest extends HazelcastTestSupport {
+    private static final Config JAVA_CONFIG = javaConfig();
+    private static final Config DEFAULT_XML_CONFIG = defaultXmlConfig();
+    private static final Config EMPTY_XML_CONFIG = emptyXmlConfig();
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {"Java - hazelcast-default.xml", JAVA_CONFIG, DEFAULT_XML_CONFIG},
+                {"Java - empty XML", JAVA_CONFIG, EMPTY_XML_CONFIG},
+                {"hazelcast-default.xml - empty XML", DEFAULT_XML_CONFIG, EMPTY_XML_CONFIG}
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public String name;
+    @Parameterized.Parameter(1)
+    public Config c1;
+    @Parameterized.Parameter(2)
+    public Config c2;
+
+    @Test
+    public void testCompatibility() {
+        ConfigCompatibilityChecker.isCompatible(c1, c2);
+    }
+
+    private static Config javaConfig() {
+        return new Config();
+    }
+
+    private static Config defaultXmlConfig() {
+        return new XmlConfigBuilder(ConfigDefaultsTest.class.getClassLoader().getResourceAsStream("hazelcast-default.xml")).build();
+    }
+
+    private static Config emptyXmlConfig() {
+        return buildConfig("<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n</hazelcast>\n");
+    }
+
+    private static Config buildConfig(String xml) {
+        final ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
+        return new XmlConfigBuilder(bis).build();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -373,8 +373,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         Config config2 = new InMemoryXmlConfig(xml);
         config2.getGroupConfig().setPassword(pass);
 
-        assertTrue(config.isCompatible(config2));
-        assertTrue(config2.isCompatible(config));
+        assertTrue(ConfigCompatibilityChecker.isCompatible(config, config2));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorTest.java
@@ -159,7 +159,7 @@ public class PartitionStateGeneratorTest {
     public void testXmlPartitionGroupConfig() {
         Config config = new ClasspathXmlConfig("hazelcast-fullconfig.xml");
         PartitionGroupConfig partitionGroupConfig = config.getPartitionGroupConfig();
-        assertFalse(partitionGroupConfig.isEnabled());
+        assertTrue(partitionGroupConfig.isEnabled());
         assertEquals(PartitionGroupConfig.MemberGroupType.CUSTOM, partitionGroupConfig.getGroupType());
         assertEquals(2, partitionGroupConfig.getMemberGroupConfigs().size());
     }

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -41,12 +41,16 @@
         <password>dev-pass</password>
     </group>
     <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>
+    <instance-name>dummy</instance-name>
     <management-center enabled="true" update-interval="5">http://mywebserver:8080</management-center>
+    <properties>
+        <property name="foo">bar</property>
+    </properties>
     <wan-replication name="my-wan-cluster">
         <wan-publisher group-name="tokyo">
             <class-name>com.hazelcast.enterprise.wan.replication.WanBatchReplication</class-name>
-            <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>
             <queue-capacity>1000</queue-capacity>
+            <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>
             <properties>
                 <property name="batch.size">50</property>
                 <property name="batch.max.delay.millis">3000</property>
@@ -74,31 +78,41 @@
         </wan-consumer>
     </wan-replication>
     <network>
+        <public-address>dummy</public-address>
         <port auto-increment="true" port-count="100">5701</port>
         <!-- If the address should be reused. See NetworkConfig.setReuseAddress for more information. -->
-        <reuse-address>false</reuse-address>
+        <reuse-address>true</reuse-address>
         <outbound-ports>
             <ports>33000-35000</ports>
             <ports>37000,37001,37002,37003</ports>
             <ports>38000,38500-38600</ports>
         </outbound-ports>
         <join>
-            <multicast enabled="true">
-                <multicast-group>224.2.2.3</multicast-group>
-                <multicast-port>54327</multicast-port>
-                <multicast-timeout-seconds>2</multicast-timeout-seconds>
-                <multicast-time-to-live>32</multicast-time-to-live>
+            <multicast enabled="true" loopbackModeEnabled="true">
+                <multicast-group>1.2.3.4</multicast-group>
+                <multicast-port>12345</multicast-port>
+                <multicast-timeout-seconds>5</multicast-timeout-seconds>
+                <multicast-time-to-live>10</multicast-time-to-live>
                 <trusted-interfaces>
                     <interface>10.10.1.*</interface>
                     <interface>10.10.2.*</interface>
                 </trusted-interfaces>
             </multicast>
-            <tcp-ip enabled="false">
-                <interface>127.0.0.1</interface>
+            <tcp-ip enabled="false" connection-timeout-seconds="123">
+                <required-member>dummy</required-member>
+                <member>dummy1</member>
+                <member>dummy2</member>
+                <interface>127.0.0.10</interface>
+                <members>dummy3,dummy4</members>
+                <member-list>
+                    <member>dummy5</member>
+                    <member>dummy6</member>
+                </member-list>
             </tcp-ip>
             <aws enabled="false">
                 <access-key>my-access-key</access-key>
                 <secret-key>my-secret-key</secret-key>
+                <iam-role>dummy</iam-role>
                 <!--optional, default is us-east-1 -->
                 <region>us-west-1</region>
                 <!--optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property -->
@@ -108,17 +122,25 @@
                 <tag-key>type</tag-key>
                 <tag-value>hz-nodes</tag-value>
             </aws>
+<!--            <discovery-strategies>
+                <node-filter class="DummyFilterClass"/>
+                <discovery-strategy class="DummyClass" enabled="true">
+                    <properties>
+                        <property name="foo">bar</property>
+                    </properties>
+                </discovery-strategy>
+            </discovery-strategies>-->
         </join>
-        <interfaces enabled="false">
+        <interfaces enabled="true">
             <interface>10.10.1.*</interface>
         </interfaces>
-        <ssl enabled="false">
+        <ssl enabled="true">
             <factory-class-name>com.hazelcast.examples.MySSLContextFactory</factory-class-name>
             <properties>
                 <property name="foo">bar</property>
             </properties>
         </ssl>
-        <socket-interceptor enabled="false">
+        <socket-interceptor enabled="true">
             <class-name>com.hazelcast.examples.MySocketInterceptor</class-name>
             <properties>
                 <property name="foo">bar</property>
@@ -142,7 +164,7 @@
             <iteration-count>19</iteration-count>
         </symmetric-encryption>
     </network>
-    <partition-group enabled="false" group-type="CUSTOM">
+    <partition-group enabled="true" group-type="CUSTOM">
         <member-group>
             <interface>10.10.0.*</interface>
             <interface>10.10.3.*</interface>
@@ -155,10 +177,22 @@
         </member-group>
     </partition-group>
     <executor-service name="default">
+        <statistics-enabled>false</statistics-enabled>
         <pool-size>16</pool-size>
         <queue-capacity>1000</queue-capacity>
     </executor-service>
+    <durable-executor-service name="dummy">
+        <pool-size>10</pool-size>
+        <durability>2</durability>
+        <capacity>10</capacity>
+    </durable-executor-service>
+    <scheduled-executor-service name="dummy">
+        <pool-size>10</pool-size>
+        <durability>2</durability>
+        <capacity>50</capacity>
+    </scheduled-executor-service>
     <queue name="default">
+        <statistics-enabled>false</statistics-enabled>
         <!--
             Maximum size of the queue. When a JVM's local queue size reaches the maximum,
             all put/offer operations will get blocked until the queue size
@@ -166,14 +200,22 @@
             Any integer between 0 and Integer.MAX_VALUE. 0 means
             Integer.MAX_VALUE. Default is 0.
         -->
-        <max-size>0</max-size>
+        <max-size>10</max-size>
 
-        <backup-count>0</backup-count>
-        <async-backup-count>0</async-backup-count>
+        <backup-count>2</backup-count>
+        <async-backup-count>2</async-backup-count>
+        <empty-queue-ttl>12</empty-queue-ttl>
 
         <item-listeners>
             <item-listener include-value="true">com.hazelcast.examples.ItemListener</item-listener>
         </item-listeners>
+        <queue-store enabled="true">
+            <!--<class-name>DummyClass</class-name>-->
+            <factory-class-name>DummyFactoryClass</factory-class-name>
+            <properties>
+                <property name="foo">bar</property>
+            </properties>
+        </queue-store>
 
         <quorum-ref>quorumRuleWithThreeMembers</quorum-ref>
     </queue>
@@ -185,35 +227,38 @@
            OBJECT : values will be stored in their object forms
            NATIVE : values will be stored in non-heap region of JVM
         -->
-        <in-memory-format>BINARY</in-memory-format>
+        <in-memory-format>OBJECT</in-memory-format>
         <!--
             Whether statistical information (hits, creation time, last access time etc.) should be gathered and stored.
             You can disable if you do not plan to use eviction on your entries.
         -->
-        <statistics-enabled>true</statistics-enabled>
+        <statistics-enabled>false</statistics-enabled>
+
+        <optimize-queries>true</optimize-queries>
+        <cache-deserialized-values>ALWAYS</cache-deserialized-values>
         <!--
             Number of backups. If 1 is set as the backup-count for example,
             then all entries of the map will be copied to another JVM for
             fail-safety. 0 means no backup.
         -->
-        <backup-count>1</backup-count>
+        <backup-count>2</backup-count>
 
         <!--
             Number of async backups. 0 means no backup.
         -->
-        <async-backup-count>1</async-backup-count>
+        <async-backup-count>2</async-backup-count>
 
         <!--
             Maximum number of seconds for each item to live.
             Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
         -->
-        <time-to-live-seconds>0</time-to-live-seconds>
+        <time-to-live-seconds>2</time-to-live-seconds>
 
         <!--
             Maximum number of seconds for each item to stay idle (untouched).
             Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
         -->
-        <max-idle-seconds>0</max-idle-seconds>
+        <max-idle-seconds>2</max-idle-seconds>
         <!--
             Valid values are:
             NONE (no eviction),
@@ -221,14 +266,15 @@
             LFU (Least Frequently Used).
             NONE is the default.
         -->
-        <eviction-policy>NONE</eviction-policy>
+        <eviction-policy>LRU</eviction-policy>
         <!--
             Maximum size of the map. When max size is reached,
             map is evicted based on the policy defined.
             Any integer between 0 and Integer.MAX_VALUE. 0 means
             Integer.MAX_VALUE. Default is 0.
         -->
-        <max-size policy="PER_NODE">0</max-size>
+
+        <max-size policy="PER_NODE">20</max-size>
         <!--
             `eviction-percentage` property is deprecated.
 
@@ -242,7 +288,7 @@
             As of version 3.7, eviction mechanism changed.
             It uses a probabilistic algorithm based on sampling. Please see documentation for further details
         -->
-        <min-eviction-check-millis>100</min-eviction-check-millis>
+        <min-eviction-check-millis>200</min-eviction-check-millis>
 
         <!--
             While recovering from split-brain (network partitioning),
@@ -261,7 +307,13 @@
 
             Beware that `merge-policy` is not supported for NATIVE in-memory format.
         -->
-        <merge-policy>com.hazelcast.map.merge.PutIfAbsentMapMergePolicy</merge-policy>
+        <merge-policy>com.hazelcast.map.merge.HigherHitsMapMergePolicy</merge-policy>
+
+        <read-backup-data>true</read-backup-data>
+
+        <hot-restart>
+            <fsync>true</fsync>
+        </hot-restart>
 
         <!--
             Used to store Map entries in a backing store. If configured entries will be loaded from this store on startup.
@@ -301,6 +353,7 @@
                 <filter-impl>com.example.WanTestFilter1</filter-impl>
                 <filter-impl>com.example.WanTestFilter2</filter-impl>
             </filters>
+            <republishing-enabled>false</republishing-enabled>
         </wan-replication-ref>
 
         <indexes>
@@ -347,17 +400,30 @@
     <multimap name="default">
         <backup-count>1</backup-count>
         <async-backup-count>0</async-backup-count>
+        <statistics-enabled>false</statistics-enabled>
+        <binary>false</binary>
         <value-collection-type>SET</value-collection-type>
         <entry-listeners>
             <entry-listener include-value="true" local="true">com.hazelcast.examples.EntryListener</entry-listener>
         </entry-listeners>
     </multimap>
 
+    <replicatedmap name="dummy">
+        <in-memory-format>BINARY</in-memory-format>
+        <concurrency-level>12</concurrency-level>
+        <replication-delay-millis>12</replication-delay-millis>
+        <async-fillup>false</async-fillup>
+        <statistics-enabled>false</statistics-enabled>
+        <entry-listeners>
+            <entry-listener include-value="false" local="true">DummyListener</entry-listener>
+        </entry-listeners>
+    </replicatedmap>
+
     <list name="default">
         <statistics-enabled>false</statistics-enabled>
-        <max-size>0</max-size>
-        <backup-count>1</backup-count>
-        <async-backup-count>0</async-backup-count>
+        <max-size>5</max-size>
+        <backup-count>2</backup-count>
+        <async-backup-count>2</async-backup-count>
         <item-listeners>
             <item-listener include-value="true">com.hazelcast.examples.ItemListener</item-listener>
         </item-listeners>
@@ -374,9 +440,12 @@
     </set>
 
     <topic name="default">
+        <statistics-enabled>false</statistics-enabled>
+        <global-ordering-enabled>true</global-ordering-enabled>
         <message-listeners>
             <message-listener>com.hazelcast.examples.MessageListener</message-listener>
         </message-listeners>
+        <multi-threading-enabled>false</multi-threading-enabled>
     </topic>
 
 
@@ -409,27 +478,44 @@
 
     <cache name="default">
         <key-type class-name="java.lang.Object"/>
-        <value-type class-name="java.lang.Object"/>
+        <value-type class-name="java.lang.String"/>
         <statistics-enabled>false</statistics-enabled>
         <management-enabled>false</management-enabled>
 
         <read-through>true</read-through>
         <write-through>true</write-through>
-        <cache-loader-factory
-                class-name="com.example.cache.MyCacheLoaderFactory"/>
-        <cache-writer-factory
-                class-name="com.example.cache.MyCacheWriterFactory"/>
-        <expiry-policy-factory
-                class-name="com.example.cache.MyExpirePolicyFactory"/>
+        <cache-loader-factory class-name="com.example.cache.MyCacheLoaderFactory"/>
+        <cache-writer-factory class-name="com.example.cache.MyCacheWriterFactory"/>
+        <expiry-policy-factory class-name="com.example.cache.MyExpirePolicyFactory">
+            <timed-expiry-policy-factory expiry-policy-type="ETERNAL" duration-amount="123" time-unit="MICROSECONDS"/>
+        </expiry-policy-factory>
 
         <cache-entry-listeners>
-            <cache-entry-listener old-value-required="false" synchronous="false">
-                <cache-entry-listener-factory
-                        class-name="com.example.cache.MyEntryListenerFactory"/>
-                <cache-entry-event-filter-factory
-                        class-name="com.example.cache.MyEntryEventFilterFactory"/>
+            <cache-entry-listener old-value-required="true" synchronous="true">
+                <cache-entry-listener-factory class-name="com.example.cache.MyEntryListenerFactory"/>
+                <cache-entry-event-filter-factory class-name="com.example.cache.MyEntryEventFilterFactory"/>
             </cache-entry-listener>
         </cache-entry-listeners>
+        <in-memory-format>OBJECT</in-memory-format>
+        <backup-count>2</backup-count>
+        <async-backup-count>2</async-backup-count>
+        <eviction comparator-class-name="DummyClass" eviction-policy="LRU" max-size-policy="FREE_NATIVE_MEMORY_PERCENTAGE"
+                  size="50"/>
+        <wan-replication-ref name="my-wan-cluster">
+            <merge-policy>hz.PASS_THROUGH</merge-policy>
+            <filters>
+                <filter-impl>com.example.WanTestFilter1</filter-impl>
+                <filter-impl>com.example.WanTestFilter2</filter-impl>
+            </filters>
+        </wan-replication-ref>
+        <quorum-ref>dummyQuorum</quorum-ref>
+        <partition-lost-listeners>
+            <partition-lost-listener>DummyListener</partition-lost-listener>
+        </partition-lost-listeners>
+        <merge-policy>DummyPolicy</merge-policy>
+        <hot-restart>
+            <fsync>true</fsync>
+        </hot-restart>
     </cache>
 
     <listeners>
@@ -441,6 +527,11 @@
 
     <serialization>
         <portable-version>0</portable-version>
+        <use-native-byte-order>true</use-native-byte-order>
+        <byte-order>LITTLE_ENDIAN</byte-order>
+        <enable-compression>true</enable-compression>
+        <enable-shared-object>true</enable-shared-object>
+        <allow-unsafe>true</allow-unsafe>
         <data-serializable-factories>
             <data-serializable-factory factory-id="1">com.hazelcast.examples.DataSerializableFactory
             </data-serializable-factory>
@@ -449,15 +540,17 @@
             <portable-factory factory-id="1">com.hazelcast.examples.PortableFactory</portable-factory>
         </portable-factories>
         <serializers>
-            <global-serializer>com.hazelcast.examples.GlobalSerializerFactory</global-serializer>
+            <global-serializer override-java-serialization="true">com.hazelcast.examples.GlobalSerializerFactory</global-serializer>
             <serializer type-class="com.hazelcast.examples.DummyType"
                         class-name="com.hazelcast.examples.SerializerFactory"/>
         </serializers>
-        <check-class-def-errors>true</check-class-def-errors>
+        <check-class-def-errors>false</check-class-def-errors>
     </serialization>
 
-    <native-memory allocator-type="POOLED" enabled="true">
+    <native-memory allocator-type="STANDARD" enabled="true">
         <size unit="MEGABYTES" value="256"/>
+        <min-block-size>123</min-block-size>
+        <page-size>123</page-size>
         <metadata-space-percentage>12.5</metadata-space-percentage>
     </native-memory>
 


### PR DESCRIPTION
Here we move the old config compatibility checker to the test code since it is no longer used in production. We also expand on this compatibility checker to include as many configuration as possible and use it to check if the default values in the XML config, the Java config and hazelcast-default.xml are the same. The XML generator tests were already using this compatibility checker so expanding it uncovered some missing config values. The changes :

- fix the "default" value in the hazelcast-config.xsd for the networkConfig/joinConfig/multicastConfig/loopbackModeEnabled from true to false
- fix documentation for the some default values
- add fluent API for generating XML
- add missing tags to xml generator