### PR TITLE
Less verbose logging on closed connection

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -263,7 +263,7 @@ public class ClientConnection implements SocketConnection, DiscardableMetricsPro
         try {
             innerClose();
         } catch (Exception e) {
-            logger.warning(e);
+            logger.warning("Exception while closing connection" + e.getMessage());
         }
 
         if (lifecycleService.isRunning()) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -37,6 +37,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.nio.channels.CancelledKeyException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -287,7 +288,7 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
         }
 
         if (ioService.isActive()) {
-            if (closeCause == null || closeCause instanceof EOFException) {
+            if (closeCause == null || closeCause instanceof EOFException || closeCause instanceof CancelledKeyException) {
                 logger.info(message);
             } else {
                 logger.warning(message, closeCause);


### PR DESCRIPTION
Fixes #8681 - the handler looks differently than in 3.6.3 though, but there were cases when the logging could still be verbose.
