### PR TITLE
[DO-NOT-MERGE] Do not log business exceptions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
@@ -17,6 +17,7 @@
 package com.hazelcast.durableexecutor;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.spi.BusinessException;
 import com.hazelcast.spi.annotation.Beta;
 
 /**
@@ -24,7 +25,7 @@ import com.hazelcast.spi.annotation.Beta;
  * result of the task is overwritten. This means the task is executed but the result isn't available anymore
  */
 @Beta
-public class StaleTaskIdException extends HazelcastException {
+public class StaleTaskIdException extends HazelcastException implements BusinessException {
 
     public StaleTaskIdException(String message) {
         super(message);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.ringbuffer;
 
+import com.hazelcast.spi.BusinessException;
+
 /**
  * An {@link RuntimeException} that is thrown when accessing an item in the {@link Ringbuffer} using a sequence that is smaller
  * than the current head sequence and that the ringbuffer store is disabled. This means that the item isn't available in the
  * ringbuffer and it cannot be loaded from the store either, thus being completely unavailable.
  */
-public class StaleSequenceException extends RuntimeException {
+public class StaleSequenceException extends RuntimeException implements BusinessException {
 
     private final long headSeq;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/BusinessException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/BusinessException.java
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-package com.hazelcast.scheduledexecutor;
-
-import com.hazelcast.core.HazelcastException;
-import com.hazelcast.spi.BusinessException;
+package com.hazelcast.spi;
 
 /**
- * Exception thrown by the {@link IScheduledFuture} during any operation on a stale (=previously destroyed) task.
+ * Marked interface for exceptions.
+ *
+ * When an exception is marked with this interface then
+ * it won't be logged by {@link Operation#logError(Throwable)}
+ *
+ * It's intended to be used for exceptions which are part of a flow,
+ * for example {@link com.hazelcast.durableexecutor.StaleTaskIdException}
+ * is always propagated to the user - there is no reason why Hazelcast
+ * should log it on its own.
  */
-public class StaleTaskException
-        extends HazelcastException implements BusinessException {
-
-    public StaleTaskException(String msg) {
-        super(msg);
-    }
-
+public interface BusinessException {
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -486,7 +486,9 @@ public abstract class Operation implements DataSerializable {
      */
     public void logError(Throwable e) {
         final ILogger logger = getLogger();
-        if (e instanceof RetryableException) {
+        if (e instanceof BusinessException) {
+            logger.finest(e.getMessage(), e);
+        } else if (e instanceof RetryableException) {
             final Level level = returnsResponse() ? Level.FINEST : Level.WARNING;
             if (logger.isLoggable(level)) {
                 logger.log(level, e.getClass().getName() + ": " + e.getMessage());


### PR DESCRIPTION
Exceptions such as StaleSequenceException are part of a normal
flow. They are propagated to user code and there is no reason
why Hazelcast should log them by default.

Fixes #9051