### PR TITLE
Explicitly specify Maven repositories to be used during OSGi provisioning test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
@@ -44,7 +44,7 @@ public class HazelcastOSGiIntegrationTest {
         oldMavenRepoProperty = System.getProperty(MAVEN_REPOSITORIES_PROP);
         System.setProperty(MAVEN_REPOSITORIES_PROP, MAVEN_REPOSITORIES);
 
-        String url = "reference:file:" + PathUtils.getBaseDir() + "/hazelcast/target/classes";
+        String url = "reference:file:" + PathUtils.getBaseDir() + "/target/classes";
         UrlProvisionOption hzBundle = bundle(url);
         CompositeOption junitBundles = junitBundles();
         return options(hzBundle, junitBundles);
@@ -67,6 +67,9 @@ public class HazelcastOSGiIntegrationTest {
 
     @Test
     public void serviceRetrievedSuccessfully() {
+        // Is this test failing in your IDE?
+        // Some versions of Intellij IDEA use a wrong working directory in multi-module
+        // Maven projects. See this for a fix: https://youtrack.jetbrains.com/issue/IDEA-60965
         HazelcastOSGiService service = getService();
         assertNotNull(service);
     }

--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
@@ -2,7 +2,6 @@ package com.hazelcast.osgi;
 
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -10,8 +9,12 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
+import org.ops4j.pax.exam.options.CompositeOption;
+import org.ops4j.pax.exam.options.UrlProvisionOption;
 import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory;
 import org.ops4j.pax.exam.util.PathUtils;
+import org.ops4j.pax.url.maven.commons.MavenConstants;
+import org.ops4j.pax.url.mvn.ServiceConstants;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
@@ -26,16 +29,25 @@ import static org.ops4j.pax.exam.CoreOptions.options;
 @RunWith(JUnit4TestRunner.class)
 @Category(QuickTest.class)
 @ExamReactorStrategy(AllConfinedStagedReactorFactory.class)
-@Ignore(value = "https://github.com/hazelcast/hazelcast/issues/9537")
 public class HazelcastOSGiIntegrationTest {
 
     @Inject
     private BundleContext bundleContext;
 
+    private static final String MAVEN_REPOSITORIES_PROP = ServiceConstants.PID + MavenConstants.PROPERTY_REPOSITORIES;
+    private static final String MAVEN_REPOSITORIES = "https://osgi.sonatype.org/content/groups/pax-runner@id=paxrunner,"
+                                                   + "https://repo1.maven.org/maven2@id=central";
+    private String oldMavenRepoProperty;
+
     @Configuration
     public Option[] config() {
-        return options(bundle("reference:file:" + PathUtils.getBaseDir() + "/hazelcast/target/classes"),
-                junitBundles());
+        oldMavenRepoProperty = System.getProperty(MAVEN_REPOSITORIES_PROP);
+        System.setProperty(MAVEN_REPOSITORIES_PROP, MAVEN_REPOSITORIES);
+
+        String url = "reference:file:" + PathUtils.getBaseDir() + "/hazelcast/target/classes";
+        UrlProvisionOption hzBundle = bundle(url);
+        CompositeOption junitBundles = junitBundles();
+        return options(hzBundle, junitBundles);
     }
 
     @After
@@ -45,6 +57,11 @@ public class HazelcastOSGiIntegrationTest {
                 bundle.uninstall();
                 break;
             }
+        }
+        if (oldMavenRepoProperty == null) {
+            System.clearProperty(MAVEN_REPOSITORIES_PROP);
+        } else {
+            System.setProperty(MAVEN_REPOSITORIES_PROP, oldMavenRepoProperty);
         }
     }
 


### PR DESCRIPTION
Fixes #9537

*Reasoning:*
When no repository is explicitly specified via system properties nor (Maven) settings.xml
then the PAX runner uses [fallback repositories](https://github.com/ops4j/org.ops4j.pax.url/blob/942e7fa2e152311843db81bdd5fc059bbc17e607/pax-url-maven-commons/src/main/java/org/ops4j/pax/url/maven/commons/MavenSettingsImpl.java#L95-L95
).

The fallback repositories are configured to use the HTTP schema.
Maven repo servers send HTTP 301 redirect to HTTPS, but the PAX
does not follow it and blindly stores the redirect page as a .JAR
into a local Maven repository and then use it.

Obviously this "JAR" fails during validation. It also means it poisons
your local Maven repo with rubbish and the rubbish stays there even
after the test! If this test is still failing for you then try clean your maven repo:
```shell
rm -rf ~/.m2/repository/org/apache/felix
rm -rf ~/.m2/repository/org/ops4j/pax
```