### PR TITLE
Split ClockTest into a QuickTest and SlowTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/Clock.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/Clock.java
@@ -18,6 +18,8 @@ package com.hazelcast.util;
 
 import com.hazelcast.nio.ClassLoaderUtil;
 
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+
 /**
  * Abstracts the system clock to simulate different clocks without changing the actual system time.
  *
@@ -28,7 +30,7 @@ import com.hazelcast.nio.ClassLoaderUtil;
  *
  * <b>WARNING:</b> This class is a singleton.
  * Once the class has been initialized, the clock implementation or offset cannot be changed.
- * To use this class properly in unit or integration tests, please have a look at {@code ClockTest}.
+ * To use this class properly in unit or integration tests, please have a look at {@code ClockIntegrationTest}.
  */
 public final class Clock {
 
@@ -43,16 +45,16 @@ public final class Clock {
     }
 
     static {
-        CLOCK = initClock();
+        CLOCK = createClock();
     }
 
-    private static ClockImpl initClock() {
+    static ClockImpl createClock() {
         String clockImplClassName = System.getProperty(ClockProperties.HAZELCAST_CLOCK_IMPL);
         if (clockImplClassName != null) {
             try {
                 return ClassLoaderUtil.newInstance(null, clockImplClassName);
             } catch (Exception e) {
-                throw ExceptionUtil.rethrow(e);
+                throw rethrow(e);
             }
         }
 
@@ -62,7 +64,7 @@ public final class Clock {
             try {
                 offset = Long.parseLong(clockOffset);
             } catch (NumberFormatException e) {
-                throw ExceptionUtil.rethrow(e);
+                throw rethrow(e);
             }
         }
         if (offset != 0L) {
@@ -83,7 +85,7 @@ public final class Clock {
     /**
      * Default clock implementation, which is used if no properties are defined. It will return the system time.
      */
-    private static final class SystemClock extends ClockImpl {
+    static final class SystemClock extends ClockImpl {
 
         @Override
         protected long currentTimeMillis() {
@@ -95,11 +97,11 @@ public final class Clock {
      * Clock implementation that returns the system time with a static offset, which is used if
      * {@link ClockProperties#HAZELCAST_CLOCK_OFFSET} is defined.
      */
-    private static final class SystemOffsetClock extends ClockImpl {
+    static final class SystemOffsetClock extends ClockImpl {
 
         private final long offset;
 
-        private SystemOffsetClock(final long offset) {
+        SystemOffsetClock(final long offset) {
             this.offset = offset;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/AbstractClockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/AbstractClockTest.java
@@ -82,7 +82,6 @@ public abstract class AbstractClockTest extends HazelcastTestSupport {
             Method method = instanceClass.getMethod("shutdown");
             method.invoke(isolatedNode);
             isolatedNode = null;
-            System.gc();
         } catch (Exception e) {
             throw new RuntimeException("Could not start shutdown Hazelcast instance", e);
         }

--- a/hazelcast/src/test/java/com/hazelcast/util/ClockIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ClockIntegrationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class ClockIntegrationTest extends AbstractClockTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @After
+    public void tearDown() {
+        shutdownIsolatedNode();
+        resetClock();
+    }
+
+    @Test
+    public void test_whenConfiguringClockOffset_thenSystemOffsetClockIsCreated() {
+        System.setProperty(ClockProperties.HAZELCAST_CLOCK_OFFSET, "-999999999");
+        startIsolatedNode();
+
+        long systemMillis = System.currentTimeMillis();
+        sleepSeconds(1);
+        long offsetMillis = getClusterTime(isolatedNode);
+        assertTrue(format("ClusterTime should be far behind the normal clock! %d < %d", offsetMillis, systemMillis),
+                offsetMillis < systemMillis);
+    }
+
+    @Test
+    public void test_whenConfiguringInvalidClockOffset_thenExceptionIsThrown() {
+        System.setProperty(ClockProperties.HAZELCAST_CLOCK_OFFSET, "InvalidNumber");
+
+        expectedException.expectCause(new RootCauseMatcher(NumberFormatException.class));
+        startIsolatedNode();
+    }
+
+    @Test
+    public void test_whenConfiguringNonExistingClockImpl_thenExceptionIsThrown() {
+        System.setProperty(ClockProperties.HAZELCAST_CLOCK_IMPL, "NonExistingClockImpl");
+
+        expectedException.expectCause(new RootCauseMatcher(ClassNotFoundException.class));
+        startIsolatedNode();
+    }
+}


### PR DESCRIPTION
`ClockTest` seems to crash our CI builds quite often. The test method
`test_whenConfiguringClockOffset_thenSystemOffsetClockIsCreated()` takes
over 3 seconds to complete. The `SystemClockChangeTest` which uses the
same classloader magic takes up to 3 minutes (it's a `NightlyTest`).

This commit splits up the `ClockTest` into a really quick unit test of all
single components and skips the classloading magic for the singleton
part of the `Clock` implementation. This should fix the immediate issue
with our builds, but needs further investigation of the root cause.

Part of https://github.com/hazelcast/hazelcast/issues/9650