### PR TITLE
[BACKPORT] Memcache: BulkGet implemented as a single command

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandConstants.java
@@ -54,7 +54,7 @@ public final class TextCommandConstants {
 
     public enum TextCommandType {
         GET((byte) 0),
-        PARTIAL_GET((byte) 1),
+        BULK_GET((byte) 1),
         GETS((byte) 2),
         SET((byte) 3),
         APPEND((byte) 4),

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandService.java
@@ -19,6 +19,10 @@ package com.hazelcast.internal.ascii;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.ascii.memcache.Stats;
 
+import java.util.Map;
+import java.util.Set;
+
+@SuppressWarnings("checkstyle:methodcount")
 public interface TextCommandService {
 
     boolean offer(String queueName, Object value);
@@ -32,6 +36,8 @@ public interface TextCommandService {
     void sendResponse(TextCommand textCommand);
 
     Object get(String mapName, String key);
+
+    Map<String, Object> getAll(String mapName, Set<String> keys);
 
     byte[] getByteArray(String mapName, String key);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -21,7 +21,9 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
+import com.hazelcast.internal.ascii.memcache.BulkGetCommandProcessor;
 import com.hazelcast.internal.ascii.memcache.DeleteCommandProcessor;
+import com.hazelcast.internal.ascii.memcache.EntryConverter;
 import com.hazelcast.internal.ascii.memcache.ErrorCommandProcessor;
 import com.hazelcast.internal.ascii.memcache.GetCommandProcessor;
 import com.hazelcast.internal.ascii.memcache.IncrementCommandProcessor;
@@ -43,6 +45,8 @@ import com.hazelcast.util.EmptyStatement;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -62,7 +66,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.HTTP_PUT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.INCREMENT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.NO_OP;
-import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.PARTIAL_GET;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.BULK_GET;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.PREPEND;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.QUIT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.REPLACE;
@@ -95,12 +99,15 @@ public class TextCommandServiceImpl implements TextCommandService {
     private volatile ResponseThreadRunnable responseThreadRunnable;
     private volatile boolean running = true;
 
+    private final Object mutex = new Object();
+
     public TextCommandServiceImpl(Node node) {
         this.node = node;
         this.hazelcast = node.hazelcastInstance;
         this.logger = node.getLogger(this.getClass().getName());
-        textCommandProcessors[GET.getValue()] = new GetCommandProcessor(this, true);
-        textCommandProcessors[PARTIAL_GET.getValue()] = new GetCommandProcessor(this, false);
+        EntryConverter entryConverter = new EntryConverter(this, node.getLogger(EntryConverter.class));
+        textCommandProcessors[GET.getValue()] = new GetCommandProcessor(this, entryConverter);
+        textCommandProcessors[BULK_GET.getValue()] = new BulkGetCommandProcessor(this, entryConverter);
         textCommandProcessors[SET.getValue()] = new SetCommandProcessor(this);
         textCommandProcessors[APPEND.getValue()] = new SetCommandProcessor(this);
         textCommandProcessors[PREPEND.getValue()] = new SetCommandProcessor(this);
@@ -207,8 +214,13 @@ public class TextCommandServiceImpl implements TextCommandService {
 
     @Override
     public void processRequest(TextCommand command) {
+        startResponseThreadIfNotRunning();
+        node.nodeEngine.getExecutionService().execute("hz:text", new CommandExecutor(command));
+    }
+
+    private void startResponseThreadIfNotRunning() {
         if (responseThreadRunnable == null) {
-            synchronized (this) {
+            synchronized (mutex) {
                 if (responseThreadRunnable == null) {
                     responseThreadRunnable = new ResponseThreadRunnable();
                     HazelcastThreadGroup hazelcastThreadGroup = node.getHazelcastThreadGroup();
@@ -219,12 +231,17 @@ public class TextCommandServiceImpl implements TextCommandService {
                 }
             }
         }
-        node.nodeEngine.getExecutionService().execute("hz:text", new CommandExecutor(command));
     }
 
     @Override
     public Object get(String mapName, String key) {
         return hazelcast.getMap(mapName).get(key);
+    }
+
+    @Override
+    public Map<String, Object> getAll(String mapName, Set<String> keys) {
+        IMap<String, Object> map = hazelcast.getMap(mapName);
+        return map.getAll(keys);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommand.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.memcache;
+
+import com.hazelcast.internal.ascii.AbstractTextCommand;
+import com.hazelcast.internal.ascii.TextCommandConstants;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+
+import static com.hazelcast.nio.IOUtil.copyToHeapBuffer;
+
+public class BulkGetCommand extends AbstractTextCommand {
+
+    private final List<String> keys;
+    private ByteBuffer byteBuffer;
+
+    protected BulkGetCommand(List<String> keys) {
+        super(TextCommandConstants.TextCommandType.BULK_GET);
+        this.keys = keys;
+    }
+
+    public List<String> getKeys() {
+        return keys;
+    }
+
+    @Override
+    public boolean readFrom(ByteBuffer src) {
+        return true;
+    }
+
+    @Override
+    public boolean writeTo(ByteBuffer dst) {
+        copyToHeapBuffer(byteBuffer, dst);
+        return !byteBuffer.hasRemaining();
+    }
+
+    public void setResult(Collection<MemcacheEntry> result) {
+        int size = TextCommandConstants.END.length;
+        for (MemcacheEntry entry : result) {
+            size += entry.getBytes().length;
+        }
+        byteBuffer = ByteBuffer.allocate(size);
+        for (MemcacheEntry entry : result) {
+            byte[] bytes = entry.getBytes();
+            byteBuffer.put(bytes);
+        }
+        byteBuffer.put(TextCommandConstants.END);
+        byteBuffer.flip();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/BulkGetCommandProcessor.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.memcache;
+
+import com.hazelcast.internal.ascii.TextCommandService;
+import com.hazelcast.util.collection.ComposedKeyMap;
+import com.hazelcast.util.collection.InternalSetMultimap;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.internal.ascii.memcache.MemcacheUtils.parseMemcacheKey;
+
+public class BulkGetCommandProcessor extends MemcacheCommandProcessor<BulkGetCommand> {
+
+    private final EntryConverter entryConverter;
+
+    public BulkGetCommandProcessor(TextCommandService textCommandService, EntryConverter entryConverter) {
+        super(textCommandService);
+        this.entryConverter = entryConverter;
+    }
+
+    @Override
+    public void handle(BulkGetCommand request) {
+        List<String> memcacheKeys = request.getKeys();
+
+        InternalSetMultimap<String, String> keysPerMap = new InternalSetMultimap<String, String>();
+        ComposedKeyMap<String, String, String> mapNameAndKey2memcacheKey = new ComposedKeyMap<String, String, String>();
+        for (String memcacheKey : memcacheKeys) {
+            MapNameAndKeyPair mapNameAndKeyPair = parseMemcacheKey(memcacheKey);
+            String mapName = mapNameAndKeyPair.getMapName();
+            String hzKey = mapNameAndKeyPair.getKey();
+            keysPerMap.put(mapName, hzKey);
+            mapNameAndKey2memcacheKey.put(mapName, hzKey, memcacheKey);
+        }
+
+        Collection<MemcacheEntry> allResults = new ArrayList<MemcacheEntry>();
+        for (Map.Entry<String, Set<String>> mapKeys : keysPerMap.entrySet()) {
+            String mapName = mapKeys.getKey();
+            Set<String> keys = mapKeys.getValue();
+            Collection<MemcacheEntry> mapResult = getAll(mapName, keys, mapNameAndKey2memcacheKey);
+            allResults.addAll(mapResult);
+        }
+        int missCount = memcacheKeys.size() - allResults.size();
+        for (int i = 0; i < missCount; i++) {
+            textCommandService.incrementGetMissCount();
+        }
+
+        request.setResult(allResults);
+        textCommandService.sendResponse(request);
+    }
+
+    private Collection<MemcacheEntry> getAll(String mapName, Set<String> keys,
+                                             ComposedKeyMap<String, String, String> mapNameAndKey2memcacheKey) {
+        Map<String, Object> entries = textCommandService.getAll(mapName, keys);
+        Collection<MemcacheEntry> result = new ArrayList<MemcacheEntry>(entries.size());
+        for (Map.Entry<String, Object> entry : entries.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            String origKey = mapNameAndKey2memcacheKey.get(mapName, key);
+            MemcacheEntry memcacheEntry = entryConverter.toEntry(origKey, value);
+            textCommandService.incrementGetHitCount();
+            result.add(memcacheEntry);
+        }
+        return result;
+    }
+
+    @Override
+    public void handleRejection(BulkGetCommand request) {
+        throw new UnsupportedOperationException("not used, this method should be removed from the interface");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/EntryConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/EntryConverter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.memcache;
+
+import com.hazelcast.internal.ascii.TextCommandService;
+import com.hazelcast.logging.ILogger;
+
+import static com.hazelcast.util.StringUtil.stringToBytes;
+
+/**
+ * Produced {@link MemcacheEntry} from key and values
+ *
+ */
+public final class EntryConverter {
+    private final TextCommandService textCommandService;
+    private final ILogger logger;
+
+    public EntryConverter(TextCommandService textCommandService, ILogger logger) {
+        this.textCommandService = textCommandService;
+        this.logger = logger;
+    }
+
+    public MemcacheEntry toEntry(String key, Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        MemcacheEntry entry = null;
+        if (value instanceof MemcacheEntry) {
+            entry = (MemcacheEntry) value;
+        } else if (value instanceof byte[]) {
+            entry = new MemcacheEntry(key, ((byte[]) value), 0);
+        } else if (value instanceof String) {
+            entry = new MemcacheEntry(key, stringToBytes((String) value), 0);
+        } else {
+            try {
+                entry = new MemcacheEntry(key, textCommandService.toByteArray(value), 0);
+            } catch (Exception e) {
+                logger.warning(e);
+            }
+        }
+        return entry;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommand.java
@@ -28,7 +28,7 @@ public class GetCommand extends AbstractTextCommand {
 
     protected final String key;
     private ByteBuffer value;
-    private ByteBuffer lastOne;
+    private ByteBuffer endMarker;
 
     public GetCommand(TextCommandConstants.TextCommandType type, String key) {
         super(type);
@@ -48,11 +48,11 @@ public class GetCommand extends AbstractTextCommand {
         return true;
     }
 
-    public void setValue(MemcacheEntry entry, boolean singleGet) {
+    public void setValue(MemcacheEntry entry) {
         if (entry != null) {
             value = entry.toNewBuffer();
         }
-        lastOne = (singleGet) ? ByteBuffer.wrap(TextCommandConstants.END) : null;
+        endMarker = ByteBuffer.wrap(TextCommandConstants.END);
     }
 
     @Override
@@ -60,11 +60,9 @@ public class GetCommand extends AbstractTextCommand {
         if (value != null) {
             copyToHeapBuffer(value, dst);
         }
-        if (lastOne != null) {
-            copyToHeapBuffer(lastOne, dst);
-        }
+        copyToHeapBuffer(endMarker, dst);
         return !((value != null && value.hasRemaining())
-                || (lastOne != null && lastOne.hasRemaining()));
+                || endMarker.hasRemaining());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
@@ -20,6 +20,8 @@ import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.nio.ascii.TextReadHandler;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.StringTokenizer;
 
 public class GetCommandParser implements CommandParser {
@@ -32,11 +34,12 @@ public class GetCommandParser implements CommandParser {
             readHandler.publishRequest(r);
         } else {
             StringTokenizer st = new StringTokenizer(key);
+            List<String> keys = new ArrayList<String>();
             while (st.hasMoreTokens()) {
-                PartialGetCommand r = new PartialGetCommand(st.nextToken());
-                readHandler.publishRequest(r);
+                String singleKey = st.nextToken();
+                keys.add(singleKey);
             }
-            readHandler.publishRequest(new EndCommand());
+            readHandler.publishRequest(new BulkGetCommand(keys));
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MapNameAndKeyPair.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MapNameAndKeyPair.java
@@ -16,19 +16,29 @@
 
 package com.hazelcast.internal.ascii.memcache;
 
-import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.PARTIAL_GET;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 
-public class PartialGetCommand extends GetCommand {
+/**
+ * Value object for (mapName, key) pair
+ */
+public final class MapNameAndKeyPair {
+    private final String mapName;
+    private final String key;
 
-    public PartialGetCommand(String key) {
-        super(PARTIAL_GET, key);
+    public MapNameAndKeyPair(String mapName, String key) {
+        checkNotNull(mapName);
+        checkNotNull(key);
+
+        this.mapName = mapName;
+        this.key = key;
     }
 
-    @Override
-    public String toString() {
-        return "PartialGetCommand{"
-                + "key='"
-                + key + '\''
-                + '}';
+    public String getMapName() {
+        return mapName;
     }
+
+    public String getKey() {
+        return key;
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/MemcacheUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii.memcache;
+
+import com.hazelcast.core.HazelcastException;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+import static com.hazelcast.internal.ascii.memcache.MemcacheCommandProcessor.DEFAULT_MAP_NAME;
+import static com.hazelcast.internal.ascii.memcache.MemcacheCommandProcessor.MAP_NAME_PRECEDER;
+
+public final class MemcacheUtils {
+
+    private MemcacheUtils() {
+
+    }
+
+    /**
+     * Parse Memcache key into (MapName, Key) pair.
+     *
+     * @param key
+     * @return
+     */
+    public static MapNameAndKeyPair parseMemcacheKey(String key) {
+        key = decodeKey(key);
+        String mapName = DEFAULT_MAP_NAME;
+        int index = key.indexOf(':');
+        if (index != -1) {
+            mapName = MAP_NAME_PRECEDER + key.substring(0, index);
+            key = key.substring(index + 1);
+        }
+        return new MapNameAndKeyPair(mapName, key);
+    }
+
+    private static String decodeKey(String key) {
+        try {
+            return URLDecoder.decode(key, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new HazelcastException(e);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextReadHandler.java
@@ -193,6 +193,15 @@ public class TextReadHandler implements ReadHandler {
     }
 
     public void publishRequest(TextCommand command) {
+        if (!isCommandTypeEnabled(command)) {
+            return;
+        }
+        long requestId = (command.shouldReply()) ? requestIdGen++ : -1;
+        command.init(this, requestId);
+        textCommandService.processRequest(command);
+    }
+
+    private boolean isCommandTypeEnabled(TextCommand command) {
         if (!connectionTypeSet) {
             if (command instanceof HttpCommand) {
                 boolean isMancenterRequest = ((HttpCommand) command).getURI().
@@ -201,21 +210,19 @@ public class TextReadHandler implements ReadHandler {
                         startsWith(HttpCommandProcessor.URI_CLUSTER_MANAGEMENT_BASE_URL);
                 if (!restEnabled && (!isMancenterRequest && !isClusterManagementRequest)) {
                     connection.close("REST not enabled", null);
-                    return;
+                    return false;
                 }
                 connection.setType(ConnectionType.REST_CLIENT);
             } else {
                 if (!memcacheEnabled) {
                     connection.close("Memcached not enabled", null);
-                    return;
+                    return false;
                 }
                 connection.setType(ConnectionType.MEMCACHE_CLIENT);
             }
             connectionTypeSet = true;
         }
-        long requestId = (command.shouldReply()) ? requestIdGen++ : -1;
-        command.init(this, requestId);
-        textCommandService.processRequest(command);
+        return true;
     }
 
     private void processCmd(String cmd) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenVisitor.java
@@ -22,7 +22,7 @@ import com.hazelcast.query.impl.FalsePredicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.util.collection.ArrayUtils;
-import com.hazelcast.util.collection.InternalMultiMap;
+import com.hazelcast.util.collection.InternalListMultiMap;
 
 import java.util.List;
 import java.util.Map;
@@ -49,7 +49,7 @@ public class BetweenVisitor extends AbstractVisitor {
     @Override
     public Predicate visit(AndPredicate andPredicate, Indexes indexes) {
         final Predicate[] originalPredicates = andPredicate.predicates;
-        InternalMultiMap<String, GreaterLessPredicate> candidates =
+        InternalListMultiMap<String, GreaterLessPredicate> candidates =
                 findCandidatesAndGroupByAttribute(originalPredicates, indexes);
 
         if (candidates == null) {
@@ -155,9 +155,9 @@ public class BetweenVisitor extends AbstractVisitor {
     /**
      * Find GreaterLessPredicates with equal flag set to true and group them by attribute name
      */
-    private InternalMultiMap<String, GreaterLessPredicate> findCandidatesAndGroupByAttribute(Predicate[] predicates,
-                                                                                             Indexes indexService) {
-        InternalMultiMap<String, GreaterLessPredicate> candidates = null;
+    private InternalListMultiMap<String, GreaterLessPredicate> findCandidatesAndGroupByAttribute(Predicate[] predicates,
+                                                                                                 Indexes indexService) {
+        InternalListMultiMap<String, GreaterLessPredicate> candidates = null;
         for (Predicate predicate : predicates) {
             if (!(predicate instanceof GreaterLessPredicate)) {
                 continue;
@@ -176,10 +176,10 @@ public class BetweenVisitor extends AbstractVisitor {
         return candidates;
     }
 
-    private InternalMultiMap<String, GreaterLessPredicate> addIntoCandidates(
-            GreaterLessPredicate predicate, InternalMultiMap<String, GreaterLessPredicate> currentCandidates) {
+    private InternalListMultiMap<String, GreaterLessPredicate> addIntoCandidates(
+            GreaterLessPredicate predicate, InternalListMultiMap<String, GreaterLessPredicate> currentCandidates) {
         if (currentCandidates == null) {
-            currentCandidates = new InternalMultiMap<String, GreaterLessPredicate>();
+            currentCandidates = new InternalListMultiMap<String, GreaterLessPredicate>();
         }
         String attributeName = predicate.attributeName;
         currentCandidates.put(attributeName, predicate);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrToInVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrToInVisitor.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.util.collection.InternalMultiMap;
+import com.hazelcast.util.collection.InternalListMultiMap;
 
 import java.util.List;
 import java.util.Map;
@@ -54,7 +54,7 @@ public class OrToInVisitor extends AbstractVisitor {
             return orPredicate;
         }
 
-        InternalMultiMap<String, Integer> candidates = findAndGroupCandidates(originalInnerPredicates);
+        InternalListMultiMap<String, Integer> candidates = findAndGroupCandidates(originalInnerPredicates);
         if (candidates == null) {
             return orPredicate;
         }
@@ -121,15 +121,15 @@ public class OrToInVisitor extends AbstractVisitor {
         return newPredicates;
     }
 
-    private InternalMultiMap<String, Integer> findAndGroupCandidates(Predicate[] innerPredicates) {
-        InternalMultiMap<String, Integer> candidates = null;
+    private InternalListMultiMap<String, Integer> findAndGroupCandidates(Predicate[] innerPredicates) {
+        InternalListMultiMap<String, Integer> candidates = null;
         for (int i = 0; i < innerPredicates.length; i++) {
             Predicate p = innerPredicates[i];
             if (p.getClass().equals(EqualPredicate.class)) {
                 EqualPredicate equalPredicate = (EqualPredicate) p;
                 String attribute = equalPredicate.attributeName;
                 if (candidates == null) {
-                    candidates = new InternalMultiMap<String, Integer>();
+                    candidates = new InternalListMultiMap<String, Integer>();
                 }
                 candidates.put(attribute, i);
             }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/ComposedKeyMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/ComposedKeyMap.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Map with a composed key.
+ *
+ * It's not thread safe and it does not allow nulls.
+ *
+ * It's biased towards use-cases where you have a smaller set of first keys.
+ *
+ * Alternative implementation could avoid map nesting and wrap keys inside
+ * a <code>ComposedKey</code> object.
+ *
+ * @param <K1>
+ * @param <K2>
+ * @param <V>
+ */
+public class ComposedKeyMap<K1, K2, V> {
+    private final Map<K1, Map<K2, V>> backingMap;
+
+    public ComposedKeyMap() {
+        backingMap = new HashMap<K1, Map<K2, V>>();
+    }
+
+    public V put(K1 key1, K2 key2, V value) {
+        checkNotNull(key1, "Key1 cannot be null");
+        checkNotNull(key2, "Key2 cannot be null");
+        checkNotNull(value, "Value cannot be null");
+
+        Map<K2, V> innerMap = backingMap.get(key1);
+        if (innerMap == null) {
+            innerMap = new HashMap<K2, V>();
+            backingMap.put(key1, innerMap);
+        }
+        return innerMap.put(key2, value);
+    }
+
+    public V get(K1 key1, K2 key2) {
+        checkNotNull(key1, "Key1 cannot be null");
+        checkNotNull(key2, "Key2 cannot be null");
+
+        Map<K2, V> innerMap = backingMap.get(key1);
+        if (innerMap == null) {
+            return null;
+        }
+        return innerMap.get(key2);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InternalListMultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InternalListMultiMap.java
@@ -34,10 +34,10 @@ import java.util.Set;
  * @param <K>
  * @param <V>
  */
-public class InternalMultiMap<K, V> {
+public class InternalListMultiMap<K, V> {
     private final Map<K, List<V>> backingMap;
 
-    public InternalMultiMap() {
+    public InternalListMultiMap() {
         this.backingMap = new HashMap<K, List<V>>();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InternalSetMultimap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InternalSetMultimap.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Simplistic implementation of MultiMap.
+ * It's not thread-safe, concurrent access has to be externally synchronized.
+ *
+ * It does not allow duplicates: The same value can be associated with the same key once only. Duplicates are
+ * eliminated.
+ *
+ * The name has a prefix Internal- to avoid confusion with {@link com.hazelcast.core.MultiMap}
+ *
+ * @param <K>
+ * @param <V>
+ */
+public class InternalSetMultimap<K, V> {
+    private final Map<K, Set<V>> backingMap;
+
+    public InternalSetMultimap() {
+        this.backingMap = new HashMap<K, Set<V>>();
+    }
+
+    /**
+     * Associate value to a given key. It has no effect if the value is already associated with the key.
+     *
+     * @param key
+     * @param value
+     */
+    public void put(K key, V value) {
+        checkNotNull(key, "Key cannot be null");
+        checkNotNull(value, "Value cannot be null");
+
+        Set<V> values = backingMap.get(key);
+        if (values == null) {
+            values = new HashSet<V>();
+            backingMap.put(key, values);
+        }
+        values.add(value);
+    }
+
+    /**
+     * Return Set of values associated with a given key
+     *
+     * @param key
+     * @return
+     */
+    public Set<V> get(K key) {
+        checkNotNull(key, "Key cannot be null");
+        return backingMap.get(key);
+    }
+
+    public Set<Map.Entry<K, Set<V>>> entrySet() {
+        return backingMap.entrySet();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/memcache/MemcacheUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/memcache/MemcacheUtilsTest.java
@@ -16,17 +16,23 @@
 
 package com.hazelcast.internal.ascii.memcache;
 
-import com.hazelcast.internal.ascii.NoOpCommand;
-import com.hazelcast.internal.ascii.TextCommandConstants;
+import org.junit.Test;
 
-public class EndCommand extends NoOpCommand {
+import static org.junit.Assert.*;
 
-    public EndCommand() {
-        super(TextCommandConstants.END);
+public class MemcacheUtilsTest {
+
+    @Test
+    public void withDefaultMap() {
+        MapNameAndKeyPair mapNameKeyPair = MemcacheUtils.parseMemcacheKey("key");
+        assertEquals("hz_memcache_default", mapNameKeyPair.getMapName());
+        assertEquals("key", mapNameKeyPair.getKey());
     }
 
-    @Override
-    public String toString() {
-        return "EndCommand{}";
+    @Test
+    public void withExplicitMap() {
+        MapNameAndKeyPair mapNameKeyPair = MemcacheUtils.parseMemcacheKey("map:key");
+        assertEquals("hz_memcache_map", mapNameKeyPair.getMapName());
+        assertEquals("key", mapNameKeyPair.getKey());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/ComposedKeyMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/ComposedKeyMapTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ComposedKeyMapTest {
+
+    private ComposedKeyMap<String, String, String> map = new ComposedKeyMap<String, String, String>();
+
+    @Test
+    public void givenEmpty_whenPut_thenReturnNull() {
+        String prevValue = map.put("1", "2", "value");
+        assertNull(prevValue);
+    }
+
+    @Test
+    public void givenValueAssociated_whenPut_thenReturnPreviousValue() {
+        map.put("1", "2", "prevValue");
+        String prevValue = map.put("1", "2", "newValue");
+        assertEquals("prevValue", prevValue);
+    }
+
+    @Test
+    public void givenEmpty_whenGet_thenReturnNull() {
+        String value = map.get("key1", "key2");
+        assertNull(value);
+    }
+
+    @Test
+    public void givenHasEntry_whenGetWithDifferent2ndKey_thenReturnNull() {
+        map.put("key1", "key2", "value");
+
+        String value = map.get("key1", "wrongKey2");
+        assertNull(value);
+    }
+
+    @Test
+    public void givenHasEntry_whenGetWithTheSameKeys_thenReturnValue() {
+        map.put("key1", "key2", "value");
+
+        String value = map.get("key1", "key2");
+        assertEquals("value", value);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/InternalListMultiMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/InternalListMultiMapTest.java
@@ -35,13 +35,13 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class InternalMultiMapTest {
+public class InternalListMultiMapTest {
 
-    private InternalMultiMap<Integer, String> multiMap;
+    private InternalListMultiMap<Integer, String> multiMap;
 
     @Before
     public void setUp() {
-        this.multiMap = new InternalMultiMap<Integer, String>();
+        this.multiMap = new InternalListMultiMap<Integer, String>();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/InternalSetMultiMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/InternalSetMultiMapTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class InternalSetMultiMapTest {
+
+    private InternalSetMultimap<Integer, String> multiMap;
+
+    @Before
+    public void setUp() {
+        this.multiMap = new InternalSetMultimap<Integer, String>();
+    }
+
+    @Test
+    public void put_whenEmpty_thenInsertItIntoCollection() {
+        multiMap.put(1, "value");
+        Collection<String> results = multiMap.get(1);
+
+        assertThat(results, hasSize(1));
+        assertThat(results, contains("value"));
+    }
+
+    @Test
+    public void givenKeyHasValueAlreadyAssociated_whenTheSameValueIsAssociatedAgain_thenDuplicateIsEliminated() {
+        multiMap.put(1, "value");
+        multiMap.put(1, "value");multiMap.put(1, "value");
+
+        Collection<String> results = multiMap.get(1);
+
+        assertThat(results, hasSize(1));
+        assertThat(results, contains("value"));
+    }
+
+    @Test
+    public void entrySet_whenEmpty_thenReturnEmptySet() {
+        Set<?> entries = multiMap.entrySet();
+        assertThat(entries, hasSize(0));
+    }
+}


### PR DESCRIPTION
Fixes #9637, backport of #9642

The old implementation generated PartialGetCommand per each key
and EndCommand. Commands are executed on a multi-threaded
executor service: PartialGetCommand can be re-ordered with EndCommand.

The new implementation has 2 advantages
1. Uses map.getAll() <- it gives better performance than calling get() per each key
2. Having a single command eliminates races.

(cherry picked from commit f87f2b5)