### PR TITLE
Remove argument-less waitAllForSafeState()

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAdvancedTest.java
@@ -31,7 +31,7 @@ public class CardinalityEstimatorAdvancedTest extends HazelcastTestSupport {
         estimator.add(1L);
         for (int i = 0; i < k; i++) {
             HazelcastInstance newInstance = nodeFactory.newHazelcastInstance();
-            waitAllForSafeState();
+            waitAllForSafeState(instance, newInstance);
             CardinalityEstimator newEstimator = newInstance.getCardinalityEstimator(name);
             assertEquals((long) 1 + i, newEstimator.estimate());
             newEstimator.add(String.valueOf(i + 1));
@@ -57,7 +57,7 @@ public class CardinalityEstimatorAdvancedTest extends HazelcastTestSupport {
 
         for (int i = 0; i < k; i++) {
             HazelcastInstance newInstance = nodeFactory.newHazelcastInstance();
-            waitAllForSafeState();
+            waitAllForSafeState(instance, newInstance);
             CardinalityEstimator newEstimator = newInstance.getCardinalityEstimator(name);
             assertEquals(estimateSoFar, newEstimator.estimate());
 
@@ -92,7 +92,6 @@ public class CardinalityEstimatorAdvancedTest extends HazelcastTestSupport {
                             try {
                                 counter.incrementAndGet();
                                 instances[id] = nodeFactory.newHazelcastInstance();
-                                waitAllForSafeState();
                                 instances[id].getCardinalityEstimator(name)
                                         .add(String.valueOf(counter.get()));
                             } catch (Exception e) {
@@ -114,6 +113,7 @@ public class CardinalityEstimatorAdvancedTest extends HazelcastTestSupport {
                 assertEquals(expectedValue, newEstimator.estimate());
                 instance.shutdown();
                 instance = instances[0];
+                waitAllForSafeState(instances);
             }
         } finally {
             ex.shutdownNow();

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -69,7 +69,7 @@ public class ListSplitBrainTest extends HazelcastTestSupport {
 
         assertSizeEventually(100, list);
 
-        waitAllForSafeState();
+        waitAllForSafeState(h1, h2, h3);
 
         closeConnectionBetween(h1, h3);
         closeConnectionBetween(h2, h3);

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -51,7 +51,7 @@ public class QueueSplitBrainTest extends HazelcastTestSupport {
             queue.add("item" + i);
         }
 
-        waitAllForSafeState();
+        waitAllForSafeState(h1, h2, h3);
 
         closeConnectionBetween(h1, h3);
         closeConnectionBetween(h2, h3);

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
@@ -97,7 +97,7 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
         HazelcastInstance instance = hzFactory.newHazelcastInstance(config);
         warmUpPartitions(instance);
 
-        waitAllForSafeState();
+        waitAllForSafeState(hz, instance);
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/MigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MigrationTest.java
@@ -59,7 +59,7 @@ public class MigrationTest extends HazelcastTestSupport {
         }
 
         HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(config);
-        waitAllForSafeState();
+        waitAllForSafeState(instance1, instance2);
 
         assertEquals("Some records have been lost.", size, map.values().size());
         for (int i = 0; i < size; i++) {
@@ -67,7 +67,7 @@ public class MigrationTest extends HazelcastTestSupport {
         }
 
         HazelcastInstance instance3 = nodeFactory.newHazelcastInstance(config);
-        waitAllForSafeState();
+        waitAllForSafeState(instance1, instance2, instance3);
 
         assertEquals("Some records have been lost.", size, map.values().size());
         for (int i = 0; i < size; i++) {
@@ -101,7 +101,7 @@ public class MigrationTest extends HazelcastTestSupport {
         instance2.shutdown();
         instance3.shutdown();
 
-        waitAllForSafeState();
+        waitAllForSafeState(instance1);
         assertEquals("Some records have been lost.", size, map.values().size());
         for (int i = 0; i < size; i++) {
             assertEquals(i, map.get(i).intValue());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MapInvalidationMetaDataMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MapInvalidationMetaDataMigrationTest.java
@@ -76,7 +76,7 @@ public class MapInvalidationMetaDataMigrationTest extends HazelcastTestSupport {
         HazelcastInstance instance3 = factory.newHazelcastInstance(config);
         waitAllForSafeState(instance3);
         instance2.shutdown();
-        waitAllForSafeState();
+        waitAllForSafeState(instance3);
 
         Map<Integer, Long> destination = getPartitionToSequenceMap(mapName, instance3);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexingTest.java
@@ -68,7 +68,7 @@ public class QueryIndexingTest extends HazelcastTestSupport {
     public void testResultsHaveNullFields_whenPredicateTestsForNull() {
         IMap<Integer, Employee> map = h1.getMap("employees");
         map.putAll(employees);
-        waitAllForSafeState();
+        waitAllForSafeState(h1, h2);
 
         Collection<Employee> matchingEntries = runQueryNTimes(3, h2.<String, Employee>getMap("employees"));
 
@@ -86,7 +86,7 @@ public class QueryIndexingTest extends HazelcastTestSupport {
         map.addIndex("city", true);
 
         map.putAll(employees);
-        waitAllForSafeState();
+        waitAllForSafeState(h1, h2);
 
         Collection<Employee> matchingEntries = runQueryNTimes(3, h2.<String, Employee>getMap("employees"));
         assertEquals(count / 2, matchingEntries.size());

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTest.java
@@ -891,7 +891,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
     public HazelcastInstance[] createClusterWithCount(int count, Config config) {
         factory = createHazelcastInstanceFactory();
         HazelcastInstance[] instances = factory.newInstances(config, count);
-        waitAllForSafeState();
+        waitAllForSafeState(instances);
         return instances;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -631,10 +631,6 @@ public abstract class HazelcastTestSupport {
         }
     }
 
-    public static void waitAllForSafeState() {
-        waitAllForSafeState(HazelcastInstanceFactory.getAllHazelcastInstances());
-    }
-
     public static void waitAllForSafeState(Collection<HazelcastInstance> instances) {
         waitAllForSafeState(instances, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }
@@ -656,6 +652,13 @@ public abstract class HazelcastTestSupport {
     }
 
     public static void waitAllForSafeState(HazelcastInstance... nodes) {
+        if (nodes.length == 0) {
+            throw new IllegalArgumentException("waitAllForSafeState(HazelcastInstance... nodes) cannot be called with " +
+                    "an empty array. " +
+                    "It's too easy to mistake it for the old argument-less waitAllForSafeState(). " +
+                    "The old version was removed as it was implemented via Hazelcast.getAllHazelcastInstances() " +
+                    "- this uses a static map internally and it's causing issues when tests are running in parallel.");
+        }
         waitAllForSafeState(asList(nodes));
     }
 


### PR DESCRIPTION
It was implemented via Hazelcast.getAllHazelcastInstances()
This  call uses a static map internally and it's causing issues when tests are running in parallel.

Fixes #9217, #9124