### PR TITLE
Small cleanup of classloading related classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassloadingMutexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/distributedclassloading/impl/ClassloadingMutexProvider.java
@@ -29,9 +29,9 @@ import java.io.Closeable;
  * The provided mutexes are closeable as we want to know when the granular mutexes from Java are no longer needed.
  */
 public class ClassloadingMutexProvider {
+
     private static final String JAVA_VERSION_WHERE_PARALLEL_CLASSLOADING_IS_NOT_POSSIBLE = "1.6";
     private static final boolean USE_PARALLEL_LOADING = isParallelClassLoadingPossible();
-
 
     private final ContextMutexFactory mutexFactory = new ContextMutexFactory();
     private final GlobalMutex globalMutex = new GlobalMutex();

--- a/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
@@ -19,17 +19,16 @@ package com.hazelcast.nio;
 import com.hazelcast.internal.distributedclassloading.impl.ClassSource;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
-import com.hazelcast.util.EmptyStatement;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.util.Preconditions.isNotNull;
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * Utility class to deal with classloaders.
@@ -59,12 +58,13 @@ public final class ClassLoaderUtil {
         primitives.put("double", double.class);
         primitives.put("char", char.class);
         primitives.put("void", void.class);
-        PRIMITIVE_CLASSES = Collections.unmodifiableMap(primitives);
+        PRIMITIVE_CLASSES = unmodifiableMap(primitives);
     }
 
     private ClassLoaderUtil() {
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> T newInstance(ClassLoader classLoader, final String className) throws Exception {
         classLoader = classLoader == null ? ClassLoaderUtil.class.getClassLoader() : classLoader;
         Constructor<T> constructor = CONSTRUCTOR_CACHE.get(classLoader, className);
@@ -72,7 +72,7 @@ public final class ClassLoaderUtil {
             return constructor.newInstance();
         }
         Class<T> klass = (Class<T>) loadClass(classLoader, className);
-        return (T) newInstance(klass, classLoader, className);
+        return newInstance(klass, classLoader, className);
     }
 
     public static <T> T newInstance(Class<T> klass, ClassLoader classLoader, String className) throws Exception {
@@ -86,9 +86,7 @@ public final class ClassLoaderUtil {
         return constructor.newInstance();
     }
 
-    public static Class<?> loadClass(final ClassLoader classLoader, final String className)
-            throws ClassNotFoundException {
-
+    public static Class<?> loadClass(final ClassLoader classLoader, final String className) throws ClassNotFoundException {
         isNotNull(className, "className");
         if (className.length() <= MAX_PRIM_CLASSNAME_LENGTH && Character.isLowerCase(className.charAt(0))) {
             final Class primitiveClass = PRIMITIVE_CLASSES.get(className);
@@ -101,18 +99,17 @@ public final class ClassLoaderUtil {
             theClassLoader = Thread.currentThread().getContextClassLoader();
         }
 
-        // First try to load it through the given classloader
+        // first try to load it through the given classloader
         if (theClassLoader != null) {
             try {
                 return tryLoadClass(className, theClassLoader);
             } catch (ClassNotFoundException ignore) {
-
-                // Reset selected classloader and try with others
+                // reset selected classloader and try with others
                 theClassLoader = null;
             }
         }
 
-        // If failed and this is a Hazelcast class try again with our classloader
+        // if failed and this is a Hazelcast class try again with our classloader
         if (className.startsWith(HAZELCAST_BASE_PACKAGE) || className.startsWith(HAZELCAST_ARRAY)) {
             theClassLoader = ClassLoaderUtil.class.getClassLoader();
         }
@@ -130,17 +127,12 @@ public final class ClassLoaderUtil {
             Class<?> clazz = loadClass(classLoader, className);
             return clazz != null;
         } catch (ClassNotFoundException e) {
-            EmptyStatement.ignore(e);
+            return false;
         }
-        return false;
-
     }
 
-    private static Class<?> tryLoadClass(String className, ClassLoader classLoader)
-            throws ClassNotFoundException {
-
+    private static Class<?> tryLoadClass(String className, ClassLoader classLoader) throws ClassNotFoundException {
         Class<?> clazz;
-
         if (!CLASS_CACHE_DISABLED) {
             clazz = CLASS_CACHE.get(classLoader, className);
             if (clazz != null) {
@@ -201,18 +193,19 @@ public final class ClassLoaderUtil {
     }
 
     private static final class ClassLoaderWeakCache<V> {
+
         private final ConcurrentMap<ClassLoader, ConcurrentMap<String, WeakReference<V>>> cache;
 
         private ClassLoaderWeakCache() {
-            // Guess 16 classloaders to not waste to much memory (16 is default concurrency level)
+            // let's guess 16 classloaders to not waste too much memory (16 is default concurrency level)
             cache = new ConcurrentReferenceHashMap<ClassLoader, ConcurrentMap<String, WeakReference<V>>>(16);
         }
 
-        private V put(ClassLoader classLoader, String className, V value) {
+        private void put(ClassLoader classLoader, String className, V value) {
             ClassLoader cl = classLoader == null ? ClassLoaderUtil.class.getClassLoader() : classLoader;
             ConcurrentMap<String, WeakReference<V>> innerCache = cache.get(cl);
             if (innerCache == null) {
-                // Let's guess a start of 100 classes per classloader
+                // let's guess a start of 100 classes per classloader
                 innerCache = new ConcurrentHashMap<String, WeakReference<V>>(100);
                 ConcurrentMap<String, WeakReference<V>> old = cache.putIfAbsent(cl, innerCache);
                 if (old != null) {
@@ -220,7 +213,6 @@ public final class ClassLoaderUtil {
                 }
             }
             innerCache.put(className, new WeakReference<V>(value));
-            return value;
         }
 
         public V get(ClassLoader classloader, String className) {
@@ -239,8 +231,8 @@ public final class ClassLoaderUtil {
     }
 
     private static boolean shouldBypassCache(Class clazz) {
-        //dynamically loaded class should not be cached here as they are already cached
-        //in the DistributedLoadingService (when cache is enabled)
+        // dynamically loaded class should not be cached here, as they are already
+        // cached in the DistributedLoadingService (when cache is enabled)
         return (clazz.getClassLoader() instanceof ClassSource);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ClassLoaderUtilTest.java
@@ -1,0 +1,19 @@
+package com.hazelcast.nio;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClassLoaderUtilTest extends HazelcastTestSupport {
+
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(ClassLoaderUtil.class);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.util;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -34,28 +35,27 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ServiceLoaderTest {
+public class ServiceLoaderTest extends HazelcastTestSupport {
 
     @Test
-    public void selectingSimpleSingleClassLoader()
-            throws Exception {
+    public void testConstructor() {
+        assertUtilityConstructor(ServiceLoader.class);
+    }
 
+    @Test
+    public void selectingSimpleSingleClassLoader() {
         List<ClassLoader> classLoaders = ServiceLoader.selectClassLoaders(null);
         assertEquals(1, classLoaders.size());
     }
 
     @Test
-    public void selectingSimpleGivenClassLoader()
-            throws Exception {
-
+    public void selectingSimpleGivenClassLoader() {
         List<ClassLoader> classLoaders = ServiceLoader.selectClassLoaders(new URLClassLoader(new URL[0]));
         assertEquals(2, classLoaders.size());
     }
 
     @Test
-    public void selectingSimpleDifferentThreadContextClassLoader()
-            throws Exception {
-
+    public void selectingSimpleDifferentThreadContextClassLoader() {
         Thread currentThread = Thread.currentThread();
         ClassLoader tccl = currentThread.getContextClassLoader();
         currentThread.setContextClassLoader(new URLClassLoader(new URL[0]));
@@ -65,9 +65,7 @@ public class ServiceLoaderTest {
     }
 
     @Test
-    public void selectingTcclAndGivenClassLoader()
-            throws Exception {
-
+    public void selectingTcclAndGivenClassLoader() {
         Thread currentThread = Thread.currentThread();
         ClassLoader tccl = currentThread.getContextClassLoader();
         currentThread.setContextClassLoader(new URLClassLoader(new URL[0]));
@@ -77,9 +75,7 @@ public class ServiceLoaderTest {
     }
 
     @Test
-    public void selectingSameTcclAndGivenClassLoader()
-            throws Exception {
-
+    public void selectingSameTcclAndGivenClassLoader() {
         ClassLoader same = new URLClassLoader(new URL[0]);
 
         Thread currentThread = Thread.currentThread();
@@ -91,9 +87,7 @@ public class ServiceLoaderTest {
     }
 
     @Test
-    public void loadServicesSingleClassLoader()
-            throws Exception {
-
+    public void loadServicesSingleClassLoader() throws Exception {
         Class<ServiceLoaderTestInterface> type = ServiceLoaderTestInterface.class;
         String factoryId = "com.hazelcast.ServiceLoaderTestInterface";
 
@@ -107,9 +101,7 @@ public class ServiceLoaderTest {
     }
 
     @Test
-    public void loadServicesSimpleGivenClassLoader()
-            throws Exception {
-
+    public void loadServicesSimpleGivenClassLoader() throws Exception {
         Class<ServiceLoaderTestInterface> type = ServiceLoaderTestInterface.class;
         String factoryId = "com.hazelcast.ServiceLoaderTestInterface";
 
@@ -125,9 +117,7 @@ public class ServiceLoaderTest {
     }
 
     @Test
-    public void loadServicesSimpleDifferentThreadContextClassLoader()
-            throws Exception {
-
+    public void loadServicesSimpleDifferentThreadContextClassLoader() throws Exception {
         Class<ServiceLoaderTestInterface> type = ServiceLoaderTestInterface.class;
         String factoryId = "com.hazelcast.ServiceLoaderTestInterface";
 
@@ -146,9 +136,7 @@ public class ServiceLoaderTest {
     }
 
     @Test
-    public void loadServicesTcclAndGivenClassLoader()
-            throws Exception {
-
+    public void loadServicesTcclAndGivenClassLoader() throws Exception {
         Class<ServiceLoaderTestInterface> type = ServiceLoaderTestInterface.class;
         String factoryId = "com.hazelcast.ServiceLoaderTestInterface";
 
@@ -169,9 +157,7 @@ public class ServiceLoaderTest {
     }
 
     @Test
-    public void loadServicesSameTcclAndGivenClassLoader()
-            throws Exception {
-
+    public void loadServicesSameTcclAndGivenClassLoader() throws Exception {
         Class<ServiceLoaderTestInterface> type = ServiceLoaderTestInterface.class;
         String factoryId = "com.hazelcast.ServiceLoaderTestInterface";
 
@@ -192,13 +178,12 @@ public class ServiceLoaderTest {
     }
 
     @Test
-    public void loadServicesWithSpaceInURL()
-            throws Exception {
-
+    public void loadServicesWithSpaceInURL() throws Exception {
         Class<ServiceLoaderSpacesTestInterface> type = ServiceLoaderSpacesTestInterface.class;
         String factoryId = "com.hazelcast.ServiceLoaderSpacesTestInterface";
 
-        ClassLoader given = new URLClassLoader(new URL[]{new URL(ClassLoader.getSystemResource("test with spaces").toExternalForm().replace("%20", " ") + "/")});
+        URL url = new URL(ClassLoader.getSystemResource("test with spaces").toExternalForm().replace("%20", " ") + "/");
+        ClassLoader given = new URLClassLoader(new URL[]{url});
 
         Set<ServiceLoaderSpacesTestInterface> implementations = new HashSet<ServiceLoaderSpacesTestInterface>();
         Iterator<ServiceLoaderSpacesTestInterface> iterator = ServiceLoader.iterator(type, factoryId, given);
@@ -212,14 +197,12 @@ public class ServiceLoaderTest {
     public interface ServiceLoaderTestInterface {
     }
 
-    public static class ServiceLoaderTestInterfaceImpl
-            implements ServiceLoaderTestInterface {
+    public static class ServiceLoaderTestInterfaceImpl implements ServiceLoaderTestInterface {
     }
 
     public interface ServiceLoaderSpacesTestInterface {
     }
 
-    public static class ServiceLoaderSpacesTestInterfaceImpl
-            implements ServiceLoaderSpacesTestInterface {
+    public static class ServiceLoaderSpacesTestInterfaceImpl implements ServiceLoaderSpacesTestInterface {
     }
 }


### PR DESCRIPTION
* ensured that `ByteArrayOutputStream` in `FilteringClassLoader` is closed
* made a `byte[]` buffer a field to re-use it in `FilteringClassLoader`
* used a pre-compiled `Pattern` in `FilteringClassLoader` to reduce litter
* suppressed some unavoidable warnings
* added tests for private constructors
* added `@PrivateApi` to `FilteringClassLoader`
* added missing `@Override` annotations in ServiceLoader

The only code changes should be in `FilteringClassLoader`, which is not used in production.

Part of https://github.com/hazelcast/hazelcast/issues/9650