### PR TITLE
Upgrade log4j version to the latest patch release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <maven.failsafe.plugin.version>2.17</maven.failsafe.plugin.version>
         <maven.cobertura.plugin.version>2.6</maven.cobertura.plugin.version>
 
-        <log4j.version>1.2.12</log4j.version>
+        <log4j.version>1.2.17</log4j.version>
         <log4j2.version>2.0.1</log4j2.version>
         <slf4j.api.version>1.6.0</slf4j.api.version>
 


### PR DESCRIPTION
Log4j is still used in our tests. Eventually we should migrate
to either slfj4+logback or log4j2