### PR TITLE
Use Log4j2 in tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientLoggerConfigurationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientLoggerConfigurationTest.java
@@ -1,23 +1,32 @@
 package com.hazelcast.client.impl;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.logging.AbstractLogger;
+import com.hazelcast.logging.Log4j2Factory;
+import com.hazelcast.test.SaveLoggingPropertiesRule;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LogEvent;
+import com.hazelcast.logging.LoggerFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.PropertyConfigurator;
 import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.Properties;
-import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.logging.Level;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -26,15 +35,19 @@ public class ClientLoggerConfigurationTest extends HazelcastTestSupport {
 
     private static TestHazelcastFactory hazelcastFactory;
     private static HazelcastInstance client;
-    private final String RANDOM_STRING = randomString();
-    private final String LOG_FILENAME = randomString();
-    private File logFile;
+
+    @Rule
+    public SaveLoggingPropertiesRule saveLoggingPropertiesRule = new SaveLoggingPropertiesRule();
+
+    @Before
+    public void setUp() {
+        System.clearProperty("hazelcast.logging.type");
+        System.clearProperty("hazelcast.logging.class");
+    }
 
     @After
-    public void deleteLogFile () {
-        System.clearProperty("hazelcast.logging.type");
-        logFile = new File("./" + LOG_FILENAME);
-        logFile.delete();
+    public void tearDown() {
+        hazelcastFactory.shutdownAll();
     }
 
     @Test
@@ -48,45 +61,34 @@ public class ClientLoggerConfigurationTest extends HazelcastTestSupport {
     }
 
     // Test with programmatic or system property configuration according to boolean parameter.
-    protected void testLoggingWithConfiguration(boolean programmaticConfiguration) throws IOException {
 
+    // the idea of the test is to configure a specific logging type for a client and then
+    // test its LoggingService produce instances of the expected Logger impl
+    protected void testLoggingWithConfiguration(boolean programmaticConfiguration) throws IOException {
         hazelcastFactory = new TestHazelcastFactory();
         Config cg = new Config();
         cg.setProperty( "hazelcast.logging.type", "jdk" );
         hazelcastFactory.newHazelcastInstance(cg);
 
-        //Setting log4j properties for logging to a file.
-        Properties props = new Properties();
-        props.setProperty("log4j.rootLogger" , "INFO, FILE");
-        props.setProperty("log4j.appender.FILE" , "org.apache.log4j.FileAppender");
-        props.setProperty("log4j.appender.FILE.layout" , "org.apache.log4j.PatternLayout");
-        props.setProperty("log4j.appender.FILE.layout.ConversionPattern",RANDOM_STRING + "\n");
-        props.setProperty("log4j.appender.FILE.File","./" + LOG_FILENAME);
-        props.setProperty("log4j.appender.FILE.ImmediateFlush" , "true");
-        PropertyConfigurator.configure(props);
 
         ClientConfig config = new ClientConfig() ;
         if (programmaticConfiguration) {
-            config.setProperty( "hazelcast.logging.type", "log4j" );
-        }
-        else {
-            System.setProperty( "hazelcast.logging.type", "log4j" );
+            config.setProperty( "hazelcast.logging.type", "log4j2");
+        } else {
+            System.setProperty( "hazelcast.logging.type", "log4j2");
         }
         client = hazelcastFactory.newHazelcastClient(config);
-        client.shutdown();
-        hazelcastFactory.shutdownAll();
 
-        boolean matchFound = false;
-        logFile = new File("./" + LOG_FILENAME);
-        Scanner scanner = new Scanner(logFile);
-        while (scanner.hasNextLine()) {
-            String line = scanner.nextLine();
-            if(line.contains(RANDOM_STRING)){
-                matchFound = true;
-                break;
-            }
-        }
-        assertTrue(matchFound);
+        ILogger clientLogger = client.getLoggingService().getLogger("loggerName");
+        // this part is fragile.
+        // client wraps the actual logger in its own class
+        ILogger actualLogger = (ILogger) getFromField(clientLogger, "logger");
+        Class<?> clientLoggerClass = actualLogger.getClass();
+
+        ILogger expectedLogger = new Log4j2Factory().getLogger("expectedLogger");
+        Class<?> expectedLoggerClass = expectedLogger.getClass();
+
+        assertSame(expectedLoggerClass, clientLoggerClass);
     }
 }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
@@ -8,11 +8,12 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +44,7 @@ public class ClientMapNearCacheStaleReadTest extends HazelcastTestSupport {
     private static final int MAX_RUNTIME = 30;
     private static final String MAP_NAME = "test";
     private static final String KEY = "key123";
-    private static final Logger LOGGER = Logger.getLogger(ClientMapNearCacheStaleReadTest.class);
+    private static final ILogger LOGGER = Logger.getLogger(ClientMapNearCacheStaleReadTest.class);
 
     private AtomicInteger valuePut;
     private AtomicBoolean stop;
@@ -117,14 +118,14 @@ public class ClientMapNearCacheStaleReadTest extends HazelcastTestSupport {
 
         // fail after stopping hazelcast instance
         if (msg != null) {
-            LOGGER.warn(msg);
+            LOGGER.warning(msg);
             fail(msg);
         }
 
         // fail if strict is required and assertion was violated
         if (strict && assertionViolationCount.get() > 0) {
             msg = "Assertion violated " + assertionViolationCount.get() + " times.";
-            LOGGER.warn(msg);
+            LOGGER.warning(msg);
             fail(msg);
         }
     }
@@ -209,20 +210,20 @@ public class ClientMapNearCacheStaleReadTest extends HazelcastTestSupport {
                 int valueMap = parseInt(valueMapStr);
                 if (valueMap != i) {
                     assertionViolationCount.incrementAndGet();
-                    LOGGER.warn("Assertion violated! (valueMap = " + valueMap + ", i = " + i + ")");
+                    LOGGER.warning("Assertion violated! (valueMap = " + valueMap + ", i = " + i + ")");
 
                     // sleep to ensure Near Cache invalidation is really lost
                     try {
                         Thread.sleep(100);
                     } catch (InterruptedException e) {
-                        LOGGER.warn("Interrupted: " + e.getMessage());
+                        LOGGER.warning("Interrupted: " + e.getMessage());
                     }
 
                     // test again and stop if really lost
                     valueMapStr = map.get(KEY);
                     valueMap = parseInt(valueMapStr);
                     if (valueMap != i) {
-                        LOGGER.warn("Near Cache invalidation lost! (valueMap = " + valueMap + ", i = " + i + ")");
+                        LOGGER.warning("Near Cache invalidation lost! (valueMap = " + valueMap + ", i = " + i + ")");
                         failed.set(true);
                         stop.set(true);
                     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ringbuffer/RingbufferTest.java
@@ -38,7 +38,6 @@ public class RingbufferTest extends HazelcastTestSupport {
 
     @Before
     public void init() {
-        setLoggingLog4j();
         Config config = new Config();
         config.addRingBufferConfig(new RingbufferConfig("rb*").setCapacity(CAPACITY));
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicStressTest.java
@@ -17,7 +17,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestThread;
 import com.hazelcast.test.annotation.NightlyTest;
-import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,8 +39,6 @@ public class ClientReliableTopicStressTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        setLoggingLog4j();
-        setLogLevel(Level.DEBUG);
         logger = Logger.getLogger(getClass());
 
         Config config = new Config();
@@ -62,8 +59,6 @@ public class ClientReliableTopicStressTest extends HazelcastTestSupport {
 
     @After
     public void teardown() {
-        resetLogLevel();
-
         HazelcastClient.shutdownAll();
         Hazelcast.shutdownAll();
     }

--- a/hazelcast-client/src/test/resources/log4j2.xml
+++ b/hazelcast-client/src/test/resources/log4j2.xml
@@ -25,11 +25,9 @@
     <Root level="INFO">
       <AppenderRef ref="Console" />
     </Root>
+
+      <!-- example how to set log levels
     <Logger name="com.hazelcast.instance" level="debug" />
-    <Logger name="com.hazelcast.cluster" level="debug" />
-    <Logger name="com.hazelcast.internal.cluster" level="debug" />
-    <Logger name="com.hazelcast.internal.partition" level="debug" />
-    <Logger name="com.hazelcast.spi.hotrestart.cluster" level="debug" />
-    <Logger name="com.hazelcast.test.mocknetwork" level="debug" />
+    -->
   </Loggers>
 </Configuration>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/CustomSpringJUnit4ClassRunner.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spring;
 
 import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.TestLoggingUtils;
 import org.junit.runners.model.InitializationError;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -26,6 +27,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class CustomSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner {
 
     static {
+        TestLoggingUtils.initializeLogging();
         System.setProperty("java.net.preferIPv4Stack", "true");
         GroupProperty.WAIT_SECONDS_BEFORE_JOIN.setSystemProperty("1");
         GroupProperty.PHONE_HOME_ENABLED.setSystemProperty("false");

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MapAggregatePerformanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MapAggregatePerformanceTest.java
@@ -135,7 +135,6 @@ public class MapAggregatePerformanceTest extends HazelcastTestSupport {
         config.addMapConfig(mapConfig);
 
         config.setProperty("hazelcast.query.predicate.parallel.evaluation", "true");
-        config.setProperty("hazelcast.logging.type", "log4j");
 
         HazelcastInstance instance = factory.newInstances(config)[0];
         return instance.getMap("aggr");

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MapWordCountAggregationPerformanceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MapWordCountAggregationPerformanceTest.java
@@ -76,7 +76,6 @@ public class MapWordCountAggregationPerformanceTest extends HazelcastTestSupport
 
         config.setProperty("hazelcast.query.predicate.parallel.evaluation", "true");
         config.setProperty("hazelcast.aggregation.accumulation.parallel.evaluation", "true");
-        config.setProperty("hazelcast.logging.type", "log4j");
 
         HazelcastInstance[] hazelcastInstances = new HazelcastInstance[memberCount];
         for (int i = 0; i < memberCount; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterShutdownTest.java
@@ -9,9 +9,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -23,17 +20,6 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClusterShutdownTest extends HazelcastTestSupport {
-
-    @Before
-    public void setUp() {
-        setLoggingLog4j();
-        setLogLevel(Level.TRACE);
-    }
-
-    @After
-    public void tearDown() {
-        resetLogLevel();
-    }
 
     @Test
     public void cluster_mustBeShutDown_by_singleMember_when_clusterState_ACTIVE() {

--- a/hazelcast/src/test/java/com/hazelcast/executor/LongRunningTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/LongRunningTaskTest.java
@@ -30,7 +30,6 @@ public class LongRunningTaskTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        setLoggingLog4j();
         Config config = new Config().setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + CALL_TIMEOUT);
         hz = createHazelcastInstance(config);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/SystemLogPluginTest.java
@@ -27,8 +27,6 @@ public class SystemLogPluginTest extends AbstractDiagnosticsPluginTest {
 
     @Before
     public void setup() {
-        setLoggingLog4j();
-
         config = new Config();
         config.setProperty(LOG_PARTITIONS.getName(), "true");
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -15,7 +15,6 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,9 +40,6 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
 
     @Before
     public void setUp() throws Exception {
-        setLoggingLog4j();
-        setLogLevel(Level.TRACE);
-
         URL root = new URL(MancenterServlet.class.getResource("/"), "../test-classes");
         String baseDir = URLDecoder.decode(root.getFile(), "UTF-8");
         String sourceDir = baseDir + "/../../src/test/webapp";
@@ -56,8 +52,6 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
 
     @After
     public void tearDown() throws Exception {
-        resetLogLevel();
-
         Hazelcast.shutdownAll();
         jettyServer.stop();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceTest.java
@@ -5,9 +5,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -20,16 +18,8 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class ManagementCenterServiceTest extends HazelcastTestSupport {
 
-    @Before
-    public void setUp() {
-        setLoggingLog4j();
-        setLogLevel(Level.DEBUG);
-    }
-
     @After
     public void tearDown() {
-        resetLogLevel();
-
         Hazelcast.shutdownAll();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -10,10 +10,7 @@ import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
-import org.apache.log4j.Level;
 import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,17 +43,6 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
     private final File preloadFileInvalidMagicBytes = getFileFromResources("nearcache-invalid-magicbytes.store");
     private final File preloadFileInvalidFileFormat = getFileFromResources("nearcache-invalid-fileformat.store");
     private final File preloadFileNegativeFileFormat = getFileFromResources("nearcache-negative-fileformat.store");
-
-    @BeforeClass
-    public static void initLogger() {
-        setLoggingLog4j();
-        setLogLevel(Level.INFO);
-    }
-
-    @AfterClass
-    public static void resetLogger() {
-        resetLogLevel();
-    }
 
     @After
     public void deleteFiles() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaManagerTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,9 +47,6 @@ public class PartitionReplicaManagerTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        setLoggingLog4j();
-        setLogLevel(Level.TRACE);
-
         factory = createHazelcastInstanceFactory(1);
         hazelcastInstance = factory.newHazelcastInstance();
 
@@ -63,8 +59,6 @@ public class PartitionReplicaManagerTest extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
-        resetLogLevel();
-
         factory.terminateAll();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest.java
@@ -25,8 +25,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -65,9 +63,6 @@ public class PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest exten
 
     @Before
     public void setUp() {
-        setLoggingLog4j();
-        setLogLevel(Level.TRACE);
-
         ILogger logger = getLogger(PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest.class);
         ClusterServiceImpl clusterService = mock(ClusterServiceImpl.class);
 
@@ -91,11 +86,6 @@ public class PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest exten
         when(partitionService.getMigrationManager()).thenReturn(migrationManager);
 
         replicaStateChecker = new PartitionReplicaStateChecker(node, partitionService);
-    }
-
-    @After
-    public void tearDown() {
-        resetLogLevel();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/logging/LoggerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/LoggerTest.java
@@ -1,10 +1,12 @@
 package com.hazelcast.logging;
 
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.SaveLoggingPropertiesRule;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -18,14 +20,17 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class LoggerTest {
+public class LoggerTest extends HazelcastTestSupport {
 
     private static final String LOGGING_TYPE_PROPERTY_NAME = "hazelcast.logging.type";
+    private static final String LOGGING_CLASS_PROPERTY_NAME = "hazelcast.logging.class";
     private static final String LOGGING_TYPE_LOG4J = "log4j";
     private static final String LOGGING_TYPE_LOG4J2 = "log4j2";
 
     private static Field LOGGER_FACTORY_FIELD;
-    private static String backupLoggingTypeProperty;
+
+    @Rule
+    public SaveLoggingPropertiesRule saveLoggingPropertiesRule = new SaveLoggingPropertiesRule();
 
     @BeforeClass
     public static void beforeClass() {
@@ -36,12 +41,6 @@ public class LoggerTest {
             throw new IllegalStateException(
                     "Couldn't retrieve \"loggerFactory\" field from " + Logger.class.getName() + " class !", e);
         }
-        backupLoggingTypeProperty = System.getProperty(LOGGING_TYPE_PROPERTY_NAME);
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        System.setProperty(LOGGING_TYPE_PROPERTY_NAME, backupLoggingTypeProperty);
     }
 
     @Before
@@ -53,6 +52,7 @@ public class LoggerTest {
             throw new IllegalStateException(
                     "Couldn't clear \"loggerFactory\" field from " + Logger.class.getName() + " class !", e);
         }
+        System.clearProperty(LOGGING_CLASS_PROPERTY_NAME);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/StoreLatencyPlugin_MapIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/StoreLatencyPlugin_MapIntegrationTest.java
@@ -32,8 +32,6 @@ public class StoreLatencyPlugin_MapIntegrationTest extends HazelcastTestSupport 
 
     @Before
     public void setup() throws Exception {
-        setLoggingLog4j();
-
         Config config = new Config()
                 .setProperty("hazelcast.diagnostics.enabled", "true")
                 .setProperty("hazelcast.diagnostics.storeLatency.period.seconds", "1");

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreDataLoadingContinuesWhenNodeJoins.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreDataLoadingContinuesWhenNodeJoins.java
@@ -78,7 +78,6 @@ public class MapStoreDataLoadingContinuesWhenNodeJoins extends HazelcastTestSupp
     public void testNoDeadLockDuringJoin() throws Exception {
         // create shared hazelcast config
         final Config config = new XmlConfigBuilder().build();
-        config.setProperty("hazelcast.logging.type", "log4j");
 
         // disable JMX to make sure lazy loading works asynchronously
         config.setProperty("hazelcast.jmx", "false");
@@ -162,7 +161,6 @@ public class MapStoreDataLoadingContinuesWhenNodeJoins extends HazelcastTestSupp
     public void testDataLoadedCorrectly() throws Exception {
         // create shared hazelcast config
         final Config config = new XmlConfigBuilder().build();
-        config.setProperty("hazelcast.logging.type", "log4j");
         // disable JMX to make sure lazy loading works asynchronously
         config.setProperty("hazelcast.jmx", "false");
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStaleReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStaleReadTest.java
@@ -5,12 +5,13 @@ import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +44,7 @@ public class NearCacheStaleReadTest extends HazelcastTestSupport {
     private static final int MAX_RUNTIME = 30;
     private static final String KEY = "key123";
     private static final String MAP_NAME = "testMap" + NearCacheStaleReadTest.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(NearCacheStaleReadTest.class);
+    private static final ILogger LOGGER = Logger.getLogger(NearCacheStaleReadTest.class);
 
     private IMap<String, String> map;
     private AtomicInteger valuePut;
@@ -62,7 +63,6 @@ public class NearCacheStaleReadTest extends HazelcastTestSupport {
         // create hazelcast config
         Config config = getConfig();
         config.setProperty("hazelcast.invalidation.max.tolerated.miss.count", "0");
-        config.setProperty("hazelcast.logging.type", "log4j");
         config.setProperty(MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), "2");
         // configure Near Cache
         NearCacheConfig nearCacheConfig = getNearCacheConfig();
@@ -120,14 +120,14 @@ public class NearCacheStaleReadTest extends HazelcastTestSupport {
 
         // fail after stopping hazelcast instance
         if (msg != null) {
-            LOGGER.warn(msg);
+            LOGGER.warning(msg);
             fail(msg);
         }
 
         // fail if strict is required and assertion was violated
         if (strict && assertionViolationCount.get() > 0) {
             msg = "Assertion violated " + assertionViolationCount.get() + " times.";
-            LOGGER.warn(msg);
+            LOGGER.warning(msg);
             fail(msg);
         }
     }
@@ -196,20 +196,20 @@ public class NearCacheStaleReadTest extends HazelcastTestSupport {
                 int valueMap = parseInt(valueMapStr);
                 if (valueMap != i) {
                     assertionViolationCount.incrementAndGet();
-                    LOGGER.warn("Assertion violated! (valueMap = " + valueMap + ", i = " + i + ")");
+                    LOGGER.warning("Assertion violated! (valueMap = " + valueMap + ", i = " + i + ")");
 
                     // sleep to ensure Near Cache invalidation is really lost
                     try {
                         Thread.sleep(100);
                     } catch (InterruptedException e) {
-                        LOGGER.warn("Interrupted: " + e.getMessage());
+                        LOGGER.warning("Interrupted: " + e.getMessage());
                     }
 
                     // test again and stop if really lost
                     valueMapStr = map.get(KEY);
                     valueMap = parseInt(valueMapStr);
                     if (valueMap != i) {
-                        LOGGER.warn("Near Cache invalidation lost! (valueMap = " + valueMap + ", i = " + i + ")");
+                        LOGGER.warning("Near Cache invalidation lost! (valueMap = " + valueMap + ", i = " + i + ")");
                         failed.set(true);
                         stop.set(true);
                     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheCoalescingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheCoalescingTest.java
@@ -33,17 +33,6 @@ public class QueryCacheCoalescingTest extends HazelcastTestSupport {
     @SuppressWarnings("unchecked")
     private static final Predicate<Integer, Integer> TRUE_PREDICATE = TruePredicate.INSTANCE;
 
-    @Before
-    public void setUp() {
-        setLoggingLog4j();
-        setLogLevel(org.apache.log4j.Level.DEBUG);
-    }
-
-    @After
-    public void tearDown() {
-        resetLogLevel();
-    }
-
     @Test
     public void testCoalescingModeWorks() {
         String mapName = randomString();

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -48,7 +48,7 @@ public class MockIOService implements IOService {
     public volatile PacketHandler packetHandler;
 
     public MockIOService(int port) throws Exception {
-        loggingService = new LoggingServiceImpl("somegroup", "log4j", BuildInfoProvider.getBuildInfo());
+        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo());
         hazelcastThreadGroup = new HazelcastThreadGroup(
                 "hz",
                 loggingService.getLogger(HazelcastThreadGroup.class),

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -51,7 +51,7 @@ public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport 
         addressB = new Address("127.0.0.1", 5702);
         addressC = new Address("127.0.0.1", 5703);
 
-        loggingService = new LoggingServiceImpl("somegroup", "log4j", BuildInfoProvider.getBuildInfo());
+        loggingService = new LoggingServiceImpl("somegroup", "log4j2", BuildInfoProvider.getBuildInfo());
         logger = loggingService.getLogger(TcpIpConnection_AbstractTest.class);
 
         metricsRegistryA = newMetricsRegistry();

--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiServiceTest.java
@@ -8,12 +8,8 @@ import com.hazelcast.osgi.impl.HazelcastInternalOSGiService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -33,9 +29,6 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class HazelcastOSGiServiceTest extends HazelcastTestSupport {
-
-    private static String loggingType;
-    private static Level log4jLogLevel;
 
     private TestBundle bundle;
     private TestBundleContext bundleContext;
@@ -80,27 +73,6 @@ public class HazelcastOSGiServiceTest extends HazelcastTestSupport {
                     throw new IllegalStateException("You cannot deregister!");
                 }
             }
-        }
-    }
-
-    @BeforeClass
-    public static void beforeClass() {
-        loggingType = System.getProperty("hazelcast.logging.type");
-        Logger rootLogger = Logger.getRootLogger();
-        if ("log4j".equals(loggingType)) {
-            log4jLogLevel = rootLogger.getLevel();
-        }
-        rootLogger.setLevel(Level.TRACE);
-        System.setProperty("hazelcast.logging.type", "log4j");
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        if (loggingType != null) {
-            System.setProperty("hazelcast.logging.type", loggingType);
-        }
-        if (log4jLogLevel != null) {
-            Logger.getRootLogger().setLevel(log4jLogLevel);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/impl/HazelcastOSGiScriptingTest.java
@@ -4,12 +4,8 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.osgi.TestBundle;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
@@ -21,9 +17,6 @@ import org.osgi.framework.BundleException;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public abstract class HazelcastOSGiScriptingTest {
-
-    protected static String loggingType;
-    protected static Level log4jLogLevel;
 
     protected TestBundle bundle;
 
@@ -45,27 +38,6 @@ public abstract class HazelcastOSGiScriptingTest {
         }
 
     };
-
-    @BeforeClass
-    public static void beforeClass() {
-        loggingType = System.getProperty("hazelcast.logging.type");
-        Logger rootLogger = Logger.getRootLogger();
-        if ("log4j".equals(loggingType)) {
-            log4jLogLevel = rootLogger.getLevel();
-        }
-        rootLogger.setLevel(Level.TRACE);
-        System.setProperty("hazelcast.logging.type", "log4j");
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        if (loggingType != null) {
-            System.setProperty("hazelcast.logging.type", loggingType);
-        }
-        if (log4jLogLevel != null) {
-            Logger.getRootLogger().setLevel(log4jLogLevel);
-        }
-    }
 
     @Before
     public void setup() throws BundleException {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
@@ -181,7 +181,6 @@ public class IndexSplitBrainTest extends HazelcastTestSupport {
     }
 
     protected void setCommonProperties(Config config) {
-        config.setProperty(GroupProperty.LOGGING_TYPE.getName(), "log4j");
         config.setProperty(GroupProperty.PHONE_HOME_ENABLED.getName(), "false");
         config.setProperty("hazelcast.mancenter.enabled", "false");
         config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "1");

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReorderedReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReorderedReplicationTest.java
@@ -63,7 +63,6 @@ public class ReplicatedMapReorderedReplicationTest extends HazelcastTestSupport 
 
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
         final Config config = new Config();
-        config.setProperty("hazelcast.logging.type", "log4j");
         final HazelcastInstance[] instances = factory
                 .newInstances(config, nodeCount);
 

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapWriteOrderTest.java
@@ -76,7 +76,6 @@ public class ReplicatedMapWriteOrderTest extends ReplicatedMapAbstractTest {
 
     @Test
     public void testDataIntegrity() throws InterruptedException {
-        setLoggingLog4j();
         System.out.println("nodeCount = " + nodeCount);
         System.out.println("operations = " + operations);
         System.out.println("keyCount = " + keyCount);

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -61,9 +61,10 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
     private static final boolean THREAD_CONTENTION_INFO_AVAILABLE;
 
     static {
-        String logging = "hazelcast.logging.type";
-        if (System.getProperty(logging) == null) {
-            System.setProperty(logging, "log4j2");
+        String loggingType = "hazelcast.logging.type";
+        String loggingClass = "hazelcast.logging.class";
+        if (System.getProperty(loggingType) == null && System.getProperty(loggingClass) == null) {
+            System.setProperty(loggingClass, TestLoggerFactory.class.getName());
             System.setProperty("isThreadContextMapInheritable", "true");
         }
         if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -60,12 +60,14 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
     private static final boolean THREAD_CPU_TIME_INFO_AVAILABLE;
     private static final boolean THREAD_CONTENTION_INFO_AVAILABLE;
 
+    private static String LOGGING_TYPE_PROP_NAME = "hazelcast.logging.type";
+    private static String LOGGING_CLASS_PROP_NAME = "hazelcast.logging.class";
+
     static {
-        String loggingType = "hazelcast.logging.type";
-        String loggingClass = "hazelcast.logging.class";
-        if (System.getProperty(loggingType) == null && System.getProperty(loggingClass) == null) {
-            System.setProperty(loggingClass, TestLoggerFactory.class.getName());
+        if (shouldForceTestLoggingFactory()) {
+            System.setProperty(LOGGING_CLASS_PROP_NAME, TestLoggerFactory.class.getName());
             System.setProperty("isThreadContextMapInheritable", "true");
+            System.clearProperty(LOGGING_TYPE_PROP_NAME);
         }
         if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
             System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
@@ -110,6 +112,16 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
             }
         }
         THREAD_CONTENTION_INFO_AVAILABLE = threadContentionInfoAvailable;
+    }
+
+    private static boolean shouldForceTestLoggingFactory() {
+        if (JenkinsDetector.isOnJenkins()) {
+            return true;
+        }
+        if (System.getProperty(LOGGING_TYPE_PROP_NAME) == null && System.getProperty(LOGGING_CLASS_PROP_NAME) == null) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -60,15 +60,8 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
     private static final boolean THREAD_CPU_TIME_INFO_AVAILABLE;
     private static final boolean THREAD_CONTENTION_INFO_AVAILABLE;
 
-    private static String LOGGING_TYPE_PROP_NAME = "hazelcast.logging.type";
-    private static String LOGGING_CLASS_PROP_NAME = "hazelcast.logging.class";
-
     static {
-        if (shouldForceTestLoggingFactory()) {
-            System.setProperty(LOGGING_CLASS_PROP_NAME, TestLoggerFactory.class.getName());
-            System.setProperty("isThreadContextMapInheritable", "true");
-            System.clearProperty(LOGGING_TYPE_PROP_NAME);
-        }
+        TestLoggingUtils.initializeLogging();
         if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
             System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
         }
@@ -112,16 +105,6 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
             }
         }
         THREAD_CONTENTION_INFO_AVAILABLE = threadContentionInfoAvailable;
-    }
-
-    private static boolean shouldForceTestLoggingFactory() {
-        if (JenkinsDetector.isOnJenkins()) {
-            return true;
-        }
-        if (System.getProperty(LOGGING_TYPE_PROP_NAME) == null && System.getProperty(LOGGING_CLASS_PROP_NAME) == null) {
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.util.EmptyStatement;
-import org.apache.log4j.MDC;
+import org.apache.logging.log4j.ThreadContext;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.internal.runners.statements.RunAfters;
@@ -63,7 +63,8 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
     static {
         String logging = "hazelcast.logging.type";
         if (System.getProperty(logging) == null) {
-            System.setProperty(logging, "log4j");
+            System.setProperty(logging, "log4j2");
+            System.setProperty("isThreadContextMapInheritable", "true");
         }
         if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
             System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
@@ -128,13 +129,13 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
     }
 
     static void setThreadLocalTestMethodName(String name) {
-        MDC.put("test-name", name);
+        ThreadContext.put("test-name", name);
         TEST_NAME_THREAD_LOCAL.set(name);
     }
 
     static void removeThreadLocalTestMethodName() {
         TEST_NAME_THREAD_LOCAL.remove();
-        MDC.remove("test-name");
+        ThreadContext.remove("test-name");
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.util.EmptyStatement;
-import org.apache.logging.log4j.ThreadContext;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.internal.runners.statements.RunAfters;
@@ -125,13 +124,13 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
     }
 
     static void setThreadLocalTestMethodName(String name) {
-        ThreadContext.put("test-name", name);
+        TestLoggingUtils.setThreadLocalTestMethodName(name);
         TEST_NAME_THREAD_LOCAL.set(name);
     }
 
     static void removeThreadLocalTestMethodName() {
+        TestLoggingUtils.removeThreadLocalTestMethodName();
         TEST_NAME_THREAD_LOCAL.remove();
-        ThreadContext.remove("test-name");
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -42,9 +42,6 @@ import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.test.jitter.JitterRule;
-import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.ComparisonFailure;
 import org.junit.Rule;
@@ -56,7 +53,6 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -88,8 +84,6 @@ import static org.junit.Assert.fail;
 public abstract class HazelcastTestSupport {
 
     public static final int ASSERT_TRUE_EVENTUALLY_TIMEOUT;
-
-    private static Level logLevel;
 
     @Rule
     public JitterRule jitterRule = new JitterRule();
@@ -262,46 +256,8 @@ public abstract class HazelcastTestSupport {
     // ########## logging ##########
     // #############################
 
-    public static void setLoggingLog4j() {
-        System.setProperty("hazelcast.logging.type", "log4j");
-    }
-
-    public static void setLogLevel(Level level) {
-        if (isLog4jLoaded() && logLevel == null) {
-            logLevel = setLogLevelOnAllLoggers(level);
-        }
-    }
-
-    public static void resetLogLevel() {
-        if (isLog4jLoaded() && logLevel != null) {
-            setLogLevelOnAllLoggers(logLevel);
-            logLevel = null;
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Level setLogLevelOnAllLoggers(Level level) {
-        Logger rootLogger = Logger.getRootLogger();
-        Level oldLevel = rootLogger.getLevel();
-        rootLogger.setLevel(level);
-
-        Enumeration<Logger> currentLoggers = LogManager.getCurrentLoggers();
-        while (currentLoggers.hasMoreElements()) {
-            currentLoggers.nextElement().setLevel(level);
-        }
-
-        return oldLevel;
-    }
-
-    private static boolean isLog4jLoaded() {
-        setLoggingLog4j();
-        try {
-            Class.forName("org.apache.log4j.Logger");
-            Class.forName("org.apache.log4j.Level");
-            return true;
-        } catch (Throwable ignored) {
-            return false;
-        }
+    public static void setLoggingLog4j2() {
+        System.setProperty("hazelcast.logging.type", "log4j2");
     }
 
     // ###########################

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1105,6 +1105,24 @@ public abstract class HazelcastTestSupport {
     }
 
     // ###################################
+    // ########## reflection utils #######
+    // ###################################
+
+    public static Object getFromField(Object target, String fieldName) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            if (!Modifier.isPublic(field.getModifiers())) {
+                field.setAccessible(true);
+            }
+            return field.get(target);
+        } catch (NoSuchFieldException e) {
+            throw new AssertionError(e);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    // ###################################
     // ########## inner classes ##########
     // ###################################
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -252,14 +252,6 @@ public abstract class HazelcastTestSupport {
         System.err.println(sb.toString());
     }
 
-    // #############################
-    // ########## logging ##########
-    // #############################
-
-    public static void setLoggingLog4j2() {
-        System.setProperty("hazelcast.logging.type", "log4j2");
-    }
-
     // ###########################
     // ########## sleep ##########
     // ###########################

--- a/hazelcast/src/test/java/com/hazelcast/test/SaveLoggingPropertiesRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SaveLoggingPropertiesRule.java
@@ -1,0 +1,41 @@
+package com.hazelcast.test;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Rule to save and restore logging-related System properties.
+ *
+ * It's useful for tests poking test configuration.
+ *
+ */
+public class SaveLoggingPropertiesRule implements TestRule {
+    private static final String LOGGING_TYPE_PROP_NAME = "hazelcast.logging.type";
+    private static final String LOGGING_CLASS_PROP_NAME = "hazelcast.logging.class";
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                String oldLoggingType = System.getProperty(LOGGING_TYPE_PROP_NAME);
+                String oldLoggingClass = System.getProperty(LOGGING_CLASS_PROP_NAME);
+                try {
+                    base.evaluate();
+                } finally {
+                    setOrClearProperty(LOGGING_TYPE_PROP_NAME, oldLoggingType);
+                    setOrClearProperty(LOGGING_CLASS_PROP_NAME, oldLoggingClass);
+                }
+            }
+
+            private void setOrClearProperty(String propertyName, String value) {
+                if (value == null) {
+                    System.clearProperty(propertyName);
+                } else {
+                    System.setProperty(propertyName, value);
+                }
+            }
+        };
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/TestLoggerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestLoggerFactory.java
@@ -1,0 +1,127 @@
+package com.hazelcast.test;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Log4j2Factory;
+import com.hazelcast.logging.LogEvent;
+import com.hazelcast.logging.LoggerFactory;
+
+import java.util.logging.Level;
+
+/**
+ * The factory uses log4j2 internally, however loggers always
+ * return true to guards such as `isFinestEnabled()` etc.
+ *
+ * The real filtering is happening in the log4js once again.
+ * Thus it covers branches guarded by is-level-enabled checks
+ * yet the real logging is configurable via log4j2.xml
+ *
+ */
+public class TestLoggerFactory implements LoggerFactory {
+
+    private Log4j2Factory log4j2Factory = new Log4j2Factory();
+
+    @Override
+    public ILogger getLogger(String name) {
+        ILogger logger = log4j2Factory.getLogger(name);
+        return new DelegatingTestLogger(logger);
+    }
+
+    private static class DelegatingTestLogger implements ILogger {
+        private ILogger delegate;
+
+        private DelegatingTestLogger(ILogger delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void finest(String message) {
+            delegate.finest(message);
+        }
+
+        @Override
+        public void finest(Throwable thrown) {
+            delegate.finest(thrown);
+        }
+
+        @Override
+        public void finest(String message, Throwable thrown) {
+            delegate.finest(message, thrown);
+        }
+
+        @Override
+        public boolean isFinestEnabled() {
+            return true;
+        }
+
+        @Override
+        public void fine(String message) {
+            delegate.fine(message);
+        }
+
+        @Override
+        public boolean isFineEnabled() {
+            return true;
+        }
+
+        @Override
+        public void info(String message) {
+            delegate.info(message);
+        }
+
+        @Override
+        public void warning(String message) {
+            delegate.warning(message);
+        }
+
+        @Override
+        public void warning(Throwable thrown) {
+            delegate.warning(thrown);
+        }
+
+        @Override
+        public void warning(String message, Throwable thrown) {
+            delegate.warning(message, thrown);
+        }
+
+        @Override
+        public void severe(String message) {
+            delegate.severe(message);
+        }
+
+        @Override
+        public void severe(Throwable thrown) {
+            delegate.severe(thrown);
+        }
+
+        @Override
+        public void severe(String message, Throwable thrown) {
+            delegate.severe(message, thrown);
+        }
+
+        @Override
+        public void log(Level level, String message) {
+            delegate.log(level, message);
+        }
+
+        @Override
+        public void log(Level level, String message, Throwable thrown) {
+            delegate.log(level, message, thrown);
+        }
+
+        @Override
+        public void log(LogEvent logEvent) {
+            delegate.log(logEvent);
+        }
+
+        @Override
+        public Level getLevel() {
+            return Level.ALL;
+        }
+
+        @Override
+        public boolean isLoggable(Level level) {
+            return true;
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/TestLoggingUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestLoggingUtils.java
@@ -1,21 +1,50 @@
 package com.hazelcast.test;
 
+import org.apache.logging.log4j.ThreadContext;
+
 public final class TestLoggingUtils {
     private static String LOGGING_TYPE_PROP_NAME = "hazelcast.logging.type";
     private static String LOGGING_CLASS_PROP_NAME = "hazelcast.logging.class";
+
+    private static final boolean IS_LOG4J2_AVAILABLE = isClassAvailable("org.apache.logging.log4j.Logger");
 
     private TestLoggingUtils() {
     }
 
     public static void initializeLogging() {
         if (shouldForceTestLoggingFactory()) {
-            System.setProperty(LOGGING_CLASS_PROP_NAME, TestLoggerFactory.class.getName());
+            String factoryClassName = TestLoggerFactory.class.getName();
+            System.setProperty(LOGGING_CLASS_PROP_NAME, factoryClassName);
             System.setProperty("isThreadContextMapInheritable", "true");
             System.clearProperty(LOGGING_TYPE_PROP_NAME);
         }
     }
 
+    static void setThreadLocalTestMethodName(String methodName) {
+        if (IS_LOG4J2_AVAILABLE) {
+            ThreadContext.put("test-name", methodName);
+        }
+    }
+
+    static void removeThreadLocalTestMethodName() {
+        if (IS_LOG4J2_AVAILABLE) {
+            ThreadContext.remove("test-name");
+        }
+    }
+
+    private static boolean isClassAvailable(String classname) {
+        try {
+            Class.forName(classname);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
     private static boolean shouldForceTestLoggingFactory() {
+        if (!IS_LOG4J2_AVAILABLE) {
+            return false;
+        }
         if (JenkinsDetector.isOnJenkins()) {
             return true;
         }
@@ -24,4 +53,6 @@ public final class TestLoggingUtils {
         }
         return false;
     }
+
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestLoggingUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestLoggingUtils.java
@@ -1,0 +1,27 @@
+package com.hazelcast.test;
+
+public final class TestLoggingUtils {
+    private static String LOGGING_TYPE_PROP_NAME = "hazelcast.logging.type";
+    private static String LOGGING_CLASS_PROP_NAME = "hazelcast.logging.class";
+
+    private TestLoggingUtils() {
+    }
+
+    public static void initializeLogging() {
+        if (shouldForceTestLoggingFactory()) {
+            System.setProperty(LOGGING_CLASS_PROP_NAME, TestLoggerFactory.class.getName());
+            System.setProperty("isThreadContextMapInheritable", "true");
+            System.clearProperty(LOGGING_TYPE_PROP_NAME);
+        }
+    }
+
+    private static boolean shouldForceTestLoggingFactory() {
+        if (JenkinsDetector.isOnJenkins()) {
+            return true;
+        }
+        if (System.getProperty(LOGGING_TYPE_PROP_NAME) == null && System.getProperty(LOGGING_CLASS_PROP_NAME) == null) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ErrorHandlingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ErrorHandlingTest.java
@@ -10,7 +10,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,20 +28,12 @@ public class ErrorHandlingTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        setLoggingLog4j();
-        setLogLevel(Level.TRACE);
-
         Config config = new Config();
         config.addRingBufferConfig(new RingbufferConfig("foo")
                 .setCapacity(100)
                 .setTimeToLiveSeconds(0));
         HazelcastInstance hz = createHazelcastInstance(config);
         topic = (ReliableTopicProxy<String>) hz.<String>getReliableTopic("foo");
-    }
-
-    @After
-    public void tearDown() {
-        resetLogLevel();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
@@ -9,8 +9,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -28,9 +26,6 @@ public class LossToleranceTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        setLoggingLog4j();
-        setLogLevel(Level.TRACE);
-
         Config config = new Config();
         config.addRingBufferConfig(new RingbufferConfig("foo")
                 .setCapacity(100)
@@ -39,11 +34,6 @@ public class LossToleranceTest extends HazelcastTestSupport {
 
         topic = (ReliableTopicProxy<String>) hz.<String>getReliableTopic("foo");
         ringbuffer = topic.ringbuffer;
-    }
-
-    @After
-    public void tearDown() {
-        resetLogLevel();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerAdapterTest.java
@@ -8,9 +8,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -34,17 +31,6 @@ import static org.mockito.Mockito.when;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ReliableMessageListenerAdapterTest extends HazelcastTestSupport {
-
-    @Before
-    public void setUp() {
-        setLoggingLog4j();
-        setLogLevel(Level.TRACE);
-    }
-
-    @After
-    public void tearDown() {
-        resetLogLevel();
-    }
 
     @Test
     public void testRegistration() {

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
@@ -8,8 +8,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.log4j.Level;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -29,17 +27,9 @@ public class ReliableTopicDestroyTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        setLoggingLog4j();
-        setLogLevel(Level.TRACE);
-
         HazelcastInstance hz = createHazelcastInstance();
         topic = (ReliableTopicProxy<String>) hz.<String>getReliableTopic("foo");
         ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
-    }
-
-    @After
-    public void teardown() {
-        resetLogLevel();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
@@ -41,7 +41,6 @@ public class TransactionImpl_TwoPhaseIntegrationTest extends HazelcastTestSuppor
 
     @Before
     public void setup() {
-        setLoggingLog4j();
         cluster = createHazelcastInstanceFactory(2).newInstances(getConfig());
         localNodeEngine = getNodeEngineImpl(cluster[0]);
         localTxService = getTransactionManagerService(cluster[0]);

--- a/hazelcast/src/test/resources/log4j.properties
+++ b/hazelcast/src/test/resources/log4j.properties
@@ -29,3 +29,6 @@ log4j.logger.com.hazelcast.spi.hotrestart.cluster=debug
 log4j.logger.com.hazelcast.test.mocknetwork=debug
 
 log4j.rootLogger=info, stdout
+
+# WARNING: This config file is no longer used in Hazelcast tests
+# Use log4j2.xml to configure test logging

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,9 @@
         <maven.cobertura.plugin.version>2.6</maven.cobertura.plugin.version>
 
         <log4j.version>1.2.17</log4j.version>
-        <log4j2.version>2.0.1</log4j2.version>
+
+        <!--- This is the last log4j2 version working with Java 6 -->
+        <log4j2.version>2.3</log4j2.version>
         <slf4j.api.version>1.6.0</slf4j.api.version>
 
         <junit.version>4.12</junit.version>
@@ -1006,9 +1008,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
 ## Still work in progress. 

Steps to be done:
- [x] Tests should not poke global logging setting.
- [x] Configure test runners to use log4j2 when no other logging is explicitly configured
- [x] Configure log4j2 to have the same feature as our current logging. This includes appending test name to each logging line. 
- [x] Tests should use a specialized logging factory to cover branches guarderded behind `isFooEnabled()` checks. 
- [ ] Check EE tests do not depend on log4j

Why to upgrade?
- log4j1 is no longer maintained
- I suspect it has a dead-lock causing occasional test-failures. 