### PR TITLE
Wait for cluster safe state after starting new nodes in tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAdvancedTest.java
@@ -56,6 +56,8 @@ public class AtomicLongAdvancedTest extends HazelcastTestSupport {
         atomicLong.set(100);
         for (int i = 0; i < k; i++) {
             HazelcastInstance newInstance = nodeFactory.newHazelcastInstance();
+            waitAllForSafeState(nodeFactory.getAllHazelcastInstances());
+
             IAtomicLong newAtomicLong = newInstance.getAtomicLong(name);
             assertEquals((long) 100 + i, newAtomicLong.get());
             newAtomicLong.incrementAndGet();
@@ -96,6 +98,7 @@ public class AtomicLongAdvancedTest extends HazelcastTestSupport {
                     });
                 }
                 assertOpenEventually(countDownLatch);
+                waitAllForSafeState(nodeFactory.getAllHazelcastInstances());
 
                 // if there is an exception while incrementing in parallel threads, find number of exceptions
                 // and subtract the number from expectedValue.


### PR DESCRIPTION
The test was failing because one node went into shutdown even though migrations were still ongoing. Eventually, the shutdown procedure timed out and the node was terminated causing partition loss. As we expect that the cluster is in a safe state before continuing, we add an explicit wait statement after starting new nodes. In cases of slow tests this will cause a timeout exception which is more easily detected than assertion failures on lost partition data.

Affected issue: https://github.com/hazelcast/hazelcast/issues/9202