### PR TITLE
Throw TransactionTimedOutException when unable to lock key for update

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
@@ -17,6 +17,7 @@
 package com.hazelcast.core;
 
 import com.hazelcast.query.Predicate;
+import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.transaction.TransactionalObject;
 
 import java.util.Collection;
@@ -93,8 +94,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * Locks the key and then gets and returns the value to which the specified key is mapped.
      * Lock will be released at the end of the transaction (either commit or rollback).
      *
+     * @throws NullPointerException         if the specified key is null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#get(Object)
-     * @throws NullPointerException if the specified key is null.
      */
     V getForUpdate(Object key);
 
@@ -119,8 +121,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * <p/>
      * The object to be put will be accessible only in the current transaction context till transaction is committed.
      *
+     * @throws NullPointerException         if the specified key or value is null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#put(Object, Object)
-     * @throws NullPointerException if the specified key or value is null.
      */
     @Override
     V put(K key, V value);
@@ -130,8 +133,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * <p/>
      * The object to be put will be accessible only in the current transaction context till transaction is committed.
      *
+     * @throws NullPointerException         if the specified key, value or timeunit is null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#put(Object, Object, long, java.util.concurrent.TimeUnit)
-     * @throws NullPointerException if the specified key, value or timeunit is null.
      */
     V put(K key, V value, long ttl, TimeUnit timeunit);
 
@@ -140,8 +144,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * <p/>
      * The object to be set will be accessible only in the current transaction context till transaction is committed.
      *
+     * @throws NullPointerException         if the specified key or value is null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#set(Object, Object)
-     * @throws NullPointerException if the specified key or value is null.
      */
     @Override
     void set(K key, V value);
@@ -151,8 +156,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * <p/>
      * The object to be put will be accessible only in the current transaction context until the transaction is committed.
      *
+     * @throws NullPointerException         if the specified key or value is null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#putIfAbsent(Object, Object)
-     * @throws NullPointerException if the specified key or value is null.
      */
     @Override
     V putIfAbsent(K key, V value);
@@ -162,8 +168,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * <p/>
      * The object to be replaced will be accessible only in the current transaction context until the transaction is committed.
      *
+     * @throws NullPointerException         if the specified key or null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#replace(Object, Object)
-     * @throws NullPointerException if the specified key or null.
      */
     @Override
     V replace(K key, V value);
@@ -173,8 +180,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * <p/>
      * The object to be replaced will be accessible only in the current transaction context until the transaction is committed.
      *
+     * @throws NullPointerException         if the specified key, oldValue or newValue is null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#replace(Object, Object, Object)
-     * @throws NullPointerException if the specified key, oldValue or newValue is null.
      */
     @Override
     boolean replace(K key, V oldValue, V newValue);
@@ -184,8 +192,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * <p/>
      * The object to be removed will be removed from only the current transaction context until the transaction is committed.
      *
+     * @throws NullPointerException         if the specified key is null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#remove(Object)
-     * @throws NullPointerException if the specified key is null.
      */
     @Override
     V remove(Object key);
@@ -195,8 +204,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * <p/>
      * The object to be deleted will be removed from only the current transaction context until the transaction is committed.
      *
+     * @throws NullPointerException         if the specified key is null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#delete(Object)
-     * @throws NullPointerException if the specified key is null.
      */
     @Override
     void delete(Object key);
@@ -206,8 +216,9 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
      * <p/>
      * The object to be removed will be removed from only the current transaction context until the transaction is committed.
      *
+     * @throws NullPointerException         if the specified key or value null.
+     * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#remove(Object, Object)
-     * @throws NullPointerException if the specified key or value null.
      */
     @Override
     boolean remove(Object key, Object value);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -30,9 +30,9 @@ import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.TransactionalDistributedObject;
 import com.hazelcast.spi.partition.IPartitionService;
-import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionOptions.TransactionType;
+import com.hazelcast.transaction.TransactionTimedOutException;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.ThreadUtil;
@@ -269,7 +269,7 @@ public abstract class TransactionalMapProxySupport
             Future<VersionedValue> future = operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId);
             versionedValue = future.get();
             if (versionedValue == null) {
-                throw new TransactionException("Transaction couldn't obtain lock for the key: " + toObjectIfNeeded(key));
+                throw new TransactionTimedOutException("Transaction couldn't obtain lock for the key: " + toObjectIfNeeded(key));
             }
             valueMap.put(key, versionedValue);
             return versionedValue;


### PR DESCRIPTION
Previously TransactionTimeout was thrown, now throw TransactionTimedOutException. Update the javadoc to point out that this exception can be thrown from the methods that do mutation.

Affected issue : https://github.com/hazelcast/hazelcast/issues/9374