### PR TITLE
Inject HazelcastInstance in HazelcastInstanceAware commands

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
@@ -186,7 +186,7 @@ public class ClientScheduledFutureProxy<V>
     @Override
     public V get()
             throws InterruptedException, ExecutionException {
-        return this.get0().join();
+        return this.get0().get();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceBasicTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.scheduledexecutor;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
+import com.hazelcast.scheduledexecutor.ScheduledExecutorServiceBasicTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceBasicTest {
+
+    private TestHazelcastFactory factory;
+
+    @After
+    public void teardown() {
+        if (factory != null) {
+            factory.terminateAll();
+        }
+    }
+
+    @Override
+    public HazelcastInstance[] createClusterWithCount(int count) {
+        factory = new TestHazelcastFactory();
+        return factory.newInstances(new Config(), count);
+    }
+
+    @Override
+    public IScheduledExecutorService getScheduledExecutor(HazelcastInstance[] instances, String name) {
+        return factory.newHazelcastClient().getScheduledExecutorService(name);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/scheduledexecutor/ClientScheduledExecutorServiceSlowTest.java
@@ -1,4 +1,21 @@
 /*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
  * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,16 +37,26 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
-import com.hazelcast.scheduledexecutor.ScheduledExecutorServiceTest;
+import com.hazelcast.scheduledexecutor.ScheduledExecutorServiceSlowTest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
-public class ClientScheduledExecutorServiceTest extends ScheduledExecutorServiceTest {
+@Category({SlowTest.class, ParallelTest.class})
+public class ClientScheduledExecutorServiceSlowTest extends ScheduledExecutorServiceSlowTest {
+
+    private TestHazelcastFactory factory;
+
+    @After
+    public void teardown() {
+        if (factory != null) {
+            factory.terminateAll();
+        }
+    }
 
     @Override
     public HazelcastInstance[] createClusterWithCount(int count) {
@@ -39,18 +66,6 @@ public class ClientScheduledExecutorServiceTest extends ScheduledExecutorService
 
     @Override
     public IScheduledExecutorService getScheduledExecutor(HazelcastInstance[] instances, String name) {
-        return ((TestHazelcastFactory) factory).newHazelcastClient().getScheduledExecutorService(name);
-    }
-
-    @Override
-    public void getErroneous()
-            throws InterruptedException {
-        // Ignore - pending client change to support the ExecutionException wrapper
-    }
-
-    @Override
-    public void getErroneous_durable()
-            throws InterruptedException {
-        // Ignore - pending client change to support the ExecutionException wrapper
+        return factory.newHazelcastClient().getScheduledExecutorService(name);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultMessageTask.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService;
+import com.hazelcast.scheduledexecutor.impl.ScheduledTaskResult;
 import com.hazelcast.scheduledexecutor.impl.operations.GetResultOperation;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.ScheduledExecutorPermission;
@@ -97,5 +98,19 @@ public class ScheduledExecutorTaskGetResultMessageTask
     @Override
     public Object[] getParameters() {
         return new Object[] { parameters.handlerUrn };
+    }
+
+    /**
+     * Exceptions may be wrapped in ExecutionExceptionDecorator, the wrapped ExecutionException should be sent to
+     * the client.
+     * @param throwable
+     */
+    @Override
+    protected void sendClientMessage(Throwable throwable) {
+        if (throwable instanceof ScheduledTaskResult.ExecutionExceptionDecorator) {
+            super.sendClientMessage(throwable.getCause());
+        } else {
+            super.sendClientMessage(throwable);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorServiceProxy.java
@@ -88,6 +88,7 @@ public class ScheduledExecutorServiceProxy
     public IScheduledFuture schedule(Runnable command, long delay, TimeUnit unit) {
         checkNotNull(command, "Command is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         ScheduledRunnableAdapter<?> callable = createScheduledRunnableAdapter(command);
         return schedule(callable, delay, unit);
@@ -97,6 +98,7 @@ public class ScheduledExecutorServiceProxy
     public <V> IScheduledFuture<V> schedule(Callable<V> command, long delay, TimeUnit unit) {
         checkNotNull(command, "Command is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         String name = extractNameOrGenerateOne(command);
         int partitionId = getTaskOrKeyPartitionId(command, name);
@@ -111,6 +113,7 @@ public class ScheduledExecutorServiceProxy
     public IScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
         checkNotNull(command, "Command is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         String name = extractNameOrGenerateOne(command);
         int partitionId = getTaskOrKeyPartitionId(command, name);
@@ -126,6 +129,7 @@ public class ScheduledExecutorServiceProxy
     public IScheduledFuture<?> scheduleOnMember(Runnable command, Member member, long delay, TimeUnit unit) {
         checkNotNull(member, "Member is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         return scheduleOnMembers(command, Collections.singleton(member), delay, unit).get(member);
     }
@@ -134,6 +138,7 @@ public class ScheduledExecutorServiceProxy
     public <V> IScheduledFuture<V> scheduleOnMember(Callable<V> command, Member member, long delay, TimeUnit unit) {
         checkNotNull(member, "Member is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         return scheduleOnMembers(command, Collections.singleton(member), delay, unit).get(member);
     }
@@ -143,6 +148,7 @@ public class ScheduledExecutorServiceProxy
                                                            long period, TimeUnit unit) {
         checkNotNull(member, "Member is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         return scheduleOnMembersAtFixedRate(command, Collections.singleton(member), initialDelay, period, unit).get(member);
     }
@@ -151,6 +157,7 @@ public class ScheduledExecutorServiceProxy
     public IScheduledFuture<?> scheduleOnKeyOwner(Runnable command, Object key, long delay, TimeUnit unit) {
         checkNotNull(command, "Command is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         ScheduledRunnableAdapter<?> callable = createScheduledRunnableAdapter(command);
         return scheduleOnKeyOwner(callable, key, delay, unit);
@@ -161,6 +168,7 @@ public class ScheduledExecutorServiceProxy
         checkNotNull(command, "Command is null");
         checkNotNull(key, "Key is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         String name = extractNameOrGenerateOne(command);
         int partitionId = getKeyPartitionId(key);
@@ -176,6 +184,7 @@ public class ScheduledExecutorServiceProxy
         checkNotNull(command, "Command is null");
         checkNotNull(key, "Key is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         String name = extractNameOrGenerateOne(command);
         int partitionId = getKeyPartitionId(key);
@@ -190,6 +199,7 @@ public class ScheduledExecutorServiceProxy
     public Map<Member, IScheduledFuture<?>> scheduleOnAllMembers(Runnable command, long delay, TimeUnit unit) {
         checkNotNull(command, "Command is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
         return scheduleOnMembers(command, getNodeEngine().getClusterService().getMembers(), delay, unit);
     }
 
@@ -197,6 +207,7 @@ public class ScheduledExecutorServiceProxy
     public <V> Map<Member, IScheduledFuture<V>> scheduleOnAllMembers(Callable<V> command, long delay, TimeUnit unit) {
         checkNotNull(command, "Command is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
         return scheduleOnMembers(command, getNodeEngine().getClusterService().getMembers(), delay, unit);
     }
 
@@ -205,6 +216,7 @@ public class ScheduledExecutorServiceProxy
                                                                             TimeUnit unit) {
         checkNotNull(command, "Command is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
        return scheduleOnMembersAtFixedRate(command, getNodeEngine().getClusterService().getMembers(),
                initialDelay, period, unit);
     }
@@ -215,6 +227,7 @@ public class ScheduledExecutorServiceProxy
         checkNotNull(command, "Command is null");
         checkNotNull(members, "Members is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         ScheduledRunnableAdapter callable = createScheduledRunnableAdapter(command);
         return (Map<Member, IScheduledFuture<?>>) scheduleOnMembers(callable, members, delay, unit);
@@ -226,6 +239,7 @@ public class ScheduledExecutorServiceProxy
         checkNotNull(command, "Command is null");
         checkNotNull(members, "Members is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         String name = extractNameOrGenerateOne(command);
         Map<Member, IScheduledFuture<V>> futures = new HashMap<Member, IScheduledFuture<V>>();
@@ -247,6 +261,7 @@ public class ScheduledExecutorServiceProxy
         checkNotNull(command, "Command is null");
         checkNotNull(members, "Members is null");
         checkNotNull(unit, "Unit is null");
+        attachHazelcastInstance(command);
 
         String name = extractNameOrGenerateOne(command);
         ScheduledRunnableAdapter<?> adapter = createScheduledRunnableAdapter(command);
@@ -398,7 +413,9 @@ public class ScheduledExecutorServiceProxy
         return createFutureProxy(address, taskName);
     }
 
-    private void attachHazelcastInstance(HazelcastInstanceAware future) {
-        future.setHazelcastInstance(getNodeEngine().getHazelcastInstance());
+    private void attachHazelcastInstance(Object object) {
+        if (object instanceof HazelcastInstanceAware) {
+            ((HazelcastInstanceAware) object).setHazelcastInstance(getNodeEngine().getHazelcastInstance());
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledFutureProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledFutureProxy.java
@@ -157,7 +157,7 @@ public final class ScheduledFutureProxy<V>
     public V get()
             throws InterruptedException, ExecutionException {
         try {
-            return this.get0().join();
+            return this.get0().get();
         } catch (ScheduledTaskResult.ExecutionExceptionDecorator ex) {
             return sneakyThrow(ex.getCause());
         }

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.scheduledexecutor;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ICountDownLatch;
 import com.hazelcast.core.IMap;
@@ -32,17 +31,16 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionLostEvent;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.RootCauseMatcher;
 import com.hazelcast.util.executor.ManagedExecutorService;
-import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,25 +51,18 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.scheduledexecutor.TaskUtils.named;
-import static com.hazelcast.util.ExceptionUtil.peel;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
+public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceTestSupport {
 
-    protected TestHazelcastInstanceFactory factory;
-
-    @After
-    public void tearDown() {
-        if (factory != null) {
-            factory.shutdownAll();
-        }
-    }
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
 
     @Test
     public void config()
@@ -88,7 +79,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         HazelcastInstance[] instances = createClusterWithCount(1, config);
         IScheduledFuture future = instances[0].getScheduledExecutorService(schedulerName)
-                                              .schedule(new PlainCallableTask(), 0, TimeUnit.SECONDS);
+                                              .schedule(new PlainCallableTask(), 0, SECONDS);
 
         NodeEngineImpl nodeEngine = getNodeEngineImpl(instances[0]);
         ManagedExecutorService mes = (ManagedExecutorService) nodeEngine.getExecutionService()
@@ -114,7 +105,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = instances[0].getScheduledExecutorService(schedulerName);
         IScheduledFuture<Double> future = executorService.schedule(
-                named(taskName, new PlainCallableTask()), delay, TimeUnit.SECONDS);
+                named(taskName, new PlainCallableTask()), delay, SECONDS);
 
         future.get();
 
@@ -138,10 +129,10 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         IScheduledExecutorService executorService = instances[0].getScheduledExecutorService(schedulerName);
         IScheduledFuture future = executorService.schedule(
-                named(taskName, new ICountdownLatchRunnableTask("latch", instances[0])), delay, TimeUnit.SECONDS);
+                named(taskName, new ICountdownLatchRunnableTask("latch")), delay, SECONDS);
 
 
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await(10, SECONDS);
 
         ScheduledTaskHandler handler = future.getHandler();
         assertEquals(schedulerName, handler.getSchedulerName());
@@ -157,16 +148,16 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         Object key = generateKeyOwnedBy(instances[1]);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> future = executorService.scheduleOnKeyOwner(
-                 new PlainCallableTask(), key, (int) delay, TimeUnit.SECONDS);
+                 new PlainCallableTask(), key, (int) delay, SECONDS);
 
         future.get();
         ScheduledTaskStatistics stats = future.getStats();
 
         assertEquals(1, stats.getTotalRuns());
-        assertNotNull(stats.getLastIdleTime(TimeUnit.SECONDS));
-        assertNotNull(stats.getLastRunDuration(TimeUnit.SECONDS));
-        assertNotNull(stats.getTotalIdleTime(TimeUnit.SECONDS));
-        assertNotNull(stats.getTotalRunTime(TimeUnit.SECONDS));
+        assertNotNull(stats.getLastIdleTime(SECONDS));
+        assertNotNull(stats.getLastRunDuration(SECONDS));
+        assertNotNull(stats.getTotalIdleTime(SECONDS));
+        assertNotNull(stats.getTotalRunTime(SECONDS));
         assertNotNull(stats.getTotalRuns());
     }
 
@@ -178,66 +169,18 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> future = executorService.scheduleOnMember(
-                new PlainCallableTask(), instances[0].getCluster().getLocalMember(), (int) delay, TimeUnit.SECONDS);
+                new PlainCallableTask(), instances[0].getCluster().getLocalMember(), (int) delay, SECONDS);
 
         future.get();
         ScheduledTaskStatistics stats = future.getStats();
 
         assertEquals(1, stats.getTotalRuns());
-        assertNotNull(stats.getLastIdleTime(TimeUnit.SECONDS));
-        assertNotNull(stats.getLastRunDuration(TimeUnit.SECONDS));
-        assertNotNull(stats.getTotalIdleTime(TimeUnit.SECONDS));
-        assertNotNull(stats.getTotalRunTime(TimeUnit.SECONDS));
+        assertNotNull(stats.getLastIdleTime(SECONDS));
+        assertNotNull(stats.getLastRunDuration(SECONDS));
+        assertNotNull(stats.getTotalIdleTime(SECONDS));
+        assertNotNull(stats.getTotalRunTime(SECONDS));
         assertNotNull(stats.getTotalRuns());
     }
-
-    @Test
-    public void stats_manyRepetitionsTask()
-            throws ExecutionException, InterruptedException {
-        HazelcastInstance[] instances = createClusterWithCount(4);
-
-        ICountDownLatch latch = instances[0].getCountDownLatch("latch");
-        latch.trySetCount(6);
-
-        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
-        IScheduledFuture future = executorService.scheduleAtFixedRate(
-                new ICountdownLatchRunnableTask("latch", instances[0]), 0, 10, TimeUnit.SECONDS);
-
-
-        latch.await(120, TimeUnit.SECONDS);
-        sleepSeconds(4); // Wait for run-cycle to finish before cancelling, in order for stats to get updated.
-        future.cancel(false);
-
-        ScheduledTaskStatistics stats = future.getStats();
-        assertEquals(6, stats.getTotalRuns());
-    }
-
-    @Test
-    public void stats_longRunningTask_durable()
-            throws ExecutionException, InterruptedException {
-        HazelcastInstance[] instances = createClusterWithCount(4);
-
-        String key = generateKeyOwnedBy(instances[1]);
-
-        ICountDownLatch latch = instances[0].getCountDownLatch("latch");
-        latch.trySetCount(6);
-
-        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
-        IScheduledFuture future = executorService.scheduleOnKeyOwnerAtFixedRate(
-                new ICountdownLatchRunnableTask("latch", instances[0]), key, 0, 10, TimeUnit.SECONDS);
-
-        Thread.sleep(12000);
-
-        instances[1].getLifecycleService().shutdown();
-
-        latch.await(70, TimeUnit.SECONDS);
-        sleepSeconds(4); // Wait for run-cycle to finish before cancelling, in order for stats to get updated.
-        future.cancel(false);
-
-        ScheduledTaskStatistics stats = future.getStats();
-        assertEquals(6, stats.getTotalRuns());
-    }
-
 
     @Test
     public void scheduleAndGet_withCallable()
@@ -249,7 +192,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> future = executorService.schedule(
-                new PlainCallableTask(), delay, TimeUnit.SECONDS);
+                new PlainCallableTask(), delay, SECONDS);
 
         double result = future.get();
 
@@ -270,7 +213,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> future = executorService.scheduleOnKeyOwner(
-                new PlainCallableTask(), key, delay, TimeUnit.SECONDS);
+                new PlainCallableTask(), key, delay, SECONDS);
 
         double resultFromOriginalTask = future.get();
 
@@ -280,28 +223,6 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         assertEquals(expectedResult, resultFromOriginalTask, 0);
         assertEquals(expectedResult, resultFromMigratedTask, 0);
-        assertEquals(true, future.isDone());
-        assertEquals(false, future.isCancelled());
-    }
-
-    @Test
-    public void schedule_withLongSleepingCallable_blockingOnGet()
-            throws ExecutionException, InterruptedException {
-
-        int delay = 0;
-        double expectedResult = 169.4;
-
-        HazelcastInstance[] instances = createClusterWithCount(2);
-        ICountDownLatch runsCountLatch = instances[0].getCountDownLatch("runsCountLatchName");
-        runsCountLatch.trySetCount(1);
-
-        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
-        IScheduledFuture<Double> future = executorService.schedule(
-                new ICountdownLatchCallableTask("runsCountLatchName", 15000, instances[0]), delay, TimeUnit.SECONDS);
-
-        double result = future.get();
-
-        assertEquals(expectedResult, result, 0);
         assertEquals(true, future.isDone());
         assertEquals(false, future.isCancelled());
     }
@@ -327,7 +248,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         executorService.scheduleOnKeyOwner(
                 new ICountdownLatchMapIncrementCallableTask("map", "runEntryCounterName",
-                        "runsCountLatchName", instances[0]), key, delay, TimeUnit.SECONDS);
+                        "runsCountLatchName"), key, delay, SECONDS);
 
         Thread.sleep(2000);
         instances[0].getLifecycleService().shutdown();
@@ -354,12 +275,12 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> future = executorService.schedule(
-                new ICountdownLatchCallableTask("runsCountLatchName", 15000, instances[0]), delay, TimeUnit.SECONDS);
+                new ICountdownLatchCallableTask("runsCountLatchName", 15000), delay, SECONDS);
 
         Thread.sleep(4000);
         future.cancel(false);
 
-        runsCountLatch.await(15, TimeUnit.SECONDS);
+        runsCountLatch.await(15, SECONDS);
 
         assertEquals(true, future.isDone());
         assertEquals(true, future.isCancelled());
@@ -375,7 +296,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> future = executorService.schedule(
-                new PlainCallableTask(), delay, TimeUnit.SECONDS);
+                new PlainCallableTask(), delay, SECONDS);
 
         double result = future.get();
 
@@ -393,10 +314,10 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         executorService.schedule(
-                named(taskName, new PlainCallableTask()), delay, TimeUnit.SECONDS);
+                named(taskName, new PlainCallableTask()), delay, SECONDS);
 
         executorService.schedule(
-                named(taskName, new PlainCallableTask()), delay, TimeUnit.SECONDS);
+                named(taskName, new PlainCallableTask()), delay, SECONDS);
     }
 
     @Test(expected = CancellationException.class)
@@ -439,7 +360,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture future = executorService.scheduleAtFixedRate(
-                new ICountdownLatchRunnableTask("latch", instances[0]), 1, 1, TimeUnit.SECONDS);
+                new ICountdownLatchRunnableTask("latch"), 1, 1, SECONDS);
 
 
         Thread.sleep(5000);
@@ -465,10 +386,10 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture future = executorService.scheduleOnKeyOwnerAtFixedRate(
-                new ICountdownLatchRunnableTask("latch", instances[0]), key,0, 1, TimeUnit.SECONDS);
+                new ICountdownLatchRunnableTask("latch"), key,0, 1, SECONDS);
 
 
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await(10, SECONDS);
 
         assertFalse(future.isCancelled());
         assertFalse(future.isDone());
@@ -508,7 +429,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> first = executorService.schedule(
-                named(taskName, new PlainCallableTask()), delay, TimeUnit.SECONDS);
+                named(taskName, new PlainCallableTask()), delay, SECONDS);
 
         first.dispose();
         first.get();
@@ -521,10 +442,10 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
-        executorService.schedule(new PlainCallableTask(), delay, TimeUnit.SECONDS);
+        executorService.schedule(new PlainCallableTask(), delay, SECONDS);
         executorService.shutdown();
 
-        executorService.schedule(new PlainCallableTask(), delay, TimeUnit.SECONDS);
+        executorService.schedule(new PlainCallableTask(), delay, SECONDS);
     }
     @Test()
     public void schedule_whenPartitionLost()
@@ -533,7 +454,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
-        final IScheduledFuture future = executorService.schedule(new PlainCallableTask(), delay, TimeUnit.SECONDS);
+        final IScheduledFuture future = executorService.schedule(new PlainCallableTask(), delay, SECONDS);
         ScheduledTaskHandler handler = future.getHandler();
 
         int partitionOwner = handler.getPartitionId();
@@ -554,7 +475,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         });
     }
 
-    @Test(expected = StaleTaskException.class)
+    @Test
     public void schedule_getHandlerDisposeThenRecreateFutureAndGet()
             throws ExecutionException, InterruptedException {
         int delay = 1;
@@ -563,11 +484,13 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> first = executorService.schedule(
-                named(taskName, new PlainCallableTask()), delay, TimeUnit.SECONDS);
+                named(taskName, new PlainCallableTask()), delay, SECONDS);
 
         ScheduledTaskHandler handler = first.getHandler();
         first.dispose();
 
+        expected.expect(ExecutionException.class);
+        expected.expectCause(new RootCauseMatcher(StaleTaskException.class));
         executorService.getScheduledFuture(handler).get();
     }
 
@@ -580,7 +503,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         Callable<Double> task = new PlainPartitionAwareCallableTask();
         IScheduledFuture<Double> first = executorService.schedule(
-                task, delay, TimeUnit.SECONDS);
+                task, delay, SECONDS);
 
 
         ScheduledTaskHandler handler = first.getHandler();
@@ -602,45 +525,9 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         latch.trySetCount(1);
 
         executorService.schedule(
-                new StatefullRunnableTask("latch", "runC", "loadC", instances[1]), 2, TimeUnit.SECONDS);
+                new StatefulRunnableTask("latch", "runC", "loadC"), 2, SECONDS);
 
-        latch.await(10, TimeUnit.SECONDS);
-    }
-
-    @Test
-    public void schedule_withStatefulRunnable_durable()
-            throws ExecutionException, InterruptedException {
-
-        HazelcastInstance[] instances = createClusterWithCount(4);
-        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
-        int waitStateSyncPeriodToAvoidPassiveState = 2000;
-
-        String key = generateKeyOwnedBy(instances[1]);
-        ICountDownLatch latch = instances[0].getCountDownLatch("latch");
-        IAtomicLong runC = instances[0].getAtomicLong("runC");
-        IAtomicLong loadC = instances[0].getAtomicLong("loadC");
-
-        latch.trySetCount(1);
-
-        IScheduledFuture future = executorService.scheduleOnKeyOwnerAtFixedRate(
-                new StatefullRunnableTask("latch", "runC", "loadC", instances[1]),
-                key, 10, 10, TimeUnit.SECONDS);
-
-        // Wait for task to get scheduled and start
-        latch.await(11, TimeUnit.SECONDS);
-
-        Thread.sleep(waitStateSyncPeriodToAvoidPassiveState);
-
-        instances[1].getLifecycleService().shutdown();
-
-        // Reset latch - task should be running on a replica now
-        latch.trySetCount(7);
-        latch.await(70, TimeUnit.SECONDS);
-        future.cancel(false);
-
-        assertEquals(getPartitionService(instances[0]).getPartitionId(key), future.getHandler().getPartitionId());
-        assertEquals(8, runC.get(), 1);
-        assertEquals(1, loadC.get());
+        latch.await(10, SECONDS);
     }
 
     @Test
@@ -653,10 +540,10 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         ICountDownLatch latch = instances[0].getCountDownLatch("latch");
         latch.trySetCount(3);
 
-        IScheduledFuture future = s.scheduleAtFixedRate(new ICountdownLatchRunnableTask("latch", instances[0]),
-                0, 1, TimeUnit.SECONDS);
+        IScheduledFuture future = s.scheduleAtFixedRate(new ICountdownLatchRunnableTask("latch"),
+                0, 1, SECONDS);
 
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await(10, SECONDS);
         future.cancel(false);
 
         assertEquals(0, latch.getCount());
@@ -672,7 +559,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         MemberImpl member = getNodeEngineImpl(instances[0]).getLocalMember();
         IScheduledFuture<Double> future = executorService.scheduleOnMember(new PlainCallableTask(),
-                member, delay, TimeUnit.SECONDS);
+                member, delay, SECONDS);
 
         assertEquals(true, future.getHandler().isAssignedToMember());
         assertEquals(25.0, future.get(), 0);
@@ -689,10 +576,9 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         latch.trySetCount(4);
 
         Map<Member, IScheduledFuture<?>> futures = s
-                .scheduleOnAllMembersAtFixedRate(new ICountdownLatchRunnableTask("latch", instances[0]),
-                        0, 3, TimeUnit.SECONDS);
+                .scheduleOnAllMembersAtFixedRate(new ICountdownLatchRunnableTask("latch"), 0, 3, SECONDS);
 
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await(10, SECONDS);
 
         assertEquals(0, latch.getCount());
         assertEquals(4, futures.size());
@@ -710,8 +596,8 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         ICountDownLatch latch = instances[0].getCountDownLatch("latch");
         latch.trySetCount(1);
 
-        s.scheduleOnKeyOwner(new ICountdownLatchRunnableTask("latch", instances[0]),
-                key, 2, TimeUnit.SECONDS).get();
+        s.scheduleOnKeyOwner(new ICountdownLatchRunnableTask("latch"),
+                key, 2, SECONDS).get();
         assertEquals(0, latch.getCount());
 
     }
@@ -728,8 +614,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         ICountDownLatch latch = instances[0].getCountDownLatch("latch");
         latch.trySetCount(1);
 
-        IScheduledFuture future = s.scheduleOnKeyOwner(
-                new ICountdownLatchRunnableTask("latch", instances[0]), key, 2, TimeUnit.SECONDS);
+        IScheduledFuture future = s.scheduleOnKeyOwner(new ICountdownLatchRunnableTask("latch"), key, 2, SECONDS);
 
         instances[1].getLifecycleService().shutdown();
         future.get();
@@ -747,7 +632,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         Callable<Double> task = new PlainPartitionAwareCallableTask();
         IScheduledFuture<Double> first = executorService.scheduleOnKeyOwner(
-                task, key, delay, TimeUnit.SECONDS);
+                task, key, delay, SECONDS);
 
 
         ScheduledTaskHandler handler = first.getHandler();
@@ -770,8 +655,8 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         latch.trySetCount(5);
 
         IScheduledFuture future = executorService.scheduleOnKeyOwnerAtFixedRate(
-                new ICountdownLatchRunnableTask("latch", instances[0]), key,
-                0, 1, TimeUnit.SECONDS);
+                new ICountdownLatchRunnableTask("latch"), key,
+                0, 1, SECONDS);
 
         ScheduledTaskHandler handler = future.getHandler();
         int expectedPartition = instances[0].getPartitionService()
@@ -780,7 +665,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         assertEquals(expectedPartition, handler.getPartitionId());
 
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await(10, SECONDS);
         assertEquals(0, latch.getCount());
     }
 
@@ -792,7 +677,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         HazelcastInstance[] instances = createClusterWithCount(2);
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> first = executorService.schedule(
-                named(taskName, new PlainCallableTask()), delay, TimeUnit.SECONDS);
+                named(taskName, new PlainCallableTask()), delay, SECONDS);
 
         ScheduledTaskHandler handler = first.getHandler();
         IScheduledFuture<Double> copy = executorService.getScheduledFuture(handler);
@@ -806,7 +691,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
 
         HazelcastInstance[] instances = createClusterWithCount(3);
         IScheduledExecutorService s = getScheduledExecutor(instances, "s");
-        s.scheduleOnAllMembers(new PlainCallableTask(), 0, TimeUnit.SECONDS);
+        s.scheduleOnAllMembers(new PlainCallableTask(), 0, SECONDS);
 
         Set<Member> members = instances[0].getCluster().getMembers();
         Map<Member, List<IScheduledFuture<Double>>> allScheduled = s.getAllScheduledFutures();
@@ -820,8 +705,7 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void getErroneous()
-            throws InterruptedException {
+    public void getErroneous() throws InterruptedException, ExecutionException {
         int delay = 2;
         String taskName = "Test";
         String completionLatchName = "completionLatch";
@@ -834,22 +718,16 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         latch.trySetCount(1);
 
         IScheduledFuture<Double> future = executorService.scheduleOnKeyOwner(
-                named(taskName, new ErroneousCallableTask(completionLatchName, instances[1])), key, delay, TimeUnit.SECONDS);
+                named(taskName, new ErroneousCallableTask(completionLatchName)), key, delay, SECONDS);
 
-        latch.await(10, TimeUnit.SECONDS);
-        try {
-            Object result = future.get();
-            fail("Unexpected result " + result);
-        } catch (ExecutionException ex) {
-            assertEquals("Erroneous task", peel(ex).getMessage());
-        } catch (Exception ex) {
-            fail("Wrong exception type " + ex);
-        }
+        latch.await(10, SECONDS);
+        expected.expect(ExecutionException.class);
+        expected.expectCause(new RootCauseMatcher(IllegalStateException.class, "Erroneous task"));
+        Object result = future.get();
     }
 
     @Test
-    public void getErroneous_durable()
-            throws InterruptedException {
+    public void getErroneous_durable() throws InterruptedException, ExecutionException {
         int delay = 2;
         String taskName = "Test";
         String completionLatchName = "completionLatch";
@@ -862,228 +740,14 @@ public class ScheduledExecutorServiceTest extends HazelcastTestSupport {
         latch.trySetCount(1);
 
         IScheduledFuture<Double> future = executorService.scheduleOnKeyOwner(
-                named(taskName, new ErroneousCallableTask(completionLatchName, instances[1])), key, delay, TimeUnit.SECONDS);
+                named(taskName, new ErroneousCallableTask(completionLatchName)), key, delay, SECONDS);
 
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await(10, SECONDS);
         instances[1].getLifecycleService().shutdown();
         Thread.sleep(2000);
 
-        try {
-            Object result = future.get();
-            fail("Unexpected result " + result);
-        } catch (ExecutionException ex) {
-            assertEquals("Erroneous task", peel(ex).getMessage());
-            assertTrue(future.isDone());
-        } catch (Exception ex) {
-            fail("Wrong exception type " + ex);
-        }
-
+        expected.expect(ExecutionException.class);
+        expected.expectCause(new RootCauseMatcher(IllegalStateException.class, "Erroneous task"));
+        Object result = future.get();
     }
-
-    public IScheduledExecutorService getScheduledExecutor(HazelcastInstance[] instances, String name) {
-        return instances[0].getScheduledExecutorService(name);
-    }
-
-    public HazelcastInstance[] createClusterWithCount(int count) {
-        return createClusterWithCount(count, new Config());
-    }
-
-    public HazelcastInstance[] createClusterWithCount(int count, Config config) {
-        factory = createHazelcastInstanceFactory();
-        HazelcastInstance[] instances = factory.newInstances(config, count);
-        waitAllForSafeState(instances);
-        return instances;
-    }
-
-    static class StatefullRunnableTask
-            implements Runnable, Serializable,
-                       HazelcastInstanceAware, StatefulTask<String, Integer> {
-
-        final String latchName;
-
-        final String runCounterName;
-
-        final String loadCounterName;
-
-        int status = 0;
-
-        transient HazelcastInstance instance;
-
-        StatefullRunnableTask(String runsCountLatchName, String runCounterName, String loadCounterName, HazelcastInstance instance) {
-            this.latchName = runsCountLatchName;
-            this.runCounterName = runCounterName;
-            this.loadCounterName = loadCounterName;
-            this.instance = instance;
-        }
-
-        @Override
-        public void run() {
-            status++;
-            instance.getAtomicLong(runCounterName).set(status);
-            instance.getCountDownLatch(latchName).countDown();
-        }
-
-        @Override
-        public void load(Map<String, Integer> snapshot) {
-            status = snapshot.get("status");
-            instance.getAtomicLong(loadCounterName).incrementAndGet();
-        }
-
-        @Override
-        public void save(Map<String, Integer> snapshot) {
-            snapshot.put("status", status);
-        }
-
-        @Override
-        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
-            this.instance = hazelcastInstance;
-        }
-    }
-
-    static class ICountdownLatchCallableTask
-            implements Callable<Double>, Serializable, HazelcastInstanceAware {
-
-        final String runLatchName;
-
-        final int sleepPeriod;
-
-        transient HazelcastInstance instance;
-
-        ICountdownLatchCallableTask(String runLatchName,
-                                    int sleepPeriod, HazelcastInstance instance) {
-            this.runLatchName = runLatchName;
-            this.instance = instance;
-            this.sleepPeriod = sleepPeriod;
-        }
-
-        @Override
-        public Double call() {
-            try {
-                Thread.sleep(sleepPeriod);
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-            }
-
-            instance.getCountDownLatch(runLatchName).countDown();
-            return 77 * 2.2;
-        }
-
-        @Override
-        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
-            this.instance = hazelcastInstance;
-        }
-    }
-
-    static class ICountdownLatchMapIncrementCallableTask
-            implements Runnable, Serializable, HazelcastInstanceAware {
-
-        final String runLatchName;
-
-        final String runEntryCounterName;
-
-        final String mapName;
-
-        transient HazelcastInstance instance;
-
-        ICountdownLatchMapIncrementCallableTask(String mapName, String runEntryCounterName,
-                                                String runLatchName, HazelcastInstance instance) {
-            this.mapName = mapName;
-            this.runEntryCounterName = runEntryCounterName;
-            this.runLatchName = runLatchName;
-            this.instance = instance;
-        }
-
-        @Override
-        public void run() {
-            instance.getAtomicLong(runEntryCounterName).incrementAndGet();
-
-            IMap<String, Integer> map = instance.getMap(mapName);
-            for (int i = 0; i < 100000; i++) {
-                if (map.get(String.valueOf(i)) == i) {
-                    map.put(String.valueOf(i), i + 1);
-                }
-            }
-
-            instance.getCountDownLatch(runLatchName).countDown();
-        }
-
-        @Override
-        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
-            this.instance = hazelcastInstance;
-        }
-    }
-
-    static class ICountdownLatchRunnableTask implements Runnable, Serializable, HazelcastInstanceAware {
-
-        final String runsCountlatchName;
-
-        transient HazelcastInstance instance;
-
-        ICountdownLatchRunnableTask(String runsCountlatchName, HazelcastInstance instance) {
-            this.runsCountlatchName = runsCountlatchName;
-            this.instance = instance;
-        }
-
-        @Override
-        public void run() {
-            instance.getCountDownLatch(runsCountlatchName).countDown();
-        }
-
-        @Override
-        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
-            this.instance = hazelcastInstance;
-        }
-    }
-
-    static class PlainCallableTask implements Callable<Double>, Serializable {
-
-        @Override
-        public Double call()
-                throws Exception {
-            return 5 * 5.0;
-        }
-
-    }
-
-    static class ErroneousCallableTask implements Callable<Double>, Serializable, HazelcastInstanceAware {
-
-        private String completionLatchName;
-
-        private transient HazelcastInstance instance;
-
-        ErroneousCallableTask(String completionLatchName, HazelcastInstance instance) {
-            this.completionLatchName = completionLatchName;
-            this.instance = instance;
-        }
-
-        @Override
-        public Double call()
-                throws Exception {
-            try {
-                throw new IllegalStateException("Erroneous task");
-            } finally {
-                instance.getCountDownLatch(completionLatchName).countDown();
-            }
-        }
-
-        @Override
-        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
-            this.instance = hazelcastInstance;
-        }
-    }
-
-    static class PlainPartitionAwareCallableTask implements Callable<Double>, Serializable, PartitionAware<String> {
-
-        @Override
-        public Double call()
-                throws Exception {
-            return 5 * 5.0;
-        }
-
-        @Override
-        public String getPartitionKey() {
-            return "TestKey";
-        }
-    }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hazelcast.scheduledexecutor;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.core.ICountDownLatch;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({SlowTest.class, ParallelTest.class})
+public class ScheduledExecutorServiceSlowTest
+        extends ScheduledExecutorServiceTestSupport {
+
+    @Test
+    public void schedule_withLongSleepingCallable_blockingOnGet()
+            throws ExecutionException, InterruptedException {
+
+        int delay = 0;
+        double expectedResult = 169.4;
+
+        HazelcastInstance[] instances = createClusterWithCount(2);
+        ICountDownLatch runsCountLatch = instances[0].getCountDownLatch("runsCountLatchName");
+        runsCountLatch.trySetCount(1);
+
+        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
+        IScheduledFuture<Double> future = executorService.schedule(
+                new ScheduledExecutorServiceBasicTest.ICountdownLatchCallableTask("runsCountLatchName", 15000), delay, SECONDS);
+
+        double result = future.get();
+
+        assertEquals(expectedResult, result, 0);
+        assertEquals(true, future.isDone());
+        assertEquals(false, future.isCancelled());
+    }
+
+    @Test
+    public void schedule_withStatefulRunnable_durable()
+            throws ExecutionException, InterruptedException {
+
+        HazelcastInstance[] instances = createClusterWithCount(4);
+        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
+        int waitStateSyncPeriodToAvoidPassiveState = 2000;
+
+        String key = generateKeyOwnedBy(instances[1]);
+        ICountDownLatch latch = instances[0].getCountDownLatch("latch");
+        IAtomicLong runC = instances[0].getAtomicLong("runC");
+        IAtomicLong loadC = instances[0].getAtomicLong("loadC");
+
+        latch.trySetCount(1);
+
+        IScheduledFuture future = executorService.scheduleOnKeyOwnerAtFixedRate(
+                new ScheduledExecutorServiceBasicTest.StatefulRunnableTask("latch", "runC", "loadC"),
+                key, 10, 10, SECONDS);
+
+        // Wait for task to get scheduled and start
+        latch.await(11, SECONDS);
+
+        Thread.sleep(waitStateSyncPeriodToAvoidPassiveState);
+
+        instances[1].getLifecycleService().shutdown();
+
+        // Reset latch - task should be running on a replica now
+        latch.trySetCount(7);
+        latch.await(70, SECONDS);
+        future.cancel(false);
+
+        assertEquals(getPartitionService(instances[0]).getPartitionId(key), future.getHandler().getPartitionId());
+        assertEquals(8, runC.get(), 1);
+        assertEquals(1, loadC.get());
+    }
+
+    @Test
+    public void stats_longRunningTask_durable()
+            throws ExecutionException, InterruptedException {
+        HazelcastInstance[] instances = createClusterWithCount(4);
+
+        String key = generateKeyOwnedBy(instances[1]);
+
+        ICountDownLatch latch = instances[0].getCountDownLatch("latch");
+        latch.trySetCount(6);
+
+        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
+        IScheduledFuture future = executorService.scheduleOnKeyOwnerAtFixedRate(
+                new ScheduledExecutorServiceBasicTest.ICountdownLatchRunnableTask("latch"), key, 0, 10, SECONDS);
+
+        Thread.sleep(12000);
+
+        instances[1].getLifecycleService().shutdown();
+
+        latch.await(70, SECONDS);
+        sleepSeconds(4); // Wait for run-cycle to finish before cancelling, in order for stats to get updated.
+        future.cancel(false);
+
+        ScheduledTaskStatistics stats = future.getStats();
+        assertEquals(6, stats.getTotalRuns());
+    }
+
+    @Test
+    public void stats_manyRepetitionsTask()
+            throws ExecutionException, InterruptedException {
+        HazelcastInstance[] instances = createClusterWithCount(4);
+
+        ICountDownLatch latch = instances[0].getCountDownLatch("latch");
+        latch.trySetCount(6);
+
+        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
+        IScheduledFuture future = executorService.scheduleAtFixedRate(
+                new ScheduledExecutorServiceBasicTest.ICountdownLatchRunnableTask("latch"), 0, 10, SECONDS);
+
+
+        latch.await(120, SECONDS);
+        sleepSeconds(4); // Wait for run-cycle to finish before cancelling, in order for stats to get updated.
+        future.cancel(false);
+
+        ScheduledTaskStatistics stats = future.getStats();
+        assertEquals(6, stats.getTotalRuns());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hazelcast.scheduledexecutor;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.PartitionAware;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * Common methods used in ScheduledExecutorService tests
+ */
+public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
+
+    public IScheduledExecutorService getScheduledExecutor(HazelcastInstance[] instances, String name) {
+        return instances[0].getScheduledExecutorService(name);
+    }
+
+    public HazelcastInstance[] createClusterWithCount(int count) {
+        return createClusterWithCount(count, new Config());
+    }
+
+    public HazelcastInstance[] createClusterWithCount(int count, Config config) {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = factory.newInstances(config, count);
+        waitAllForSafeState(instances);
+        return instances;
+    }
+
+    static class StatefulRunnableTask
+            implements Runnable, Serializable, HazelcastInstanceAware, StatefulTask<String, Integer> {
+
+        final String latchName;
+
+        final String runCounterName;
+
+        final String loadCounterName;
+
+        int status = 0;
+
+        transient HazelcastInstance instance;
+
+        StatefulRunnableTask(String runsCountLatchName, String runCounterName, String loadCounterName) {
+            this.latchName = runsCountLatchName;
+            this.runCounterName = runCounterName;
+            this.loadCounterName = loadCounterName;
+        }
+
+        @Override
+        public void run() {
+            status++;
+            instance.getAtomicLong(runCounterName).set(status);
+            instance.getCountDownLatch(latchName).countDown();
+        }
+
+        @Override
+        public void load(Map<String, Integer> snapshot) {
+            status = snapshot.get("status");
+            instance.getAtomicLong(loadCounterName).incrementAndGet();
+        }
+
+        @Override
+        public void save(Map<String, Integer> snapshot) {
+            snapshot.put("status", status);
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.instance = hazelcastInstance;
+        }
+    }
+
+    static class ICountdownLatchCallableTask
+            implements Callable<Double>, Serializable, HazelcastInstanceAware {
+
+        final String runLatchName;
+
+        final int sleepPeriod;
+
+        transient HazelcastInstance instance;
+
+        ICountdownLatchCallableTask(String runLatchName,
+                                    int sleepPeriod) {
+            this.runLatchName = runLatchName;
+            this.sleepPeriod = sleepPeriod;
+        }
+
+        @Override
+        public Double call() {
+            try {
+                Thread.sleep(sleepPeriod);
+            } catch (InterruptedException e) {
+                Thread.interrupted();
+            }
+
+            instance.getCountDownLatch(runLatchName).countDown();
+            return 77 * 2.2;
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.instance = hazelcastInstance;
+        }
+    }
+
+    static class ICountdownLatchMapIncrementCallableTask
+            implements Runnable, Serializable, HazelcastInstanceAware {
+
+        final String runLatchName;
+
+        final String runEntryCounterName;
+
+        final String mapName;
+
+        transient HazelcastInstance instance;
+
+        ICountdownLatchMapIncrementCallableTask(String mapName, String runEntryCounterName,
+                                                String runLatchName) {
+            this.mapName = mapName;
+            this.runEntryCounterName = runEntryCounterName;
+            this.runLatchName = runLatchName;
+        }
+
+        @Override
+        public void run() {
+            instance.getAtomicLong(runEntryCounterName).incrementAndGet();
+
+            IMap<String, Integer> map = instance.getMap(mapName);
+            for (int i = 0; i < 100000; i++) {
+                if (map.get(String.valueOf(i)) == i) {
+                    map.put(String.valueOf(i), i + 1);
+                }
+            }
+
+            instance.getCountDownLatch(runLatchName).countDown();
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.instance = hazelcastInstance;
+        }
+    }
+
+    static class ICountdownLatchRunnableTask implements Runnable, Serializable, HazelcastInstanceAware {
+
+        final String runsCountlatchName;
+
+        transient HazelcastInstance instance;
+
+        ICountdownLatchRunnableTask(String runsCountlatchName) {
+            this.runsCountlatchName = runsCountlatchName;
+        }
+
+        @Override
+        public void run() {
+            instance.getCountDownLatch(runsCountlatchName).countDown();
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.instance = hazelcastInstance;
+        }
+    }
+
+    static class PlainCallableTask implements Callable<Double>, Serializable {
+
+        @Override
+        public Double call()
+                throws Exception {
+            return 5 * 5.0;
+        }
+
+    }
+
+    static class ErroneousCallableTask implements Callable<Double>, Serializable, HazelcastInstanceAware {
+
+        private String completionLatchName;
+
+        private transient HazelcastInstance instance;
+
+        ErroneousCallableTask(String completionLatchName) {
+            this.completionLatchName = completionLatchName;
+        }
+
+        @Override
+        public Double call()
+                throws Exception {
+            try {
+                throw new IllegalStateException("Erroneous task");
+            } finally {
+                instance.getCountDownLatch(completionLatchName).countDown();
+            }
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.instance = hazelcastInstance;
+        }
+    }
+
+    static class PlainPartitionAwareCallableTask implements Callable<Double>, Serializable, PartitionAware<String> {
+
+        @Override
+        public Double call()
+                throws Exception {
+            return 5 * 5.0;
+        }
+
+        @Override
+        public String getPartitionKey() {
+            return "TestKey";
+        }
+    }
+
+    public static class HazelcastInstanceAwareRunnable implements Callable<Boolean>, HazelcastInstanceAware, Serializable,
+                                                                  NamedTask {
+        private transient volatile HazelcastInstance instance;
+        private final String name;
+
+        public HazelcastInstanceAwareRunnable(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void setHazelcastInstance(final HazelcastInstance instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public Boolean call() {
+            return (instance != null);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledHazelcastInstanceAwareTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledHazelcastInstanceAwareTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hazelcast.scheduledexecutor;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ScheduledHazelcastInstanceAwareTest extends HazelcastTestSupport {
+
+    private TestHazelcastInstanceFactory factory;
+    private HazelcastInstance[] members;
+    protected IScheduledExecutorService scheduledExecutorService;
+
+    @Before
+    public void setup() {
+        factory = createHazelcastInstanceFactory(2);
+        members = factory.newInstances();
+        scheduledExecutorService = members[0].getScheduledExecutorService(randomName());
+    }
+
+    @Test
+    public void test_hazelcastInstanceIsInjected_whenSchedulingOnSameMember()
+            throws ExecutionException, InterruptedException {
+        IScheduledFuture<Boolean> injected = scheduledExecutorService.schedule(
+                new HazelcastInstanceAwareRunnable(randomNameOwnedBy(members[0])),200, MILLISECONDS);
+        assertTrue("HazelcastInstance should have been injected", injected.get());
+    }
+
+    @Test
+    public void test_hazelcastInstanceIsInjected_whenSchedulingOnOtherMember()
+            throws ExecutionException, InterruptedException {
+        IScheduledFuture<Boolean> injected = scheduledExecutorService.schedule(
+                new HazelcastInstanceAwareRunnable(randomNameOwnedBy(members[1])),200, MILLISECONDS);
+        assertTrue("HazelcastInstance should have been injected", injected.get());
+    }
+
+    public static class HazelcastInstanceAwareRunnable implements Callable<Boolean>, HazelcastInstanceAware, Serializable,
+                                                                  NamedTask {
+        private transient volatile HazelcastInstance instance;
+        private final String name;
+
+        public HazelcastInstanceAwareRunnable(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void setHazelcastInstance(final HazelcastInstance instance) {
+            this.instance = instance;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public Boolean call() {
+            return (instance != null);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledHazelcastInstanceAwareTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledHazelcastInstanceAwareTest.java
@@ -18,10 +18,7 @@
 package com.hazelcast.scheduledexecutor;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -29,8 +26,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.Serializable;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -38,17 +33,15 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ScheduledHazelcastInstanceAwareTest extends HazelcastTestSupport {
+public class ScheduledHazelcastInstanceAwareTest extends ScheduledExecutorServiceTestSupport {
 
-    private TestHazelcastInstanceFactory factory;
     private HazelcastInstance[] members;
     protected IScheduledExecutorService scheduledExecutorService;
 
     @Before
     public void setup() {
-        factory = createHazelcastInstanceFactory(2);
-        members = factory.newInstances();
-        scheduledExecutorService = members[0].getScheduledExecutorService(randomName());
+        members = createClusterWithCount(2);
+        scheduledExecutorService = getScheduledExecutor(members, randomName());
     }
 
     @Test
@@ -65,30 +58,5 @@ public class ScheduledHazelcastInstanceAwareTest extends HazelcastTestSupport {
         IScheduledFuture<Boolean> injected = scheduledExecutorService.schedule(
                 new HazelcastInstanceAwareRunnable(randomNameOwnedBy(members[1])),200, MILLISECONDS);
         assertTrue("HazelcastInstance should have been injected", injected.get());
-    }
-
-    public static class HazelcastInstanceAwareRunnable implements Callable<Boolean>, HazelcastInstanceAware, Serializable,
-                                                                  NamedTask {
-        private transient volatile HazelcastInstance instance;
-        private final String name;
-
-        public HazelcastInstanceAwareRunnable(String name) {
-            this.name = name;
-        }
-
-        @Override
-        public void setHazelcastInstance(final HazelcastInstance instance) {
-            this.instance = instance;
-        }
-
-        @Override
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public Boolean call() {
-            return (instance != null);
-        }
     }
 }


### PR DESCRIPTION
When a `HazelcastInstanceAware` command is passed as argument to one of the `schedule*` methods in `IScheduledExecutorService`, inject the `HazelcastInstance`.

In case the command is deserialized on another member, `HazelcastInstance` is already injected by https://github.com/vbekiaris/hazelcast/blob/d2694664aaf0d0e4bc9a8b792e300672cb0e48a2/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/AbstractSerializationService.java#L268-L268 . However when the command is scheduled on the local member, `HazelcastInstance` was not injected at all.

Fixes #9675 