### PR TITLE
[DONT MERGE] Fixed a classloader leak in ThreadLocalRandom

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -308,8 +308,6 @@
     <suppress checks="NPathComplexity|CyclomaticComplexity" files="com/hazelcast/map/impl/SimpleEntryView"/>
 
     <!-- Adopted public domain code with different style -->
-    <suppress checks="MagicNumber|DeclarationOrder|ConstantName|MultipleVariableDeclarations|NeedBracesCheck|Whitespace"
-              files="com/hazelcast/internal/util/ThreadLocalRandom"/>
     <suppress checks="MagicNumber|FileLength|DeclarationOrder|RedundantModifier|InnerAssignment|NPath|Cyclomatic"
               files="com/hazelcast/util/ConcurrentReferenceHashMap"/>
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/LifecycleServiceImpl.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.internal.util.ThreadLocalRandom;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.UuidUtil;
 import com.hazelcast.util.executor.PoolExecutorThreadFactory;
@@ -142,6 +143,7 @@ public final class LifecycleServiceImpl implements LifecycleService {
         fireLifecycleEvent(SHUTDOWN);
 
         shutdownExecutor();
+        ThreadLocalRandom.remove();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/LifecycleServiceImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.LifecycleService;
 import com.hazelcast.internal.jmx.ManagementService;
+import com.hazelcast.internal.util.ThreadLocalRandom;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.UuidUtil;
@@ -99,6 +100,7 @@ public class LifecycleServiceImpl implements LifecycleService {
             }
             HazelcastInstanceFactory.remove(instance);
             fireLifecycleEvent(SHUTDOWN);
+            ThreadLocalRandom.remove();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandom.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandom.java
@@ -16,25 +16,19 @@
 
 package com.hazelcast.internal.util;
 
-/*
- * Written by Doug Lea with assistance from members of JCP JSR-166
- * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/publicdomain/zero/1.0/
- */
-
 import java.util.Random;
 
 /**
- * A random number generator isolated to the current thread.  Like the
+ * A random number generator isolated to the current thread. Like the
  * global {@link java.util.Random} generator used by the {@link
  * java.lang.Math} class, a {@code ThreadLocalRandom} is initialized
  * with an internally generated seed that may not otherwise be
  * modified. When applicable, use of {@code ThreadLocalRandom} rather
  * than shared {@code Random} objects in concurrent programs will
- * typically encounter much less overhead and contention.  Use of
+ * typically encounter much less overhead and contention. Use of
  * {@code ThreadLocalRandom} is particularly appropriate when multiple
- * tasks (for example, each a {@link java.util.concurrent.ForkJoinTask}) use random numbers
- * in parallel in thread pools.
+ * tasks (for example, each a {@code java.util.concurrent.ForkJoinTask})
+ * use random numbers in parallel in thread pools.
  *
  * <p>Usages of this class should typically be of the form:
  * {@code ThreadLocalRandom.current().nextX(...)} (where
@@ -45,14 +39,31 @@ import java.util.Random;
  * <p>This class also provides additional commonly used bounded random
  * generation methods.
  *
- * @since 1.7
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ *
  * @author Doug Lea
  */
-public class ThreadLocalRandom extends Random {
+public final class ThreadLocalRandom extends Random {
+
+    private static final long serialVersionUID = -5851777807851030925L;
+
     // same constants as Random, but must be redeclared because private
-    private static final long multiplier = 0x5DEECE66DL;
-    private static final long addend = 0xBL;
-    private static final long mask = (1L << 48) - 1;
+    private static final long MULTIPLIER = 0x5DEECE66DL;
+    private static final long ADDEND = 0xBL;
+    private static final long SHIFT = 48;
+    private static final long MASK = (1L << SHIFT) - 1;
+
+    /**
+     * The actual ThreadLocal
+     */
+    private static final ThreadLocal<ThreadLocalRandom> LOCAL_RANDOM =
+            new ThreadLocal<ThreadLocalRandom>() {
+                protected ThreadLocalRandom initialValue() {
+                    return new ThreadLocalRandom();
+                }
+            };
 
     /**
      * The random seed. We can't use super.seed.
@@ -61,33 +72,28 @@ public class ThreadLocalRandom extends Random {
 
     /**
      * Initialization flag to permit calls to setSeed to succeed only
-     * while executing the Random constructor.  We can't allow others
+     * while executing the Random constructor. We can't allow others
      * since it would cause setting seed in one part of a program to
      * unintentionally impact other usages by the thread.
      */
-    boolean initialized;
+    private boolean initialized;
 
     // Padding to help avoid memory contention among seed updates in
     // different TLRs in the common case that they are located near
     // each other.
-    @SuppressWarnings("unused")
-    private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
-
-    /**
-     * The actual ThreadLocal
-     */
-    private static final ThreadLocal<ThreadLocalRandom> localRandom =
-            new ThreadLocal<ThreadLocalRandom>() {
-                protected ThreadLocalRandom initialValue() {
-                    return new ThreadLocalRandom();
-                }
-            };
-
+    private long pad0;
+    private long pad1;
+    private long pad2;
+    private long pad3;
+    private long pad4;
+    private long pad5;
+    private long pad6;
+    private long pad7;
 
     /**
      * Constructor called only by localRandom.initialValue.
      */
-    ThreadLocalRandom() {
+    private ThreadLocalRandom() {
         super();
         initialized = true;
     }
@@ -98,24 +104,34 @@ public class ThreadLocalRandom extends Random {
      * @return the current thread's {@code ThreadLocalRandom}
      */
     public static ThreadLocalRandom current() {
-        return localRandom.get();
+        return LOCAL_RANDOM.get();
     }
 
     /**
-     * Throws {@code UnsupportedOperationException}.  Setting seeds in
+     * Removes the current thread's {@code ThreadLocalRandom}.
+     */
+    public static void remove() {
+        LOCAL_RANDOM.remove();
+    }
+
+    /**
+     * Throws {@code UnsupportedOperationException}. Setting seeds in
      * this generator is not supported.
      *
      * @throws UnsupportedOperationException always
      */
+    @Override
     public void setSeed(long seed) {
-        if (initialized)
+        if (initialized) {
             throw new UnsupportedOperationException();
-        rnd = (seed ^ multiplier) & mask;
+        }
+        rnd = (seed ^ MULTIPLIER) & MASK;
     }
 
+    @Override
     protected int next(int bits) {
-        rnd = (rnd * multiplier + addend) & mask;
-        return (int) (rnd >>> (48-bits));
+        rnd = (rnd * MULTIPLIER + ADDEND) & MASK;
+        return (int) (rnd >>> (SHIFT - bits));
     }
 
     /**
@@ -125,12 +141,12 @@ public class ThreadLocalRandom extends Random {
      * @param least the least value returned
      * @param bound the upper bound (exclusive)
      * @return the next value
-     * @throws IllegalArgumentException if least greater than or equal
-     * to bound
+     * @throws IllegalArgumentException if least greater than or equal to bound
      */
     public int nextInt(int least, int bound) {
-        if (least >= bound)
+        if (least >= bound) {
             throw new IllegalArgumentException();
+        }
         return nextInt(bound - least) + least;
     }
 
@@ -138,14 +154,14 @@ public class ThreadLocalRandom extends Random {
      * Returns a pseudorandom, uniformly distributed value
      * between 0 (inclusive) and the specified value (exclusive).
      *
-     * @param n the bound on the random number to be returned.  Must be
-     *        positive.
+     * @param n the bound on the random number to be returned. Must be positive.
      * @return the next value
      * @throws IllegalArgumentException if n is not positive
      */
     public long nextLong(long n) {
-        if (n <= 0)
+        if (n <= 0) {
             throw new IllegalArgumentException("n must be positive");
+        }
         // Divide n by two until small enough for nextInt. On each
         // iteration (at most 31 of them but usually much less),
         // randomly choose both whether to include high bit in result
@@ -156,8 +172,9 @@ public class ThreadLocalRandom extends Random {
             int bits = next(2);
             long half = n >>> 1;
             long nextn = ((bits & 2) == 0) ? half : n - half;
-            if ((bits & 1) == 0)
+            if ((bits & 1) == 0) {
                 offset += n - nextn;
+            }
             n = nextn;
         }
         return offset + nextInt((int) n);
@@ -170,12 +187,12 @@ public class ThreadLocalRandom extends Random {
      * @param least the least value returned
      * @param bound the upper bound (exclusive)
      * @return the next value
-     * @throws IllegalArgumentException if least is greater than or equal
-     * to bound
+     * @throws IllegalArgumentException if least is greater than or equal to bound
      */
     public long nextLong(long least, long bound) {
-        if (least >= bound)
+        if (least >= bound) {
             throw new IllegalArgumentException();
+        }
         return nextLong(bound - least) + least;
     }
 
@@ -183,14 +200,14 @@ public class ThreadLocalRandom extends Random {
      * Returns a pseudorandom, uniformly distributed {@code double} value
      * between 0 (inclusive) and the specified value (exclusive).
      *
-     * @param n the bound on the random number to be returned.  Must be
-     *        positive.
+     * @param n the bound on the random number to be returned. Must be positive.
      * @return the next value
      * @throws IllegalArgumentException if n is not positive
      */
     public double nextDouble(double n) {
-        if (n <= 0)
+        if (n <= 0) {
             throw new IllegalArgumentException("n must be positive");
+        }
         return nextDouble() * n;
     }
 
@@ -201,14 +218,12 @@ public class ThreadLocalRandom extends Random {
      * @param least the least value returned
      * @param bound the upper bound (exclusive)
      * @return the next value
-     * @throws IllegalArgumentException if least is greater than or equal
-     * to bound
+     * @throws IllegalArgumentException if least is greater than or equal to bound
      */
     public double nextDouble(double least, double bound) {
-        if (least >= bound)
+        if (least >= bound) {
             throw new IllegalArgumentException();
+        }
         return nextDouble() * (bound - least) + least;
     }
-
-    private static final long serialVersionUID = -5851777807851030925L;
 }


### PR DESCRIPTION
`ThreadLocalRandom` puts itself into the `ThreadLocal` storage. Since it
holds a reference to its classloader the whole class hierarchy of
Hazelcast is still reachable and cannot be garbage collected.

This leads to a PermGen Space OOME if the `FilteringClassLoader` is used
to start a whole Hazelcast instance for several times.

This is a very hacky fix, but it seems to work in my scenario.
But I'm not sure if it's a good solution and if it's the correct place to hook in.
Let's first see if the PR builder shows any unwanted side effects.

Possible fix for https://github.com/hazelcast/hazelcast/issues/9650