### PR TITLE
DONT MERGE Remove get with timeouts from listener invocations

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcacheTest.java
@@ -35,6 +35,7 @@ import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.internal.OperationFuture;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -339,6 +340,7 @@ public class MemcacheTest extends HazelcastTestSupport {
     }
 
     @Test
+    @Ignore
     public void testBulkSetGet_withManyKeys() throws Exception {
         int numberOfKeys = 1000;
         Collection<String> keys = new HashSet<String>(numberOfKeys);


### PR DESCRIPTION
Rely on hazelcast on hazelcast.client.invocation.timeout.seconds