### PR TITLE
Fixed the classloader leak in AbstractClockTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandom.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandom.java
@@ -102,6 +102,13 @@ public class ThreadLocalRandom extends Random {
     }
 
     /**
+     * Removes the current thread's {@code ThreadLocalRandom}.
+     */
+    public static void remove() {
+        localRandom.remove();
+    }
+
+    /**
      * Throws {@code UnsupportedOperationException}.  Setting seeds in
      * this generator is not supported.
      *


### PR DESCRIPTION
This is a less intrusive variant of the classloader leak fix.

Part of https://github.com/hazelcast/hazelcast/issues/9650