### PR TITLE
Added connected server version aware near cache invalidation listener…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTask.java
@@ -165,13 +165,16 @@ public final class RepairingTask implements Runnable {
             assignAndGetUuids();
         }
 
-        RepairingHandler repairingHandler = new RepairingHandler(name, nearCache, partitionService, localUuid, logger);
-        repairingHandler.initUnknownUuids(partitionUuids);
+        RepairingHandler repairingHandler = handlers.get(name);
+        if (repairingHandler == null) {
+            repairingHandler = new RepairingHandler(name, nearCache, partitionService, localUuid, logger);
+            repairingHandler.initUnknownUuids(partitionUuids);
 
-        StaleReadDetector staleReadDetector = new StaleReadDetectorImpl(repairingHandler, partitionService);
-        nearCache.unwrap(DefaultNearCache.class).getNearCacheRecordStore().setStaleReadDetector(staleReadDetector);
+            StaleReadDetector staleReadDetector = new StaleReadDetectorImpl(repairingHandler, partitionService);
+            nearCache.unwrap(DefaultNearCache.class).getNearCacheRecordStore().setStaleReadDetector(staleReadDetector);
 
-        handlers.put(name, repairingHandler);
+            handlers.put(name, repairingHandler);
+        }
 
         if (started) {
             scheduleNextRun();


### PR DESCRIPTION
… to deal with client compatibility issues

Fixes two issues related with invalidation listeners backward compatibility:
- 3.7 client should receive invalidations from 3.8 member as if they are coming from 3.7 member. To fix this [canSendInvalidation method](https://github.com/hazelcast/hazelcast/pull/9687/files#diff-5b97be3d065d7c5265d7afb77c8b5b06R132) is added.
- 3.8 client should attach invalidation listeners to 3.7 member as if it is a 3.7 client.    To fix this `ConnectedMemberVersionAwareNearCacheEventHandler` is introduced.

fixes https://github.com/hazelcast/hazelcast/issues/9674