### PR TITLE
[Backport] Fix IMap query migration detection & index data race

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientQueryDuringMigrationsStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientQueryDuringMigrationsStressTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.spi.properties.ClientProperty;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.QueryDuringMigrationsStressTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Test querying a cluster while members are shutting down and joining.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class ClientQueryDuringMigrationsStressTest extends QueryDuringMigrationsStressTest {
+
+    private HazelcastInstance[] clients;
+
+    protected void setupInternal() {
+        TestHazelcastFactory f = (TestHazelcastFactory) factory;
+        clients = new HazelcastInstance[CONCURRENT_QUERYING_CLIENTS];
+        for (int i = 0; i < CONCURRENT_QUERYING_CLIENTS; i++) {
+            clients[i] = f.newHazelcastClient(getClientConfig(getFirstMember()));
+        }
+    }
+
+    @Override
+    protected TestHazelcastInstanceFactory createFactory() {
+        return new TestHazelcastFactory();
+    }
+
+    @Override
+    protected HazelcastInstance getQueryingInstance(int ix) {
+        return clients[ix];
+    }
+
+    // get client configuration that guarantees our client will connect to the specific member
+    private ClientConfig getClientConfig(HazelcastInstance member) {
+        ClientConfig config = new ClientConfig();
+        config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
+        config.getNetworkConfig().setSmartRouting(false);
+
+        InetSocketAddress socketAddress = member.getCluster().getLocalMember().getSocketAddress();
+
+        config.getNetworkConfig().
+                addAddress(socketAddress.getHostName() + ":" + socketAddress.getPort());
+
+        return config;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -211,7 +211,11 @@ public class MapService implements ManagedService, MigrationAwareService,
         mapContainer.decreaseInvalidationListenerCount();
     }
 
-    public int getOwnerMigrationsInFlight() {
-        return migrationAwareService.getOwnerMigrationsInFlight();
+    public int getMigrationStamp() {
+        return migrationAwareService.getMigrationStamp();
+    }
+
+    public boolean validateMigrationStamp(int stamp) {
+        return migrationAwareService.validateMigrationStamp(stamp);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -330,9 +330,6 @@ class MapServiceContextImpl implements MapServiceContext {
     public void reloadOwnedPartitions() {
         IPartitionService partitionService = nodeEngine.getPartitionService();
         Collection<Integer> partitions = partitionService.getMemberPartitions(nodeEngine.getThisAddress());
-        if (partitions == null) {
-            partitions = Collections.emptySet();
-        }
         ownedPartitions.set(Collections.unmodifiableSet(new LinkedHashSet<Integer>(partitions)));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/DuplicateDetectingMultiResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/DuplicateDetectingMultiResult.java
@@ -23,12 +23,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
 
 public class DuplicateDetectingMultiResult extends AbstractSet<QueryableEntry> implements MultiResultSet {
     private Map<Data, QueryableEntry> records;
 
-    public void addResultSet(ConcurrentMap<Data, QueryableEntry> resultSet) {
+    @Override
+    public void addResultSet(Map<Data, QueryableEntry> resultSet) {
         if (records == null) {
             records = new HashMap<Data, QueryableEntry>(resultSet.size());
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/FastMultiResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/FastMultiResultSet.java
@@ -23,8 +23,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * Multiple result set for Predicates.
@@ -32,13 +32,13 @@ import java.util.concurrent.ConcurrentMap;
 public class FastMultiResultSet extends AbstractSet<QueryableEntry> implements MultiResultSet {
 
     private Set<Object> index;
-    private final List<ConcurrentMap<Data, QueryableEntry>> resultSets
-            = new ArrayList<ConcurrentMap<Data, QueryableEntry>>();
+    private final List<Map<Data, QueryableEntry>> resultSets
+            = new ArrayList<Map<Data, QueryableEntry>>();
 
     public FastMultiResultSet() {
     }
 
-    public void addResultSet(ConcurrentMap<Data, QueryableEntry> resultSet) {
+    public void addResultSet(Map<Data, QueryableEntry> resultSet) {
         resultSets.add(resultSet);
     }
 
@@ -51,14 +51,14 @@ public class FastMultiResultSet extends AbstractSet<QueryableEntry> implements M
             //todo: what is the point of this condition? Is it some kind of optimization?
             if (resultSets.size() > 3) {
                 index = new HashSet<Object>();
-                for (ConcurrentMap<Data, QueryableEntry> result : resultSets) {
+                for (Map<Data, QueryableEntry> result : resultSets) {
                     for (QueryableEntry queryableEntry : result.values()) {
                         index.add(queryableEntry.getKeyData());
                     }
                 }
                 return checkFromIndex(entry);
             } else {
-                for (ConcurrentMap<Data, QueryableEntry> resultSet : resultSets) {
+                for (Map<Data, QueryableEntry> resultSet : resultSets) {
                     if (resultSet.containsKey(entry.getKeyData())) {
                         return true;
                     }
@@ -129,7 +129,7 @@ public class FastMultiResultSet extends AbstractSet<QueryableEntry> implements M
     @Override
     public int size() {
         int size = 0;
-        for (ConcurrentMap<Data, QueryableEntry> resultSet : resultSets) {
+        for (Map<Data, QueryableEntry> resultSet : resultSets) {
             size += resultSet.size();
         }
         return size;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.query.impl.TypeConverters.NULL_CONVERTER;
 
@@ -159,10 +158,6 @@ public class IndexImpl implements Index {
     @Override
     public boolean isOrdered() {
         return ordered;
-    }
-
-    ConcurrentMap<Data, QueryableEntry> getRecordMap(Comparable indexValue) {
-        return indexStore.getRecordMap(indexValue);
     }
 
     public static final class NullObject implements Comparable, DataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexStore.java
@@ -19,7 +19,6 @@ package com.hazelcast.query.impl;
 import com.hazelcast.nio.serialization.Data;
 
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * This interface stores indexes of Query.
@@ -35,5 +34,4 @@ public interface IndexStore {
     Set<QueryableEntry> getSubRecords(ComparisonType comparisonType, Comparable searchedValue);
     Set<QueryableEntry> getRecords(Comparable value);
     Set<QueryableEntry> getRecords(Set<Comparable> values);
-    ConcurrentMap<Data, QueryableEntry> getRecordMap(Comparable indexValue);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/MultiResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/MultiResultSet.java
@@ -18,8 +18,8 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.nio.serialization.Data;
 
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * TODO:
@@ -32,5 +32,5 @@ public interface MultiResultSet extends Set<QueryableEntry> {
      *
      * @param resultSet
      */
-    void addResultSet(ConcurrentMap<Data, QueryableEntry> resultSet);
+    void addResultSet(Map<Data, QueryableEntry> resultSet);
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/SingleResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/SingleResultSet.java
@@ -21,15 +21,15 @@ import com.hazelcast.nio.serialization.Data;
 import java.util.AbstractSet;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Map;
 
 /**
  * Multiple result set for Predicates.
  */
 public class SingleResultSet extends AbstractSet<QueryableEntry> {
-    private final ConcurrentMap<Data, QueryableEntry> records;
+    private final Map<Data, QueryableEntry> records;
 
-    public SingleResultSet(ConcurrentMap<Data, QueryableEntry> records) {
+    public SingleResultSet(Map<Data, QueryableEntry> records) {
         this.records = records;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/UnsortedIndexStore.java
@@ -93,7 +93,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
             if (trend == 0) {
                 ConcurrentMap<Data, QueryableEntry> records = recordMap.get(paramFrom);
                 if (records != null) {
-                    results.addResultSet(records);
+                    copyToMultiResultSet(results, records);
                 }
                 return results;
             }
@@ -107,7 +107,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
                 if (value.compareTo(paramFrom) <= 0 && value.compareTo(paramTo) >= 0) {
                     ConcurrentMap<Data, QueryableEntry> records = recordMapEntry.getValue();
                     if (records != null) {
-                        results.addResultSet(records);
+                        copyToMultiResultSet(results, records);
                     }
                 }
             }
@@ -148,7 +148,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
                 if (valid) {
                     ConcurrentMap<Data, QueryableEntry> records = recordMapEntry.getValue();
                     if (records != null) {
-                        results.addResultSet(records);
+                        copyToMultiResultSet(results, records);
                     }
                 }
             }
@@ -159,27 +159,13 @@ public class UnsortedIndexStore extends BaseIndexStore {
     }
 
     @Override
-    public ConcurrentMap<Data, QueryableEntry> getRecordMap(Comparable value) {
-        takeReadLock();
-        try {
-            if (value instanceof IndexImpl.NullObject) {
-                return recordsWithNullValue;
-            } else {
-                return recordMap.get(value);
-            }
-        } finally {
-            releaseReadLock();
-        }
-    }
-
-    @Override
     public Set<QueryableEntry> getRecords(Comparable value) {
         takeReadLock();
         try {
             if (value instanceof IndexImpl.NullObject) {
-                return new SingleResultSet(recordsWithNullValue);
+                return toSingleResultSet(recordsWithNullValue);
             } else {
-                return new SingleResultSet(recordMap.get(value));
+                return toSingleResultSet(recordMap.get(value));
             }
         } finally {
             releaseReadLock();
@@ -199,7 +185,7 @@ public class UnsortedIndexStore extends BaseIndexStore {
                     records = recordMap.get(value);
                 }
                 if (records != null) {
-                    results.addResultSet(records);
+                    copyToMultiResultSet(results, records);
                 }
             }
             return results;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/DelegatingMigrationAwareService.java
@@ -29,15 +29,19 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class DelegatingMigrationAwareService implements MigrationAwareService {
 
-    private static final int PARTITION_OWNER_INDEX = 0;
+    static final int PRIMARY_REPLICA_INDEX = 0;
+    static final int IN_FLIGHT_MIGRATION_STAMP = -1;
 
     private final MigrationAwareService migrationAwareService;
-    // number of currently executing migrations on the partition owner
-    private final AtomicInteger ownerMigrationsInFlight;
+    // number of started migrations on the partition owner
+    private final AtomicInteger ownerMigrationsStarted;
+    // number of completed migrations on the partition owner
+    private final AtomicInteger ownerMigrationsCompleted;
 
     public DelegatingMigrationAwareService(MigrationAwareService migrationAwareService) {
         this.migrationAwareService = migrationAwareService;
-        this.ownerMigrationsInFlight = new AtomicInteger();
+        this.ownerMigrationsStarted = new AtomicInteger();
+        this.ownerMigrationsCompleted = new AtomicInteger();
     }
 
     @Override
@@ -47,8 +51,8 @@ public class DelegatingMigrationAwareService implements MigrationAwareService {
 
     @Override
     public void beforeMigration(PartitionMigrationEvent event) {
-        if (event.getCurrentReplicaIndex() == PARTITION_OWNER_INDEX || event.getNewReplicaIndex() == PARTITION_OWNER_INDEX) {
-            ownerMigrationsInFlight.incrementAndGet();
+        if (isPrimaryReplicaMigrationEvent(event)) {
+            ownerMigrationsStarted.incrementAndGet();
         }
         migrationAwareService.beforeMigration(event);
     }
@@ -58,9 +62,9 @@ public class DelegatingMigrationAwareService implements MigrationAwareService {
         try {
             migrationAwareService.commitMigration(event);
         } finally {
-            if (event.getCurrentReplicaIndex() == PARTITION_OWNER_INDEX || event.getNewReplicaIndex() == PARTITION_OWNER_INDEX) {
-                int count = ownerMigrationsInFlight.decrementAndGet();
-                assert count >= 0;
+            if (isPrimaryReplicaMigrationEvent(event)) {
+                int completed = ownerMigrationsCompleted.incrementAndGet();
+                assert completed <= ownerMigrationsStarted.get();
             }
         }
     }
@@ -70,19 +74,45 @@ public class DelegatingMigrationAwareService implements MigrationAwareService {
         try {
             migrationAwareService.rollbackMigration(event);
         } finally {
-            if (event.getCurrentReplicaIndex() == PARTITION_OWNER_INDEX || event.getNewReplicaIndex() == PARTITION_OWNER_INDEX) {
-                int count = ownerMigrationsInFlight.decrementAndGet();
-                assert count >= 0;
+            if (isPrimaryReplicaMigrationEvent(event)) {
+                int completed = ownerMigrationsCompleted.incrementAndGet();
+                assert completed <= ownerMigrationsStarted.get();
             }
         }
     }
 
     /**
-     * Get the number of currently executing migrations. This is actually
-     * (count of beforeMigration) - (count of rollbackMigration + count of commitMigration)
-     * @return the number of migrations which are currently processed.
+     * Returns whether event involves primary replica migration.
+     * @param event migration event
+     * @return true if migration involves primary replica, false otherwise
      */
-    public int getOwnerMigrationsInFlight() {
-        return ownerMigrationsInFlight.get();
+    static boolean isPrimaryReplicaMigrationEvent(PartitionMigrationEvent event) {
+        return (event.getCurrentReplicaIndex() == PRIMARY_REPLICA_INDEX || event.getNewReplicaIndex() == PRIMARY_REPLICA_INDEX);
+    }
+
+    /**
+     * Returns a stamp to denote current migration state which can later be validated
+     * using {@link #validateMigrationStamp(int)}.
+     *
+     * @return migration stamp
+     */
+    public int getMigrationStamp() {
+        int completed = ownerMigrationsCompleted.get();
+        int started = ownerMigrationsStarted.get();
+        return completed == started ? completed : IN_FLIGHT_MIGRATION_STAMP;
+    }
+
+    /**
+     * Returns true if there's no primary replica migrations started and/or completed
+     * since issuance of the given stamp. Otherwise returns false, if there's an ongoing migration
+     * when stamp is issued or a new migration is started (and optionally completed) after stamp is issued.
+     *
+     * @param stamp a stamp
+     * @return true stamp is valid since issuance of the given stamp, false otherwise
+     */
+    public boolean validateMigrationStamp(int stamp) {
+        int completed = ownerMigrationsCompleted.get();
+        int started = ownerMigrationsStarted.get();
+        return stamp == completed && stamp == started;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryDuringMigrationsStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryDuringMigrationsStressTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.query.SampleObjects;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.test.TimeConstants.MINUTE;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+/**
+ * Test querying a cluster while members are shutting down and joining.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class QueryDuringMigrationsStressTest extends HazelcastTestSupport {
+
+    protected static final int CONCURRENT_QUERYING_CLIENTS = 10;
+    protected static final ILogger LOGGER = Logger.getLogger(QueryDuringMigrationsStressTest.class);
+
+    private static final long TEST_DURATION_SECONDS = MINUTES.toSeconds(3);
+    private static final String TEST_MAP_NAME = "employees";
+    private static final int CLUSTER_SIZE = 6;
+
+    protected TestHazelcastInstanceFactory factory = createFactory();
+
+    // members[0] stays up all the time during the test, the rest are shutdown/started during the test
+    private HazelcastInstance[] members;
+    private ExecutorService queriesExecutor;
+
+    private final AtomicBoolean testRunning = new AtomicBoolean();
+    private final AtomicBoolean testFailed = new AtomicBoolean();
+    private final Collection<String> failureMessages = Collections.synchronizedCollection(new ArrayList<String>());
+
+    private final int numberOfEntries = 100000;
+
+    @Before
+    public void setup() {
+        Config config = getConfig();
+        members = new HazelcastInstance[CLUSTER_SIZE];
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            members[i] = factory.newHazelcastInstance(config);
+        }
+
+        setupInternal();
+
+        testRunning.set(true);
+        testFailed.set(false);
+        queriesExecutor = Executors.newFixedThreadPool(CONCURRENT_QUERYING_CLIENTS);
+    }
+
+    protected void setupInternal() {
+    }
+
+    @After
+    public void teardown() {
+        queriesExecutor.shutdown();
+        factory.terminateAll();
+    }
+
+    // Test on a cluster where members shutdown & startup, map without indexes
+    @Test(timeout = 4 * MINUTE)
+    public void testQueryMapWithoutIndexes_whileShutdownStartup() throws InterruptedException {
+        IMap<String, SampleObjects.Employee> map = getMapWithoutIndexes();
+        populateMap(map);
+        queryDuringMigrations();
+    }
+
+    // Test on a cluster where members shutdown & startup, map with indexes
+    // see also https://github.com/hazelcast/hazelcast/issues/8931, https://github.com/hazelcast/hazelcast/issues/8046
+    // and https://github.com/hazelcast/hazelcast/issues/9043
+    @Test(timeout = 4 * MINUTE)
+    public void testQueryMapWithIndexes_whileShutdownStartup() throws InterruptedException {
+        IMap<String, SampleObjects.Employee> map = getMapWithIndexes();
+        populateMap(map);
+        queryDuringMigrations();
+    }
+
+    private void queryDuringMigrations() throws InterruptedException {
+        Future[] queryingFutures = queryContinuously();
+
+        Future shuffleMembersFuture = shuffleMembers();
+
+        // let the test run for 3 minutes or until failed, whichever comes first
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertFalse(failureMessages.toString(), testFailed.get());
+            }
+        }, TEST_DURATION_SECONDS);
+
+        // stop querying threads
+        testRunning.set(false);
+
+        for (Future f : queryingFutures) {
+            try {
+                f.get();
+            } catch (ExecutionException e) {
+                fail("A querying thread failed with exception " + e.getMessage());
+            }
+        }
+
+        try {
+            // await member shuffling thread to stop
+            shuffleMembersFuture.get();
+        } catch (ExecutionException e) {
+            // ignore the failure, not related to the test itself
+            e.printStackTrace();
+        }
+    }
+
+    private Future shuffleMembers() {
+        return spawn(new MemberUpDownMonkey(members));
+    }
+
+    private void populateMap(IMap<String, SampleObjects.Employee> map) {
+        for (int i = 0; i < numberOfEntries; i++) {
+            SampleObjects.Employee e = new SampleObjects.Employee(i, "name" + i, i, true, i);
+            map.put("name" + i, e);
+        }
+        LOGGER.info("Done populating map with " + numberOfEntries + " entries.");
+    }
+
+    private Future[] queryContinuously() {
+        Future[] futures = new Future[CONCURRENT_QUERYING_CLIENTS];
+        for (int i = 0; i < futures.length; i++) {
+            futures[i] = queriesExecutor.submit(new QueryRunnable(getQueryingInstance(i)));
+        }
+        return futures;
+    }
+
+    protected HazelcastInstance getQueryingInstance(int ix) {
+        return getFirstMember();
+    }
+
+    protected final HazelcastInstance getFirstMember() {
+        return members[0];
+    }
+
+    private class QueryRunnable implements Runnable {
+
+        private final IMap map;
+        // query age min-max range, min is randomized, max = min+1000
+        private final Random random = new Random();
+        private final int numberOfResults = 1000;
+
+        QueryRunnable(HazelcastInstance hz) {
+            this.map = hz.getMap(TEST_MAP_NAME);
+        }
+
+        @Override
+        public void run() {
+            int min, max, correctResultsCount = 0;
+            while (testRunning.get()) {
+                try {
+                    min = random.nextInt(numberOfEntries - numberOfResults);
+                    max = min + numberOfResults;
+                    String sql = (min % 2 == 0)
+                            ? "age >= " + min + " AND age < " + max // sorted
+                            : "id >= " + min + " AND id < " + max;  //unsorted
+                    Collection<SampleObjects.Employee> employees = map.values(new SqlPredicate(sql));
+                    if (employees.size() != numberOfResults) {
+                        String message = "Obtained " + employees.size() + " results for query '" + sql + "'";
+                        System.err.println(message);
+                        failureMessages.add(message);
+                        testFailed.set(true);
+                        testRunning.set(false);
+                    } else {
+                        correctResultsCount++;
+                        if (correctResultsCount % 20 == 0) {
+                            LOGGER.info("Obtained " + correctResultsCount + " correct results");
+                        }
+                    }
+                } catch (RuntimeException e) {
+                    // runtime exception caught, fail the test and rethrow
+                    failureMessages.add("A query thread failed with: " + e.getMessage());
+                    testFailed.set(true);
+                    testRunning.set(false);
+                    LOGGER.severe("Query thread failed with exception", e);
+                    throw e;
+                }
+            }
+        }
+    }
+
+    private class MemberUpDownMonkey implements Runnable {
+        private final HazelcastInstance[] instances;
+
+        MemberUpDownMonkey(HazelcastInstance[] allInstances) {
+            this.instances = new HazelcastInstance[allInstances.length - 1];
+            // exclude 0-index instance
+            System.arraycopy(allInstances, 1, instances, 0, allInstances.length - 1);
+        }
+
+        @Override
+        public void run() {
+            int i = 0;
+            int nextInstance;
+            while (testRunning.get()) {
+                instances[i].shutdown();
+                nextInstance = (i + 1) % instances.length;
+                sleepSeconds(2);
+
+                instances[i] = factory.newHazelcastInstance();
+                sleepSeconds(2);
+                // move to next member
+                i = nextInstance;
+            }
+        }
+    }
+
+    // obtain a reference to test map from 0-th member with indexes created for Employee attributes
+    private IMap<String, SampleObjects.Employee> getMapWithIndexes() {
+        IMap<String, SampleObjects.Employee> map = getFirstMember().getMap(TEST_MAP_NAME);
+        map.addIndex("id", false);
+        map.addIndex("age", true);
+        return map;
+    }
+
+    // obtain a reference to test map from 0-th member without indexes
+    private IMap<String, SampleObjects.Employee> getMapWithoutIndexes() {
+        return getFirstMember().getMap(TEST_MAP_NAME);
+    }
+
+    protected TestHazelcastInstanceFactory createFactory() {
+        return createHazelcastInstanceFactory();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -47,8 +47,10 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Map;
+import java.util.Set;
 
 import static com.hazelcast.instance.TestUtil.toData;
 import static java.util.Arrays.asList;
@@ -473,7 +475,7 @@ public class IndexTest {
         index.saveEntryIndex(record50, null);
         assertEquals(new HashSet<QueryableEntry>(asList(record5, record50)), index.getRecords(555L));
 
-        ConcurrentMap<Data, QueryableEntry> records = index.getRecordMap(555L);
+        Map<Data, QueryableEntry> records = getRecordMap(index, 555L);
         assertNotNull(records);
         assertEquals(2, records.size());
         assertEquals(record5, records.get(record5.getKeyData()));
@@ -499,7 +501,7 @@ public class IndexTest {
 
         assertEquals(Collections.<QueryableEntry>singleton(record50), index.getRecords(555L));
 
-        records = index.getRecordMap(555L);
+        records = getRecordMap(index, 555L);
         assertNotNull(records);
         assertEquals(null, records.get(5L));
         assertEquals(record50, records.get(toData(50L)));
@@ -519,7 +521,7 @@ public class IndexTest {
 
         assertEquals(0, index.getRecords(555L).size());
 
-        records = index.getRecordMap(555L);
+        records = getRecordMap(index, 555L);
         assertNull(records);
         assertEquals(0, index.getRecords(555L).size());
         assertEquals(1, index.getSubRecordsBetween(55L, 555L).size());
@@ -531,10 +533,22 @@ public class IndexTest {
 
         assertEquals(0, index.getRecords(66L).size());
 
-        assertNull(index.getRecordMap(66L));
+        assertNull(getRecordMap(index, 66L));
         assertEquals(0, index.getRecords(555L).size());
         assertEquals(0, index.getSubRecordsBetween(55L, 555L).size());
         assertEquals(0, index.getSubRecordsBetween(66L, 555L).size());
         assertEquals(0, index.getSubRecordsBetween(555L, 555L).size());
+    }
+
+    private Map<Data, QueryableEntry> getRecordMap(IndexImpl index, Comparable indexValue) {
+        Set<QueryableEntry> records = index.getRecords(indexValue);
+        if (records.isEmpty()) {
+            return null;
+        }
+        Map<Data, QueryableEntry> recordMap = new HashMap<Data, QueryableEntry>(records.size());
+        for (QueryableEntry entry : records) {
+            recordMap.put(entry.getKeyData(), entry);
+        }
+        return recordMap;
     }
 }


### PR DESCRIPTION
- Current in-flight migration detection mechanism is racy. `partitionStateVersion`
observed at the beginning of query execution can be the already updated `partitionStateVersion`.
So, any change of `partitionStateVersion` may not be noticed.
There's no ordering between `commitMigration()` / `rollbackMigration()` and update of `partitionStateVersion`, because we can apply promotion commits and source migration commits in batches to increase availability. That's why `commitMigration()` / `rollbackMigration()` and update of `partitionStateVersion` can be executed concurrently.
Instead of comparing `partitionStateVersion` and counting in-flight migrations, Map service now uses two counters; one for started migrations and one for completed migrations. We always increment counters on each migration.
`CountingMigrationAwareService` exposes a migration stamp when requested and a method to check whether stamps is still valid. If stamp is valid, that means there's no ongoing and/or completed change in primary partition ownership on that member.

- IndexStores leak their internal data while returning result.
Both sorted and unsorted `IndexStore`s, exposes their internal value maps
to the returned result set. If a new index is added or an existing one is removed,
because of either map mutation operations (put/remove) or migration process,
then returned result set changes unexpectedly.
As a fix to this leakage, we now copy result set while returning from index store.

Fixes #8931
Fixes #8046
Backport of #9688