### PR TITLE
Fix wrong scheduled task count caused by backup replicas

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -160,7 +160,7 @@ public class DistributedScheduledExecutorService
         int partitionId = event.getPartitionId();
         if (event.getMigrationEndpoint() == MigrationEndpoint.DESTINATION) {
             discardStash(event.getPartitionId(), event.getCurrentReplicaIndex());
-        } else {
+        } else if (event.getCurrentReplicaIndex() == 0) {
             ScheduledExecutorPartition partition = partitions[partitionId];
             partition.promoteStash();
         }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -250,7 +250,7 @@ public class ScheduledExecutorContainer {
                     doSchedule(descriptor);
                 }
 
-                descriptor.setMasterReplica(true);
+                descriptor.setTaskOwner(true);
             } catch (Exception e) {
                 throw rethrow(e);
             }
@@ -346,7 +346,7 @@ public class ScheduledExecutorContainer {
                 throw new IllegalArgumentException();
         }
 
-        descriptor.setMasterReplica(true);
+        descriptor.setTaskOwner(true);
         descriptor.setScheduledFuture(future);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -249,6 +249,8 @@ public class ScheduledExecutorContainer {
                 if (descriptor.shouldSchedule()) {
                     doSchedule(descriptor);
                 }
+
+                descriptor.setMasterReplica(true);
             } catch (Exception e) {
                 throw rethrow(e);
             }
@@ -344,6 +346,7 @@ public class ScheduledExecutorContainer {
                 throw new IllegalArgumentException();
         }
 
+        descriptor.setMasterReplica(true);
         descriptor.setScheduledFuture(future);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
@@ -41,12 +41,12 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
 
     /**
      * Only accessed through a member lock or partition threads
-     * Used to identify which replica of the task is the master, to only return that instance
+     * Used to identify which replica of the task is the owner, to only return that instance
      * when {@link com.hazelcast.scheduledexecutor.impl.operations.GetAllScheduledOperation} operation is triggered.
-     * This flag is set to true only on ititial scheduling of a task, and on after a promotion (stashed or migration),
+     * This flag is set to true only on initial scheduling of a task, and on after a promotion (stashed or migration),
      * in the latter case the other replicas get disposed.
      */
-    private transient boolean masterReplica;
+    private transient boolean isTaskOwner;
 
     /**
      * SPMC (see. Member owned tasks)
@@ -87,12 +87,12 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
         return definition;
     }
 
-    public boolean isMasterReplica() {
-        return masterReplica;
+    public boolean isTaskOwner() {
+        return isTaskOwner;
     }
 
-    public void setMasterReplica(boolean masterReplica) {
-        this.masterReplica = masterReplica;
+    void setTaskOwner(boolean taskOwner) {
+        this.isTaskOwner = taskOwner;
     }
 
     ScheduledTaskStatisticsImpl getStatsSnapshot() {
@@ -211,7 +211,7 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
                 + "future=" + future + ", "
                 + "stats=" + stats + ", "
                 + "state=" + state + ", "
-                + "masterReplica=" + masterReplica + ", "
+                + "isTaskOwner=" + isTaskOwner + ", "
                 + "result=" + resultRef.get()
                 + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskDescriptor.java
@@ -40,6 +40,15 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
     private ScheduledFuture<?> future;
 
     /**
+     * Only accessed through a member lock or partition threads
+     * Used to identify which replica of the task is the master, to only return that instance
+     * when {@link com.hazelcast.scheduledexecutor.impl.operations.GetAllScheduledOperation} operation is triggered.
+     * This flag is set to true only on ititial scheduling of a task, and on after a promotion (stashed or migration),
+     * in the latter case the other replicas get disposed.
+     */
+    private transient boolean masterReplica;
+
+    /**
      * SPMC (see. Member owned tasks)
      */
     private volatile ScheduledTaskStatisticsImpl stats;
@@ -76,6 +85,14 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
 
     public TaskDefinition getDefinition() {
         return definition;
+    }
+
+    public boolean isMasterReplica() {
+        return masterReplica;
+    }
+
+    public void setMasterReplica(boolean masterReplica) {
+        this.masterReplica = masterReplica;
     }
 
     ScheduledTaskStatisticsImpl getStatsSnapshot() {
@@ -194,6 +211,7 @@ public class ScheduledTaskDescriptor implements IdentifiedDataSerializable {
                 + "future=" + future + ", "
                 + "stats=" + stats + ", "
                 + "state=" + state + ", "
+                + "masterReplica=" + masterReplica + ", "
                 + "result=" + resultRef.get()
                 + '}';
     }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOperation.java
@@ -64,7 +64,9 @@ public class GetAllScheduledOperation
         for (ScheduledExecutorContainer container : containers) {
             Collection<ScheduledTaskDescriptor> tasks = container.getTasks();
             for (ScheduledTaskDescriptor task : tasks) {
-                handlers.add(container.offprintHandler(task.getDefinition().getName()));
+                if (task.isMasterReplica()) {
+                    handlers.add(container.offprintHandler(task.getDefinition().getName()));
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOperation.java
@@ -64,7 +64,7 @@ public class GetAllScheduledOperation
         for (ScheduledExecutorContainer container : containers) {
             Collection<ScheduledTaskDescriptor> tasks = container.getTasks();
             for (ScheduledTaskDescriptor task : tasks) {
-                if (task.isMasterReplica()) {
+                if (task.isTaskOwner()) {
                     handlers.add(container.offprintHandler(task.getDefinition().getName()));
                 }
             }

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
@@ -821,37 +821,23 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
         IScheduledExecutorService s = getScheduledExecutor(instances, "s");
 
         int expectedTotal = 11;
-        IScheduledFuture lastFuture = null;
+        IScheduledFuture[] futures = new IScheduledFuture[expectedTotal];
         for (int i=0; i < expectedTotal; i++) {
-            lastFuture = s.schedule(new PlainCallableTask(), 0, SECONDS);
+            futures[i] = s.schedule(new PlainCallableTask(i), 0, SECONDS);
         }
 
         assertEquals(expectedTotal, countScheduledTasksOn(s), 0);
 
         // Dispose 1 task
-        lastFuture.dispose();
+        futures[0].dispose();
 
         // Recount
-
         assertEquals(expectedTotal - 1, countScheduledTasksOn(s), 0);
-    }
 
-    @Test
-    public void scheduleRandomPartitions_getAllScheduled_durable()
-            throws ExecutionException, InterruptedException {
-
-        HazelcastInstance[] instances = createClusterWithCount(3);
-        IScheduledExecutorService s = getScheduledExecutor(instances, "s");
-        String key = generateKeyOwnedBy(instances[1]);
-
-        int expectedTotal = 11;
-        for (int i=0; i < expectedTotal; i++) {
-            s.scheduleOnKeyOwner(new PlainCallableTask(), key,0, SECONDS);
+        // Verify all tasks
+        for (int i=1; i < expectedTotal; i++) {
+            assertEquals(25.0 + i, futures[i].get());
         }
-
-        instances[1].getLifecycleService().shutdown();
-
-        assertEquals(expectedTotal, countScheduledTasksOn(s), 0);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
@@ -143,6 +143,30 @@ public class ScheduledExecutorServiceSlowTest
     }
 
     @Test
+    public void scheduleRandomPartitions_getAllScheduled_durable()
+            throws ExecutionException, InterruptedException {
+
+        HazelcastInstance[] instances = createClusterWithCount(3);
+        IScheduledExecutorService s = getScheduledExecutor(instances, "s");
+        String key = generateKeyOwnedBy(instances[1]);
+
+        int expectedTotal = 11;
+        IScheduledFuture[] futures = new IScheduledFuture[expectedTotal];
+        for (int i=0; i < expectedTotal; i++) {
+            futures[i] = s.schedule(new PlainCallableTask(i), 0, SECONDS);
+        }
+
+        instances[1].getLifecycleService().shutdown();
+
+        assertEquals(expectedTotal, countScheduledTasksOn(s), 0);
+
+        // Verify all tasks
+        for (int i=0; i < expectedTotal; i++) {
+            assertEquals(25.0 + i, futures[i].get());
+        }
+    }
+
+    @Test
     public void scheduleRandomPartitions_periodicTask_getAllScheduled_durable()
             throws ExecutionException, InterruptedException {
 

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -21,11 +21,13 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.IMap;
+import com.hazelcast.core.Member;
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -47,6 +49,17 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
         HazelcastInstance[] instances = factory.newInstances(config, count);
         waitAllForSafeState(instances);
         return instances;
+    }
+
+    public int countScheduledTasksOn(IScheduledExecutorService scheduledExecutorService) {
+        Map<Member, List<IScheduledFuture<Double>>> allScheduled = scheduledExecutorService.getAllScheduledFutures();
+
+        int total = 0;
+        for (Member member : allScheduled.keySet()) {
+            total += allScheduled.get(member).size();
+        }
+
+        return total;
     }
 
     static class StatefulRunnableTask

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -199,10 +199,19 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
 
     static class PlainCallableTask implements Callable<Double>, Serializable {
 
+        private int delta = 0;
+
+        public PlainCallableTask() {
+        }
+
+        public PlainCallableTask(int delta) {
+            this.delta = delta;
+        }
+
         @Override
         public Double call()
                 throws Exception {
-            return 5 * 5.0;
+            return 5 * 5.0 + delta;
         }
 
     }


### PR DESCRIPTION
When scheduling tasks on random partitions, the getAllScheduled call
returns twice as many futures from the expected result. The reason
seems to be the backup replicas which are also returned, even though they are
just stashed placeholders having no future scheduled. To address this, we introduced
a flag, marking the main copy of the task as master upon initital scheduling or promotions
and using that when building the list of tasks to return to the API call.

Fixes #9694 