### PR TITLE
Ability to register user exception types to ClientExceptionFactory

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.client.impl;
 
-import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.cache.impl.JCacheDetector;
 import com.hazelcast.cardinality.CardinalityEstimator;
 import com.hazelcast.cardinality.impl.CardinalityEstimatorService;
 import com.hazelcast.client.ClientExtension;
@@ -29,6 +29,7 @@ import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.impl.client.DistributedObjectInfo;
+import com.hazelcast.client.impl.protocol.ClientExceptionFactory;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientGetDistributedObjectsCodec;
 import com.hazelcast.client.proxy.ClientClusterProxy;
@@ -107,6 +108,7 @@ import com.hazelcast.internal.metrics.metricsets.GarbageCollectionMetricSet;
 import com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet;
 import com.hazelcast.internal.metrics.metricsets.RuntimeMetricSet;
 import com.hazelcast.internal.metrics.metricsets.ThreadMetricSet;
+import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
@@ -188,6 +190,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final ClientICacheManager hazelcastCacheManager;
 
     private final ClientLockReferenceIdGenerator lockReferenceIdGenerator;
+    private final ClientExceptionFactory clientExceptionFactory;
 
     public HazelcastClientInstanceImpl(ClientConfig config,
                                        ClientConnectionManagerFactory clientConnectionManagerFactory,
@@ -232,6 +235,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
         lockReferenceIdGenerator = new ClientLockReferenceIdGenerator();
         nearCacheManager = clientExtension.createNearCacheManager();
+        clientExceptionFactory = initClientExceptionFactory();
     }
 
     private Diagnostics initDiagnostics(ClientConfig config) {
@@ -738,5 +742,14 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public ClientLockReferenceIdGenerator getLockReferenceIdGenerator() {
         return lockReferenceIdGenerator;
+    }
+
+    private ClientExceptionFactory initClientExceptionFactory() {
+        boolean jCacheAvailable = JCacheDetector.isJCacheAvailable(getClientConfig().getClassLoader());
+        return new ClientExceptionFactory(jCacheAvailable);
+    }
+
+    public ClientExceptionFactory getClientExceptionFactory() {
+        return clientExceptionFactory;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
@@ -105,8 +105,15 @@ public final class ClientProtocolErrorCodes {
     public static final int STALE_TASK_ID = 80;
     public static final int DUPLICATE_TASK = 81;
     public static final int STALE_TASK = 82;
-    public static final int CANCELLED_TASK = 83;
-    public static final int REJECTED_TASK = 84;
+
+    // These exception codes are reserved to by used by hazelcast-jet project
+    public static final int JET_EXCEPTIONS_RANGE_START = 500;
+    public static final int JET_EXCEPTIONS_RANGE_END = 600;
+
+    /**
+     * These codes onwards are reserved to be used by the end-user
+     */
+    public static final int USER_EXCEPTIONS_RANGE_START = 1000;
 
     private ClientProtocolErrorCodes() {
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientExceptionFactoryTestSimple.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientExceptionFactoryTestSimple.java
@@ -1,0 +1,64 @@
+package com.hazelcast.client.protocol;
+
+import com.hazelcast.client.impl.protocol.ClientExceptionFactory;
+import com.hazelcast.client.impl.protocol.ClientExceptionFactory.ExceptionFactory;
+import com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+// It's called Simple, because the ClientExceptionFactoryTest is parametrized
+public class ClientExceptionFactoryTestSimple {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private ClientExceptionFactory exceptionFactory = new ClientExceptionFactory(false);
+
+    private static class MyException extends Exception {}
+
+    @Test
+    public void testDuplicateErrorCode() {
+        thrown.expect(HazelcastException.class);
+        exceptionFactory.register(ClientProtocolErrorCodes.ARRAY_INDEX_OUT_OF_BOUNDS,
+                    MyException.class, new ExceptionFactory() {
+                        @Override
+                        public Throwable createException(String message, Throwable cause) {
+                            return new MyException();
+                        }
+                    });
+    }
+
+    @Test
+    public void testDuplicateExceptionClass() {
+        thrown.expect(HazelcastException.class);
+        exceptionFactory.register(10000,
+                ArrayIndexOutOfBoundsException.class, new ExceptionFactory() {
+                    @Override
+                    public Throwable createException(String message, Throwable cause) {
+                        return new ArrayIndexOutOfBoundsException(message);
+                    }
+                });
+    }
+
+    @Test
+    public void testIncorrectClassFromFactory() {
+        thrown.expect(HazelcastException.class);
+        exceptionFactory.register(10000,
+                MyException.class, new ExceptionFactory() {
+                    @Override
+                    public Throwable createException(String message, Throwable cause) {
+                        return new ArrayIndexOutOfBoundsException(message);
+                    }
+                });
+    }
+
+}


### PR DESCRIPTION
* Make `ClientExceptionFactory.register()` method public
* Removed duplicately added exception classes under different codes and added checks to prevent that in future
* Moved `ClientExceptionFactory` creation from `ClientInvocationServiceSupport` to `HazelcastClientInstanceImpl`

Functionality is needed for Jet so that our exception is not repported as `UndefinedErrorCodeException`