### PR TITLE
Log warning on invalid client-side near cache config

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigValidator.java
@@ -66,8 +66,8 @@ public final class ConfigValidator {
         checkEvictionConfig(nearCacheConfig.getEvictionConfig(), true);
 
         if (isClient && nearCacheConfig.isCacheLocalEntries()) {
-            throw new IllegalArgumentException(
-                    "The Near Cache option `cache-local-entries` is not supported in client configurations!");
+            LOGGER.warning("The Near Cache option `cache-local-entries` is not supported in client configurations. "
+                    + "Remove this option from your client configuration, future versions may fail startup with an exception.");
         }
         checkPreloaderConfig(nearCacheConfig, isClient);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -103,6 +104,8 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
      * Not supported client configuration, so test is expected to throw exception.
      */
     @Test(expected = IllegalArgumentException.class)
+    @Ignore("As of 3.8 a warning is logged when client configuration specifies cache-local-entries option. "
+            + "This test is to be enabled again in 3.9, when this configuration will throw an exception.")
     public void checkNearCacheConfig_withUnsupportedClientConfig() {
         checkNearCacheConfig(getNearCacheConfig(BINARY), true);
     }


### PR DESCRIPTION
Log warning when client-side near-cache config includes invalid option cache-local-entries option 

Reasoning: `cache-local-entries` option in client-side `NearCacheConfig` was silently ignored in previous releases. Throwing an exception was introduced in #8970 thus an application upgraded from 3.7 or earlier to 3.8 with an offending client-side configuration would fail on startup with an `IllegalArgumentException` whereas it was previously silently working. With this PR a warning will be logged in 3.8 to indicate erroneous usage of this configuration option and fail-fast behavior will be implemented in 3.9 (#9712).