### PR TITLE
Deprecated getAsReadOnly() methods in configuration classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig.ExpiryPolicyType;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.CompleteConfiguration;
@@ -226,9 +226,10 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
     }
 
     /**
-     * Gets immutable version of this cache configuration.
+     * Gets immutable version of this configuration.
      *
-     * @return Immutable version of this cache configuration.
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
      */
     public CacheConfigReadOnly<K, V> getAsReadOnly() {
         return new CacheConfigReadOnly<K, V>(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -65,6 +65,12 @@ public class CacheEvictionConfig extends EvictionConfig {
         super(config);
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     @Override
     public CacheEvictionConfig getAsReadOnly() {
         if (readOnly == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
@@ -47,6 +47,12 @@ public class CachePartitionLostListenerConfig extends ListenerConfig implements 
         className = config.getClassName();
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     @Override
     public CachePartitionLostListenerConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -143,9 +143,10 @@ public class CacheSimpleConfig {
     }
 
     /**
-     * Gets the immutable version of this simple cache config.
+     * Gets immutable version of this configuration.
      *
-     * @return Immutable version of this simple cache config.
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
      */
     public CacheSimpleConfig getAsReadOnly() {
         if (readOnly == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleEntryListenerConfig.java
@@ -38,6 +38,12 @@ public class CacheSimpleEntryListenerConfig {
     public CacheSimpleEntryListenerConfig() {
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public CacheSimpleEntryListenerConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new CacheSimpleEntryListenerConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -60,13 +60,6 @@ public class CardinalityEstimatorConfig {
         this(config.getName(), config.getBackupCount(), config.getAsyncBackupCount());
     }
 
-    public CardinalityEstimatorConfigReadOnly getAsReadOnly() {
-        if (readOnly == null) {
-            readOnly = new CardinalityEstimatorConfigReadOnly(this);
-        }
-        return readOnly;
-    }
-
     /**
      * Gets the name of the cardinality estimator.
      *
@@ -153,8 +146,14 @@ public class CardinalityEstimatorConfig {
                 + asyncBackupCount + ", readOnly=" + readOnly + '}';
     }
 
-    private static class CardinalityEstimatorConfigReadOnly
-            extends CardinalityEstimatorConfig {
+    CardinalityEstimatorConfigReadOnly getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new CardinalityEstimatorConfigReadOnly(this);
+        }
+        return readOnly;
+    }
+
+    private static class CardinalityEstimatorConfigReadOnly extends CardinalityEstimatorConfig {
 
         CardinalityEstimatorConfigReadOnly(CardinalityEstimatorConfig config) {
             super(config);

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -48,6 +48,12 @@ public class DiscoveryConfig {
         this.discoveryStrategyConfigs.addAll(discoveryStrategyConfigs);
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public DiscoveryConfig getAsReadOnly() {
         if (readonly != null) {
             return readonly;

--- a/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
@@ -71,13 +71,6 @@ public class DurableExecutorConfig {
         this(config.getName(), config.getPoolSize(), config.getDurability(), config.getCapacity());
     }
 
-    public DurableExecutorConfigReadOnly getAsReadOnly() {
-        if (readOnly == null) {
-            readOnly = new DurableExecutorConfigReadOnly(this);
-        }
-        return readOnly;
-    }
-
     /**
      * Gets the name of the executor task.
      *
@@ -171,9 +164,16 @@ public class DurableExecutorConfig {
                 + '}';
     }
 
+    DurableExecutorConfigReadOnly getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new DurableExecutorConfigReadOnly(this);
+        }
+        return readOnly;
+    }
+
     private static class DurableExecutorConfigReadOnly extends DurableExecutorConfig {
 
-        public DurableExecutorConfigReadOnly(DurableExecutorConfig config) {
+        DurableExecutorConfigReadOnly(DurableExecutorConfig config) {
             super(config);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
@@ -72,6 +72,12 @@ public class EntryListenerConfig extends ListenerConfig {
         className = config.getClassName();
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     @Override
     public EntryListenerConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -168,6 +168,12 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
         FREE_NATIVE_MEMORY_PERCENTAGE
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public EvictionConfig getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new EvictionConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
@@ -60,6 +60,12 @@ public class ExecutorConfig {
         this.statisticsEnabled = config.statisticsEnabled;
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public ExecutorConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new ExecutorConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ItemListenerConfig.java
@@ -46,6 +46,12 @@ public class ItemListenerConfig extends ListenerConfig {
         className = config.getClassName();
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     @Override
     public ItemListenerConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
@@ -156,6 +156,12 @@ public class JobTrackerConfig {
         this.chunkSize = chunkSize;
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public JobTrackerConfig getAsReadOnly() {
         return new JobTrackerConfigReadOnly(this);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/ListConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListConfig.java
@@ -34,6 +34,12 @@ public class ListConfig extends CollectionConfig<ListConfig> {
         super(config);
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     @Override
     public ListConfig getAsReadOnly() {
         if (readOnly == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/ListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListenerConfig.java
@@ -64,6 +64,12 @@ public class ListenerConfig {
         this.implementation = isNotNull(implementation, "implementation");
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public ListenerConfig getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new ListenerConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
@@ -106,9 +106,10 @@ public class LockConfig {
     }
 
     /**
-     * Creates a readonly copy of this {@link LockConfig}.
+     * Gets immutable version of this configuration.
      *
-     * @return the readonly copy.
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
      */
     public LockConfig getAsReadOnly() {
         return new LockConfigReadonly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/MapAttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapAttributeConfig.java
@@ -65,6 +65,12 @@ public class MapAttributeConfig {
         extractor = config.getExtractor();
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public MapAttributeConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new MapAttributeConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -196,6 +196,12 @@ public class MapConfig {
         this.hotRestartConfig = new HotRestartConfig(config.hotRestartConfig);
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public MapConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new MapConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapIndexConfig.java
@@ -59,6 +59,12 @@ public class MapIndexConfig {
         ordered = config.isOrdered();
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public MapIndexConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new MapIndexConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/MapPartitionLostListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapPartitionLostListenerConfig.java
@@ -43,6 +43,12 @@ public class MapPartitionLostListenerConfig extends ListenerConfig {
         className = config.getClassName();
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     @Override
     public MapPartitionLostListenerConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapStoreConfig.java
@@ -81,6 +81,12 @@ public class MapStoreConfig {
         properties.putAll(config.getProperties());
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public MapStoreConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new MapStoreConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
@@ -108,6 +108,12 @@ public class MaxSizeConfig implements DataSerializable, Serializable {
         FREE_NATIVE_MEMORY_PERCENTAGE
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public MaxSizeConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new MaxSizeConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
@@ -113,6 +113,12 @@ public class MemberAttributeConfig {
         attributes.remove(key);
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public MemberAttributeConfig asReadOnly() {
         return new MemberAttributeConfigReadOnly(this);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
@@ -67,13 +67,14 @@ public class MultiMapConfig {
         this.asyncBackupCount = defConfig.asyncBackupCount;
         this.statisticsEnabled = defConfig.statisticsEnabled;
         this.listenerConfigs = new ArrayList<EntryListenerConfig>(defConfig.getEntryListenerConfigs());
-//        this.partitionStrategyConfig = defConfig.getPartitioningStrategyConfig();
+        //this.partitionStrategyConfig = defConfig.getPartitioningStrategyConfig();
     }
 
     /**
-     * Gets the immutable version of this MultiMap config.
+     * Gets immutable version of this configuration.
      *
-     * @return Immutable version of this MultiMap config.
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
      */
     public MultiMapConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
@@ -227,8 +228,8 @@ public class MultiMapConfig {
      * @param backupCount the number of synchronous backups to set for this MultiMap
      * @return the current MultiMapConfig
      * @throws IllegalArgumentException if backupCount smaller than 0,
-     *             or larger than the maximum number of backup
-     *             or the sum of the backups and async backups is larger than the maximum number of backups
+     *                                  or larger than the maximum number of backup
+     *                                  or the sum of the backups and async backups is larger than the maximum number of backups
      * @see #setAsyncBackupCount(int)
      */
     public MultiMapConfig setBackupCount(int backupCount) {
@@ -251,8 +252,8 @@ public class MultiMapConfig {
      * @param asyncBackupCount the number of asynchronous synchronous backups to set
      * @return the updated MultiMapConfig
      * @throws IllegalArgumentException if asyncBackupCount smaller than 0,
-     *             or larger than the maximum number of backup
-     *             or the sum of the backups and async backups is larger than the maximum number of backups
+     *                                  or larger than the maximum number of backup
+     *                                  or the sum of the backups and async backups is larger than the maximum number of backups
      * @see #setBackupCount(int)
      * @see #getAsyncBackupCount()
      */

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -186,6 +186,12 @@ public class NearCacheConfig implements DataSerializable, Serializable {
         }
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public NearCacheConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new NearCacheConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
@@ -91,13 +91,6 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
         this.filename = checkNotNull(filename, "filename cannot be null!");
     }
 
-    NearCachePreloaderConfig getAsReadOnly() {
-        if (readOnly == null) {
-            readOnly = new NearCachePreloaderConfigReadOnly(this);
-        }
-        return readOnly;
-    }
-
     public boolean isEnabled() {
         return enabled;
     }
@@ -160,6 +153,13 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
                 + ", storeInitialDelaySeconds=" + storeInitialDelaySeconds
                 + ", storeIntervalSeconds=" + storeIntervalSeconds
                 + '}';
+    }
+
+    NearCachePreloaderConfig getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new NearCachePreloaderConfigReadOnly(this);
+        }
+        return readOnly;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PartitioningStrategyConfig.java
@@ -45,6 +45,12 @@ public class PartitioningStrategyConfig {
         this.partitionStrategy = partitionStrategy;
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public PartitioningStrategyConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new PartitioningStrategyConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfig.java
@@ -69,6 +69,12 @@ public class PredicateConfig {
         this.implementation = isNotNull(implementation, "implementation");
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public PredicateConfig getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new PredicateConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfig.java
@@ -144,7 +144,12 @@ public class QueryCacheConfig {
         this.indexConfigs = other.indexConfigs;
     }
 
-
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public QueryCacheConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new QueryCacheConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
@@ -79,9 +79,10 @@ public class QueueConfig {
     }
 
     /**
-     * Returns a read only copy of the queue configuration.
+     * Gets immutable version of this configuration.
      *
-     * @return A read only copy of the queue configuration.
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
      */
     public QueueConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueStoreConfig.java
@@ -57,6 +57,12 @@ public class QueueStoreConfig {
         return this;
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public QueueStoreConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new QueueStoreConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -262,15 +262,6 @@ public class ReliableTopicConfig {
         return this;
     }
 
-    /**
-     * Returns a readonly version of the ReliableTopicConfig.
-     *
-     * @return a readonly version of this reliable topic config.
-     */
-    public ReliableTopicConfig getAsReadOnly() {
-        return new ReliableTopicConfigReadOnly(this);
-    }
-
     @Override
     public String toString() {
         return "ReliableTopicConfig{"
@@ -281,6 +272,16 @@ public class ReliableTopicConfig {
                 + ", statisticsEnabled=" + statisticsEnabled
                 + ", listenerConfigs=" + listenerConfigs
                 + '}';
+    }
+
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
+    public ReliableTopicConfig getAsReadOnly() {
+        return new ReliableTopicConfigReadOnly(this);
     }
 
     static class ReliableTopicConfigReadOnly extends ReliableTopicConfig {

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -256,6 +256,12 @@ public class ReplicatedMapConfig {
         this.asyncFillup = asyncFillup;
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public ReplicatedMapConfig getAsReadOnly() {
         return new ReplicatedMapConfigReadOnly(this);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
@@ -218,15 +218,6 @@ public class RingbufferConfig {
     }
 
     /**
-     * Creates a readonly copy of this RingbufferConfig.
-     *
-     * @return the readonly copy.
-     */
-    public RingbufferConfig getAsReadOnly() {
-        return new RingbufferConfigReadonly(this);
-    }
-
-    /**
      * Gets the time to live in seconds.
      *
      * @return the time to live in seconds. Returns 0 the time to live if the items don't expire.
@@ -321,6 +312,16 @@ public class RingbufferConfig {
     public RingbufferConfig setRingbufferStoreConfig(RingbufferStoreConfig ringbufferStoreConfig) {
         this.ringbufferStoreConfig = ringbufferStoreConfig;
         return this;
+    }
+
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
+    public RingbufferConfig getAsReadOnly() {
+        return new RingbufferConfigReadonly(this);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferStoreConfig.java
@@ -111,19 +111,25 @@ public class RingbufferStoreConfig {
         return this;
     }
 
-    public RingbufferStoreConfigReadOnly getAsReadOnly() {
-        if (readOnly == null) {
-            readOnly = new RingbufferStoreConfigReadOnly(this);
-        }
-        return readOnly;
-    }
-
     public String toString() {
         return "RingbufferStoreConfig{"
                 + "enabled=" + enabled
                 + ", className='" + className + '\''
                 + ", properties=" + properties
                 + '}';
+    }
+
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
+    public RingbufferStoreConfigReadOnly getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new RingbufferStoreConfigReadOnly(this);
+        }
+        return readOnly;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
@@ -67,13 +67,6 @@ public class ScheduledExecutorConfig {
         this(config.getName(), config.getDurability(), config.getCapacity(), config.getPoolSize());
     }
 
-    public ScheduledExecutorConfig.ScheduledExecutorConfigReadOnly getAsReadOnly() {
-        if (readOnly == null) {
-            readOnly = new ScheduledExecutorConfig.ScheduledExecutorConfigReadOnly(this);
-        }
-        return readOnly;
-    }
-
     /**
      * Gets the name of the executor task.
      *
@@ -170,6 +163,13 @@ public class ScheduledExecutorConfig {
                 + ", poolSize-" + poolSize
                 + ", capacity-" + capacity
                 + '}';
+    }
+
+    ScheduledExecutorConfig getAsReadOnly() {
+        if (readOnly == null) {
+            readOnly = new ScheduledExecutorConfig.ScheduledExecutorConfigReadOnly(this);
+        }
+        return readOnly;
     }
 
     private static class ScheduledExecutorConfigReadOnly extends ScheduledExecutorConfig {

--- a/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
@@ -61,6 +61,12 @@ public class SemaphoreConfig {
         this.asyncBackupCount = config.getAsyncBackupCount();
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public SemaphoreConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new SemaphoreConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/SetConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SetConfig.java
@@ -34,6 +34,12 @@ public class SetConfig extends CollectionConfig<SetConfig> {
         super(config);
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     @Override
     public SetConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
@@ -67,6 +67,12 @@ public class TopicConfig {
         this.listenerConfigs = new ArrayList<ListenerConfig>(config.getMessageListenerConfigs());
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public TopicConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new TopicConfigReadOnly(this);

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -56,6 +56,12 @@ public class WanReplicationRef implements DataSerializable, Serializable {
         republishingEnabled = ref.republishingEnabled;
     }
 
+    /**
+     * Gets immutable version of this configuration.
+     *
+     * @return Immutable version of this configuration.
+     * @deprecated this method will be removed in 3.9; it is meant for internal usage only.
+     */
     public WanReplicationRefReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new WanReplicationRefReadOnly(this);

--- a/hazelcast/src/test/java/com/hazelcast/config/DurableExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/DurableExecutorConfigTest.java
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-package com.hazelcast.durableexecutor.impl.operations;
+package com.hazelcast.config;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;


### PR DESCRIPTION
* deprecated all `getAsReadOnly()` and `asReadOnly()` methods
* made new `getAsReadOnly()` methods from 3.8 package private
* moved package private methods down to the read-only class definition
* moved `DurableExecutorConfigTest` to the config package