### PR TITLE
Add WAN javadoc and fix wan sync counters

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -48,10 +48,27 @@ public class WanPublisherConfig implements DataSerializable {
         return this;
     }
 
+    /**
+     * Get the capacity of the queue for WAN replication events. IMap, ICache, normal and backup events count against
+     * the queue capacity separately. When the queue capacity is reached, backup events are dropped while normal
+     * replication events behave as determined by the {@link #getQueueFullBehavior()}.
+     * The default queue size for replication queues is {@value #DEFAULT_QUEUE_CAPACITY}.
+     *
+     * @return the queue capacity
+     */
     public int getQueueCapacity() {
         return queueCapacity;
     }
 
+    /**
+     * Set the capacity of the queue for WAN replication events. IMap, ICache, normal and backup events count against
+     * the queue capacity separately. When the queue capacity is reached, backup events are dropped while normal
+     * replication events behave as determined by the {@link #getQueueFullBehavior()}.
+     * The default queue size for replication queues is {@value #DEFAULT_QUEUE_CAPACITY}.
+     *
+     * @param queueCapacity the queue capacity
+     * @return this configuration
+     */
     public WanPublisherConfig setQueueCapacity(int queueCapacity) {
         this.queueCapacity = queueCapacity;
         return this;
@@ -79,6 +96,14 @@ public class WanPublisherConfig implements DataSerializable {
         return className;
     }
 
+    /**
+     * Set the name of the class implementing the WanReplicationEndpoint.
+     * NOTE: OS and EE have different interfaces that this class should implement.
+     * For OS see {@link com.hazelcast.wan.WanReplicationEndpoint}.
+     *
+     * @param className the name of the class implementation for the WAN replication
+     * @return the wan publisher config
+     */
     public WanPublisherConfig setClassName(String className) {
         this.className = className;
         return this;
@@ -88,6 +113,14 @@ public class WanPublisherConfig implements DataSerializable {
         return implementation;
     }
 
+    /**
+     * Set the implementation of the WanReplicationEndpoint.
+     * NOTE: OS and EE have different interfaces that this object should implement.
+     * For OS see {@link com.hazelcast.wan.WanReplicationEndpoint}.
+     *
+     * @param implementation the implementation for the WAN replication
+     * @return the wan publisher config
+     */
     public WanPublisherConfig setImplementation(Object implementation) {
         this.implementation = implementation;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -87,15 +87,37 @@ public class WanReplicationRef implements DataSerializable, Serializable {
         return this;
     }
 
+    /**
+     * Add class name implementing the CacheWanEventFilter or MapWanEventFilter for filtering WAN replication events.
+     * NOTE : EE only
+     *
+     * @param filter the class name
+     * @return this configuration
+     */
     public WanReplicationRef addFilter(String filter) {
         filters.add(filter);
         return this;
     }
 
+    /**
+     * Return the list of class names implementing the CacheWanEventFilter or MapWanEventFilter for filtering WAN replication
+     * events.
+     * NOTE : EE only
+     *
+     * @return list of class names implementing the CacheWanEventFilter or MapWanEventFilter
+     */
     public List<String> getFilters() {
         return filters;
     }
 
+    /**
+     * Set the list of class names implementing the CacheWanEventFilter or MapWanEventFilter for filtering WAN replication
+     * events.
+     * NOTE : EE only
+     *
+     * @param filters the list of class names implementing CacheWanEventFilter or MapWanEventFilter
+     * @return this configuration
+     */
     public WanReplicationRef setFilters(List<String> filters) {
         this.filters = filters;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationPublisher.java
@@ -16,18 +16,40 @@
 
 package com.hazelcast.wan;
 
+import com.hazelcast.config.WANQueueFullBehavior;
+import com.hazelcast.config.WanPublisherConfig;
+
 /**
  * This interface offers the implementation of different kinds of replication techniques like
  * TCP, UDP or maybe even an JMS based service
  */
 public interface WanReplicationPublisher {
 
+    /**
+     * Publish the {@code eventObject} WAN replication event. The event may be dropped if queue capacity has been reached.
+     *
+     * @param serviceName the service publishing the event
+     * @param eventObject the replication event
+     */
     void publishReplicationEvent(String serviceName, ReplicationEventObject eventObject);
 
+    /**
+     * Publish the {@code eventObject} WAN replication event backup. The event may be dropped if queue capacity has been reached.
+     *
+     * @param serviceName the service publishing the event
+     * @param eventObject the replication backup event
+     */
     void publishReplicationEventBackup(String serviceName, ReplicationEventObject eventObject);
 
     void publishReplicationEvent(WanReplicationEvent wanReplicationEvent);
 
+    /**
+     * Check the capacity of the WAN replication queues.
+     *
+     * @throws WANReplicationQueueFullException if queue capacity has been reached and
+     *                                          {@link WanPublisherConfig#getQueueFullBehavior()} is
+     *                                          set to {@link WANQueueFullBehavior#THROW_EXCEPTION}
+     */
     void checkWanReplicationQueues();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.wan;
 
+import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.monitor.WanSyncState;
 import com.hazelcast.spi.CoreService;
@@ -67,15 +68,36 @@ public interface WanReplicationService
 
     void checkWanReplicationQueues(String name);
 
+    /**
+     * Initiate wan sync for a specific map.
+     * NOTE: not supported on OS, only on EE
+     *
+     * @param wanReplicationName the name of the wan replication config
+     * @param targetGroupName    the group name on the target cluster
+     * @param mapName            the map name
+     * @throws UnsupportedOperationException if the operation is not supported (not EE)
+     * @throws InvalidConfigurationException if there is no WAN replication config for {@code wanReplicationName}
+     * @throws SyncFailedException           if there is a sync request in progress
+     */
     void syncMap(String wanReplicationName, String targetGroupName, String mapName);
 
+    /**
+     * Initiate wan sync for all maps.
+     * NOTE: not supported on OS, only on EE
+     *
+     * @param wanReplicationName the name of the wan replication config
+     * @param targetGroupName    the group name on the target cluster
+     * @throws UnsupportedOperationException if the operation is not supported (not EE)
+     * @throws InvalidConfigurationException if there is no WAN replication config for {@code wanReplicationName}
+     * @throws SyncFailedException           if there is a sync request in progress
+     */
     void syncAllMaps(String wanReplicationName, String targetGroupName);
 
     /**
      * Clears WAN replication queues of the given wanReplicationName for the given target.
      *
-     * @param wanReplicationName
-     * @param targetGroupName
+     * @param wanReplicationName the name of the wan replication config
+     * @param targetGroupName    the target cluster group name
      */
     void clearQueues(String wanReplicationName, String targetGroupName);
 


### PR DESCRIPTION
- the AbstractWanPublisher.counterMap was being set after putting the wan events in the staging queue. The striped executor might have already processed some events causing a wrong count or NPE on AbstractWanPublisher.removeReplicationEvent. The fix first sets the counters before adding items into the staging queue, thus preventing the executor from observing events that are not included in the counterMap
- while checking if a backup event should be dropped in AbstractWanPublisher.isEventDroppingNeeded, the if statement allowed a backup event to be dropped even if the backup counter hasn't yet reached the queue size but the currentElementCount counter has. The if statement has been fixed to drop the backup event only if the backup counter has reached the queue size, regardless of the currentElementCount
- add javadoc for WAN related functionalities