### PR TITLE
DefaultWriteBehindProcessor improvement for partial failures at storeAll/deleteAll

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -249,8 +249,8 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
                     result = operationType.processBatch(map, mapStore);
                 } catch (Exception ex) {
                     Iterator<Object> keys = batchMap.keySet().iterator();
-                    for (Object key = null; keys.hasNext(); key = keys.next()) {
-                        if (!map.containsKey(key)) {
+                    while (keys.hasNext()) {
+                        if (!map.containsKey(DefaultWriteBehindProcessor.this.toObject(keys.next()))) {
                             keys.remove();
                         }
                     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -243,7 +244,18 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
             public boolean run() throws Exception {
                 callBeforeStoreListeners(batchMap.values());
                 final Map map = convertToObject(batchMap);
-                final boolean result = operationType.processBatch(map, mapStore);
+                boolean result;
+                try {
+                    result = operationType.processBatch(map, mapStore);
+                } catch (Exception ex) {
+                    Iterator<Object> keys = batchMap.keySet().iterator();
+                    for (Object key = null; keys.hasNext(); key = keys.next()) {
+                        if (!map.containsKey(key)) {
+                            keys.remove();
+                        }
+                    }
+                    throw ex;
+                }
                 callAfterStoreListeners(batchMap.values());
                 return result;
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -260,9 +260,6 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
                 return result;
             }
 
-            /**
-             * Call when store failed.
-             */
             @Override
             public List<DelayedEntry> failureList() {
                 failedDelayedEntries = new ArrayList<DelayedEntry>(batchMap.values().size());


### PR DESCRIPTION
- added agreed piece of code in the DefaultWriteBihindProcessor;
- added a test case in the WriteBehindFailAndRetryTest;

Fixes #9733