### PR TITLE
Minor changes in the QueryEngine. Groundwork for #9715

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -139,7 +139,6 @@ import com.hazelcast.map.merge.PassThroughMergePolicy;
 import com.hazelcast.map.merge.PutIfAbsentMapMergePolicy;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.util.ConstructorFunction;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.MAP_DS_FACTORY;
@@ -279,7 +278,6 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int READ_AND_RESET_ACCUMULATOR = 127;
     public static final int SET_READ_CURSOR = 128;
     public static final int ACCUMULATOR_CONSUMER = 129;
-    public static final int CACHED_QUERY_ENTRY = 130;
     public static final int LAZY_MAP_ENTRY = 131;
     public static final int TRIGGER_LOAD_IF_NEEDED = 132;
     public static final int IS_KEYLOAD_FINISHED = 133;
@@ -929,11 +927,6 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[ACCUMULATOR_CONSUMER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new AccumulatorConsumerOperation();
-            }
-        };
-        constructors[CACHED_QUERY_ENTRY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new CachedQueryEntry();
             }
         };
         constructors[LAZY_MAP_ENTRY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -45,7 +45,7 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
     @Override
     public void run() throws Exception {
         QueryRunner queryRunner = mapServiceContext.getMapQueryRunner(getName());
-        result = queryRunner.run(query);
+        result = queryRunner.runIndexOrPartitionScanQueryOnOwnedPartitions(query);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -44,7 +44,7 @@ public class QueryPartitionOperation extends MapOperation implements PartitionAw
     public void run() {
         QueryRunner queryRunner = mapServiceContext.getMapQueryRunner(getName());
         try {
-            result = queryRunner.runUsingPartitionScanOnSinglePartition(query, getPartitionId());
+            result = queryRunner.runPartitionScanQueryOnGivenOwnedPartition(query, getPartitionId());
         } catch (ExecutionException e) {
             throw new HazelcastException(e);
         } catch (InterruptedException e) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -17,20 +17,14 @@
 package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.query.impl.getters.Extractors;
-
-import java.io.IOException;
 
 /**
  * Entry of the Query.
  */
-public class CachedQueryEntry extends QueryableEntry implements IdentifiedDataSerializable {
+public class CachedQueryEntry extends QueryableEntry {
 
     protected Data keyData;
     protected Object keyObject;
@@ -142,28 +136,6 @@ public class CachedQueryEntry extends QueryableEntry implements IdentifiedDataSe
     @Override
     public int hashCode() {
         return keyData.hashCode();
-    }
-
-    @Override
-    public int getFactoryId() {
-        return MapDataSerializerHook.F_ID;
-    }
-
-    @Override
-    public int getId() {
-        return MapDataSerializerHook.CACHED_QUERY_ENTRY;
-    }
-
-    @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeData(keyData);
-        out.writeData(valueData);
-    }
-
-    @Override
-    public void readData(ObjectDataInput in) throws IOException {
-        keyData = in.readData();
-        valueData = in.readData();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryRunnerTest.java
@@ -62,7 +62,7 @@ public class QueryRunnerTest extends HazelcastTestSupport {
     public void runFullQuery() throws ExecutionException, InterruptedException {
         Predicate predicate = Predicates.equal("this", value);
         Query query = Query.of().mapName(map.getName()).predicate(predicate).iterationType(IterationType.ENTRY).build();
-        QueryResult result = (QueryResult) queryRunner.run(query);
+        QueryResult result = (QueryResult) queryRunner.runIndexOrPartitionScanQueryOnOwnedPartitions(query);
 
         assertEquals(1, result.getRows().size());
         assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));
@@ -72,7 +72,7 @@ public class QueryRunnerTest extends HazelcastTestSupport {
     public void runPartitionScanQueryOnSinglePartition() throws ExecutionException, InterruptedException {
         Predicate predicate = Predicates.equal("this", value);
         Query query = Query.of().mapName(map.getName()).predicate(predicate).iterationType(IterationType.ENTRY).build();
-        QueryResult result = (QueryResult) queryRunner.runUsingPartitionScanOnSinglePartition(query, partitionId);
+        QueryResult result = (QueryResult) queryRunner.runPartitionScanQueryOnGivenOwnedPartition(query, partitionId);
 
         assertEquals(1, result.getRows().size());
         assertEquals(map.get(key), toObject(result.getRows().iterator().next().getValue()));


### PR DESCRIPTION
Groundwork for #9715. 

Query threading looks as follows:

- query threads goes to a node and does an index scan, if no result it does a partition scan on all **local** partitions.
- then if no result for certain partitions the query is replied on partition threads for those "missing" partitions.

- in OS it works OK, but in EE, the partition scan should happen on partition threads only. So it should not do any partition scan on query-threads -> this was causing the nullpointer, since the query-thread which spawned queries on partition-threads (expecting the calls to be local only) - but on migrations these calls used to go to remote nodes and the query-entries were serialized - this was not intended. 
Idea of the fix:

- in EE only index can be asked on query threads - partition scan should run on partition threads only,

In this PR:

- CachedQueryEntry not serializable any more - it was just made serializable as a work-around. 
- One method in QueryRunner made protected -> EE side overrides it
- Naming refactoring -> to avoid some confusion