### PR TITLE
Test fix testClientEndpointsDelaySeconds_whenHeartbeatResumed

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.core.LifecycleService;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.logging.Logger;
@@ -288,20 +289,15 @@ public class ClientHeartbeatTest extends ClientTestSupport {
         clientConfig.setProperty(ClientProperty.HEARTBEAT_INTERVAL.getName(), "1000");
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
-        final AtomicLong stateChangeCount = new AtomicLong();
 
         final CountDownLatch disconnectedLatch = new CountDownLatch(1);
-        final CountDownLatch connectedLatch = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+
+        LifecycleService lifecycleService = client.getLifecycleService();
+        lifecycleService.addLifecycleListener(new LifecycleListener() {
             @Override
             public void stateChanged(LifecycleEvent event) {
-                stateChangeCount.incrementAndGet();
-                Logger.getLogger(this.getClass()).info("state event : " + event);
                 if (LifecycleEvent.LifecycleState.CLIENT_DISCONNECTED == event.getState()) {
                     disconnectedLatch.countDown();
-                }
-                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
-                    connectedLatch.countDown();
                 }
             }
         });
@@ -309,6 +305,20 @@ public class ClientHeartbeatTest extends ClientTestSupport {
         blockMessagesFromInstance(hazelcastInstance, client);
         //Wait for client to disconnect because of hearBeat problem.
         assertOpenEventually(disconnectedLatch);
+
+        final CountDownLatch connectedLatch = new CountDownLatch(1);
+        final AtomicLong stateChangeCount = new AtomicLong();
+        lifecycleService.addLifecycleListener(new LifecycleListener() {
+            @Override
+            public void stateChanged(LifecycleEvent event) {
+                stateChangeCount.incrementAndGet();
+                Logger.getLogger(this.getClass()).info("state event : " + event);
+                if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED == event.getState()) {
+                    connectedLatch.countDown();
+                }
+            }
+        });
+
         unblockMessagesFromInstance(hazelcastInstance, client);
         //Wait for client to connect back after heartbeat issue is resolved
         assertOpenEventually(connectedLatch);
@@ -318,7 +328,7 @@ public class ClientHeartbeatTest extends ClientTestSupport {
         assertTrueAllTheTime(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(2, stateChangeCount.get());
+                assertEquals(1, stateChangeCount.get());
             }
         }, delaySeconds * 2);
     }


### PR DESCRIPTION
Test meant to wait  CLIENT_DISCONNECTED and CLIENT_CONNECTED.
But because events fired on an executor, in an unlucky run,
we got CLIENT_STARTED and CLIENT_CONNECTED before expected
events come. Although these events totally healthy, they
were incrementing the count value used for testing.

I changed the test so that the count value used for testing
is incremented only after first CLIENT_DISCONNECTED fired.

fixes https://github.com/hazelcast/hazelcast/issues/9719