### PR TITLE
Improve disabled/no task hot backup status

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/HotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/HotRestartService.java
@@ -60,4 +60,11 @@ public interface HotRestartService {
      * directories will be left as-is.
      */
     void interruptBackupTask();
+
+    /**
+     * Returns if hot backup is enabled.
+     *
+     * @return {@code true} if hot backup is enabled, {@code false} otherwise
+     */
+    boolean isHotBackupEnabled();
 }

--- a/hazelcast/src/main/java/com/hazelcast/hotrestart/NoOpHotRestartService.java
+++ b/hazelcast/src/main/java/com/hazelcast/hotrestart/NoOpHotRestartService.java
@@ -21,6 +21,7 @@ package com.hazelcast.hotrestart;
  * not available or not enabled.
  */
 public class NoOpHotRestartService implements HotRestartService {
+    private static final BackupTaskStatus NO_TASK_BACKUP_STATUS = new BackupTaskStatus(BackupTaskState.NO_TASK, 0, 0);
 
     @Override
     public void backup() {
@@ -32,7 +33,7 @@ public class NoOpHotRestartService implements HotRestartService {
 
     @Override
     public BackupTaskStatus getBackupTaskStatus() {
-        return new BackupTaskStatus(BackupTaskState.NOT_STARTED, 0, 0);
+        return NO_TASK_BACKUP_STATUS;
     }
 
     @Override
@@ -41,5 +42,10 @@ public class NoOpHotRestartService implements HotRestartService {
 
     @Override
     public void interruptBackupTask() {
+    }
+
+    @Override
+    public boolean isHotBackupEnabled() {
+        return false;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/hotrestart/NoopHotRestartServicesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/hotrestart/NoopHotRestartServicesTest.java
@@ -23,7 +23,8 @@ public class NoopHotRestartServicesTest {
         service.getBackupTaskStatus();
         service.interruptBackupTask();
         service.interruptLocalBackupTask();
-        assertEquals(new BackupTaskStatus(BackupTaskState.NOT_STARTED, 0, 0), service.getBackupTaskStatus());
+        assertFalse(service.isHotBackupEnabled());
+        assertEquals(new BackupTaskStatus(BackupTaskState.NO_TASK, 0, 0), service.getBackupTaskStatus());
     }
 
     @Test


### PR DESCRIPTION
- add public method for checking if hot backup is enabled
- return NO_TASK instead of SUCCESS if no task has been run yet or if hot backup is disabled

EE part : https://github.com/hazelcast/hazelcast-enterprise/pull/1271