### PR TITLE
Custom DiscoveryService fixes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientNetworkConfig.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.hazelcast.util.Preconditions.isNotNull;
+
 /**
  * Contains configuration parameters for client network related behaviour
  */
@@ -59,9 +61,10 @@ public class ClientNetworkConfig {
      * Defines the Discovery Provider SPI configuration
      *
      * @param discoveryConfig the Discovery Provider SPI configuration
+     * @throws java.lang.IllegalArgumentException if discoveryConfig is null
      */
     public void setDiscoveryConfig(DiscoveryConfig discoveryConfig) {
-        this.discoveryConfig = discoveryConfig;
+        this.discoveryConfig = isNotNull(discoveryConfig, "discoveryConfig");
     }
 
     /**

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -294,11 +294,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         ILogger logger = loggingService.getLogger(DiscoveryService.class);
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
         DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig().getAsReadOnly();
-        if (discoveryConfig == null || !discoveryConfig.isEnabled()) {
-            logger.warning("Discovery SPI is enabled but no DiscoveryStrategy is configured. "
-                    + "Please define a DiscoveryStrategy to use Discovery SPI.");
-            return null;
-        }
+
         DiscoveryServiceProvider factory = discoveryConfig.getDiscoveryServiceProvider();
         if (factory == null) {
             factory = new DefaultDiscoveryServiceProvider();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -28,6 +28,8 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 public class DiscoveryAddressProvider
         implements AddressProvider {
 
@@ -41,7 +43,8 @@ public class DiscoveryAddressProvider
 
     @Override
     public Collection<InetSocketAddress> loadAddresses() {
-        Iterable<DiscoveryNode> discoveredNodes = discoveryService.discoverNodes();
+        Iterable<DiscoveryNode> discoveredNodes = checkNotNull(discoveryService.discoverNodes(),
+                "Discovered nodes cannot be null!");
 
         Collection<InetSocketAddress> possibleMembers = new ArrayList<InetSocketAddress>();
         for (DiscoveryNode discoveryNode : discoveredNodes) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressTranslator.java
@@ -24,6 +24,8 @@ import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 public class DiscoveryAddressTranslator
         implements AddressTranslator {
 
@@ -71,7 +73,8 @@ public class DiscoveryAddressTranslator
 
     @Override
     public void refresh() {
-        Iterable<DiscoveryNode> discoveredNodes = discoveryService.discoverNodes();
+        Iterable<DiscoveryNode> discoveredNodes = checkNotNull(discoveryService.discoverNodes(),
+                "Discovered nodes cannot be null!");
 
         Map<Address, Address> privateToPublic = new HashMap<Address, Address>();
         for (DiscoveryNode discoveryNode : discoveredNodes) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
@@ -26,6 +26,8 @@ import com.hazelcast.spi.discovery.integration.DiscoveryService;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 public class DiscoveryJoiner
         extends TcpIpJoiner {
 
@@ -40,7 +42,8 @@ public class DiscoveryJoiner
 
     @Override
     protected Collection<Address> getPossibleAddresses() {
-        Iterable<DiscoveryNode> discoveredNodes = discoveryService.discoverNodes();
+        Iterable<DiscoveryNode> discoveredNodes = checkNotNull(discoveryService.discoverNodes(),
+                "Discovered nodes cannot be null!");
 
         MemberImpl localMember = node.nodeEngine.getLocalMember();
         Address localAddress = localMember.getAddress();


### PR DESCRIPTION
- `DiscoveryService.discoverNodes()` should not return null,
added preconditions to places it's called.
- `DiscoveryServiceProvider` & `DiscoveryService` should be called
even when no DiscoveryStrategy exists.
- `ClientNetworkConfig.setDiscoveryConfig()` shouldn't accept null
similar to server side `JoinConfig.setDiscoveryConfig()`.

Follow up fix for #9722 & #9741