### PR TITLE
[DO NOT MERGE] Adding destroy capabilities to MapLoader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/IsPartitionLoadedOperation.java
@@ -20,20 +20,25 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
 
+/**
+ * Does not create recordstore on demand
+ */
 public class IsPartitionLoadedOperation extends MapOperation implements PartitionAwareOperation, ReadonlyOperation {
 
     private boolean isFinished;
 
     public IsPartitionLoadedOperation() {
+        createRecordStoreOnDemand = false;
     }
 
     public IsPartitionLoadedOperation(String name) {
         super(name);
+        createRecordStoreOnDemand = false;
     }
 
     @Override
     public void run() {
-        isFinished = recordStore.isLoaded();
+        isFinished = recordStore == null || recordStore.isLoaded();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -167,6 +167,8 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     @Override
     public void destroy() {
+        recordStoreLoader.destroy();
+        keyLoader.destroy();
         clearPartition(false);
         storage.destroy(false);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreLoader.java
@@ -31,6 +31,10 @@ interface RecordStoreLoader {
         public Future loadValues(List<Data> keys, boolean replaceExistingValues) {
             return null;
         }
+
+        @Override
+        public void destroy() {
+        }
     };
 
     /**
@@ -41,4 +45,10 @@ interface RecordStoreLoader {
      * @return future for checking when loading is complete
      */
     Future<?> loadValues(List<Data> keys, boolean replaceExistingValues);
+
+    /**
+     * Destroys the loader and gracefully cancels the background tasks.
+     * Does not wait for the tasks to finish.
+     */
+    void destroy();
 }


### PR DESCRIPTION
Gracefully stops map-loader's processing if the map has been destroyed while map-loader has been in-flight.

Improves the lifecycle handling for cases like #5035.

Does not fully solve the life-cycle handling problem. In order to do it we would need some life-cycle orchestration which would require remote calls to create proxies, etc.