### PR TITLE
Move mem cost calculation to support change in EE

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -319,9 +319,6 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
             oldRecord = putRecord(key, record);
             if (oldRecord == null) {
                 nearCacheStats.incrementOwnedEntryCount();
-            } else {
-                long oldRecordMemoryCost = getTotalStorageMemoryCost(key, oldRecord);
-                nearCacheStats.decrementOwnedEntryMemoryCost(oldRecordMemoryCost);
             }
             onPut(key, value, record, oldRecord);
         } catch (Throwable error) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -76,6 +76,9 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
     protected R putRecord(K key, R record) {
         R oldRecord = records.put(key, record);
         nearCacheStats.incrementOwnedEntryMemoryCost(getTotalStorageMemoryCost(key, record));
+        if (oldRecord != null) {
+            nearCacheStats.decrementOwnedEntryMemoryCost(getTotalStorageMemoryCost(key, oldRecord));
+        }
         return oldRecord;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -390,7 +390,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
                 + ", lockedEntryCount=" + lockedEntryCount
                 + ", dirtyEntryCount=" + dirtyEntryCount
                 + ", heapCost=" + heapCost
-                + ", nearCacheStats=" + nearCacheStats
+                + ", nearCacheStats=" + (nearCacheStats != null ? nearCacheStats : "")
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -390,6 +390,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
                 + ", lockedEntryCount=" + lockedEntryCount
                 + ", dirtyEntryCount=" + dirtyEntryCount
                 + ", heapCost=" + heapCost
+                + ", nearCacheStats=" + nearCacheStats
                 + '}';
     }
 }


### PR DESCRIPTION
Moved memory cost calculation one level deeper, to support a change in EE.
hazelcast/hazelcast-enterprise#1276