### PR TITLE
Fix wrong task count when having multiple scheduled executors

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.scheduledexecutor.impl;
+
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
+import com.hazelcast.util.ConstructorFunction;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+public abstract class AbstractScheduledExecutorContainerHolder implements ScheduledExecutorContainerHolder {
+
+    final NodeEngine nodeEngine;
+
+    final ConcurrentMap<String, ScheduledExecutorContainer> containers =
+            new ConcurrentHashMap<String, ScheduledExecutorContainer>();
+
+    public AbstractScheduledExecutorContainerHolder(NodeEngine nodeEngine) {
+        this.nodeEngine = nodeEngine;
+    }
+
+    public ScheduledExecutorContainer getContainer(String name) {
+        checkNotNull(name, "Name can't be null");
+        return containers.get(name);
+    }
+
+    public ScheduledExecutorContainer getOrCreateContainer(String name) {
+        checkNotNull(name, "Name can't be null");
+
+        return getOrPutIfAbsent(containers, name, getContainerConstructorFunction());
+    }
+
+    public Collection<ScheduledExecutorContainer> getContainers() {
+        return Collections.unmodifiableCollection(containers.values());
+    }
+
+    public void destroy() {
+        for (ScheduledExecutorContainer container : containers.values()) {
+            ((InternalExecutionService) nodeEngine.getExecutionService())
+                    .shutdownScheduledDurableExecutor(container.getName());
+        }
+    }
+
+    @Override
+    public void destroyContainer(String name) {
+        ScheduledExecutorContainer container = containers.remove(name);
+        if (container != null) {
+            container.destroy();
+        }
+    }
+
+    protected abstract ConstructorFunction<String, ScheduledExecutorContainer> getContainerConstructorFunction();
+}

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -116,9 +116,11 @@ public class DistributedScheduledExecutorService
 
     @Override
     public void destroyDistributedObject(String name) {
-        if (shutdownExecutors.remove(name) != null) {
+        if (shutdownExecutors.remove(name) == null) {
             ((InternalExecutionService) nodeEngine.getExecutionService()).shutdownScheduledDurableExecutor(name);
         }
+
+        resetContainerInPartitionsAndMemberBin(name);
     }
 
     public void shutdownExecutor(String name) {
@@ -172,4 +174,13 @@ public class DistributedScheduledExecutorService
         partition.disposeObsoleteReplicas(thresholdReplicaIndex);
     }
 
+    private void resetContainerInPartitionsAndMemberBin(String name) {
+        if (memberBin != null) {
+            memberBin.destroyContainer(name);
+        }
+
+        for (ScheduledExecutorPartition partition : partitions) {
+            partition.destroyContainer(name);
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainerHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainerHolder.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.scheduledexecutor.impl;
 
-import java.util.Collection;
-
 public interface ScheduledExecutorContainerHolder {
+
+    ScheduledExecutorContainer getContainer(String name);
 
     ScheduledExecutorContainer getOrCreateContainer(String name);
 
-    Collection<ScheduledExecutorContainer> getContainers();
+    void destroy();
+
+    void destroyContainer(String name);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorMemberBin.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorMemberBin.java
@@ -19,25 +19,13 @@ package com.hazelcast.scheduledexecutor.impl;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
 import com.hazelcast.util.ConstructorFunction;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
-import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
-import static com.hazelcast.util.Preconditions.checkNotNull;
-
-public class ScheduledExecutorMemberBin implements ScheduledExecutorContainerHolder {
+public class ScheduledExecutorMemberBin extends AbstractScheduledExecutorContainerHolder {
 
     private final ILogger logger;
 
     private final NodeEngine nodeEngine;
-
-    private final ConcurrentMap<String, ScheduledExecutorContainer> containers =
-            new ConcurrentHashMap<String, ScheduledExecutorContainer>();
 
     private final ConstructorFunction<String, ScheduledExecutorContainer> containerConstructorFunction =
             new ConstructorFunction<String, ScheduledExecutorContainer>() {
@@ -54,25 +42,14 @@ public class ScheduledExecutorMemberBin implements ScheduledExecutorContainerHol
             };
 
     public ScheduledExecutorMemberBin(NodeEngine nodeEngine) {
+        super(nodeEngine);
         this.logger = nodeEngine.getLogger(getClass());
         this.nodeEngine = nodeEngine;
     }
 
-    public ScheduledExecutorContainer getOrCreateContainer(String name) {
-        checkNotNull(name, "Name can't be null");
-
-        return getOrPutIfAbsent(containers, name, containerConstructorFunction);
-    }
-
-    public Collection<ScheduledExecutorContainer> getContainers() {
-        return Collections.unmodifiableCollection(containers.values());
-    }
-
-    public void destroy() {
-        for (ScheduledExecutorContainer container : containers.values()) {
-            ((InternalExecutionService) nodeEngine.getExecutionService())
-                    .shutdownScheduledDurableExecutor(container.getName());
-        }
+    @Override
+    public ConstructorFunction<String, ScheduledExecutorContainer> getContainerConstructorFunction() {
+        return containerConstructorFunction;
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/GetAllScheduledOperation.java
@@ -60,13 +60,15 @@ public class GetAllScheduledOperation
     private void populateScheduledForHolder(List<ScheduledTaskHandler> handlers, DistributedScheduledExecutorService service,
                                             int holderId) {
         ScheduledExecutorContainerHolder partition = service.getPartitionOrMemberBin(holderId);
-        Collection<ScheduledExecutorContainer> containers = partition.getContainers();
-        for (ScheduledExecutorContainer container : containers) {
-            Collection<ScheduledTaskDescriptor> tasks = container.getTasks();
-            for (ScheduledTaskDescriptor task : tasks) {
-                if (task.isTaskOwner()) {
-                    handlers.add(container.offprintHandler(task.getDefinition().getName()));
-                }
+        ScheduledExecutorContainer container = partition.getContainer(schedulerName);
+        if (container == null || service.isShutdown(schedulerName)) {
+            return;
+        }
+
+        Collection<ScheduledTaskDescriptor> tasks = container.getTasks();
+        for (ScheduledTaskDescriptor task : tasks) {
+            if (task.isTaskOwner()) {
+                handlers.add(container.offprintHandler(task.getDefinition().getName()));
             }
         }
     }


### PR DESCRIPTION
When scheduling tasks with multiple executors, calling getAllScheduled on one of them returns tasks scheduled per member but for all executors rather than for the one we called the getAllScheduled from.

This change is patching the operation to only work on a specific container given its name, and also introduces minor class hierarchy improvements, and proper resetting of a container when its proxy gets destroyed.
Fix #9784