### PR TITLE
Do not log business exceptions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
@@ -17,6 +17,7 @@
 package com.hazelcast.durableexecutor;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.spi.exception.SilentException;
 import com.hazelcast.spi.annotation.Beta;
 
 /**
@@ -24,7 +25,7 @@ import com.hazelcast.spi.annotation.Beta;
  * result of the task is overwritten. This means the task is executed but the result isn't available anymore
  */
 @Beta
-public class StaleTaskIdException extends HazelcastException {
+public class StaleTaskIdException extends HazelcastException implements SilentException {
 
     public StaleTaskIdException(String message) {
         super(message);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.ringbuffer;
 
+import com.hazelcast.spi.exception.SilentException;
+
 /**
  * An {@link RuntimeException} that is thrown when accessing an item in the {@link Ringbuffer} using a sequence that is smaller
  * than the current head sequence and that the ringbuffer store is disabled. This means that the item isn't available in the
  * ringbuffer and it cannot be loaded from the store either, thus being completely unavailable.
  */
-public class StaleSequenceException extends RuntimeException {
+public class StaleSequenceException extends RuntimeException implements SilentException {
 
     private final long headSeq;
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StaleTaskException.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StaleTaskException.java
@@ -17,12 +17,13 @@
 package com.hazelcast.scheduledexecutor;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.spi.exception.SilentException;
 
 /**
  * Exception thrown by the {@link IScheduledFuture} during any operation on a stale (=previously destroyed) task.
  */
 public class StaleTaskException
-        extends HazelcastException {
+        extends HazelcastException implements SilentException {
 
     public StaleTaskException(String msg) {
         super(msg);

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/SilentException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/SilentException.java
@@ -14,17 +14,23 @@
  * limitations under the License.
  */
 
-package com.hazelcast.quorum;
+package com.hazelcast.spi.exception;
 
-import com.hazelcast.spi.exception.SilentException;
-import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.spi.Operation;
 
 /**
- * An exception thrown when the cluster size is below the defined threshold.
+ * Marked interface for exceptions.
+ *
+ * When an exception is marked with this interface then
+ * it won't be logged by {@link Operation#logError(Throwable)}
+ *
+ * It's intended to be used for exceptions which are part of a flow,
+ * for example {@link com.hazelcast.durableexecutor.StaleTaskIdException}
+ * is always propagated to the user - there is no reason why Hazelcast
+ * should log it on its own.
+ *
+ * The exception is silent from Hazelcast point of view only. Obviously
+ * it's very visible for user code.
  */
-public class QuorumException extends TransactionException implements SilentException {
-
-    public QuorumException(String message) {
-        super(message);
-    }
+public interface SilentException {
 }


### PR DESCRIPTION
Exceptions such as StaleSequenceException are part of a normal
flow. They are propagated to user code and there is no reason
why Hazelcast should log them by default.

Fixes #9051, #9781