### PR TITLE
[WIP] Rolling upgrade cleanup & utils

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -307,7 +307,7 @@ public class DefaultNodeExtension implements NodeExtension {
     // otherwise, if overridden with GroupProperty#INIT_CLUSTER_VERSION, use this one
     // otherwise, if not overridden, use current node's codebase version
     private ClusterVersion getClusterOrNodeVersion() {
-        if (node.getClusterService() != null && node.getClusterService().getClusterVersion() != null) {
+        if (node.getClusterService() != null && !node.getClusterService().getClusterVersion().isUnknown()) {
             return node.getClusterService().getClusterVersion();
         } else {
             String overriddenClusterVersion = node.getProperties().getString(GroupProperty.INIT_CLUSTER_VERSION);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -501,7 +501,7 @@ public class ClusterJoinManager {
 
             node.setMasterAddress(thisAddress);
 
-            if (clusterService.getClusterVersion() == null) {
+            if (clusterService.getClusterVersion().isUnknown()) {
                 clusterService.getClusterStateManager().setClusterVersion(version.asClusterVersion());
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/version/ClusterVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/ClusterVersion.java
@@ -107,6 +107,10 @@ public final class ClusterVersion implements IdentifiedDataSerializable, Compara
         }
     }
 
+    public boolean isUnknown() {
+        return this.major == 0 && this.minor == 0;
+    }
+
     @Override
     public int getFactoryId() {
         return ClusterDataSerializerHook.F_ID;

--- a/hazelcast/src/main/java/com/hazelcast/version/ClusterVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/ClusterVersion.java
@@ -56,6 +56,26 @@ public final class ClusterVersion implements IdentifiedDataSerializable, Compara
         return minor;
     }
 
+    public boolean isEqualTo(ClusterVersion version) {
+        return this.equals(version);
+    }
+
+    public boolean isLessThan(ClusterVersion version) {
+        return this.major < version.major || this.major == version.major && this.minor < version.minor;
+    }
+
+    public boolean isLessOrEqual(ClusterVersion version) {
+        return isLessThan(version) || isEqualTo(version);
+    }
+
+    public boolean isGreaterThan(ClusterVersion version) {
+        return this.major > version.major || this.major == version.major && this.minor > version.minor;
+    }
+
+    public boolean isGreaterOrEqual(ClusterVersion version) {
+        return isGreaterThan(version) || isEqualTo(version);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/hazelcast/src/main/java/com/hazelcast/version/ClusterVersionAssertion.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/ClusterVersionAssertion.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.version;
+
+/**
+ * Assertion that may be used to verify the ClusterVersion conditions in the production code
+ */
+public final class ClusterVersionAssertion {
+
+    private final ClusterVersion actual;
+
+    private ClusterVersionAssertion(ClusterVersion clusterVersion) {
+        this.actual = clusterVersion;
+    }
+
+    public void isLessThan(ClusterVersion version) {
+        if (!actual.isLessThan(version)) {
+            fail("not less than", version.toString());
+        }
+    }
+
+    public void isLessOrEqual(ClusterVersion version) {
+        if (!actual.isLessOrEqual(version)) {
+            fail("not less or equal", version.toString());
+        }
+    }
+
+    public void isGreaterThan(ClusterVersion version) {
+        if (!actual.isGreaterThan(version)) {
+            fail("not greater than", version.toString());
+        }
+    }
+
+    public void isGreaterOrEqual(ClusterVersion version) {
+        if (!actual.isGreaterOrEqual(version)) {
+            fail("not greater or equal", version.toString());
+        }
+    }
+
+    public void isEqualTo(ClusterVersion version) {
+        if (!actual.isEqualTo(version)) {
+            fail("not equal to", version.toString());
+        }
+    }
+
+    public void isUnknown() {
+        if (!actual.isUnknown()) {
+            fail("not unknown");
+        }
+    }
+
+    public void isNotUnknown() {
+        if (actual.isUnknown()) {
+            fail("unknown");
+        }
+    }
+
+    private void fail(String msg, String version) {
+        throw new IllegalVersionException(
+                String.format("Actual cluster version %s is %s %s", actual.toString(), msg, version));
+    }
+
+    private void fail(String msg) {
+        fail(msg, "");
+    }
+
+    public static ClusterVersionAssertion assertThat(ClusterVersion actualClusterVersion) {
+        return new ClusterVersionAssertion(actualClusterVersion);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/version/IllegalVersionException.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/IllegalVersionException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.version;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * Exception thrown whenever there is a Version or ClusterVersion mismatch
+ */
+public class IllegalVersionException extends HazelcastException {
+
+    public IllegalVersionException() {
+    }
+
+    public IllegalVersionException(final String message) {
+        super(message);
+    }
+
+    public IllegalVersionException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public IllegalVersionException(final Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
@@ -89,7 +89,7 @@ public final class MemberVersion
     }
 
     public boolean isUnknown() {
-        return this.equals(UNKNOWN);
+        return this.major == 0 && this.minor == 0 && this.patch == 0;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/version/VersionAssertion.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/VersionAssertion.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.version;
+
+import com.hazelcast.nio.Version;
+
+/**
+ * Assertion that may be used to verify the Version conditions in the production code
+ */
+public final class VersionAssertion {
+
+    private final Version actual;
+
+    private VersionAssertion(Version version) {
+        this.actual = version;
+    }
+
+    public void isLessThan(Version version) {
+        if (!actual.isLessThan(version)) {
+            fail("not less than", version.toString());
+        }
+    }
+
+    public void isLessOrEqual(Version version) {
+        if (!actual.isLessOrEqual(version)) {
+            fail("not less or equal", version.toString());
+        }
+    }
+
+    public void isGreaterThan(Version version) {
+        if (!actual.isGreaterThan(version)) {
+            fail("not greater than", version.toString());
+        }
+    }
+
+    public void isGreaterOrEqual(Version version) {
+        if (!actual.isGreaterOrEqual(version)) {
+            fail("not greater or equal", version.toString());
+        }
+    }
+
+    public void isEqualTo(Version version) {
+        if (!actual.isEqualTo(version)) {
+            fail("not equal to", version.toString());
+        }
+    }
+
+    public void isUnknown() {
+        if (!actual.isUnknown()) {
+            fail("not unknown");
+        }
+    }
+
+    public void isNotUnknown() {
+        if (actual.isUnknown()) {
+            fail("unknown");
+        }
+    }
+
+    private void fail(String msg, String version) {
+        throw new IllegalVersionException(
+                String.format("Actual cluster version %s is %s %s", actual.toString(), msg, version));
+    }
+
+    private void fail(String msg) {
+        fail(msg, "");
+    }
+
+    public static VersionAssertion assertThat(Version actualVersion) {
+        return new VersionAssertion(actualVersion);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/version/Versions.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/Versions.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.version;
+
+import com.hazelcast.nio.Version;
+
+/**
+ * Version & ClusterVersion constants
+ */
+public final class Versions {
+
+    /**
+     * Version 3.8
+     */
+    public static final ClusterVersion CLUSTER_VERSION_3_8 = ClusterVersion.of("3.8");
+
+    /**
+     * Version 3.9
+     */
+    public static final ClusterVersion CLUSTER_VERSION_3_9 = ClusterVersion.of("3.8");
+
+    /**
+     * Version 8
+     */
+    public static final Version VERSION_8 = Version.of(8);
+
+    /**
+     * Version 9
+     */
+    public static final Version VERSION_9 = Version.of(9);
+
+    private Versions() {
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.hazelcast.instance.BuildInfoProvider.BUILD_INFO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -156,7 +155,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
                 latch.countDown();
             }
         };
-        nullifyClusterVersionAndVerifyListener(latch, failed, listener);
+        makeClusterVersionUnknownAndVerifyListener(latch, failed, listener);
     }
 
     @Test
@@ -175,23 +174,23 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
                 latch.countDown();
             }
         };
-        nullifyClusterVersionAndVerifyListener(latch, failed, listener);
+        makeClusterVersionUnknownAndVerifyListener(latch, failed, listener);
         System.clearProperty(GroupProperty.INIT_CLUSTER_VERSION.getName());
     }
 
-    private void nullifyClusterVersionAndVerifyListener(CountDownLatch latch, AtomicBoolean failed,
-                                                        ClusterVersionListener listener)
+    private void makeClusterVersionUnknownAndVerifyListener(CountDownLatch latch, AtomicBoolean failed,
+                                                            ClusterVersionListener listener)
             throws NoSuchFieldException, IllegalAccessException {
         // directly set clusterVersion field's value to null
         Field setClusterVersionMethod = ClusterStateManager.class.getDeclaredField("clusterVersion");
         setClusterVersionMethod.setAccessible(true);
-        setClusterVersionMethod.set(node.getClusterService().getClusterStateManager(), null);
+        setClusterVersionMethod.set(node.getClusterService().getClusterStateManager(), ClusterVersion.UNKNOWN);
         // register listener and assert it's successful
         assertTrue(nodeExtension.registerListener(listener));
         // listener was executed
         assertOpenEventually(latch);
         // clusterVersion field's value was actually null
-        assertNull(node.getClusterService().getClusterStateManager().getClusterVersion());
+        assertTrue(node.getClusterService().getClusterStateManager().getClusterVersion().isUnknown());
         // listener received node's codebase version as new cluster version
         assertFalse(failed.get());
     }

--- a/hazelcast/src/test/java/com/hazelcast/version/ClusterVersionAssertionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/ClusterVersionAssertionTest.java
@@ -1,0 +1,131 @@
+package com.hazelcast.version;
+
+import org.junit.Test;
+
+import static com.hazelcast.version.ClusterVersion.of;
+import static com.hazelcast.version.ClusterVersionAssertion.assertThat;
+
+public class ClusterVersionAssertionTest {
+
+    @Test(expected = IllegalVersionException.class)
+    public void lessThan_fail_equal() throws Exception {
+        assertThat(of("3.8")).isLessThan(of("3.8"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void lessThan_fail_less() throws Exception {
+        assertThat(of("3.8")).isLessThan(of("3.7"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void lessThan_fail_lessMajor() throws Exception {
+        assertThat(of("3.8")).isLessThan(of("2.7"));
+    }
+
+    @Test
+    public void lessThan() throws Exception {
+        assertThat(of("3.8")).isLessThan(of("3.9"));
+        assertThat(of("3.8")).isLessThan(of("4.1"));
+        assertThat(of("3.8")).isLessThan(of("4.8"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void lessOrEqual_fail() throws Exception {
+        assertThat(of("3.8")).isLessOrEqual(of("3.7"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void lessOrEqual_fail_lessMajor() throws Exception {
+        assertThat(of("3.8")).isLessOrEqual(of("2.7"));
+    }
+
+    @Test
+    public void lessOrEqual() throws Exception {
+        assertThat(of("3.8")).isLessOrEqual(of("3.8"));
+        assertThat(of("3.8")).isLessOrEqual(of("3.9"));
+        assertThat(of("3.8")).isLessOrEqual(of("4.1"));
+        assertThat(of("3.8")).isLessOrEqual(of("4.8"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void greaterThan_fail_equal() throws Exception {
+        assertThat(of("3.8")).isGreaterThan(of("3.8"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void greaterThan_fail_less() throws Exception {
+        assertThat(of("3.8")).isGreaterThan(of("3.9"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void greaterThan_fail_greatedMajor() throws Exception {
+        assertThat(of("3.8")).isGreaterThan(of("4.1"));
+    }
+
+    @Test
+    public void greaterThan() throws Exception {
+        assertThat(of("3.8")).isGreaterThan(of("2.7"));
+        assertThat(of("3.8")).isGreaterThan(of("3.3"));
+        assertThat(of("3.8")).isGreaterThan(of("3.7"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void greaterOrEqual_fail() throws Exception {
+        assertThat(of("3.8")).isGreaterOrEqual(of("3.9"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void greaterOrEqual_fail_greatedMajor() throws Exception {
+        assertThat(of("3.8")).isGreaterOrEqual(of("4.1"));
+    }
+
+    @Test
+    public void greaterOrEqual() throws Exception {
+        assertThat(of("3.8")).isGreaterOrEqual(of("2.7"));
+        assertThat(of("3.8")).isGreaterOrEqual(of("3.1"));
+        assertThat(of("3.8")).isGreaterOrEqual(of("3.7"));
+        assertThat(of("3.8")).isGreaterOrEqual(of("3.8"));
+    }
+
+    @Test
+    public void equalTo() throws Exception {
+        assertThat(of("3.8")).isEqualTo(of("3.8"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void equalTo_smaller() throws Exception {
+        assertThat(of("3.8")).isEqualTo(of("2.7"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void equalTo_greater() throws Exception {
+        assertThat(of("3.8")).isEqualTo(of("4.7"));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void isUnknown_fail() throws Exception {
+        assertThat(of("3.8")).isUnknown();
+    }
+
+    @Test
+    public void isUnknown() throws Exception {
+        assertThat(of("0.0")).isUnknown();
+        assertThat(ClusterVersion.UNKNOWN).isUnknown();
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void isNotUnknown_fail() throws Exception {
+        assertThat(ClusterVersion.UNKNOWN).isNotUnknown();
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void isNotUnknown_fail_explicit() throws Exception {
+        assertThat(of("0.0")).isNotUnknown();
+    }
+
+    @Test
+    public void isNotUnknown() throws Exception {
+        assertThat(of("3.8")).isNotUnknown();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/version/VersionAssertionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/VersionAssertionTest.java
@@ -1,0 +1,109 @@
+package com.hazelcast.version;
+
+import com.hazelcast.nio.Version;
+import org.junit.Test;
+
+import static com.hazelcast.nio.Version.of;
+import static com.hazelcast.version.VersionAssertion.assertThat;
+
+public class VersionAssertionTest {
+
+    @Test(expected = IllegalVersionException.class)
+    public void lessThan_fail_equal() throws Exception {
+        assertThat(of(8)).isLessThan(of(8));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void lessThan_fail_less() throws Exception {
+        assertThat(of(8)).isLessThan(of(7));
+    }
+
+    @Test
+    public void lessThan() throws Exception {
+        assertThat(of(8)).isLessThan(of(9));
+        assertThat(of(8)).isLessThan(of(11));
+        assertThat(of(8)).isLessThan(of(13));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void lessOrEqual_fail() throws Exception {
+        assertThat(of(8)).isLessOrEqual(of(7));
+    }
+
+    @Test
+    public void lessOrEqual() throws Exception {
+        assertThat(of(8)).isLessOrEqual(of(8));
+        assertThat(of(8)).isLessOrEqual(of(9));
+        assertThat(of(8)).isLessOrEqual(of(11));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void greaterThan_fail_equal() throws Exception {
+        assertThat(of(8)).isGreaterThan(of(8));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void greaterThan_fail_less() throws Exception {
+        assertThat(of(8)).isGreaterThan(of(9));
+    }
+
+    @Test
+    public void greaterThan() throws Exception {
+        assertThat(of(8)).isGreaterThan(of(3));
+        assertThat(of(8)).isGreaterThan(of(7));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void greaterOrEqual_fail() throws Exception {
+        assertThat(of(8)).isGreaterOrEqual(of(9));
+    }
+
+    @Test
+    public void greaterOrEqual() throws Exception {
+        assertThat(of(8)).isGreaterOrEqual(of(1));
+        assertThat(of(8)).isGreaterOrEqual(of(7));
+        assertThat(of(8)).isGreaterOrEqual(of(8));
+    }
+
+    @Test
+    public void equalTo() throws Exception {
+        assertThat(of(8)).isEqualTo(of(8));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void equalTo_smaller() throws Exception {
+        assertThat(of(8)).isEqualTo(of(2));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void equalTo_greater() throws Exception {
+        assertThat(of(8)).isEqualTo(of(11));
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void isUnknown_fail() throws Exception {
+        assertThat(of(8)).isUnknown();
+    }
+
+    @Test
+    public void isUnknown() throws Exception {
+        assertThat(of(-1)).isUnknown();
+        assertThat(Version.UNKNOWN).isUnknown();
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void isNotUnknown_fail() throws Exception {
+        assertThat(Version.UNKNOWN).isNotUnknown();
+    }
+
+    @Test(expected = IllegalVersionException.class)
+    public void isNotUnknown_fail_explicit() throws Exception {
+        assertThat(of(-1)).isNotUnknown();
+    }
+
+    @Test
+    public void isNotUnknown() throws Exception {
+        assertThat(of(8)).isNotUnknown();
+    }
+
+}


### PR DESCRIPTION
Version & ClusterVersion may not be null anymore (UNKNOWN or value)
Enables doing assertions on Version and ClusterVersion
Introduces Version & ClusterVersion constants
Introduces IllegalVersionException throw in case the assertions fails

```
assertThat(clusterVersion).isLessThan(CLUSTER_VERSION_3_8);
assertThat(version).isLessThan(VERSION_9);
```
