### PR TITLE
Bouncing member test fixes

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientQueryBounceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientQueryBounceTest.java
@@ -17,8 +17,7 @@
 package com.hazelcast.client.map;
 
 import com.hazelcast.map.QueryBounceTest;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -26,8 +25,8 @@ import org.junit.runner.RunWith;
 /**
  * Test querying a cluster from Hazelcast clients while members are shutting down and joining.
  */
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({SlowTest.class, ParallelTest.class})
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
 public class ClientQueryBounceTest extends QueryBounceTest {
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
@@ -21,10 +21,10 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.SampleObjects;
 import com.hazelcast.query.SqlPredicate;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.jitter.JitterRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,8 +41,8 @@ import static org.junit.Assert.assertEquals;
 /**
  * Query map while members of the cluster are being shutdown and started
  */
-@RunWith(HazelcastParallelClassRunner.class)
-@Category({SlowTest.class, ParallelTest.class})
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
 public class QueryBounceTest {
 
     private static final String TEST_MAP_NAME = "employees";
@@ -53,6 +53,9 @@ public class QueryBounceTest {
 
     @Rule
     public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getConfig()).build();
+
+    @Rule
+    public JitterRule jitterRule = new JitterRule();
 
     @Rule
     public TestName testName = new TestName();

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
@@ -236,10 +236,12 @@ public class BounceMemberRule implements TestRule {
                 }
                 sleepSeconds(1);
             }
+            testRunning.set(false);
+            waitForFutures(futures);
+        } else {
+            waitForFutures(futures);
+            testRunning.set(false);
         }
-
-        testRunning.set(false);
-        waitForFutures(futures);
     }
 
     public static Builder with(Config memberConfig) {
@@ -469,15 +471,19 @@ public class BounceMemberRule implements TestRule {
         public void run() {
             int i = 0;
             int nextInstance;
-            while (testRunning.get()) {
-                instances[i].shutdown();
-                nextInstance = (i + 1) % instances.length;
-                sleepSeconds(2);
+            try {
+                while (testRunning.get()) {
+                    instances[i].shutdown();
+                    nextInstance = (i + 1) % instances.length;
+                    sleepSeconds(2);
 
-                instances[i] = factory.newHazelcastInstance();
-                sleepSeconds(2);
-                // move to next member
-                i = nextInstance;
+                    instances[i] = factory.newHazelcastInstance();
+                    sleepSeconds(2);
+                    // move to next member
+                    i = nextInstance;
+                }
+            } catch (Throwable t) {
+                t.printStackTrace();
             }
         }
     }


### PR DESCRIPTION
* When using `BounceMemberRule.test`, members bouncing thread would stop without waiting for actual test tasks to complete.
* Reverts QueryBounceTest to be executed in isolation (use serial class runner, not marked as `ParallelTest`, as was the case for `QueryDuringMigrationsStressTest` it replaced).
* Applies `JitterRule` for hiccups monitoring in `QueryBounceTest`