### PR TITLE
Fixes for Near Cache configuration

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.8.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.8.xsd
@@ -349,6 +349,11 @@
 
     <xs:complexType name="near-cache">
         <xs:all>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
+            <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
+            <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
             <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
@@ -356,8 +361,6 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
-            <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
             <xs:element name="eviction-policy" type="eviction-policy" minOccurs="0" maxOccurs="1" default="LRU">
                 <xs:annotation>
                     <xs:documentation>
@@ -365,9 +368,6 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
-            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
-            <xs:element name="local-update-policy" type="xs:string" default="INVALIDATE" minOccurs="0" maxOccurs="1"/>
             <xs:element name="cache-local-entries" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
                 <xs:annotation>
                     <xs:documentation>
@@ -375,7 +375,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="local-update-policy" type="xs:string" default="INVALIDATE" minOccurs="0" maxOccurs="1"/>
             <xs:element name="preloader" type="preloader" minOccurs="0" maxOccurs="1"/>
         </xs:all>
     </xs:complexType>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -742,13 +742,15 @@ public class ConfigXmlGenerator {
     private static void mapNearCacheConfigXmlGenerator(XmlGenerator gen, NearCacheConfig n) {
         if (n != null) {
             gen.open("near-cache")
-                    .node("max-size", n.getMaxSize())
-                    .node("time-to-live-seconds", n.getTimeToLiveSeconds())
-                    .node("max-idle-seconds", n.getMaxIdleSeconds())
-                    .node("eviction-policy", n.getEvictionPolicy())
+                    .node("in-memory-format", n.getInMemoryFormat())
                     .node("invalidate-on-change", n.isInvalidateOnChange())
-                    .node("in-memory-format", n.getInMemoryFormat());
+                    .node("time-to-live-seconds", n.getTimeToLiveSeconds())
+                    .node("max-idle-seconds", n.getMaxIdleSeconds());
             evictionConfigXmlGenerator(gen, n.getEvictionConfig());
+            gen
+                    .node("eviction-policy", n.getEvictionPolicy())
+                    .node("max-size", n.getMaxSize())
+                    .node("cache-local-entries", n.isCacheLocalEntries());
             gen.close();
         }
     }
@@ -759,9 +761,9 @@ public class ConfigXmlGenerator {
         }
         final String comparatorClass = !isNullOrEmpty(e.getComparatorClassName()) ? e.getComparatorClassName() : null;
         gen.node("eviction", null,
-                "size", e.getSize(),
                 "max-size-policy", e.getMaximumSizePolicy(),
                 "eviction-policy", e.getEvictionPolicy(),
+                "size", e.getSize(),
                 "comparator-class-name", comparatorClass);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -159,7 +159,7 @@ public class NearCacheConfig implements DataSerializable, Serializable {
         if (evictionConfig != null) {
             this.evictionConfig = evictionConfig;
         } else {
-            this.evictionConfig.setSize(maxSize);
+            this.evictionConfig.setSize(calculateMaxSize(maxSize));
             this.evictionConfig.setEvictionPolicy(EvictionPolicy.valueOf(evictionPolicy));
             this.evictionConfig.setMaximumSizePolicy(ENTRY_COUNT);
         }
@@ -263,6 +263,7 @@ public class NearCacheConfig implements DataSerializable, Serializable {
      * @deprecated since 3.8, use {@link #setEvictionConfig(EvictionConfig)} and {@link EvictionConfig#setSize(int)} instead
      */
     public NearCacheConfig setMaxSize(int maxSize) {
+        checkNotNegative(maxSize, "maxSize cannot be a negative number!");
         this.maxSize = calculateMaxSize(maxSize);
         this.evictionConfig.setSize(this.maxSize);
         this.evictionConfig.setMaximumSizePolicy(ENTRY_COUNT);

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -2393,15 +2393,22 @@
 
     <xs:complexType name="near-cache">
         <xs:all>
-            <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY">
                 <xs:annotation>
                     <xs:documentation>
-                        Maximum size of the Near Cache. When max size is reached,
-                        cache is evicted based on the policy defined.
-                        Any integer between 0 and Integer.MAX_VALUE.
-                        0 means Integer.MAX_VALUE. Default is 0.
-
-                        Deprecated since 3.8, please use &lt;eviction/&gt;
+                        Data type used to store entries.
+                        Possible values:
+                        BINARY (default): keys and values are stored as binary data.
+                        OBJECT: values are stored in their object forms.
+                        NATIVE: keys and values are stored in native memory. Only available on Hazelcast Enterprise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to evict the cached entries if the entries are changed (updated or removed).
+                        Default value is true.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -2424,6 +2431,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
             <xs:element name="eviction-policy" type="eviction-policy" minOccurs="0" maxOccurs="1" default="LRU">
                 <xs:annotation>
                     <xs:documentation>
@@ -2438,35 +2446,27 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+            <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        True to evict the cached entries if the entries are changed (updated or removed).
-                        Default value is true.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY">
-                <xs:annotation>
-                    <xs:documentation>
-                        Data type used to store entries.
-                        Possible values:
-                        BINARY (default): keys and values are stored as binary data.
-                        OBJECT: values are stored in their object forms.
-                        NATIVE: keys and values are stored in native memory. Only available on Hazelcast Enterprise.
+                        Maximum size of the Near Cache. When max size is reached,
+                        cache is evicted based on the policy defined.
+                        Any integer between 0 and Integer.MAX_VALUE.
+                        0 means Integer.MAX_VALUE. Default is 0.
+
+                        Deprecated since 3.8, please use &lt;eviction/&gt;
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="cache-local-entries" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
                 <xs:annotation>
                     <xs:documentation>
-                        True to cache local entries also.
+                        True to cache local entries, which belong to the member itself.
                         This is useful when in-memory-format for Near Cache is different than the map's one.
                         Default value is false.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="name" use="optional" type="xs:string" default="default"/>
     </xs:complexType>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import java.io.ByteArrayInputStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -135,7 +136,8 @@ public class ConfigXmlGeneratorTest {
                 .setInMemoryFormat(InMemoryFormat.NATIVE)
                 .setMaxSize(23)
                 .setEvictionPolicy("LRU")
-                .setMaxIdleSeconds(42);
+                .setMaxIdleSeconds(42)
+                .setCacheLocalEntries(true);
 
         MapConfig mapConfig = new MapConfig()
                 .setName("nearCacheTest")
@@ -153,6 +155,7 @@ public class ConfigXmlGeneratorTest {
         assertEquals("LRU", xmlNearCacheConfig.getEvictionPolicy());
         assertEquals(EvictionPolicy.LRU, xmlNearCacheConfig.getEvictionConfig().getEvictionPolicy());
         assertEquals(42, xmlNearCacheConfig.getMaxIdleSeconds());
+        assertTrue(xmlNearCacheConfig.isCacheLocalEntries());
     }
 
     private static Config getNewConfigViaXMLGenerator(Config config) {


### PR DESCRIPTION
* Unified order of parameters in XSD and created XML
* Added cache-local-entries to ConfigXmlGenerator
* Added missing conversion of maxSize to valid value for EvictionConfig
* Updated documentation for cache-local-entries in XSD

Part of https://github.com/hazelcast/hazelcast-reference-manual/issues/232