### PR TITLE
Do not deserialize Portable objects when storing into index

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/standalone/ClientMapStandaloneTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/standalone/ClientMapStandaloneTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.query.Predicates.equal;
+import static com.hazelcast.query.Predicates.or;
 import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static org.junit.Assert.assertEquals;
@@ -209,4 +210,21 @@ public class ClientMapStandaloneTest {
         assertEquals(values.iterator().next(), element);
     }
 
+    @Test
+    public void testPortable_query_with_index() throws Exception {
+        IMap<Integer, MyPortableElement> map = createMap();
+
+        for (int i = 0; i < 100; i++) {
+            MyPortableElement element = new MyPortableElement(i);
+            map.put(i, element);
+        }
+        map.addIndex("id", false);
+        Predicate predicate = or(
+                equal("id", 0),
+                equal("id", 1)
+        );
+
+        Collection values = map.values(predicate);
+        assertEquals(2, values.size());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -66,7 +66,7 @@ public class IndexImpl implements Index {
             converter = entry.getConverter(attributeName);
         }
 
-        Object newAttributeValue = extractAttributeValue(entry.getKeyData(), entry.getValue());
+        Object newAttributeValue = extractAttributeValue(entry.getKeyData(), entry.getTargetObject(false));
         if (oldRecordValue == null) {
             indexStore.newIndex(newAttributeValue, entry);
         } else {


### PR DESCRIPTION
backport of #9809
(cherry picked from commit 3e07678)