### PR TITLE
Eliminate unconditional waiting in node join/shutdown

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -176,19 +176,12 @@ public abstract class AbstractJoiner implements Joiner {
     }
 
     private void ensureConnectionToAllMembers() {
-        boolean allConnected = false;
+        boolean allConnected;
         if (clusterService.isJoined()) {
             logger.fine("Waiting for all connections");
             int connectAllWaitSeconds = node.getProperties().getSeconds(GroupProperty.CONNECT_ALL_WAIT_SECONDS);
             int checkCount = 0;
-            while (checkCount++ < connectAllWaitSeconds && !allConnected) {
-                try {
-                    //noinspection BusyWait
-                    TimeUnit.SECONDS.sleep(1);
-                } catch (InterruptedException ignored) {
-                    EmptyStatement.ignore(ignored);
-                }
-
+            do {
                 allConnected = true;
                 Collection<Member> members = clusterService.getMembers();
                 for (Member member : members) {
@@ -199,7 +192,15 @@ public abstract class AbstractJoiner implements Joiner {
                         }
                     }
                 }
-            }
+                if (!allConnected) {
+                    try {
+                        //noinspection BusyWait
+                        TimeUnit.SECONDS.sleep(1);
+                    } catch (InterruptedException ignored) {
+                        EmptyStatement.ignore(ignored);
+                    }
+                }
+            } while (checkCount++ < connectAllWaitSeconds && !allConnected);
         }
     }
 
@@ -355,7 +356,7 @@ public abstract class AbstractJoiner implements Joiner {
      * This is a pure function that must produce always the same output when called with the same parameters.
      * This logic should not be changed, otherwise compatibility will be broken.
      *
-     * @param thisAddress this address
+     * @param thisAddress   this address
      * @param targetAddress target address
      * @return true if this address should merge to target, false otherwise
      */
@@ -398,7 +399,7 @@ public abstract class AbstractJoiner implements Joiner {
         NodeEngine nodeEngine = node.nodeEngine;
         Future future = nodeEngine.getOperationService().createInvocationBuilder(ClusterServiceImpl.SERVICE_NAME,
                 new SplitBrainMergeValidationOp(node.createSplitBrainJoinMessage()), target)
-                .setTryCount(1).invoke();
+                                  .setTryCount(1).invoke();
         try {
             return (SplitBrainJoinMessage) future.get(SPLIT_BRAIN_JOIN_CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (TimeoutException e) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -178,7 +178,8 @@ class InvocationMonitor implements PacketHandler, MetricsProvider {
 
     void onMemberLeft(MemberImpl member) {
         // postpone notifying invocations since real response may arrive in the mean time.
-        scheduler.schedule(new OnMemberLeftTask(member), ON_MEMBER_LEFT_DELAY_MILLIS, MILLISECONDS);
+        scheduler.schedule(new OnMemberLeftTask(member),
+                invocationRegistry.size() == 0 ? 0 : ON_MEMBER_LEFT_DELAY_MILLIS, MILLISECONDS);
     }
 
     void execute(Runnable runnable) {

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -49,7 +49,8 @@ class MockJoiner extends AbstractJoiner {
 
         Address previousJoinAddress = null;
         long joinAddressTimeout = 0;
-        while (shouldRetry() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
+        boolean shouldRetry;
+        do {
             synchronized (registry) {
                 Address joinAddress = getJoinAddress();
                 verifyInvariant(joinAddress != null, "joinAddress should not be null");
@@ -78,13 +79,17 @@ class MockJoiner extends AbstractJoiner {
                     clusterService.setMasterAddressToJoin(null);
                 }
             }
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-                break;
+            shouldRetry = shouldRetry();
+            if (shouldRetry) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    break;
+                }
             }
-        }
+
+        } while (shouldRetry && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis));
     }
 
     private Address getJoinAddress() {


### PR DESCRIPTION
Try eliminate waiting to reduce minimal test duration.

When joining and shutting the node down there are some places where we unconditionally wait before checking if we should wait any longer. This has been eliminated, the check is done before the first wait as well. On node shutdown we always wait for response on pending invocations but there might not be any invocations in which case we can just finish the invocation system shutdown without waiting.

Depends on : https://github.com/hazelcast/hazelcast/pull/10030