### PR TITLE
ClientInvocation retryable exceptions

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -84,7 +84,6 @@ import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService;
 import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.ObjectNamespace;
-import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
@@ -330,8 +329,7 @@ public final class ProxyManager {
     }
 
     private boolean isRetryable(final Throwable t) {
-        return t instanceof RetryableException
-                || ClientInvocation.isRetryable(t);
+        return ClientInvocation.isRetrySafeException(t);
     }
 
     private void sleepForProxyInitRetry() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -29,6 +29,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.exception.RetryableException;
+import com.hazelcast.spi.exception.TargetDisconnectedException;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -176,7 +177,9 @@ public class ClientInvocation implements Runnable {
             return;
         }
 
-        if (isRetrySafeException(exception) || invocationService.isRedoOperation()) {
+        if (isRetrySafeException(exception)
+                || invocationService.isRedoOperation()
+                || (exception instanceof TargetDisconnectedException && clientMessage.isRetryable())) {
             try {
                 ClientExecutionServiceImpl executionServiceImpl = (ClientExecutionServiceImpl) this.executionService;
                 executionServiceImpl.schedule(this, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -28,7 +28,7 @@ import com.hazelcast.core.LifecycleService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.exception.RetryableException;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Handles the routing of a request from a Hazelcast client.
- *
+ * <p>
  * 1) Where should request be send?
  * 2) Should it be retried?
  * 3) How many times it is retried?
@@ -170,47 +170,26 @@ public class ClientInvocation implements Runnable {
             return;
         }
 
-        if (isRetryable(exception)) {
-            if (handleRetry()) {
-                return;
-            }
+        if ((isBindToSingleConnection() && exception instanceof IOException)
+                || System.currentTimeMillis() > retryTimeoutPointInMillis) {
+            clientInvocationFuture.complete(exception);
+            return;
         }
-        if (exception instanceof RetryableHazelcastException) {
-            if (clientMessage.isRetryable() || invocationService.isRedoOperation()) {
-                if (handleRetry()) {
-                    return;
+
+        if (isRetrySafeException(exception) || invocationService.isRedoOperation()) {
+            try {
+                ClientExecutionServiceImpl executionServiceImpl = (ClientExecutionServiceImpl) this.executionService;
+                executionServiceImpl.schedule(this, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);
+            } catch (RejectedExecutionException e) {
+                if (logger.isFinestEnabled()) {
+                    logger.finest("Retry could not be scheduled ", e);
                 }
+                clientInvocationFuture.complete(exception);
             }
+            return;
         }
+
         clientInvocationFuture.complete(exception);
-    }
-
-    private boolean handleRetry() {
-        if (isBindToSingleConnection()) {
-            return false;
-        }
-
-        if (!shouldRetry()) {
-            return false;
-        }
-
-        try {
-            rescheduleInvocation();
-        } catch (RejectedExecutionException e) {
-            if (logger.isFinestEnabled()) {
-                logger.finest("Retry could not be scheduled ", e);
-            }
-            notifyException(e);
-        }
-        return true;
-    }
-
-    private void rescheduleInvocation() {
-        executionService.schedule(this, RETRY_WAIT_TIME_IN_SECONDS, TimeUnit.SECONDS);
-    }
-
-    private boolean shouldRetry() {
-        return System.currentTimeMillis() < retryTimeoutPointInMillis;
     }
 
     private boolean isBindToSingleConnection() {
@@ -248,8 +227,10 @@ public class ClientInvocation implements Runnable {
         return sendConnection;
     }
 
-    public static boolean isRetryable(Throwable t) {
-        return t instanceof IOException || t instanceof HazelcastInstanceNotActiveException;
+    public static boolean isRetrySafeException(Throwable t) {
+        return t instanceof IOException
+                || t instanceof HazelcastInstanceNotActiveException
+                || t instanceof RetryableException;
     }
 
     public Executor getUserExecutor() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.spi.exception;
 
+import com.hazelcast.core.HazelcastException;
+
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that indicates that an operation is about to
  * be send to a non existing machine.
  */
-public class TargetDisconnectedException extends RetryableHazelcastException {
+public class TargetDisconnectedException extends HazelcastException {
 
     public TargetDisconnectedException(String message) {
         super(message);


### PR DESCRIPTION
ClientInvocation always retries RetryableExceptions without
looking at if message is idompotent or config
fixes https://github.com/hazelcast/hazelcast/issues/9817