### PR TITLE
Removed unneeded null check

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -748,7 +748,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
     }
 
     protected void storeInNearCache(Data key, Data valueData, V value, long reservationId, boolean cacheOnUpdate) {
-        if (nearCache == null || valueData == null) {
+        if (nearCache == null) {
             return;
         }
 


### PR DESCRIPTION
fixes this test failure: https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-3.x-nightly/com.hazelcast$hazelcast-client/1230/testReport/junit/com.hazelcast.client.cache.impl.nearcache/ClientCacheRecordStateStressTest/all_records_are_readable_state_in_the_end_localUpdatePolicy_CACHE_ON_UPDATE_/