### PR TITLE
Convert built-in Projections and Aggregations to IdentifiedDataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/Aggregator.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.aggregation;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
 /**
@@ -36,7 +34,6 @@ import java.io.Serializable;
  * @param <R> result type
  * @since 3.8
  */
-@BinaryInterface
 public abstract class Aggregator<I, R> implements Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AbstractAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AbstractAggregator.java
@@ -30,7 +30,7 @@ import java.util.Map;
  */
 public abstract class AbstractAggregator<I, R> extends Aggregator<I, R> {
 
-    private final String attributePath;
+    protected String attributePath;
 
     public AbstractAggregator() {
         this(null);

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AggregatorDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AggregatorDataSerializerHook.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.aggregation.impl;
+
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.AGGREGATOR_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.AGGREGATOR_DS_FACTORY_ID;
+
+public final class AggregatorDataSerializerHook implements DataSerializerHook {
+
+    public static final int F_ID = FactoryIdHelper.getFactoryId(AGGREGATOR_DS_FACTORY, AGGREGATOR_DS_FACTORY_ID);
+
+    public static final int BIG_DECIMAL_AVG = 0;
+    public static final int BIG_DECIMAL_SUM = 1;
+    public static final int BIG_INT_AVG = 2;
+    public static final int BIG_INT_SUM = 3;
+    public static final int COUNT = 4;
+    public static final int DISTINCT_VALUES = 5;
+    public static final int DOUBLE_AVG = 6;
+    public static final int DOUBLE_SUM = 7;
+    public static final int FIXED_SUM = 8;
+    public static final int FLOATING_POINT_SUM = 9;
+    public static final int INT_AVG = 10;
+    public static final int INT_SUM = 11;
+    public static final int LONG_AVG = 12;
+    public static final int LONG_SUM = 13;
+    public static final int MAX = 14;
+    public static final int MIN = 15;
+    public static final int NUMBER_AVG = 16;
+
+    private static final int LEN = NUMBER_AVG + 1;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
+
+        constructors[BIG_DECIMAL_AVG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new BigDecimalAverageAggregator();
+            }
+        };
+        constructors[BIG_DECIMAL_SUM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new BigDecimalSumAggregator();
+            }
+        };
+        constructors[BIG_INT_AVG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new BigIntegerAverageAggregator();
+            }
+        };
+        constructors[BIG_INT_SUM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new BigIntegerSumAggregator();
+            }
+        };
+        constructors[COUNT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CountAggregator();
+            }
+        };
+        constructors[DISTINCT_VALUES] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new DistinctValuesAggregator();
+            }
+        };
+        constructors[DOUBLE_AVG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new DoubleAverageAggregator();
+            }
+        };
+        constructors[DOUBLE_SUM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new DoubleSumAggregator();
+            }
+        };
+        constructors[FIXED_SUM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new FixedSumAggregator();
+            }
+        };
+        constructors[FLOATING_POINT_SUM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new FloatingPointSumAggregator();
+            }
+        };
+        constructors[INT_AVG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new IntegerAverageAggregator();
+            }
+        };
+        constructors[INT_SUM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new IntegerSumAggregator();
+            }
+        };
+        constructors[LONG_AVG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new LongAverageAggregator();
+            }
+        };
+        constructors[LONG_SUM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new LongSumAggregator();
+            }
+        };
+        constructors[MAX] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MaxAggregator();
+            }
+        };
+        constructors[MIN] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MinAggregator();
+            }
+        };
+        constructors[NUMBER_AVG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new NumberAverageAggregator();
+            }
+        };
+
+        return new ArrayDataSerializableFactory(constructors);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
@@ -17,10 +17,15 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 
-public class BigDecimalAverageAggregator<I> extends AbstractAggregator<I, BigDecimal> {
+public final class BigDecimalAverageAggregator<I> extends AbstractAggregator<I, BigDecimal>
+        implements IdentifiedDataSerializable {
 
     private BigDecimal sum = BigDecimal.ZERO;
     private long count;
@@ -57,4 +62,27 @@ public class BigDecimalAverageAggregator<I> extends AbstractAggregator<I, BigDec
                 BigDecimal.valueOf(count));
     }
 
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.BIG_DECIMAL_AVG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeObject(sum);
+        out.writeLong(count);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readObject();
+        this.count = in.readLong();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
@@ -17,10 +17,14 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 
-public class BigDecimalSumAggregator<I> extends AbstractAggregator<I, BigDecimal> {
+public final class BigDecimalSumAggregator<I> extends AbstractAggregator<I, BigDecimal> implements IdentifiedDataSerializable {
 
     private BigDecimal sum = BigDecimal.ZERO;
 
@@ -47,6 +51,28 @@ public class BigDecimalSumAggregator<I> extends AbstractAggregator<I, BigDecimal
     @Override
     public BigDecimal aggregate() {
         return sum;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.BIG_DECIMAL_SUM;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeObject(sum);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readObject();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
@@ -17,11 +17,16 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-public class BigIntegerAverageAggregator<I> extends AbstractAggregator<I, BigDecimal> {
+public final class BigIntegerAverageAggregator<I> extends AbstractAggregator<I, BigDecimal>
+        implements IdentifiedDataSerializable {
 
     private BigInteger sum = BigInteger.ZERO;
     private long count;
@@ -56,6 +61,30 @@ public class BigIntegerAverageAggregator<I> extends AbstractAggregator<I, BigDec
         }
         return new BigDecimal(sum)
                 .divide(BigDecimal.valueOf(count));
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.BIG_INT_AVG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeObject(sum);
+        out.writeLong(count);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readObject();
+        this.count = in.readLong();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerSumAggregator.java
@@ -17,10 +17,14 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
+import java.io.IOException;
 import java.math.BigInteger;
 
-public class BigIntegerSumAggregator<I> extends AbstractAggregator<I, BigInteger> {
+public final class BigIntegerSumAggregator<I> extends AbstractAggregator<I, BigInteger> implements IdentifiedDataSerializable {
 
     private BigInteger sum = BigInteger.ZERO;
 
@@ -47,6 +51,28 @@ public class BigIntegerSumAggregator<I> extends AbstractAggregator<I, BigInteger
     @Override
     public BigInteger aggregate() {
         return sum;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.BIG_INT_SUM;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeObject(sum);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readObject();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class CountAggregator<I> extends AbstractAggregator<I, Long> {
+import java.io.IOException;
+
+public final class CountAggregator<I> extends AbstractAggregator<I, Long> implements IdentifiedDataSerializable {
     private long count;
 
     public CountAggregator() {
@@ -43,5 +48,27 @@ public class CountAggregator<I> extends AbstractAggregator<I, Long> {
     @Override
     public Long aggregate() {
         return count;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.COUNT;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeLong(count);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.count = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
@@ -17,11 +17,15 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
-public class DistinctValuesAggregator<I, R> extends AbstractAggregator<I, Set<R>> {
+public final class DistinctValuesAggregator<I, R> extends AbstractAggregator<I, Set<R>> implements IdentifiedDataSerializable {
     Set<R> values = new HashSet<R>();
 
     public DistinctValuesAggregator() {
@@ -48,4 +52,34 @@ public class DistinctValuesAggregator<I, R> extends AbstractAggregator<I, Set<R>
     public Set<R> aggregate() {
         return values;
     }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.DISTINCT_VALUES;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeInt(values.size());
+        for (Object value : values) {
+            out.writeObject(value);
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        int count = in.readInt();
+        this.values = new HashSet<R>(count);
+        for (int i = 0; i < count; i++) {
+            values.add((R) in.readObject());
+        }
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class DoubleAverageAggregator<I> extends AbstractAggregator<I, Double> {
+import java.io.IOException;
+
+public final class DoubleAverageAggregator<I> extends AbstractAggregator<I, Double> implements IdentifiedDataSerializable {
 
     private double sum;
 
@@ -52,6 +57,30 @@ public class DoubleAverageAggregator<I> extends AbstractAggregator<I, Double> {
             return null;
         }
         return (sum / (double) count);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.DOUBLE_AVG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeDouble(sum);
+        out.writeLong(count);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readDouble();
+        this.count = in.readLong();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class DoubleSumAggregator<I> extends AbstractAggregator<I, Double> {
+import java.io.IOException;
+
+public final class DoubleSumAggregator<I> extends AbstractAggregator<I, Double> implements IdentifiedDataSerializable {
 
     private double sum;
 
@@ -45,6 +50,28 @@ public class DoubleSumAggregator<I> extends AbstractAggregator<I, Double> {
     @Override
     public Double aggregate() {
         return sum;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.DOUBLE_SUM;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeDouble(sum);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readDouble();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class FixedSumAggregator<I> extends AbstractAggregator<I, Long> {
+import java.io.IOException;
+
+public final class FixedSumAggregator<I> extends AbstractAggregator<I, Long> implements IdentifiedDataSerializable {
 
     private long sum;
 
@@ -45,6 +50,28 @@ public class FixedSumAggregator<I> extends AbstractAggregator<I, Long> {
     @Override
     public Long aggregate() {
         return sum;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.FIXED_SUM;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeLong(sum);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readLong();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class FloatingPointSumAggregator<I> extends AbstractAggregator<I, Double> {
+import java.io.IOException;
+
+public final class FloatingPointSumAggregator<I> extends AbstractAggregator<I, Double> implements IdentifiedDataSerializable {
 
     private double sum;
 
@@ -45,6 +50,28 @@ public class FloatingPointSumAggregator<I> extends AbstractAggregator<I, Double>
     @Override
     public Double aggregate() {
         return sum;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.FLOATING_POINT_SUM;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeDouble(sum);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readDouble();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class IntegerAverageAggregator<I> extends AbstractAggregator<I, Double> {
+import java.io.IOException;
+
+public final class IntegerAverageAggregator<I> extends AbstractAggregator<I, Double> implements IdentifiedDataSerializable {
 
     private long sum;
 
@@ -52,6 +57,30 @@ public class IntegerAverageAggregator<I> extends AbstractAggregator<I, Double> {
             return null;
         }
         return ((double) sum / (double) count);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.INT_AVG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeLong(sum);
+        out.writeLong(count);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readLong();
+        this.count = in.readLong();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class IntegerSumAggregator<I> extends AbstractAggregator<I, Long> {
+import java.io.IOException;
+
+public final class IntegerSumAggregator<I> extends AbstractAggregator<I, Long> implements IdentifiedDataSerializable {
 
     private long sum;
 
@@ -45,6 +50,28 @@ public class IntegerSumAggregator<I> extends AbstractAggregator<I, Long> {
     @Override
     public Long aggregate() {
         return sum;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.INT_SUM;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeLong(sum);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readLong();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class LongAverageAggregator<I> extends AbstractAggregator<I, Double> {
+import java.io.IOException;
+
+public final class LongAverageAggregator<I> extends AbstractAggregator<I, Double> implements IdentifiedDataSerializable {
 
     private long sum;
 
@@ -52,6 +57,30 @@ public class LongAverageAggregator<I> extends AbstractAggregator<I, Double> {
             return null;
         }
         return ((double) sum / (double) count);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.LONG_AVG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeLong(sum);
+        out.writeLong(count);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readLong();
+        this.count = in.readLong();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class LongSumAggregator<I> extends AbstractAggregator<I, Long> {
+import java.io.IOException;
+
+public final class LongSumAggregator<I> extends AbstractAggregator<I, Long> implements IdentifiedDataSerializable {
 
     private long sum;
 
@@ -45,6 +50,28 @@ public class LongSumAggregator<I> extends AbstractAggregator<I, Long> {
     @Override
     public Long aggregate() {
         return sum;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.LONG_SUM;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeLong(sum);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readLong();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class MaxAggregator<I, R extends Comparable> extends AbstractAggregator<I, R> {
+import java.io.IOException;
+
+public final class MaxAggregator<I, R extends Comparable> extends AbstractAggregator<I, R> implements IdentifiedDataSerializable {
 
     private R max;
 
@@ -55,5 +60,27 @@ public class MaxAggregator<I, R extends Comparable> extends AbstractAggregator<I
     @Override
     public R aggregate() {
         return max;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.MAX;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeObject(max);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.max = in.readObject();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class MinAggregator<I, R extends Comparable> extends AbstractAggregator<I, R> {
+import java.io.IOException;
+
+public final class MinAggregator<I, R extends Comparable> extends AbstractAggregator<I, R> implements IdentifiedDataSerializable {
 
     private R min;
 
@@ -55,5 +60,27 @@ public class MinAggregator<I, R extends Comparable> extends AbstractAggregator<I
     @Override
     public R aggregate() {
         return min;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.MIN;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeObject(min);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.min = in.readObject();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
@@ -17,8 +17,13 @@
 package com.hazelcast.aggregation.impl;
 
 import com.hazelcast.aggregation.Aggregator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class NumberAverageAggregator<I> extends AbstractAggregator<I, Double> {
+import java.io.IOException;
+
+public final class NumberAverageAggregator<I> extends AbstractAggregator<I, Double> implements IdentifiedDataSerializable {
 
     private double sum;
 
@@ -52,6 +57,30 @@ public class NumberAverageAggregator<I> extends AbstractAggregator<I, Double> {
             return null;
         }
         return (sum / (double) count);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return AggregatorDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return AggregatorDataSerializerHook.NUMBER_AVG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+        out.writeDouble(sum);
+        out.writeLong(count);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.attributePath = in.readUTF();
+        this.sum = in.readDouble();
+        this.count = in.readLong();
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -125,6 +125,12 @@ public final class FactoryIdHelper {
     public static final String USER_CODE_DEPLOYMENT_DS_FACTORY = "hazelcast.serialization.ds.user.code.deployment";
     public static final int USER_CODE_DEPLOYMENT_DS_FACTORY_ID = -40;
 
+    public static final String AGGREGATOR_DS_FACTORY = "hazelcast.serialization.ds.aggregator";
+    public static final int AGGREGATOR_DS_FACTORY_ID = -41;
+
+    public static final String PROJECTION_DS_FACTORY = "hazelcast.serialization.ds.projection";
+    public static final int PROJECTION_DS_FACTORY_ID = -42;
+
     // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";

--- a/hazelcast/src/main/java/com/hazelcast/projection/Projection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/Projection.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.projection;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
 /**
@@ -43,7 +41,6 @@ import java.io.Serializable;
  * @param <O> output type
  * @since 3.8
  */
-@BinaryInterface
 public abstract class Projection<I, O> implements Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/ProjectionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/ProjectionDataSerializerHook.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.projection.impl;
+
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PROJECTION_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PROJECTION_DS_FACTORY_ID;
+
+public final class ProjectionDataSerializerHook implements DataSerializerHook {
+
+    public static final int F_ID = FactoryIdHelper.getFactoryId(PROJECTION_DS_FACTORY, PROJECTION_DS_FACTORY_ID);
+
+    public static final int SINGLE_ATTRIBUTE = 0;
+    public static final int MULTI_ATTRIBUTE = 1;
+
+    private static final int LEN = MULTI_ATTRIBUTE + 1;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
+
+        constructors[SINGLE_ATTRIBUTE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new SingleAttributeProjection();
+            }
+        };
+        constructors[MULTI_ATTRIBUTE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MultiAttributeProjection();
+            }
+        };
+
+        return new ArrayDataSerializableFactory(constructors);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
@@ -16,17 +16,25 @@
 
 package com.hazelcast.projection.impl;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.impl.Extractable;
+
+import java.io.IOException;
 
 /**
  * Projection that extracts the values of the given attribute and returns it.
  *
  * @param <I> type of the input
  */
-public class SingleAttributeProjection<I, O> extends Projection<I, O> {
+public final class SingleAttributeProjection<I, O> extends Projection<I, O> implements IdentifiedDataSerializable {
 
-    private final String attributePath;
+    private String attributePath;
+
+    SingleAttributeProjection() {
+    }
 
     public SingleAttributeProjection(String attributePath) {
         this.attributePath = attributePath;
@@ -39,5 +47,25 @@ public class SingleAttributeProjection<I, O> extends Projection<I, O> {
             return (O) ((Extractable) input).getAttributeValue(attributePath);
         }
         throw new IllegalArgumentException("The given map entry is not extractable");
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ProjectionDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ProjectionDataSerializerHook.SINGLE_ATTRIBUTE;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attributePath);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        attributePath = in.readUTF();
     }
 }

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -27,3 +27,5 @@ com.hazelcast.internal.management.ManagementDataSerializerHook
 com.hazelcast.internal.ascii.TextProtocolsDataSerializerHook
 com.hazelcast.scheduledexecutor.impl.ScheduledExecutorDataSerializerHook
 com.hazelcast.internal.usercodedeployment.impl.UserCodeDeploymentSerializerHook
+com.hazelcast.aggregation.impl.AggregatorDataSerializerHook
+com.hazelcast.projection.impl.ProjectionDataSerializerHook


### PR DESCRIPTION
Convert built-in Projections and Aggregations to IdentifiedDataSerializable

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/1289