### PR TITLE
Fixes serializer skip length

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializer.java
@@ -151,6 +151,7 @@ final class DataSerializableSerializer implements StreamSerializer<DataSerializa
             }
             if (isFlagSet(header, EE_FLAG)) {
                 in.readByte();
+                in.readByte();
             }
 
             ds.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -81,7 +81,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
 
     private static final int FACTORY_AND_CLASS_ID_BYTE_LENGTH = 8;
     private static final int FACTORY_AND_CLASS_ID_BYTE_COMP_LENGTH = 2;
-    private static final int EE_BYTE_LENGTH = 1;
+    private static final int EE_BYTE_LENGTH = 2;
 
     private final PortableContextImpl portableContext;
     private final PortableSerializer portableSerializer;


### PR DESCRIPTION
Updated `EE_BYTE_LENGTH` & skipped bytes when `EE` flag is set