### PR TITLE
 Reset destination uuid if it is not primary

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -114,7 +114,7 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
                 while (!stopTest.get()) {
                     HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);
                     sleepSeconds(5);
-                    member.getLifecycleService().shutdown();
+                    member.getLifecycleService().terminate();
                 }
             }
         });

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -62,27 +62,30 @@ import static org.junit.Assert.assertEquals;
 @Category(NightlyTest.class)
 public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport {
 
-    private static final int POPULATOR_THREAD_COUNT = 5;
+    private static final int NEAR_CACHE_POPULATOR_THREAD_COUNT = 5;
+    private static final int TEST_RUN_SECONDS = 30;
+    private static final int INVALIDATION_BATCH_SIZE = 10000;
+    private static final int KEY_COUNT = 100000;
+    private static final int RECONCILIATION_INTERVAL_SECONDS = 30;
 
     @Override
     protected Config createConfig() {
         Config config = super.createConfig();
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "271");
         config.setProperty(GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_ENABLED.getName(), "true");
-        config.setProperty(GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), "1000");
+        config.setProperty(GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), Integer.toString(INVALIDATION_BATCH_SIZE));
         return config;
     }
 
     protected ClientConfig createClientConfig() {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setProperty("hazelcast.invalidation.max.tolerated.miss.count", "0");
-        clientConfig.setProperty("hazelcast.invalidation.reconciliation.interval.seconds", "30");
+        clientConfig.setProperty("hazelcast.invalidation.reconciliation.interval.seconds", Integer.toString(RECONCILIATION_INTERVAL_SECONDS));
         return clientConfig;
     }
 
     @Test
     public void ensure_nearCachedClient_and_member_data_sync_eventually() throws Exception {
-        final int cacheSize = 100000;
         final AtomicBoolean stopTest = new AtomicBoolean();
 
         final Config config = createConfig();
@@ -93,7 +96,7 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
 
         // populated from member.
         final Cache<Integer, Integer> memberCache = serverCacheManager.createCache(DEFAULT_CACHE_NAME, createCacheConfig(BINARY));
-        for (int i = 0; i < cacheSize; i++) {
+        for (int i = 0; i < KEY_COUNT; i++) {
             memberCache.put(i, i);
         }
 
@@ -121,12 +124,12 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
 
         threads.add(shadowMember);
 
-        for (int i = 0; i < POPULATOR_THREAD_COUNT; i++) {
+        for (int i = 0; i < NEAR_CACHE_POPULATOR_THREAD_COUNT; i++) {
             // populates client near-cache
             Thread populateClientNearCache = new Thread(new Runnable() {
                 public void run() {
                     while (!stopTest.get()) {
-                        for (int i = 0; i < cacheSize; i++) {
+                        for (int i = 0; i < KEY_COUNT; i++) {
                             clientCache.get(i);
                         }
                     }
@@ -139,7 +142,7 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
         Thread putFromMember = new Thread(new Runnable() {
             public void run() {
                 while (!stopTest.get()) {
-                    int key = getInt(cacheSize);
+                    int key = getInt(KEY_COUNT);
                     int value = getInt(Integer.MAX_VALUE);
                     memberCache.put(key, value);
 
@@ -159,14 +162,13 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
         });
         threads.add(clearFromMember);
 
-
         // start threads
         for (Thread thread : threads) {
             thread.start();
         }
 
         // stress system some seconds
-        sleepSeconds(60);
+        sleepSeconds(TEST_RUN_SECONDS);
 
         //stop threads
         stopTest.set(true);
@@ -177,7 +179,7 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                for (int i = 0; i < cacheSize; i++) {
+                for (int i = 0; i < KEY_COUNT; i++) {
                     Integer valueSeenFromMember = memberCache.get(i);
                     Integer valueSeenFromClient = clientCache.get(i);
 
@@ -215,7 +217,6 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
             }
         });
     }
-
 
     @Override
     protected CacheConfig createCacheConfig(InMemoryFormat inMemoryFormat) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -82,7 +82,7 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
                 while (!stopTest.get()) {
                     HazelcastInstance member = factory.newHazelcastInstance(config);
                     sleepSeconds(5);
-                    member.getLifecycleService().shutdown();
+                    member.getLifecycleService().terminate();
                 }
 
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -44,7 +44,12 @@ import static org.junit.Assert.assertEquals;
 @Category({NightlyTest.class})
 public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
 
-    private static final int POPULATOR_THREAD_COUNT = 3;
+    private static final int NEAR_CACHE_POPULATOR_THREAD_COUNT = 3;
+    private static final int TEST_RUN_SECONDS = 30;
+    private static final int INVALIDATION_BATCH_SIZE = 10000;
+    private static final int KEY_COUNT = 100000;
+    private static final int RECONCILIATION_INTERVAL_SECONDS = 30;
+
     private final TestHazelcastFactory factory = new TestHazelcastFactory();
 
     @After
@@ -55,7 +60,6 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
     @Test
     public void ensure_nearCachedClient_and_member_data_sync_eventually() throws Exception {
         final String mapName = "default";
-        final int mapSize = 100000;
         final AtomicBoolean stopTest = new AtomicBoolean();
 
         // members are created.
@@ -65,7 +69,7 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
 
         // map is populated form member.
         final IMap<Integer, Integer> memberMap = member.getMap(mapName);
-        for (int i = 0; i < mapSize; i++) {
+        for (int i = 0; i < KEY_COUNT; i++) {
             memberMap.put(i, i);
         }
 
@@ -90,11 +94,11 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
         threads.add(shadowMember);
 
         // populates client near-cache
-        for (int i = 0; i < POPULATOR_THREAD_COUNT; i++) {
+        for (int i = 0; i < NEAR_CACHE_POPULATOR_THREAD_COUNT; i++) {
             Thread populateClientNearCache = new Thread(new Runnable() {
                 public void run() {
                     while (!stopTest.get()) {
-                        for (int i = 0; i < mapSize; i++) {
+                        for (int i = 0; i < KEY_COUNT; i++) {
                             clientMap.get(i);
                         }
                     }
@@ -108,7 +112,7 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
         Thread putFromMember = new Thread(new Runnable() {
             public void run() {
                 while (!stopTest.get()) {
-                    int key = getInt(mapSize);
+                    int key = getInt(KEY_COUNT);
                     int value = getInt(Integer.MAX_VALUE);
                     memberMap.put(key, value);
 
@@ -117,7 +121,6 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
             }
         });
         threads.add(putFromMember);
-
 
         Thread clearFromMember = new Thread(new Runnable() {
             public void run() {
@@ -129,14 +132,11 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
         });
         threads.add(clearFromMember);
 
-
         for (Thread thread : threads) {
             thread.start();
         }
-
         // stress system some seconds
-        sleepSeconds(60);
-
+        sleepSeconds(TEST_RUN_SECONDS);
         //stop threads
         stopTest.set(true);
         for (Thread thread : threads) {
@@ -146,7 +146,7 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                for (int i = 0; i < mapSize; i++) {
+                for (int i = 0; i < KEY_COUNT; i++) {
                     Integer valueSeenFromMember = memberMap.get(i);
                     Integer valueSeenFromClient = clientMap.get(i);
 
@@ -163,7 +163,7 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
         Config config = new Config();
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "271");
         config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED.getName(), "true");
-        config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), "1000");
+        config.setProperty(GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), Integer.toString(INVALIDATION_BATCH_SIZE));
         return config;
     }
 
@@ -180,7 +180,7 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
     protected ClientConfig createClientConfig() {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setProperty("hazelcast.invalidation.max.tolerated.miss.count", "0");
-        clientConfig.setProperty("hazelcast.invalidation.reconciliation.interval.seconds", "30");
+        clientConfig.setProperty("hazelcast.invalidation.reconciliation.interval.seconds", Integer.toString(RECONCILIATION_INTERVAL_SECONDS));
         return clientConfig;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheService.java
@@ -83,9 +83,11 @@ public class CacheService extends AbstractCacheService {
         super.commitMigration(event);
 
         if (SOURCE == event.getMigrationEndpoint()) {
-            getMetaDataGenerator().resetMetadata(event.getPartitionId());
+            getMetaDataGenerator().removeUuidAndSequence(event.getPartitionId());
         } else if (DESTINATION == event.getMigrationEndpoint()) {
-            getMetaDataGenerator().getOrCreateUuid(event.getPartitionId());
+            if (event.getNewReplicaIndex() != 0) {
+                getMetaDataGenerator().regenerateUuid(event.getPartitionId());
+            }
         }
     }
 
@@ -94,9 +96,7 @@ public class CacheService extends AbstractCacheService {
         super.rollbackMigration(event);
 
         if (DESTINATION == event.getMigrationEndpoint()) {
-            getMetaDataGenerator().resetMetadata(event.getPartitionId());
-        } else if (SOURCE == event.getMigrationEndpoint()) {
-            getMetaDataGenerator().getOrCreateUuid(event.getPartitionId());
+            getMetaDataGenerator().removeUuidAndSequence(event.getPartitionId());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
@@ -94,7 +94,7 @@ public class MetaDataGenerator {
         uuids.put(partitionId, uuid);
     }
 
-    public void resetMetadata(final int partitionId) {
+    public void removeUuidAndSequence(final int partitionId) {
         // remove uuid.
         uuids.remove(partitionId);
 
@@ -106,5 +106,9 @@ public class MetaDataGenerator {
 
     public void destroyMetaDataFor(String dataStructureName) {
         sequenceGenerators.remove(dataStructureName);
+    }
+
+    public void regenerateUuid(int partitionId) {
+        uuids.put(partitionId, uuidConstructor.createNew(partitionId));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -77,9 +77,11 @@ class MapMigrationAwareService implements MigrationAwareService {
 
         if (SOURCE == event.getMigrationEndpoint()) {
             clearMapsHavingLesserBackupCountThan(event.getPartitionId(), event.getNewReplicaIndex());
-            getMetaDataGenerator().resetMetadata(event.getPartitionId());
+            getMetaDataGenerator().removeUuidAndSequence(event.getPartitionId());
         } else if (DESTINATION == event.getMigrationEndpoint()) {
-            getMetaDataGenerator().getOrCreateUuid(event.getPartitionId());
+            if (event.getNewReplicaIndex() != 0) {
+                getMetaDataGenerator().regenerateUuid(event.getPartitionId());
+            }
         }
 
         PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(event.getPartitionId());
@@ -104,9 +106,7 @@ class MapMigrationAwareService implements MigrationAwareService {
     public void rollbackMigration(PartitionMigrationEvent event) {
         if (DESTINATION == event.getMigrationEndpoint()) {
             clearMapsHavingLesserBackupCountThan(event.getPartitionId(), event.getCurrentReplicaIndex());
-            getMetaDataGenerator().resetMetadata(event.getPartitionId());
-        } else if (SOURCE == event.getMigrationEndpoint()) {
-            getMetaDataGenerator().getOrCreateUuid(event.getPartitionId());
+            getMetaDataGenerator().removeUuidAndSequence(event.getPartitionId());
         }
 
         mapServiceContext.reloadOwnedPartitions();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -102,7 +102,7 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
                 while (!stopTest.get()) {
                     HazelcastInstance member = factory.newHazelcastInstance(config);
                     sleepSeconds(5);
-                    member.getLifecycleService().shutdown();
+                    member.getLifecycleService().terminate();
                 }
 
             }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.util.RandomPicker.getInt;
@@ -41,6 +43,11 @@ import static org.junit.Assert.assertEquals;
 @Category(NightlyTest.class)
 public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
 
+    private static final int TEST_RUN_SECONDS = 30;
+    private static final int KEY_COUNT = 100000;
+    private static final int INVALIDATION_BATCH_SIZE = 10000;
+    private static final int RECONCILIATION_INTERVAL_SECONDS = 30;
+
     private final TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory();
 
     @After
@@ -48,11 +55,113 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
         factory.shutdownAll();
     }
 
+    @Test
+    public void ensure_nearCached_and_actual_data_sync_eventually() throws Exception {
+        final String mapName = "origin-map";
+        final AtomicBoolean stopTest = new AtomicBoolean();
+
+        // members are created.
+        final Config config = createConfig().addMapConfig(createMapConfig(mapName));
+        final HazelcastInstance member = factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
+
+        // map is populated form member.
+        final IMap<Integer, Integer> memberMap = member.getMap(mapName);
+        for (int i = 0; i < KEY_COUNT; i++) {
+            memberMap.put(i, i);
+        }
+
+        // a new member comes with near-cache configured.
+        final Config config2 = createConfig().addMapConfig(createMapConfig(mapName).setNearCacheConfig(createNearCacheConfig(mapName)));
+        final HazelcastInstance nearCachedMember = factory.newHazelcastInstance(config2);
+        final IMap<Integer, Integer> nearCachedMap = nearCachedMember.getMap(mapName);
+
+        List<Thread> threads = new ArrayList<Thread>();
+
+        // continuously adds and removes member
+        Thread shadowMember = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (!stopTest.get()) {
+                    HazelcastInstance member = factory.newHazelcastInstance(config);
+                    sleepSeconds(5);
+                    member.getLifecycleService().terminate();
+                }
+
+            }
+        });
+        threads.add(shadowMember);
+
+        // populates client near-cache
+        Thread populateClientNearCache = new Thread(new Runnable() {
+            public void run() {
+                while (!stopTest.get()) {
+                    for (int i = 0; i < KEY_COUNT; i++) {
+                        nearCachedMap.get(i);
+                    }
+                }
+            }
+        });
+        threads.add(populateClientNearCache);
+
+        // updates map data from member.
+        Thread putFromMember = new Thread(new Runnable() {
+            public void run() {
+                while (!stopTest.get()) {
+                    int key = getInt(KEY_COUNT);
+                    int value = getInt(Integer.MAX_VALUE);
+                    memberMap.put(key, value);
+
+                    sleepAtLeastMillis(5);
+                }
+            }
+        });
+        threads.add(putFromMember);
+
+        Thread clearFromMember = new Thread(new Runnable() {
+            public void run() {
+                while (!stopTest.get()) {
+                    memberMap.clear();
+                    sleepSeconds(5);
+                }
+            }
+        });
+        threads.add(clearFromMember);
+
+        // start threads
+        for (Thread thread : threads) {
+            thread.start();
+        }
+        // stress system some seconds
+        sleepSeconds(TEST_RUN_SECONDS);
+
+        //stop threads
+        stopTest.set(true);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                for (int i = 0; i < KEY_COUNT; i++) {
+                    Integer valueSeenFromMember = memberMap.get(i);
+                    Integer valueSeenFromClient = nearCachedMap.get(i);
+
+                    assertEquals(valueSeenFromMember, valueSeenFromClient);
+                }
+            }
+        });
+    }
+
     protected Config createConfig() {
         Config config = new Config();
+        config.setProperty("hazelcast.invalidation.reconciliation.interval.seconds",
+                Integer.toString(RECONCILIATION_INTERVAL_SECONDS));
         config.setProperty("hazelcast.invalidation.max.tolerated.miss.count", "0");
         config.setProperty("hazelcast.map.invalidation.batch.enabled", "true");
-        config.setProperty("hazelcast.map.invalidation.batch.size", "10000");
+        config.setProperty("hazelcast.map.invalidation.batch.size",
+                Integer.toString(INVALIDATION_BATCH_SIZE));
         config.setProperty("hazelcast.partition.count", "271");
         return config;
     }
@@ -71,103 +180,6 @@ public class InvalidationMemberAddRemoveTest extends NearCacheTestSupport {
                 .setSize(Integer.MAX_VALUE)
                 .setEvictionPolicy(EvictionPolicy.NONE);
         return nearCacheConfig;
-    }
-
-    @Test
-    public void ensure_nearCached_and_actual_data_sync_eventually() throws Exception {
-        final String mapName = "origin-map";
-        final int mapSize = 100000;
-        final AtomicBoolean stopTest = new AtomicBoolean();
-
-        // members are created.
-        final Config config = createConfig().addMapConfig(createMapConfig(mapName));
-        final HazelcastInstance member = factory.newHazelcastInstance(config);
-        factory.newHazelcastInstance(config);
-
-        // map is populated form member.
-        final IMap<Integer, Integer> memberMap = member.getMap(mapName);
-        for (int i = 0; i < mapSize; i++) {
-            memberMap.put(i, i);
-        }
-
-        // a new member comes with near-cache configured.
-        final Config config2 = createConfig().addMapConfig(createMapConfig(mapName).setNearCacheConfig(createNearCacheConfig(mapName)));
-        final HazelcastInstance nearCachedMember = factory.newHazelcastInstance(config2);
-        final IMap<Integer, Integer> nearCachedMap = nearCachedMember.getMap(mapName);
-
-        // continuously adds and removes member
-        Thread shadowMember = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                while (!stopTest.get()) {
-                    HazelcastInstance member = factory.newHazelcastInstance(config);
-                    sleepSeconds(5);
-                    member.getLifecycleService().terminate();
-                }
-
-            }
-        });
-
-        // populates client near-cache
-        Thread populateClientNearCache = new Thread(new Runnable() {
-            public void run() {
-                while (!stopTest.get()) {
-                    for (int i = 0; i < mapSize; i++) {
-                        nearCachedMap.get(i);
-                    }
-                }
-            }
-        });
-
-        // updates map data from member.
-        Thread putFromMember = new Thread(new Runnable() {
-            public void run() {
-                while (!stopTest.get()) {
-                    int key = getInt(mapSize);
-                    int value = getInt(Integer.MAX_VALUE);
-                    memberMap.put(key, value);
-
-                    sleepAtLeastMillis(5);
-                }
-            }
-        });
-
-        Thread clearFromMember = new Thread(new Runnable() {
-            public void run() {
-                while (!stopTest.get()) {
-                    memberMap.clear();
-                    sleepSeconds(5);
-                }
-            }
-        });
-
-        // start threads
-        putFromMember.start();
-        populateClientNearCache.start();
-        clearFromMember.start();
-        shadowMember.start();
-
-        // stress system some seconds
-        sleepSeconds(60);
-
-        //stop threads
-        stopTest.set(true);
-        shadowMember.join();
-        clearFromMember.join();
-        populateClientNearCache.join();
-        putFromMember.join();
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                for (int i = 0; i < mapSize; i++) {
-                    Integer valueSeenFromMember = memberMap.get(i);
-                    Integer valueSeenFromClient = nearCachedMap.get(i);
-
-                    assertEquals(valueSeenFromMember, valueSeenFromClient);
-                }
-            }
-        });
     }
 
 }


### PR DESCRIPTION
_Main Subject:_
This PR is related to eventually consistent near cache improvements.

_Problem:_
Issue was observed when closing a member with `terminate()` method, `shutdown()` is ok.

_Fix:_
 If migration destination is not primary replica, partition uuid should be reset because we are only trying to keep metadata on primaries in case of migrations. Metadata don't have any backup.

And also refactored `InvalidationMemberAddRemoveTest`s.

Additionally, this pr can be seen a fix attempt for the issues:
closes https://github.com/hazelcast/hazelcast/issues/9490
closes https://github.com/hazelcast/hazelcast/issues/9735
