### PR TITLE
Fix lock eviction scheduling on migration when lock expired

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
@@ -18,6 +18,9 @@ package com.hazelcast.concurrent.lock;
 
 import com.hazelcast.nio.serialization.Data;
 
+/**
+ * A lock for a specific key in a specific namespace. It contains the details of a single lock in the system.
+ */
 public interface LockResource {
 
     Data getKey();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockServiceImpl.java
@@ -273,7 +273,11 @@ public final class LockServiceImpl implements LockService, ManagedService, Remot
                 }
 
                 long leaseTime = expirationTime - now;
-                ls.scheduleEviction(lock.getKey(), lock.getVersion(), leaseTime);
+                if (leaseTime <= 0) {
+                    ls.forceUnlock(lock.getKey());
+                } else {
+                    ls.scheduleEviction(lock.getKey(), lock.getVersion(), leaseTime);
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -20,33 +20,140 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.util.Set;
 
+/**
+ * A container for multiple locks. Each lock is differentiated by a different {@code key}.
+ */
 public interface LockStore {
 
+    /**
+     * Lock a specific key.
+     *
+     * @param key         the key to lock
+     * @param caller      the identifier for the caller
+     * @param threadId    the identifier for the thread on the caller
+     * @param referenceId the identifier for the invocation of the caller (e.g. operation call ID)
+     * @param leaseTime   the lease duration in milliseconds
+     * @return if the lock was successfully acquired
+     */
     boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime);
 
+    /**
+     * Lock a specific key for use inside a transaction.
+     *
+     * @param key         the key to lock
+     * @param caller      the identifier for the caller
+     * @param threadId    the identifier for the thread on the caller
+     * @param referenceId the identifier for the invocation of the caller (e.g. operation call ID)
+     * @param leaseTime   the lease duration in milliseconds
+     * @param blockReads  whether reads for the key should be blocked (e.g. for map and multimap)
+     * @return if the lock was successfully acquired
+     */
     boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime, boolean blockReads);
 
+    /**
+     * Extend the lease time for an already locked key.
+     *
+     * @param key       the locked key
+     * @param caller    the identifier for the caller
+     * @param threadId  the identifier for the thread on the caller
+     * @param leaseTime time in milliseconds for the lease to be extended
+     * @return if the lease was extended
+     */
     boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime);
 
+    /**
+     * Unlock a specific key.
+     *
+     * @param key         the locked key
+     * @param caller      the identifier for the caller
+     * @param threadId    the identifier for the thread on the caller
+     * @param referenceId the identifier for the invocation of the caller (e.g. operation call ID)
+     * @return if the key was unlocked
+     */
     boolean unlock(Data key, String caller, long threadId, long referenceId);
 
+    /**
+     * Check if a key is locked by any caller and thread id.
+     *
+     * @param key the key
+     * @return if the key is locked
+     */
     boolean isLocked(Data key);
 
+    /**
+     * Check if a key is locked by a specific caller and thread id.
+     *
+     * @param key      the locked key
+     * @param caller   the identifier for the caller
+     * @param threadId the identifier for the thread on the caller
+     * @return if the key is locked
+     */
     boolean isLockedBy(Data key, String caller, long threadId);
 
+    /**
+     * Return the number of times a key was locked by the same owner (re-entered).
+     *
+     * @param key the key
+     * @return the reentry count
+     */
     int getLockCount(Data key);
 
+    /**
+     * Return the number of locks this store holds.
+     *
+     * @return the lock count
+     */
     int getLockedEntryCount();
 
+    /**
+     * Return the remaining lease time for a specific key.
+     *
+     * @param key the key
+     * @return the lease time in milliseconds, -1 if there is no lock, {@value Long#MAX_VALUE} if the key is locked indefinitely
+     */
     long getRemainingLeaseTime(Data key);
 
+    /**
+     * Return if the key can be locked by the caller and thread ID.
+     *
+     * @param key      the locked key
+     * @param caller   the identifier for the caller
+     * @param threadId the identifier for the thread on the caller
+     * @return if the key can be locked. Returns false if the key is already locked by a different caller or thread ID
+     */
     boolean canAcquireLock(Data key, String caller, long threadId);
 
+    /**
+     * Return whether the reads for the specific key should be blocked
+     * (see {@link #txnLock(Data, String, long, long, long, boolean)}).
+     *
+     * @param key the lock key
+     * @return if the reads should be blocked
+     */
     boolean shouldBlockReads(Data key);
 
+    /**
+     * Return all locked keys for this store. A lock may be expired when this method returns.
+     *
+     * @return all locked keys
+     */
     Set<Data> getLockedKeys();
 
+    /**
+     * Unlock the key regardless of the owner. May return {@code true} if the key is already unlocked but has
+     * waiters/signals/expired operations.
+     *
+     * @param dataKey the lock key
+     * @return if the key was unlocked or is already unlocked
+     */
     boolean forceUnlock(Data dataKey);
 
+    /**
+     * Return a string representation of the owner of the lock for a specific key. If the key is not locked returns
+     * a default string depicting no owner.
+     *
+     * @param dataKey the key
+     * @return a string description/representation of the owner
+     */
     String getOwnerInfo(Data dataKey);
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreImpl.java
@@ -58,13 +58,13 @@ public final class LockStoreImpl implements IdentifiedDataSerializable, LockStor
     private int asyncBackupCount;
 
     private LockService lockService;
-    private EntryTaskScheduler entryTaskScheduler;
+    private EntryTaskScheduler<Data, Integer> entryTaskScheduler;
 
     public LockStoreImpl() {
     }
 
     public LockStoreImpl(LockService lockService, ObjectNamespace name,
-                         EntryTaskScheduler entryTaskScheduler, int backupCount, int asyncBackupCount) {
+                         EntryTaskScheduler<Data, Integer> entryTaskScheduler, int backupCount, int asyncBackupCount) {
         this.lockService = lockService;
         this.namespace = name;
         this.entryTaskScheduler = entryTaskScheduler;
@@ -100,10 +100,7 @@ public final class LockStoreImpl implements IdentifiedDataSerializable, LockStor
     @Override
     public boolean extendLeaseTime(Data key, String caller, long threadId, long leaseTime) {
         LockResourceImpl lock = locks.get(key);
-        if (lock == null) {
-            return false;
-        }
-        return lock.extendLeaseTime(caller, threadId, leaseTime);
+        return lock != null && lock.extendLeaseTime(caller, threadId, leaseTime);
     }
 
     public LockResourceImpl getLock(Data key) {
@@ -119,10 +116,7 @@ public final class LockStoreImpl implements IdentifiedDataSerializable, LockStor
     @Override
     public boolean isLockedBy(Data key, String caller, long threadId) {
         LockResource lock = locks.get(key);
-        if (lock == null) {
-            return false;
-        }
-        return lock.isLockedBy(caller, threadId);
+        return lock != null && lock.isLockedBy(caller, threadId);
     }
 
     @Override
@@ -153,11 +147,7 @@ public final class LockStoreImpl implements IdentifiedDataSerializable, LockStor
     @Override
     public boolean canAcquireLock(Data key, String caller, long threadId) {
         LockResourceImpl lock = locks.get(key);
-        if (lock == null) {
-            return true;
-        } else {
-            return lock.canAcquireLock(caller, threadId);
-        }
+        return lock == null || lock.canAcquireLock(caller, threadId);
     }
 
     @Override
@@ -248,7 +238,7 @@ public final class LockStoreImpl implements IdentifiedDataSerializable, LockStor
         this.lockService = lockService;
     }
 
-    void setEntryTaskScheduler(EntryTaskScheduler entryTaskScheduler) {
+    void setEntryTaskScheduler(EntryTaskScheduler<Data, Integer> entryTaskScheduler) {
         this.entryTaskScheduler = entryTaskScheduler;
     }
 
@@ -314,10 +304,7 @@ public final class LockStoreImpl implements IdentifiedDataSerializable, LockStor
 
     public boolean hasSignalKey(ConditionKey conditionKey) {
         LockResourceImpl lock = locks.get(conditionKey.getKey());
-        if (lock == null) {
-            return false;
-        }
-        return lock.hasSignalKey(conditionKey);
+        return lock != null && lock.hasSignalKey(conditionKey);
     }
 
     public void registerExpiredAwaitOp(AwaitOperation awaitResponse) {

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockLeaseMemberBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockLeaseMemberBounceTest.java
@@ -1,0 +1,136 @@
+package com.hazelcast.concurrent.lock;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ILock;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.jitter.JitterRule;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.Random;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.generateKeyNotOwnedBy;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Runs a cluster of {@value MEMBER_COUNT + 1} and calls lease lock from {@value DRIVER_COUNT} drivers. During the test bounces
+ * {@value MEMBER_COUNT} cluster members (shuts down and restarts). The remaining 1 member is stable (never bounced) but no
+ * locks are owned by this member.
+ * Asserts that all locks are unlocked eventually.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class LockLeaseMemberBounceTest {
+    private static final int MEMBER_COUNT = 4;
+    private static final int DRIVER_COUNT = 4;
+    private static final int LEASE_DURATION_MILLIS = 100;
+    private static final int TEST_DURATION_SECONDS = 40;
+    private static final int LOCK_COUNT = 500;
+    private static final int CONCURRENCY = 2;
+
+    @Rule
+    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getConfig())
+                                                               .clusterSize(MEMBER_COUNT)
+                                                               .driverCount(DRIVER_COUNT).build();
+    @Rule
+    public JitterRule jitterRule = new JitterRule();
+
+    @Before
+    public void setup() {
+        // Needed because BounceMemberRule expects a before method or otherwise won't bounce, will be fixed
+    }
+
+    @Test
+    public void leaseShouldExpireWhenMemberBouncing() {
+        final HazelcastInstance steadyMember = bounceMemberRule.getSteadyMember();
+
+        String[] lockNames = new String[LOCK_COUNT];
+        for (int i = 0; i < lockNames.length; i++) {
+            lockNames[i] = generateKeyNotOwnedBy(steadyMember);
+        }
+
+        final Driver[] drivers = new Driver[DRIVER_COUNT];
+        for (int i = 0; i < drivers.length; i++) {
+            drivers[i] = new Driver(bounceMemberRule.getNextTestDriver(), lockNames);
+        }
+
+        DriverRunnable[] runnables = new DriverRunnable[drivers.length * CONCURRENCY];
+        for (int i = 0; i < drivers.length; i++) {
+            for (int j = 0; j < CONCURRENCY; j++) {
+                runnables[i * CONCURRENCY + j] = new DriverRunnable(drivers[i]);
+            }
+        }
+
+        bounceMemberRule.testRepeatedly(runnables, TEST_DURATION_SECONDS);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                for (Driver driver : drivers) {
+                    driver.doAssert();
+                }
+            }
+        }, MILLISECONDS.toSeconds(LEASE_DURATION_MILLIS) + 10);
+    }
+
+    protected Config getConfig() {
+        return new Config();
+    }
+
+
+    public static class DriverRunnable implements Runnable {
+        private final Driver client;
+
+        DriverRunnable(Driver client) {
+            this.client = client;
+        }
+
+        @Override
+        public void run() {
+            final ILock randomLock = client.getRandomLock();
+            randomLock.lock(LEASE_DURATION_MILLIS, MILLISECONDS);
+        }
+    }
+
+    public static class Driver {
+        private final ILock[] locks;
+        private Random random = new Random();
+
+        Driver(HazelcastInstance hz, String[] lockNames) {
+            locks = new ILock[lockNames.length];
+            for (int i = 0; i < locks.length; i++) {
+                locks[i] = hz.getLock(lockNames[i]);
+            }
+        }
+
+        ILock getRandomLock() {
+            return locks[random.nextInt(locks.length)];
+        }
+
+        void doAssert() {
+            for (ILock lock : locks) {
+                Assert.assertFalse(lock.isLocked());
+            }
+        }
+
+        HashSet<ILock> getAllLocked() {
+            final HashSet<ILock> locked = new HashSet<ILock>();
+            for (ILock lock : locks) {
+                if (lock.isLocked()) {
+                    locked.add(lock);
+                }
+            }
+            return locked;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockStoreImplTest.java
@@ -53,7 +53,7 @@ public class LockStoreImplTest extends HazelcastTestSupport {
     private static final int ASYNC_BACKUP_COUNT = 0;
 
     private LockService mockLockServiceImpl;
-    private EntryTaskScheduler mockScheduler;
+    private EntryTaskScheduler<Data, Integer> mockScheduler;
     private LockStoreImpl lockStore;
 
     private Data key = new HeapData();


### PR DESCRIPTION
Previously on lock migration the lock was scheduled for eviction with difference between the current cluster clock and the expiration time. If the migration lasted long enough and lock has already expired it could schedule expiration with a negative value. This would cause the lock to be expired after a period which is equal to the time elapsed from the actual expiration time - the more the migration is delayed, the more will the lease be extended.

Added some javadoc for lock classes, fixed some generics and simplified a couple of if-statements.