### PR TITLE
Updates in Serializable & DataSerializable conventions test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.cache;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.io.Serializable;
 
 /**
@@ -29,6 +31,7 @@ import java.io.Serializable;
  * (s)he should use {@link StorageTypeAwareCacheMergePolicy} which is sub-type of this interface.
  * </p>
  */
+@BinaryInterface
 public interface CacheMergePolicy extends Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.cache;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheNotExistsException.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheNotExistsException.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.cache;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * This exception class is thrown while creating {@link com.hazelcast.cache.impl.CacheRecordStore}
  * instances but the cache config does not exist on the node to create the instance on. This can
@@ -27,6 +31,7 @@ package com.hazelcast.cache;
  * For the first option, the caller can decide to just retry the operation a couple of times since
  * distribution is executed in a asynchronous way.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class CacheNotExistsException extends IllegalStateException {
 
     public CacheNotExistsException(String s) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheNotExistsException.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheNotExistsException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.cache;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This exception class is thrown while creating {@link com.hazelcast.cache.impl.CacheRecordStore}

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastExpiryPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastExpiryPolicy.java
@@ -20,7 +20,7 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryEventImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryEventImpl.java
@@ -17,12 +17,12 @@
 package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.ICache;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.event.CacheEntryEvent;
 import javax.cache.event.EventType;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * CacheEntryEvent implementation is the actual event object received by sub-interfaces of

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryEventImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryEventImpl.java
@@ -17,9 +17,12 @@
 package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.ICache;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import javax.cache.event.CacheEntryEvent;
 import javax.cache.event.EventType;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.INHERITANCE;
 
 /**
  * CacheEntryEvent implementation is the actual event object received by sub-interfaces of
@@ -35,6 +38,7 @@ import javax.cache.event.EventType;
  * @see javax.cache.event.CacheEntryRemovedListener#onRemoved(Iterable)
  * @see javax.cache.event.CacheEntryExpiredListener#onExpired(Iterable)
  */
+@BinaryInterface(reason = INHERITANCE)
 public class CacheEntryEventImpl<K, V>
         extends CacheEntryEvent<K, V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryEventImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryEventImpl.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import javax.cache.event.CacheEntryEvent;
 import javax.cache.event.EventType;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.INHERITANCE;
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * CacheEntryEvent implementation is the actual event object received by sub-interfaces of
@@ -38,7 +38,7 @@ import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.INHERI
  * @see javax.cache.event.CacheEntryRemovedListener#onRemoved(Iterable)
  * @see javax.cache.event.CacheEntryExpiredListener#onExpired(Iterable)
  */
-@BinaryInterface(reason = INHERITANCE)
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class CacheEntryEventImpl<K, V>
         extends CacheEntryEvent<K, V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
@@ -19,7 +19,7 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
@@ -27,6 +28,7 @@ import java.io.IOException;
  *
  * @see com.hazelcast.cache.impl.CacheEventData
  */
+@BinaryInterface
 public class CacheEventDataImpl
         implements CacheEventData {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
@@ -19,9 +19,11 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public class CachePartitionEventData extends CacheEventDataImpl implements CacheEventData {
 
     private int partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEvent.java
@@ -17,9 +17,9 @@
 package com.hazelcast.cache.impl.event;
 
 import com.hazelcast.core.Member;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Used to provide information about the lost partition of a cache.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/event/CachePartitionLostEvent.java
@@ -17,6 +17,9 @@
 package com.hazelcast.cache.impl.event;
 
 import com.hazelcast.core.Member;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Used to provide information about the lost partition of a cache.
@@ -24,6 +27,7 @@ import com.hazelcast.core.Member;
  * @see CachePartitionLostEvent
  * @since 3.6
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class CachePartitionLostEvent extends AbstractICacheEvent {
 
     private static final long serialVersionUID = -7445714640964238109L;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.eviction.Evictable;
 import com.hazelcast.internal.eviction.EvictionCandidate;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
@@ -32,6 +33,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class CacheRecordHashMap
         extends SampleableConcurrentHashMap<Data, CacheRecord>
         implements SampleableCacheRecordMap<Data, CacheRecord> {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -24,7 +24,7 @@ import com.hazelcast.internal.eviction.Evictable;
 import com.hazelcast.internal.eviction.EvictionCandidate;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class CacheRecordHashMap

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
@@ -18,11 +18,13 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * `HigherHitsCacheMergePolicy` merges cache entry from source to destination cache
  * if source entry has more hits than the destination one.
  */
+@BinaryInterface
 public class HigherHitsCacheMergePolicy
         implements StorageTypeAwareCacheMergePolicy {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * `HigherHitsCacheMergePolicy` merges cache entry from source to destination cache

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
@@ -18,11 +18,13 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * `LatestAccessCacheMergePolicy` merges cache entry from source to destination cache
  * if source entry has been accessed more recently than the destination entry.
  */
+@BinaryInterface
 public class LatestAccessCacheMergePolicy
         implements StorageTypeAwareCacheMergePolicy {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * `LatestAccessCacheMergePolicy` merges cache entry from source to destination cache

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination directly.

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
@@ -18,10 +18,12 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination directly.
  */
+@BinaryInterface
 public class PassThroughCacheMergePolicy
         implements StorageTypeAwareCacheMergePolicy {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
@@ -18,11 +18,13 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination
  * if it does not exist in the destination cache.
  */
+@BinaryInterface
 public class PutIfAbsentCacheMergePolicy
         implements StorageTypeAwareCacheMergePolicy {
 

--- a/hazelcast/src/main/java/com/hazelcast/client/AuthenticationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/AuthenticationException.java
@@ -17,10 +17,14 @@
 package com.hazelcast.client;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} that is thrown when there is an Authentication failure: e.g. credentials from client is not valid.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class AuthenticationException extends HazelcastException {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/client/AuthenticationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/AuthenticationException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.client;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} that is thrown when there is an Authentication failure: e.g. credentials from client is not valid.

--- a/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.client;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This exception is thrown when an exception that is coming from server is not recognized by the protocol.
  * Class name of the original exception is included in the exception
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class UndefinedErrorCodeException extends HazelcastException {
 
     private final String className;

--- a/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/UndefinedErrorCodeException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.client;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This exception is thrown when an exception that is coming from server is not recognized by the protocol.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.version.MemberVersion;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/exception/MaxMessageSizeExceeded.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/exception/MaxMessageSizeExceeded.java
@@ -17,10 +17,14 @@
 package com.hazelcast.client.impl.protocol.exception;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when client message size exceeds Integer.MAX_VALUE
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MaxMessageSizeExceeded
         extends HazelcastException {
     public MaxMessageSizeExceeded() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/exception/MaxMessageSizeExceeded.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/exception/MaxMessageSizeExceeded.java
@@ -17,9 +17,9 @@
 package com.hazelcast.client.impl.protocol.exception;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when client message size exceeds Integer.MAX_VALUE

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/common/DataAwareItemEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/common/DataAwareItemEvent.java
@@ -20,14 +20,14 @@ import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An {@link ItemEvent} that is able to store a {@link Data}.

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/common/DataAwareItemEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/common/DataAwareItemEvent.java
@@ -20,15 +20,19 @@ import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * An {@link ItemEvent} that is able to store a {@link Data}.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class DataAwareItemEvent extends ItemEvent {
 
     private static final long serialVersionUID = 1;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
@@ -18,10 +18,13 @@ package com.hazelcast.concurrent.lock;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.impl.operationparker.impl.OperationParkerImpl;
 
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * A specialization of {@link ObjectNamespace} intended to be used by ILock proxies.
@@ -47,6 +50,7 @@ import java.io.IOException;
  * @see OperationParkerImpl#cancelParkedOperations(String, Object, Throwable)
  *
  */
+@BinaryInterface(reason = PUBLIC_API)
 public final class InternalLockNamespace implements ObjectNamespace {
 
     private String name;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
@@ -18,13 +18,13 @@ package com.hazelcast.concurrent.lock;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.impl.operationparker.impl.OperationParkerImpl;
 
 import java.io.IOException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * A specialization of {@link ObjectNamespace} intended to be used by ILock proxies.

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.CompleteConfiguration;

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -22,7 +22,7 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExp
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.CompleteConfiguration;

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.Factory;

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * Read only version of {@link CacheEvictionConfig}.

--- a/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfigReadOnly.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.EventListener;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigurationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigurationException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.config;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} that is thrown when something is wrong with the server or client configuration.

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigurationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigurationException.java
@@ -17,10 +17,14 @@
 package com.hazelcast.config;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} that is thrown when something is wrong with the server or client configuration.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ConfigurationException extends HazelcastException {
 
     public ConfigurationException(String itemName, String candidate, String duplicate) {

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -23,7 +23,7 @@ import com.hazelcast.internal.eviction.EvictionStrategyType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * Read only version of {@link com.hazelcast.config.EvictionConfig}.

--- a/hazelcast/src/main/java/com/hazelcast/config/InvalidConfigurationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InvalidConfigurationException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A InvalidConfigurationException is thrown when there is an Invalid Configuration.

--- a/hazelcast/src/main/java/com/hazelcast/config/InvalidConfigurationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InvalidConfigurationException.java
@@ -16,13 +16,16 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A InvalidConfigurationException is thrown when there is an Invalid Configuration.
  * Invalid Configuration can be a wrong Xml Config or logical config errors that are found
  * at real time.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class InvalidConfigurationException extends RuntimeException {
 
 

--- a/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheConfig.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.TypedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.Factory;

--- a/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheEvictionConfig.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.TypedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
@@ -19,7 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * Contains the configuration for a size of Map.

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -19,7 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * Contains configuration for a Near Cache (read-only).

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
@@ -19,7 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.annotation.PrivateApi;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
@@ -19,14 +19,18 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+
 /**
  * Config to be used by WanReplicationConsumer instances (EE only).
  */
+@BinaryInterface(reason = PUBLIC_API)
 public class WanConsumerConfig implements DataSerializable {
 
     private Map<String, Comparable> properties = new HashMap<String, Comparable>();

--- a/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
@@ -19,13 +19,13 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * Config to be used by WanReplicationConsumer instances (EE only).

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -19,14 +19,18 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+
 /**
  * Configuration object for WAN publishers.
  */
+@BinaryInterface(reason = PUBLIC_API)
 public class WanPublisherConfig implements DataSerializable {
 
     private static final int DEFAULT_QUEUE_CAPACITY = 10000;

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -19,13 +19,13 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * Configuration object for WAN publishers.

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -19,14 +19,18 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+
 /**
  * Configuration for wan replication.
  */
+@BinaryInterface(reason = PUBLIC_API)
 public class WanReplicationConfig implements DataSerializable {
 
     private String name;

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -19,13 +19,13 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * Configuration for wan replication.

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -19,7 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRefReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRefReadOnly.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.List;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/ValidationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/ValidationException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.config.properties;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This exception is thrown from {@link com.hazelcast.config.properties.ValueValidator}

--- a/hazelcast/src/main/java/com/hazelcast/config/properties/ValidationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/properties/ValidationException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.config.properties;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This exception is thrown from {@link com.hazelcast.config.properties.ValueValidator}
  * implementations whenever the validation has not succeed for any reason.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ValidationException extends HazelcastException {
 
     public ValidationException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/console/Echo.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/Echo.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;

--- a/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.console;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 import java.util.concurrent.Callable;

--- a/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
@@ -18,6 +18,7 @@ package com.hazelcast.console;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.Serializable;
 import java.util.concurrent.Callable;
@@ -25,6 +26,7 @@ import java.util.concurrent.Callable;
 /**
  * A simulated load test.
  */
+@BinaryInterface
 public final class SimulateLoadTask implements Callable, Serializable, HazelcastInstanceAware {
 
     private static final long serialVersionUID = 1;

--- a/hazelcast/src/main/java/com/hazelcast/core/DuplicateInstanceNameException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DuplicateInstanceNameException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when a duplicate instance name is detected.

--- a/hazelcast/src/main/java/com/hazelcast/core/DuplicateInstanceNameException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DuplicateInstanceNameException.java
@@ -16,9 +16,14 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * Thrown when a duplicate instance name is detected.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class DuplicateInstanceNameException extends HazelcastException {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Map Entry event.

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
@@ -16,7 +16,10 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Map Entry event.
@@ -28,6 +31,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @see com.hazelcast.core.IMap#addEntryListener(com.hazelcast.map.listener.MapListener, boolean)
  */
 @SuppressFBWarnings("SE_BAD_FIELD")
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class EntryEvent<K, V> extends AbstractIMapEvent {
 
     private static final long serialVersionUID = -2296203982913729851L;

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Base Hazelcast exception.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastException.java
@@ -18,12 +18,12 @@ package com.hazelcast.core;
 
 import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.INHERITANCE;
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Base Hazelcast exception.
  */
-@BinaryInterface(reason = INHERITANCE)
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class HazelcastException extends RuntimeException {
 
     public HazelcastException() {

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastException.java
@@ -16,9 +16,14 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.INHERITANCE;
+
 /**
  * Base Hazelcast exception.
  */
+@BinaryInterface(reason = INHERITANCE)
 public class HazelcastException extends RuntimeException {
 
     public HazelcastException() {

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstanceNotActiveException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstanceNotActiveException.java
@@ -16,9 +16,15 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * Thrown when HazelcastInstance is not active during an invocation.
+ * TODO this Exception does not inherit from HazelcastException, is this intentional?
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class HazelcastInstanceNotActiveException extends IllegalStateException {
 
     public HazelcastInstanceNotActiveException() {

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstanceNotActiveException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstanceNotActiveException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when HazelcastInstance is not active during an invocation.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastOverloadException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastOverloadException.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.properties.GroupProperty;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.core.HazelcastException} that is thrown when the system won't handle more load due to

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastOverloadException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastOverloadException.java
@@ -16,7 +16,10 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.properties.GroupProperty;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.core.HazelcastException} that is thrown when the system won't handle more load due to
@@ -25,6 +28,7 @@ import com.hazelcast.spi.properties.GroupProperty;
  * This exception is thrown when backpressure is enabled. For more information see
  * {@link GroupProperty#BACKPRESSURE_ENABLED}.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class HazelcastOverloadException extends HazelcastException {
 
     public HazelcastOverloadException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipEvent.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.EventObject;
 import java.util.Set;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An event that is sent when a {@link InitialMembershipListener} registers itself on a {@link Cluster}. For more
@@ -31,6 +34,7 @@ import java.util.Set;
  * @see MembershipEvent
  */
 @SuppressFBWarnings("SE_BAD_FIELD")
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class InitialMembershipEvent extends EventObject {
 
     private static final long serialVersionUID = -2010865371829087371L;

--- a/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/InitialMembershipEvent.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.EventObject;
 import java.util.Set;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An event that is sent when a {@link InitialMembershipListener} registers itself on a {@link Cluster}. For more

--- a/hazelcast/src/main/java/com/hazelcast/core/ItemEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ItemEvent.java
@@ -16,7 +16,11 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.util.EventObject;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Map Item event.
@@ -24,7 +28,7 @@ import java.util.EventObject;
  * @see com.hazelcast.core.EntryEvent
  * @see com.hazelcast.core.ICollection#addItemListener(ItemListener, boolean)
  */
-
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ItemEvent<E> extends EventObject {
 
     protected E item;

--- a/hazelcast/src/main/java/com/hazelcast/core/ItemEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ItemEvent.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.EventObject;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Map Item event.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapEvent.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * Used for map-wide events like {@link com.hazelcast.core.EntryEventType#EVICT_ALL}
  * and {@link  com.hazelcast.core.EntryEventType#CLEAR_ALL}.
@@ -23,6 +27,7 @@ package com.hazelcast.core;
  * @see com.hazelcast.map.listener.MapListener
  * @see com.hazelcast.core.EntryListener
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MapEvent extends AbstractIMapEvent {
 
     private static final long serialVersionUID = -4948640313865667023L;

--- a/hazelcast/src/main/java/com/hazelcast/core/MapEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapEvent.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Used for map-wide events like {@link com.hazelcast.core.EntryEventType#EVICT_ALL}

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
@@ -22,13 +22,13 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
 import static com.hazelcast.cluster.MemberAttributeOperationType.PUT;
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 import static java.util.Collections.EMPTY_SET;
 
 @SuppressFBWarnings("SE_BAD_FIELD")

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
@@ -22,14 +22,17 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
 import static com.hazelcast.cluster.MemberAttributeOperationType.PUT;
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
 import static java.util.Collections.EMPTY_SET;
 
 @SuppressFBWarnings("SE_BAD_FIELD")
+@BinaryInterface(reason = PUBLIC_API)
 public class MemberAttributeEvent extends MembershipEvent implements DataSerializable {
 
     private MemberAttributeOperationType operationType;

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
@@ -18,6 +18,7 @@ package com.hazelcast.core;
 
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.version.MemberVersion;
 
@@ -26,9 +27,12 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.concurrent.ExecutionException;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * A {@link ExecutionException} thrown when a member left during an invocation or execution.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MemberLeftException extends ExecutionException implements RetryableException {
 
     private transient Member member;

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberLeftException.java
@@ -18,7 +18,7 @@ package com.hazelcast.core;
 
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.version.MemberVersion;
 
@@ -27,7 +27,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.concurrent.ExecutionException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link ExecutionException} thrown when a member left during an invocation or execution.

--- a/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.EventObject;
 import java.util.Set;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static java.lang.String.format;
 
 /**
@@ -31,6 +33,7 @@ import static java.lang.String.format;
  * @see MembershipListener
  */
 @SuppressFBWarnings("SE_BAD_FIELD")
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MembershipEvent extends EventObject {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MembershipEvent.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.EventObject;
 import java.util.Set;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static java.lang.String.format;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/core/Message.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Message.java
@@ -16,13 +16,18 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.util.EventObject;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Message for {@link ITopic}.
  *
  * @param <E> message type
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class Message<E> extends EventObject {
 
     protected E messageObject;

--- a/hazelcast/src/main/java/com/hazelcast/core/Message.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Message.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.EventObject;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Message for {@link ITopic}.

--- a/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
@@ -19,11 +19,14 @@ package com.hazelcast.core;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.partition.PartitionEvent;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * An event fired when a partition migration starts, completes or fails.
@@ -32,6 +35,7 @@ import java.io.IOException;
  * @see PartitionService
  * @see MigrationListener
  */
+@BinaryInterface(reason = PUBLIC_API)
 public class MigrationEvent implements DataSerializable, PartitionEvent {
 
     private int partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
@@ -19,14 +19,14 @@ package com.hazelcast.core;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.partition.PartitionEvent;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * An event fired when a partition migration starts, completes or fails.

--- a/hazelcast/src/main/java/com/hazelcast/core/OperationTimeoutException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/OperationTimeoutException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An unchecked version of {@link java.util.concurrent.TimeoutException}.

--- a/hazelcast/src/main/java/com/hazelcast/core/OperationTimeoutException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/OperationTimeoutException.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * An unchecked version of {@link java.util.concurrent.TimeoutException}.
  * <p>
@@ -26,6 +30,7 @@ package com.hazelcast.core;
  *
  * @see java.util.concurrent.TimeoutException
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class OperationTimeoutException extends HazelcastException {
 
     public OperationTimeoutException() {

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitionAwareKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitionAwareKey.java
@@ -19,7 +19,7 @@ package com.hazelcast.core;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/core/RuntimeInterruptedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/RuntimeInterruptedException.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.core;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * An unchecked version of {@link InterruptedException}.
  * <p>
@@ -29,6 +33,7 @@ package com.hazelcast.core;
  *
  * @see InterruptedException
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class RuntimeInterruptedException extends HazelcastException {
 
     public RuntimeInterruptedException() {

--- a/hazelcast/src/main/java/com/hazelcast/core/RuntimeInterruptedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/RuntimeInterruptedException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An unchecked version of {@link InterruptedException}.

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
@@ -17,14 +17,18 @@
 package com.hazelcast.durableexecutor;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.exception.SilentException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An {@link RuntimeException} that is thrown when retrieving the result of a task via {@link DurableExecutorService} if the
  * result of the task is overwritten. This means the task is executed but the result isn't available anymore
  */
 @Beta
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class StaleTaskIdException extends HazelcastException implements SilentException {
 
     public StaleTaskIdException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/StaleTaskIdException.java
@@ -17,11 +17,11 @@
 package com.hazelcast.durableexecutor;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.exception.SilentException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An {@link RuntimeException} that is thrown when retrieving the result of a task via {@link DurableExecutorService} if the

--- a/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.version.MemberVersion;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigMismatchException.java
@@ -17,10 +17,14 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Exception thrown when 2 nodes want to join, but there configuration doesn't match
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ConfigMismatchException extends HazelcastException {
     public ConfigMismatchException(String message) {
         super(message);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigMismatchException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Exception thrown when 2 nodes want to join, but there configuration doesn't match

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/VersionMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/VersionMismatchException.java
@@ -17,10 +17,14 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Indicates that the version of a joining member is not compatible with the cluster version.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class VersionMismatchException extends HazelcastException {
     public VersionMismatchException(String message) {
         super(message);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/VersionMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/VersionMismatchException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Indicates that the version of a joining member is not compatible with the cluster version.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.internal.eviction;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 import java.util.Comparator;
 
@@ -25,7 +23,6 @@ import java.util.Comparator;
  * A kind of {@link java.util.Comparator} to be used while comparing
  * entries to be evicted.
  */
-@BinaryInterface
 public abstract class EvictionPolicyComparator<K, V, E extends EvictableEntryView<K, V>>
         implements Comparator<E>, Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
@@ -18,9 +18,9 @@ package com.hazelcast.internal.eviction.impl.comparator;
 
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#LFU} policy based {@link EvictionPolicyComparator}.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
@@ -18,14 +18,14 @@ package com.hazelcast.internal.eviction.impl.comparator;
 
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#LFU} policy based {@link EvictionPolicyComparator}.
  */
-@SuppressFBWarnings(
-        value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE",
-        justification = "No need to serializable since its instance is not serialized")
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class LFUEvictionPolicyComparator extends EvictionPolicyComparator {
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
@@ -18,9 +18,9 @@ package com.hazelcast.internal.eviction.impl.comparator;
 
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#LRU} policy based {@link EvictionPolicyComparator}.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
@@ -18,14 +18,14 @@ package com.hazelcast.internal.eviction.impl.comparator;
 
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#LRU} policy based {@link EvictionPolicyComparator}.
  */
-@SuppressFBWarnings(
-        value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE",
-        justification = "No need to serializable since its instance is not serialized")
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class LRUEvictionPolicyComparator extends EvictionPolicyComparator {
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
@@ -18,9 +18,9 @@ package com.hazelcast.internal.eviction.impl.comparator;
 
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#RANDOM} policy based {@link EvictionPolicyComparator}.

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
@@ -18,14 +18,14 @@ package com.hazelcast.internal.eviction.impl.comparator;
 
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#RANDOM} policy based {@link EvictionPolicyComparator}.
  */
-@SuppressFBWarnings(
-        value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE",
-        justification = "No need to serializable since its instance is not serialized")
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class RandomEvictionPolicyComparator extends EvictionPolicyComparator {
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.IFunction;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.LifecycleService;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.IFunction;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.LifecycleService;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
@@ -38,6 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -225,6 +227,7 @@ public class BatchInvalidator extends Invalidator {
         super.reset();
     }
 
+    @BinaryInterface(reason = OTHER_CONVENTION)
     public static class InvalidationQueue extends ConcurrentLinkedQueue<Invalidation> {
         private final AtomicInteger elementCount = new AtomicInteger(0);
         private final AtomicBoolean flushingInProgress = new AtomicBoolean(false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
@@ -17,8 +17,10 @@
 package com.hazelcast.internal.nearcache.impl.invalidation;
 
 import com.hazelcast.core.IFunction;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.EventRegistration;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static java.lang.Boolean.TRUE;
 
 /**
@@ -27,12 +29,15 @@ import static java.lang.Boolean.TRUE;
 public final class InvalidationUtils {
 
     public static final long NO_SEQUENCE = -1L;
-    public static final IFunction<EventRegistration, Boolean> TRUE_FILTER = new IFunction<EventRegistration, Boolean>() {
+    public static final IFunction<EventRegistration, Boolean> TRUE_FILTER = new TrueFilter();
+
+    @BinaryInterface(reason = OTHER_CONVENTION)
+    public static class TrueFilter implements IFunction<EventRegistration, Boolean> {
         @Override
         public Boolean apply(EventRegistration eventRegistration) {
             return TRUE;
         }
-    };
+    }
 
     private InvalidationUtils() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
@@ -17,10 +17,10 @@
 package com.hazelcast.internal.nearcache.impl.invalidation;
 
 import com.hazelcast.core.IFunction;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.EventRegistration;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static java.lang.Boolean.TRUE;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -33,7 +33,7 @@ import com.hazelcast.internal.nearcache.impl.invalidation.StaleReadDetector;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 
@@ -48,7 +48,7 @@ import static com.hazelcast.internal.nearcache.NearCacheRecord.READ_PERMITTED;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.RESERVED;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.UPDATE_STARTED;
 import static com.hazelcast.internal.nearcache.impl.invalidation.StaleReadDetector.ALWAYS_FRESH;
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -33,6 +33,7 @@ import com.hazelcast.internal.nearcache.impl.invalidation.StaleReadDetector;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 
@@ -47,6 +48,7 @@ import static com.hazelcast.internal.nearcache.NearCacheRecord.READ_PERMITTED;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.RESERVED;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.UPDATE_STARTED;
 import static com.hazelcast.internal.nearcache.impl.invalidation.StaleReadDetector.ALWAYS_FRESH;
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
@@ -74,21 +76,8 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
     protected final SerializationService serializationService;
     protected final ClassLoader classLoader;
     protected final NearCacheStatsImpl nearCacheStats;
-    protected final IFunction<K, R> reserveForUpdate = new IFunction<K, R>() {
-        @Override
-        public R apply(K key) {
-            R record = null;
-            try {
-                record = valueToRecord(null);
-                onRecordCreate(key, record);
-                record.casRecordState(READ_PERMITTED, RESERVED);
-            } catch (Throwable throwable) {
-                onPutError(key, null, record, null, throwable);
-                throw rethrow(throwable);
-            }
-            return record;
-        }
-    };
+    protected final IFunction<K, R> reserveForUpdate = new ReserveForUpdateFunction();
+
     protected MaxSizeChecker maxSizeChecker;
 
     protected EvictionPolicyEvaluator<KS, R> evictionPolicyEvaluator;
@@ -493,6 +482,23 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
         @Override
         public boolean isEvictionRequired() {
             return maxSizeChecker != null && maxSizeChecker.isReachedToMaxSize();
+        }
+    }
+
+    @BinaryInterface(reason = OTHER_CONVENTION)
+    private class ReserveForUpdateFunction implements IFunction<K, R> {
+        @Override
+        public R apply(K key) {
+            R record = null;
+            try {
+                record = valueToRecord(null);
+                onRecordCreate(key, record);
+                record.casRecordState(READ_PERMITTED, RESERVED);
+            } catch (Throwable throwable) {
+                onPutError(key, null, record, null, throwable);
+                throw rethrow(throwable);
+            }
+            return record;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/HeapNearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/HeapNearCacheRecordMap.java
@@ -21,9 +21,13 @@ import com.hazelcast.internal.eviction.EvictionCandidate;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.nearcache.NearCacheRecord;
 import com.hazelcast.internal.nearcache.impl.SampleableNearCacheRecordMap;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class HeapNearCacheRecordMap<K, V extends NearCacheRecord>
         extends SampleableConcurrentHashMap<K, V>
         implements SampleableNearCacheRecordMap<K, V> {

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/HeapNearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/HeapNearCacheRecordMap.java
@@ -21,11 +21,11 @@ import com.hazelcast.internal.eviction.EvictionCandidate;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.nearcache.NearCacheRecord;
 import com.hazelcast.internal.nearcache.impl.SampleableNearCacheRecordMap;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class HeapNearCacheRecordMap<K, V extends NearCacheRecord>

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateVersionMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateVersionMismatchException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.internal.partition;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when local partition-state version doesn't match the version
  * of master member while running a migration/replication operation.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class PartitionStateVersionMismatchException extends HazelcastException {
 
     public PartitionStateVersionMismatchException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateVersionMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionStateVersionMismatchException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.internal.partition;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when local partition-state version doesn't match the version

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -26,14 +26,14 @@ import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.serialization.VersionedPortable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.Set;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 public final class SerializationUtil {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -26,19 +26,18 @@ import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.serialization.VersionedPortable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.Set;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 public final class SerializationUtil {
 
-    static final PartitioningStrategy EMPTY_PARTITIONING_STRATEGY = new PartitioningStrategy() {
-        public Object getPartitionKey(Object key) {
-            return null;
-        }
-    };
+    static final PartitioningStrategy EMPTY_PARTITIONING_STRATEGY = new EmptyPartitioningStrategy();
 
     private SerializationUtil() {
     }
@@ -120,4 +119,10 @@ public final class SerializationUtil {
         return new ObjectDataInputStream(in, ss);
     }
 
+    @BinaryInterface(reason = OTHER_CONVENTION)
+    private static class EmptyPartitioningStrategy implements PartitioningStrategy {
+        public Object getPartitionKey(Object key) {
+            return null;
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.internal.util.concurrent;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Exception thrown by the {@link ConcurrentConveyor}.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ConcurrentConveyorException.java
@@ -16,9 +16,14 @@
 
 package com.hazelcast.internal.util.concurrent;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * Exception thrown by the {@link ConcurrentConveyor}.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ConcurrentConveyorException extends RuntimeException {
     public ConcurrentConveyorException(String message) {
         super(message);

--- a/hazelcast/src/main/java/com/hazelcast/logging/LogEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LogEvent.java
@@ -17,10 +17,14 @@
 package com.hazelcast.logging;
 
 import com.hazelcast.core.Member;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.EventObject;
 import java.util.logging.LogRecord;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class LogEvent extends EventObject {
     final LogRecord logRecord;
     final Member member;

--- a/hazelcast/src/main/java/com/hazelcast/logging/LogEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LogEvent.java
@@ -17,12 +17,12 @@
 package com.hazelcast.logging;
 
 import com.hazelcast.core.Member;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.EventObject;
 import java.util.logging.LogRecord;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class LogEvent extends EventObject {

--- a/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
@@ -16,11 +16,9 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
-
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An abstract {@link EntryProcessor} that already has implemented the {@link #getBackupProcessor()}. In a most cases you

--- a/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
@@ -20,6 +20,8 @@ import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * An abstract {@link EntryProcessor} that already has implemented the {@link #getBackupProcessor()}. In a most cases you
  * want the same logic to be executed on the primary and on the backup. This implementation has this behavior.
@@ -65,6 +67,7 @@ public abstract class AbstractEntryProcessor<K, V> implements EntryProcessor<K, 
         return entryBackupProcessor;
     }
 
+    @BinaryInterface
     private class EntryBackupProcessorImpl implements EntryBackupProcessor<K, V> {
         @Override
         public void processBackup(Map.Entry<K, V> entry) {

--- a/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/MapPartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapPartitionLostEvent.java
@@ -18,9 +18,9 @@ package com.hazelcast.map;
 
 import com.hazelcast.core.AbstractIMapEvent;
 import com.hazelcast.core.Member;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Used for providing information about the lost partition for a map

--- a/hazelcast/src/main/java/com/hazelcast/map/MapPartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapPartitionLostEvent.java
@@ -18,12 +18,16 @@ package com.hazelcast.map;
 
 import com.hazelcast.core.AbstractIMapEvent;
 import com.hazelcast.core.Member;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Used for providing information about the lost partition for a map
  *
  * @see com.hazelcast.map.listener.MapPartitionLostListener
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MapPartitionLostEvent extends AbstractIMapEvent {
 
     private static final long serialVersionUID = -7445734640964238109L;

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
@@ -17,8 +17,10 @@
 package com.hazelcast.map;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.properties.GroupProperty;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static java.lang.String.format;
 
 /**
@@ -26,6 +28,7 @@ import static java.lang.String.format;
  *
  * @see GroupProperty#QUERY_RESULT_SIZE_LIMIT
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class QueryResultSizeExceededException extends HazelcastException {
 
     public QueryResultSizeExceededException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryResultSizeExceededException.java
@@ -17,10 +17,10 @@
 package com.hazelcast.map;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.properties.GroupProperty;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static java.lang.String.format;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/map/ReachedMaxSizeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/ReachedMaxSizeException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Exception thrown when a write-behind {@link com.hazelcast.core.MapStore} rejects to accept a new element.

--- a/hazelcast/src/main/java/com/hazelcast/map/ReachedMaxSizeException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/ReachedMaxSizeException.java
@@ -16,10 +16,15 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * Exception thrown when a write-behind {@link com.hazelcast.core.MapStore} rejects to accept a new element.
  * Used when {@link com.hazelcast.config.MapStoreConfig#writeCoalescing} is set to {@code false}.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ReachedMaxSizeException extends RuntimeException {
 
     private static final long serialVersionUID = -2352370861668557606L;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DataAwareEntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DataAwareEntryEvent.java
@@ -19,14 +19,14 @@ package com.hazelcast.map.impl;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class DataAwareEntryEvent extends EntryEvent {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DataAwareEntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DataAwareEntryEvent.java
@@ -19,12 +19,16 @@ package com.hazelcast.map.impl;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class DataAwareEntryEvent extends EntryEvent {
 
     private static final long serialVersionUID = 1;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryRemovingProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryRemovingProcessor.java
@@ -17,10 +17,14 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
+import java.io.IOException;
 import java.util.Map;
 
-public class EntryRemovingProcessor extends AbstractEntryProcessor {
+public class EntryRemovingProcessor extends AbstractEntryProcessor implements IdentifiedDataSerializable {
 
     public static final EntryRemovingProcessor ENTRY_REMOVING_PROCESSOR = new EntryRemovingProcessor();
 
@@ -30,5 +34,23 @@ public class EntryRemovingProcessor extends AbstractEntryProcessor {
     public Object process(Map.Entry entry) {
         ((LazyMapEntry) entry).remove();
         return null;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.ENTRY_REMOVING_PROCESSOR;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -35,6 +35,7 @@ import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
@@ -53,6 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.map.impl.eviction.Evictor.NULL_EVICTOR;
 import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static java.lang.System.getProperty;
 
 /**
@@ -70,13 +72,7 @@ public class MapContainer {
     protected final SerializationService serializationService;
     protected final QueryEntryFactory queryEntryFactory;
     protected final InterceptorRegistry interceptorRegistry = new InterceptorRegistry();
-    protected final IFunction<Object, Data> toDataFunction = new IFunction<Object, Data>() {
-        @Override
-        public Data apply(Object input) {
-            SerializationService ss = mapStoreContext.getSerializationService();
-            return ss.toData(input, partitioningStrategy);
-        }
-    };
+    protected final IFunction<Object, Data> toDataFunction = new ObjectToData();
     protected final ConstructorFunction<Void, RecordFactory> recordFactoryConstructor;
     /**
      * Holds number of registered {@link InvalidationListener} from clients.
@@ -289,6 +285,15 @@ public class MapContainer {
 
     public boolean shouldCloneOnEntryProcessing() {
         return getIndexes().hasIndex() && OBJECT.equals(mapConfig.getInMemoryFormat());
+    }
+
+    @BinaryInterface(reason = OTHER_CONVENTION)
+    private class ObjectToData implements IFunction<Object, Data> {
+        @Override
+        public Data apply(Object input) {
+            SerializationService ss = mapStoreContext.getSerializationService();
+            return ss.toData(input, partitioningStrategy);
+        }
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -35,7 +35,7 @@ import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
@@ -54,7 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.map.impl.eviction.Evictor.NULL_EVICTOR;
 import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static java.lang.System.getProperty;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -282,8 +282,9 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int TRIGGER_LOAD_IF_NEEDED = 132;
     public static final int IS_KEYLOAD_FINISHED = 133;
     public static final int REMOVE_FROM_LOAD_ALL = 134;
+    public static final int ENTRY_REMOVING_PROCESSOR = 135;
 
-    private static final int LEN = REMOVE_FROM_LOAD_ALL + 1;
+    private static final int LEN = ENTRY_REMOVING_PROCESSOR + 1;
 
     @Override
     public int getFactoryId() {
@@ -947,6 +948,11 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[REMOVE_FROM_LOAD_ALL] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new RemoveFromLoadAllOperation();
+            }
+        };
+        constructors[ENTRY_REMOVING_PROCESSOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return EntryRemovingProcessor.ENTRY_REMOVING_PROCESSOR;
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntrySimple.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntrySimple.java
@@ -16,8 +16,13 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.util.AbstractMap;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MapEntrySimple<K, V> extends AbstractMap.SimpleEntry<K, V> {
 
     private boolean modified;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntrySimple.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntrySimple.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.map.impl;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.AbstractMap;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class MapEntrySimple<K, V> extends AbstractMap.SimpleEntry<K, V> {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.UnmodifiableIterator;
@@ -31,7 +32,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 
 import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_NODE;
-
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 public final class MapKeyLoaderUtil {
 
@@ -107,13 +108,22 @@ public final class MapKeyLoaderUtil {
     }
 
     static IFunction<Data, Entry<Integer, Data>> toPartition(final IPartitionService partitionService) {
-        return new IFunction<Data, Entry<Integer, Data>>() {
-            @Override
-            public Entry<Integer, Data> apply(Data input) {
-                Integer partition = partitionService.getPartitionId(input);
-                return new MapEntrySimple<Integer, Data>(partition, input);
-            }
-        };
+        return new DataToEntry(partitionService);
+    }
+
+    @BinaryInterface(reason = OTHER_CONVENTION)
+    private static class DataToEntry implements IFunction<Data, Entry<Integer, Data>> {
+        private final IPartitionService partitionService;
+
+        public DataToEntry(IPartitionService partitionService) {
+            this.partitionService = partitionService;
+        }
+
+        @Override
+        public Entry<Integer, Data> apply(Data input) {
+            Integer partition = partitionService.getPartitionId(input);
+            return new MapEntrySimple<Integer, Data>(partition, input);
+        }
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.CollectionUtil;
 import com.hazelcast.util.UnmodifiableIterator;
@@ -32,7 +32,7 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 
 import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_NODE;
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 public final class MapKeyLoaderUtil {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.event;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.event;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * General contract for map event data.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.event;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.event;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreEvent.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.map.impl.mapstore.writebehind;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.EventObject;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * For internal usage only.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/StoreEvent.java
@@ -16,13 +16,18 @@
 
 package com.hazelcast.map.impl.mapstore.writebehind;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.util.EventObject;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * For internal usage only.
  *
  * @param <E>
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public final class StoreEvent<E> extends EventObject {
 
     private static final long serialVersionUID = -7071512331813330032L;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -35,6 +35,7 @@ import com.hazelcast.map.impl.MapManagedService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.invalidation.MemberMapMetaDataFetcher;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.ExecutionService;
@@ -44,6 +45,7 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 
 import static com.hazelcast.core.EntryEventType.INVALIDATION;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE;
@@ -88,6 +90,7 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
     /**
      * Filters out listeners other than invalidation related ones.
      */
+    @BinaryInterface(reason = OTHER_CONVENTION)
     private static class InvalidationAcceptorFilter implements IFunction<EventRegistration, Boolean> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -35,7 +35,7 @@ import com.hazelcast.map.impl.MapManagedService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.invalidation.MemberMapMetaDataFetcher;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.ExecutionService;
@@ -45,7 +45,7 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 
 import static com.hazelcast.core.EntryEventType.INVALIDATION;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -59,6 +59,7 @@ import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.DefaultObjectNamespace;
@@ -101,12 +102,14 @@ import static com.hazelcast.core.EntryEventType.CLEAR_ALL;
 import static com.hazelcast.map.impl.EntryRemovingProcessor.ENTRY_REMOVING_PROCESSOR;
 import static com.hazelcast.map.impl.LocalMapStatsProvider.EMPTY_LOCAL_MAP_STATS;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.IterableUtil.nullToEmpty;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.lang.Math.ceil;
 import static java.lang.Math.log10;
 import static java.lang.Math.min;
+import static javafx.scene.input.KeyCode.K;
 
 abstract class MapProxySupport extends AbstractDistributedObject<MapService> implements InitializingObject {
 
@@ -490,11 +493,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     }
 
     protected <K> Iterable<Data> convertToData(Iterable<K> keys) {
-        return IterableUtil.map(nullToEmpty(keys), new IFunction<K, Data>() {
-            public Data apply(K key) {
-                return toData(key);
-            }
-        });
+        return IterableUtil.map(nullToEmpty(keys), new KeyToData<K>());
     }
 
     private Operation createLoadAllOperation(List<Data> keys, boolean replaceExistingValues) {
@@ -1185,5 +1184,12 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
 
     public int getTotalBackupCount() {
         return mapConfig.getBackupCount() + mapConfig.getAsyncBackupCount();
+    }
+
+    @BinaryInterface(reason = OTHER_CONVENTION)
+    private class KeyToData<K> implements IFunction<K, Data> {
+        public Data apply(K key) {
+            return toData(key);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -59,7 +59,7 @@ import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.DefaultObjectNamespace;
@@ -102,14 +102,13 @@ import static com.hazelcast.core.EntryEventType.CLEAR_ALL;
 import static com.hazelcast.map.impl.EntryRemovingProcessor.ENTRY_REMOVING_PROCESSOR;
 import static com.hazelcast.map.impl.LocalMapStatsProvider.EMPTY_LOCAL_MAP_STATS;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.IterableUtil.nullToEmpty;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.lang.Math.ceil;
 import static java.lang.Math.log10;
 import static java.lang.Math.min;
-import static javafx.scene.input.KeyCode.K;
 
 abstract class MapProxySupport extends AbstractDistributedObject<MapService> implements InitializingObject {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
@@ -36,7 +36,7 @@ import com.hazelcast.map.impl.querycache.subscriber.NodeSubscriberContext;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
@@ -45,7 +45,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Node side implementation of {@link QueryCacheContext}.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
@@ -36,6 +36,7 @@ import com.hazelcast.map.impl.querycache.subscriber.NodeSubscriberContext;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
@@ -44,6 +45,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.SHUTTING_DOWN;
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Node side implementation of {@link QueryCacheContext}.
@@ -73,12 +75,7 @@ public class NodeQueryCacheContext implements QueryCacheContext {
         this.invokerWrapper = new NodeInvokerWrapper(nodeEngine.getOperationService());
         // init these in the end
         this.subscriberContext = new NodeSubscriberContext(this);
-        this.publisherContext = new DefaultPublisherContext(this, nodeEngine, new IFunction<String, String>() {
-            @Override
-            public String apply(String mapName) {
-                return registerLocalIMapListener(mapName);
-            }
-        });
+        this.publisherContext = new DefaultPublisherContext(this, nodeEngine, new RegisterMapListenerFunction());
         flushPublishersOnNodeShutdown();
     }
 
@@ -180,4 +177,12 @@ public class NodeQueryCacheContext implements QueryCacheContext {
             }
         }, mapName);
     }
+
+    @BinaryInterface(reason = OTHER_CONVENTION)
+    private class RegisterMapListenerFunction implements IFunction<String, String> {
+        @Override
+        public String apply(String mapName) {
+            return registerLocalIMapListener(mapName);
+        }
+    };
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
@@ -21,7 +21,7 @@ import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventData.java
@@ -20,7 +20,7 @@ import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventData.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.querycache.event;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordHashMap.java
@@ -22,11 +22,14 @@ import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.eviction.impl.strategy.sampling.SampleableEvictableStore;
 import com.hazelcast.map.impl.querycache.subscriber.record.QueryCacheRecord;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
 import java.util.EnumSet;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Evictable concurrent hash map implementation.
@@ -34,6 +37,7 @@ import java.util.EnumSet;
  * @see SampleableConcurrentHashMap
  * @see SampleableEvictableStore
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class QueryCacheRecordHashMap extends SampleableConcurrentHashMap<Data, QueryCacheRecord>
         implements SampleableEvictableStore<Data, QueryCacheRecord> {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordHashMap.java
@@ -22,14 +22,14 @@ import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.eviction.impl.strategy.sampling.SampleableEvictableStore;
 import com.hazelcast.map.impl.querycache.subscriber.record.QueryCacheRecord;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
 import java.util.EnumSet;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Evictable concurrent hash map implementation.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageSCHM.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageSCHM.java
@@ -18,14 +18,18 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An extended {@link SampleableConcurrentHashMap} with {@link com.hazelcast.core.IMap} specifics.
  *
  * @param <R> Type of records in this CHM
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class StorageSCHM<R extends Record> extends SampleableConcurrentHashMap<Data, R> {
 
     private static final int DEFAULT_INITIAL_CAPACITY = 256;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageSCHM.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageSCHM.java
@@ -18,11 +18,11 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An extended {@link SampleableConcurrentHashMap} with {@link com.hazelcast.core.IMap} specifics.

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
@@ -21,9 +21,11 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * PutIfAbsentMapMergePolicy causes the merging entry to be merged from source to destination map

--- a/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/merge/PutIfAbsentMapMergePolicy.java
@@ -21,11 +21,8 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
-
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * PutIfAbsentMapMergePolicy causes the merging entry to be merged from source to destination map

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/CombinerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/CombinerFactory.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/JobPartitionState.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/JobPartitionState.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * An implementation of this interface contains current information about

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyPredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
@@ -24,7 +24,7 @@ import com.hazelcast.mapreduce.impl.ListKeyValueSource;
 import com.hazelcast.mapreduce.impl.MapKeyValueSource;
 import com.hazelcast.mapreduce.impl.MultiMapKeyValueSource;
 import com.hazelcast.mapreduce.impl.SetKeyValueSource;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 
 import java.io.Closeable;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapper.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * <p>The LifecycleMapper interface is a more sophisticated version of {@link Mapper} normally used for more complex

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapperAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapperAdapter.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * <p>

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Mapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Mapper.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducerFactory.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/RemoteMapReduceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/RemoteMapReduceException.java
@@ -17,8 +17,11 @@
 package com.hazelcast.mapreduce;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.List;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This exception class is used to show stack traces of multiple failed
@@ -27,6 +30,7 @@ import java.util.List;
  * @deprecated Hazelcast Jet will replace, maybe re-implement this API shortly
  */
 @Deprecated
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class RemoteMapReduceException
         extends HazelcastException {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/RemoteMapReduceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/RemoteMapReduceException.java
@@ -17,11 +17,11 @@
 package com.hazelcast.mapreduce;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.List;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This exception class is used to show stack traces of multiple failed

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/TopologyChangedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/TopologyChangedException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.mapreduce;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This exception is thrown when a topology change happens during the

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/TopologyChangedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/TopologyChangedException.java
@@ -17,6 +17,9 @@
 package com.hazelcast.mapreduce;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This exception is thrown when a topology change happens during the
@@ -27,6 +30,7 @@ import com.hazelcast.core.HazelcastException;
  * @deprecated Hazelcast Jet will replace, maybe re-implement this API shortly
  */
 @Deprecated
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class TopologyChangedException
         extends HazelcastException {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationCombinerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationCombinerFactory.java
@@ -20,7 +20,7 @@ import com.hazelcast.mapreduce.CombinerFactory;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationReducerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationReducerFactory.java
@@ -20,7 +20,7 @@ import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/CountAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/CountAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
@@ -28,7 +28,7 @@ import com.hazelcast.mapreduce.impl.task.DefaultContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.impl.task.DefaultContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
@@ -25,7 +25,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
@@ -26,7 +26,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionService;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MultiMapKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MultiMapKeyValueSource.java
@@ -27,7 +27,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionService;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
@@ -26,7 +26,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
@@ -24,7 +24,7 @@ import com.hazelcast.mapreduce.Context;
 import com.hazelcast.mapreduce.impl.CombinerResultList;
 import com.hazelcast.mapreduce.impl.HashMapAdapter;
 import com.hazelcast.mapreduce.impl.MapReduceUtil;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
 import com.hazelcast.util.IConcurrentMap;
 
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType.STRONG;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType.STRONG;
 
 /**
@@ -56,14 +57,7 @@ public class DefaultContext<KeyIn, ValueIn>
     private final CombinerFactory<KeyIn, ValueIn, ?> combinerFactory;
     private final MapCombineTask mapCombineTask;
 
-    private final IFunction<KeyIn, Combiner<ValueIn, ?>> combinerFunction = new IFunction<KeyIn, Combiner<ValueIn, ?>>() {
-        @Override
-        public Combiner<ValueIn, ?> apply(KeyIn keyIn) {
-            Combiner<ValueIn, ?> combiner = combinerFactory.newCombiner(keyIn);
-            combiner.beginCombine();
-            return combiner;
-        }
-    };
+    private final IFunction<KeyIn, Combiner<ValueIn, ?>> combinerFunction = new CombinerFunction();
 
     // This field is only accessed through the updater
     private volatile int collected;
@@ -163,4 +157,13 @@ public class DefaultContext<KeyIn, ValueIn>
         }
     }
 
+    @BinaryInterface(reason = OTHER_CONVENTION)
+    private class CombinerFunction implements IFunction<KeyIn, Combiner<ValueIn, ?>> {
+        @Override
+        public Combiner<ValueIn, ?> apply(KeyIn keyIn) {
+            Combiner<ValueIn, ?> combiner = combinerFactory.newCombiner(keyIn);
+            combiner.beginCombine();
+            return combiner;
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImpl.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceFacade.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceFacade.java
@@ -21,7 +21,7 @@ import com.hazelcast.mapreduce.KeyValueSource;
 import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.mapreduce.impl.operation.ProcessStatsUpdateOperation;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/memory/NativeOutOfMemoryError.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/NativeOutOfMemoryError.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.memory;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when Hazelcast cannot allocate required native memory.

--- a/hazelcast/src/main/java/com/hazelcast/memory/NativeOutOfMemoryError.java
+++ b/hazelcast/src/main/java/com/hazelcast/memory/NativeOutOfMemoryError.java
@@ -16,9 +16,14 @@
 
 package com.hazelcast.memory;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * Thrown when Hazelcast cannot allocate required native memory.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class NativeOutOfMemoryError extends Error {
 
     public NativeOutOfMemoryError() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -18,7 +18,7 @@ package com.hazelcast.nio;
 
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.util.AddressUtil;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/BinaryInterface.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/BinaryInterface.java
@@ -30,12 +30,28 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.serialization.impl;
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.CLIENT_COMPATIBILITY;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.CLIENT_COMPATIBILITY;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/HazelcastSerializationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/HazelcastSerializationException.java
@@ -17,9 +17,8 @@
 package com.hazelcast.nio.serialization;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This is an exception thrown when an exception occurs while serializing/deserializing objects.

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/HazelcastSerializationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/HazelcastSerializationException.java
@@ -17,10 +17,14 @@
 package com.hazelcast.nio.serialization;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * This is an exception thrown when an exception occurs while serializing/deserializing objects.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class HazelcastSerializationException extends HazelcastException {
 
     public HazelcastSerializationException(final String message) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/BinaryInterface.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/BinaryInterface.java
@@ -14,11 +14,28 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.nio.serialization.impl;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.CLIENT_COMPATIBILITY;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -30,9 +47,38 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * - NEVER CHANGE THEM
  * - NEVER MAKE THEM IMPLEMENT THE VERSIONED INTERFACE
+ *
+ * For the purposes of serializable classes conventions testing, this annotation is only taken into account when
+ * used on concrete classes; it does not make sense to annotate an interface or an abstract class, because serialized form
+ * is only relevant in the context of a concrete class. However, it may be informative to use this annotation also on
+ * interfaces or abstract classes, as a warning to implementers.
  */
 @Target(TYPE)
 @Retention(RUNTIME)
 public @interface BinaryInterface {
+
+    /**
+     * Describe reasoning for annotating class with {@code @BinaryInterface}
+     * @return reason why a class is annotated
+     */
+    Reason reason() default CLIENT_COMPATIBILITY;
+
+    public enum Reason {
+        /**
+         * Class is used in client-member communication, therefore changing its serialized form will break
+         * client-member compatibility.
+         */
+        CLIENT_COMPATIBILITY,
+        /**
+         * Class is not used in client-member communication, however is part of public API so cannot be
+         * migrated to {@code IdentifiedDataSerializable}.
+         */
+        PUBLIC_API,
+        /**
+         * Class is not used in serialized form in the context of Hazelcast however is {@code Serializable} due
+         * to inheritance from a class external to Hazelcast.
+         */
+        INHERITANCE,
+    }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/BinaryInterface.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/BinaryInterface.java
@@ -75,10 +75,19 @@ public @interface BinaryInterface {
          */
         PUBLIC_API,
         /**
-         * Class is not used in serialized form in the context of Hazelcast however is {@code Serializable} due
-         * to inheritance from a class external to Hazelcast.
+         * Class may or may not be used in serialized form in the context of Hazelcast however is {@code Serializable}
+         * due to conventions and cannot be converted to {@code IdentifiedDataSerializable}. Examples:
+         * <ul>
+         *     <li>inheritance from a class external to Hazelcast e.g. {@code CacheEntryEvent}, which imposes
+         *     serializability even when not required</li>
+         *     <li>inheritance from a class external to Hazelcast, serializability may be desired, however
+         *     {@code IdentifiedDataSerializable} requires a default no-args constructor and non-final fields which
+         *     is not always possible (e.g. subclasses of {@code java.util.EventObject} & {@code java.lang.Exception})</li>
+         *     <li>a {@code Comparator} which should by convention also implement {@code Serializable}.</li>
+         * </ul>
          */
-        INHERITANCE,
+        OTHER_CONVENTION,
+
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/partition/NoDataMemberInClusterException.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/NoDataMemberInClusterException.java
@@ -17,10 +17,14 @@
 package com.hazelcast.partition;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when there is no data member in the cluster to assign partitions
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class NoDataMemberInClusterException
         extends HazelcastException {
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/NoDataMemberInClusterException.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/NoDataMemberInClusterException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.partition;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when there is no data member in the cluster to assign partitions

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostEvent.java
@@ -23,8 +23,11 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * The event that is fired when a partition lost its owner and all backups.
@@ -33,6 +36,7 @@ import java.io.IOException;
  * @see PartitionService
  * @see PartitionLostListener
  */
+@BinaryInterface(reason = PUBLIC_API)
 public class PartitionLostEvent
         implements DataSerializable, PartitionEvent {
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostEvent.java
@@ -23,11 +23,11 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * The event that is fired when a partition lost its owner and all backups.

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/DefaultPartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/DefaultPartitioningStrategy.java
@@ -18,12 +18,15 @@ package com.hazelcast.partition.strategy;
 
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link PartitioningStrategy} that checks if the key implements {@link PartitionAware}.
  * If so, the {@link PartitionAware#getPartitionKey()} is called. Otherwise null is returned.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class DefaultPartitioningStrategy implements PartitioningStrategy {
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/DefaultPartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/DefaultPartitioningStrategy.java
@@ -18,9 +18,9 @@ package com.hazelcast.partition.strategy;
 
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.core.PartitioningStrategy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link PartitioningStrategy} that checks if the key implements {@link PartitionAware}.

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringAndPartitionAwarePartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringAndPartitionAwarePartitioningStrategy.java
@@ -18,7 +18,11 @@ package com.hazelcast.partition.strategy;
 
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public final class StringAndPartitionAwarePartitioningStrategy implements PartitioningStrategy {
 
     //since the StringAndPartitionAwarePartitioningStrategy is stateless, we can just create an instance up front

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringAndPartitionAwarePartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringAndPartitionAwarePartitioningStrategy.java
@@ -18,9 +18,9 @@ package com.hazelcast.partition.strategy;
 
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.core.PartitioningStrategy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public final class StringAndPartitionAwarePartitioningStrategy implements PartitioningStrategy {

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringPartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringPartitioningStrategy.java
@@ -17,9 +17,9 @@
 package com.hazelcast.partition.strategy;
 
 import com.hazelcast.core.PartitioningStrategy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class StringPartitioningStrategy implements PartitioningStrategy {

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringPartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringPartitioningStrategy.java
@@ -17,7 +17,11 @@
 package com.hazelcast.partition.strategy;
 
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class StringPartitioningStrategy implements PartitioningStrategy {
 
     public static final StringPartitioningStrategy INSTANCE = new StringPartitioningStrategy();

--- a/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 

--- a/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;

--- a/hazelcast/src/main/java/com/hazelcast/query/PartitionPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PartitionPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/query/Predicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Predicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 

--- a/hazelcast/src/main/java/com/hazelcast/query/QueryException.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/QueryException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.query;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Exception class for the Query.

--- a/hazelcast/src/main/java/com/hazelcast/query/QueryException.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/QueryException.java
@@ -17,10 +17,14 @@
 package com.hazelcast.query;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Exception class for the Query.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class QueryException extends HazelcastException {
 
     public QueryException() {

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;

--- a/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReadingException.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReadingException.java
@@ -16,9 +16,14 @@
 
 package com.hazelcast.query.extractor;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * Exception thrown if there is any checked or unchecked exception caught in the value reading in {@link ValueReader}
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ValueReadingException extends RuntimeException {
 
     public ValueReadingException(String message, Throwable throwable) {

--- a/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReadingException.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/extractor/ValueReadingException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.query.extractor;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Exception thrown if there is any checked or unchecked exception caught in the value reading in {@link ValueReader}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.AttributeType;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.IndexImpl;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.ComparisonType;
 import com.hazelcast.query.impl.Index;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.regex.Pattern;
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;
 import com.hazelcast.query.impl.Indexes;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumEvent.java
@@ -17,15 +17,19 @@
 package com.hazelcast.quorum;
 
 import com.hazelcast.core.Member;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Collection;
 import java.util.EventObject;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An Event that is send when a {@link Quorum} changes.
  * <p/>
  * Hold member list, quorum threshold and the quorum result.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class QuorumEvent extends EventObject {
 
     private final int threshold;

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumEvent.java
@@ -17,12 +17,12 @@
 package com.hazelcast.quorum;
 
 import com.hazelcast.core.Member;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Collection;
 import java.util.EventObject;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An Event that is send when a {@link Quorum} changes.

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumException.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumException.java
@@ -16,12 +16,16 @@
 
 package com.hazelcast.quorum;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.exception.SilentException;
 import com.hazelcast.transaction.TransactionException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An exception thrown when the cluster size is below the defined threshold.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class QuorumException extends TransactionException implements SilentException {
 
     public QuorumException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/quorum/QuorumException.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/QuorumException.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.quorum;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.exception.SilentException;
 import com.hazelcast.transaction.TransactionException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An exception thrown when the cluster size is below the defined threshold.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
@@ -18,9 +18,9 @@ package com.hazelcast.replicatedmap;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when {@link com.hazelcast.core.HazelcastInstance#getReplicatedMap(String)} is invoked on a lite member.

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/ReplicatedMapCantBeCreatedOnLiteMemberException.java
@@ -18,10 +18,14 @@ package com.hazelcast.replicatedmap;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when {@link com.hazelcast.core.HazelcastInstance#getReplicatedMap(String)} is invoked on a lite member.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ReplicatedMapCantBeCreatedOnLiteMemberException
         extends HazelcastException {
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
@@ -23,6 +23,10 @@ import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.impl.record.RecordMigrationInfo;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
+import com.hazelcast.replicatedmap.merge.HigherHitsMapMergePolicy;
+import com.hazelcast.replicatedmap.merge.LatestUpdateMapMergePolicy;
+import com.hazelcast.replicatedmap.merge.PassThroughMergePolicy;
+import com.hazelcast.replicatedmap.merge.PutIfAbsentMapMergePolicy;
 import com.hazelcast.util.ConstructorFunction;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.REPLICATED_MAP_DS_FACTORY;
@@ -62,8 +66,12 @@ public class ReplicatedMapDataSerializerHook implements DataSerializerHook {
     public static final int CLEAR_OP_FACTORY = 23;
     public static final int PUT_ALL_OP_FACTORY = 24;
     public static final int RECORD_MIGRATION_INFO = 25;
+    public static final int HIGHER_HITS_MERGE_POLICY = 26;
+    public static final int LATEST_UPDATE_MERGE_POLICY = 27;
+    public static final int PASS_THROUGH_MERGE_POLICY = 28;
+    public static final int PUT_IF_ABSENT_MERGE_POLICY = 29;
 
-    private static final int LEN = RECORD_MIGRATION_INFO + 1;
+    private static final int LEN = PUT_IF_ABSENT_MERGE_POLICY + 1;
 
     private static final DataSerializableFactory FACTORY = createFactoryInternal();
 
@@ -227,6 +235,30 @@ public class ReplicatedMapDataSerializerHook implements DataSerializerHook {
             @Override
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new RecordMigrationInfo();
+            }
+        };
+        constructors[HIGHER_HITS_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return HigherHitsMapMergePolicy.INSTANCE;
+            }
+        };
+        constructors[LATEST_UPDATE_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return LatestUpdateMapMergePolicy.INSTANCE;
+            }
+        };
+        constructors[PASS_THROUGH_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return PassThroughMergePolicy.INSTANCE;
+            }
+        };
+        constructors[PUT_IF_ABSENT_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return PutIfAbsentMapMergePolicy.INSTANCE;
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/HigherHitsMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/HigherHitsMapMergePolicy.java
@@ -16,14 +16,27 @@
 
 package com.hazelcast.replicatedmap.merge;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
+import java.io.IOException;
 
 /**
  * HigherHitsMapMergePolicy causes the merging entry to be merged from source to destination map
  * if source entry has more hits than the destination one.
  */
-public class HigherHitsMapMergePolicy implements ReplicatedMapMergePolicy {
+public final class HigherHitsMapMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
+
+    /**
+     * Single instance of this class
+     */
+    public static final HigherHitsMapMergePolicy INSTANCE = new HigherHitsMapMergePolicy();
+
+    private HigherHitsMapMergePolicy() {
+    }
 
     @Override
     public Object merge(String mapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
@@ -33,4 +46,26 @@ public class HigherHitsMapMergePolicy implements ReplicatedMapMergePolicy {
         return existingEntry.getValue();
     }
 
+    @Override
+    public int getFactoryId() {
+        return ReplicatedMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.HIGHER_HITS_MERGE_POLICY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    // ensure single instance even when plain Java serialization might be used
+    private Object readResolve() {
+        return INSTANCE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/LatestUpdateMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/LatestUpdateMapMergePolicy.java
@@ -16,7 +16,13 @@
 
 package com.hazelcast.replicatedmap.merge;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
+
+import java.io.IOException;
 
 /**
  * LatestUpdateMapMergePolicy causes the merging entry to be merged from source to destination map
@@ -24,7 +30,15 @@ import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
  * <p/>
  * This policy can only be used of the clocks of the machines are in sync.
  */
-public class LatestUpdateMapMergePolicy implements ReplicatedMapMergePolicy {
+public final class LatestUpdateMapMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
+
+    /**
+     * Single instance of this class
+     */
+    public static final LatestUpdateMapMergePolicy INSTANCE = new LatestUpdateMapMergePolicy();
+
+    private LatestUpdateMapMergePolicy() {
+    }
 
     @Override
     public Object merge(String mapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
@@ -32,5 +46,28 @@ public class LatestUpdateMapMergePolicy implements ReplicatedMapMergePolicy {
             return mergingEntry.getValue();
         }
         return existingEntry.getValue();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ReplicatedMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.LATEST_UPDATE_MERGE_POLICY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    // ensure single instance even when plain Java serialization might be used
+    private Object readResolve() {
+        return INSTANCE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
@@ -56,10 +56,10 @@ public final class MergePolicyProvider {
     }
 
     private void addOutOfBoxPolicies() {
-        mergePolicyMap.put(PutIfAbsentMapMergePolicy.class.getName(), new PutIfAbsentMapMergePolicy());
-        mergePolicyMap.put(HigherHitsMapMergePolicy.class.getName(), new HigherHitsMapMergePolicy());
-        mergePolicyMap.put(PassThroughMergePolicy.class.getName(), new PassThroughMergePolicy());
-        mergePolicyMap.put(LatestUpdateMapMergePolicy.class.getName(), new LatestUpdateMapMergePolicy());
+        mergePolicyMap.put(PutIfAbsentMapMergePolicy.class.getName(), PutIfAbsentMapMergePolicy.INSTANCE);
+        mergePolicyMap.put(HigherHitsMapMergePolicy.class.getName(), HigherHitsMapMergePolicy.INSTANCE);
+        mergePolicyMap.put(PassThroughMergePolicy.class.getName(), PassThroughMergePolicy.INSTANCE);
+        mergePolicyMap.put(LatestUpdateMapMergePolicy.class.getName(), LatestUpdateMapMergePolicy.INSTANCE);
     }
 
     public ReplicatedMapMergePolicy getMergePolicy(String className) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PassThroughMergePolicy.java
@@ -16,18 +16,53 @@
 
 package com.hazelcast.replicatedmap.merge;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
+import java.io.IOException;
 
 /**
  * PassThroughMergePolicy causes the merging entry to be merged from source to destination map
  * unless merging entry is null.
  */
-public class PassThroughMergePolicy implements ReplicatedMapMergePolicy {
+public final class PassThroughMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
+
+    /**
+     * Single instance of this class
+     */
+    public static final PassThroughMergePolicy INSTANCE = new PassThroughMergePolicy();
+
+    private PassThroughMergePolicy() {
+    }
 
     @Override
     public Object merge(String mapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
         return mergingEntry == null ? existingEntry.getValue() : mergingEntry.getValue();
     }
 
+    @Override
+    public int getFactoryId() {
+        return ReplicatedMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.PASS_THROUGH_MERGE_POLICY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    // ensure single instance even when plain Java serialization might be used
+    private Object readResolve() {
+        return INSTANCE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicy.java
@@ -16,14 +16,27 @@
 
 package com.hazelcast.replicatedmap.merge;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
+import java.io.IOException;
 
 /**
  * PutIfAbsentMapMergePolicy causes the merging entry to be merged from source to destination map
  * if it does not exist in the destination map.
  */
-public class PutIfAbsentMapMergePolicy implements ReplicatedMapMergePolicy {
+public final class PutIfAbsentMapMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
+
+    /**
+     * Single instance of this class
+     */
+    public static final PutIfAbsentMapMergePolicy INSTANCE = new PutIfAbsentMapMergePolicy();
+
+    private PutIfAbsentMapMergePolicy() {
+    }
 
     @Override
     public Object merge(String mapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
@@ -31,5 +44,28 @@ public class PutIfAbsentMapMergePolicy implements ReplicatedMapMergePolicy {
             return mergingEntry.getValue();
         }
         return existingEntry.getValue();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ReplicatedMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.PUT_IF_ABSENT_MERGE_POLICY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    // ensure single instance even when plain Java serialization might be used
+    private Object readResolve() {
+        return INSTANCE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Contains classes related to cluster quorum.
+ * Classes for replicated map.
  */
 package com.hazelcast.replicatedmap;

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.ringbuffer;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.exception.SilentException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An {@link RuntimeException} that is thrown when accessing an item in the {@link Ringbuffer} using a sequence that is smaller

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/StaleSequenceException.java
@@ -16,13 +16,17 @@
 
 package com.hazelcast.ringbuffer;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.exception.SilentException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An {@link RuntimeException} that is thrown when accessing an item in the {@link Ringbuffer} using a sequence that is smaller
  * than the current head sequence and that the ringbuffer store is disabled. This means that the item isn't available in the
  * ringbuffer and it cannot be loaded from the store either, thus being completely unavailable.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class StaleSequenceException extends RuntimeException implements SilentException {
 
     private final long headSeq;

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/DuplicateTaskException.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/DuplicateTaskException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.scheduledexecutor;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An exception thrown when a task's name is already used before for another (or the same, if re-attempted) schedule.
  * Tasks under a scheduler must have unique names.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class DuplicateTaskException
         extends HazelcastException {
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/DuplicateTaskException.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/DuplicateTaskException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.scheduledexecutor;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An exception thrown when a task's name is already used before for another (or the same, if re-attempted) schedule.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StaleTaskException.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StaleTaskException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.scheduledexecutor;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.exception.SilentException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Exception thrown by the {@link IScheduledFuture} during any operation on a stale (=previously destroyed) task.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class StaleTaskException
         extends HazelcastException implements SilentException {
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StaleTaskException.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/StaleTaskException.java
@@ -17,10 +17,10 @@
 package com.hazelcast.scheduledexecutor;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.exception.SilentException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Exception thrown by the {@link IScheduledFuture} during any operation on a stale (=previously destroyed) task.

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
@@ -19,13 +19,13 @@ package com.hazelcast.scheduledexecutor.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 public class ScheduledTaskResult
         implements IdentifiedDataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
@@ -19,10 +19,13 @@ package com.hazelcast.scheduledexecutor.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 public class ScheduledTaskResult
         implements IdentifiedDataSerializable {
@@ -117,6 +120,7 @@ public class ScheduledTaskResult
 
     // ExecutionExceptions get peeled away during Operation response, this wrapper
     // helps identifying them on the proxy and re-construct them.
+    @BinaryInterface(reason = OTHER_CONVENTION)
     public static class ExecutionExceptionDecorator
             extends RuntimeException {
 

--- a/hazelcast/src/main/java/com/hazelcast/security/AbstractCredentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/AbstractCredentials.java
@@ -19,7 +19,7 @@ package com.hazelcast.security;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/security/Credentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/Credentials.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.security;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
@@ -18,7 +18,7 @@ package com.hazelcast.security;
 
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.impl.SpiPortableHook;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/AllPermissions.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/AllPermissions.java
@@ -16,10 +16,15 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.util.Enumeration;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public final class AllPermissions extends ClusterPermission {
 
     public AllPermissions() {
@@ -56,6 +61,7 @@ public final class AllPermissions extends ClusterPermission {
         return 111;
     }
 
+    @BinaryInterface(reason = OTHER_CONVENTION)
     public static final class AllPermissionsCollection extends PermissionCollection {
         private static final AllPermissions ALL_PERMISSIONS = new AllPermissions();
         private boolean all;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/AllPermissions.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/AllPermissions.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.util.Enumeration;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public final class AllPermissions extends ClusterPermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicLongPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicLongPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class AtomicLongPermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicLongPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicLongPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class AtomicLongPermission extends InstancePermission {
 
     private static final int READ = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicReferencePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicReferencePermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class AtomicReferencePermission extends InstancePermission {
 
     private static final int READ = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicReferencePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/AtomicReferencePermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class AtomicReferencePermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CachePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CachePermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class CachePermission extends InstancePermission {
 
     private static final int PUT = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CachePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CachePermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class CachePermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CardinalityEstimatorPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CardinalityEstimatorPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class CardinalityEstimatorPermission extends InstancePermission {
 
     private static final int READ = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CardinalityEstimatorPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CardinalityEstimatorPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class CardinalityEstimatorPermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ClusterPermissionCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ClusterPermissionCollection.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.security.Permission;
 import java.security.PermissionCollection;
@@ -26,7 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class ClusterPermissionCollection extends PermissionCollection {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ClusterPermissionCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ClusterPermissionCollection.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.util.Collections;
@@ -24,6 +26,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ClusterPermissionCollection extends PermissionCollection {
 
     final Set<Permission> perms = new HashSet<Permission>();

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CountDownLatchPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CountDownLatchPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class CountDownLatchPermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/CountDownLatchPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/CountDownLatchPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class CountDownLatchPermission extends InstancePermission {
 
     private static final int READ = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/DenyAllPermissionCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/DenyAllPermissionCollection.java
@@ -16,10 +16,15 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.util.Enumeration;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class DenyAllPermissionCollection extends PermissionCollection {
 
     public DenyAllPermissionCollection() {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/DenyAllPermissionCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/DenyAllPermissionCollection.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.security.Permission;
 import java.security.PermissionCollection;
 import java.util.Enumeration;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class DenyAllPermissionCollection extends PermissionCollection {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/DurableExecutorServicePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/DurableExecutorServicePermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class DurableExecutorServicePermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/DurableExecutorServicePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/DurableExecutorServicePermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class DurableExecutorServicePermission extends InstancePermission {
 
     private static final int ALL = CREATE | DESTROY;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ExecutorServicePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ExecutorServicePermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class ExecutorServicePermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ExecutorServicePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ExecutorServicePermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ExecutorServicePermission extends InstancePermission {
 
     private static final int ALL = CREATE | DESTROY;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ListPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ListPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class ListPermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ListPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ListPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ListPermission extends InstancePermission {
 
     private static final int ADD = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/LockPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/LockPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class LockPermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/LockPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/LockPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class LockPermission extends InstancePermission {
 
     private static final  int LOCK = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class MapPermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MapPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MapPermission extends InstancePermission {
 
     private static final int PUT = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MapReducePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MapReducePermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * To be able to map-reduce from a client in a secure environment

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MapReducePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MapReducePermission.java
@@ -16,9 +16,14 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * To be able to map-reduce from a client in a secure environment
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MapReducePermission extends InstancePermission {
 
     private static final int ALL = CREATE | DESTROY;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MultiMapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MultiMapPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MultiMapPermission extends MapPermission {
 
     public MultiMapPermission(String name, String... actions) {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/MultiMapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/MultiMapPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class MultiMapPermission extends MapPermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/QueuePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/QueuePermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class QueuePermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/QueuePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/QueuePermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class QueuePermission extends InstancePermission {
 
     private static final int ADD = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ReplicatedMapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ReplicatedMapPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class ReplicatedMapPermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ReplicatedMapPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ReplicatedMapPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ReplicatedMapPermission extends InstancePermission {
 
     private static final int PUT = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/RingBufferPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/RingBufferPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class RingBufferPermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/RingBufferPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/RingBufferPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class RingBufferPermission extends InstancePermission {
 
     private static final int PUT = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ScheduledExecutorPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ScheduledExecutorPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ScheduledExecutorPermission
         extends InstancePermission {
 

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/ScheduledExecutorPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/ScheduledExecutorPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class ScheduledExecutorPermission

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SemaphorePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SemaphorePermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class SemaphorePermission extends InstancePermission {
 
    private static final int ACQUIRE = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SemaphorePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SemaphorePermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class SemaphorePermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SetPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SetPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class SetPermission extends ListPermission {
 
     public SetPermission(String name, String... actions) {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/SetPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/SetPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class SetPermission extends ListPermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/TopicPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/TopicPermission.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class TopicPermission extends InstancePermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/TopicPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/TopicPermission.java
@@ -16,6 +16,11 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class TopicPermission extends InstancePermission {
 
     private static final int PUBLISH = 4;

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/TransactionPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/TransactionPermission.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.security.permission;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.security.Permission;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class TransactionPermission extends ClusterPermission {

--- a/hazelcast/src/main/java/com/hazelcast/security/permission/TransactionPermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/permission/TransactionPermission.java
@@ -16,8 +16,13 @@
 
 package com.hazelcast.security.permission;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.security.Permission;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class TransactionPermission extends ClusterPermission {
 
     public TransactionPermission() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
@@ -18,12 +18,16 @@ package com.hazelcast.spi;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * Default {@link com.hazelcast.spi.ObjectNamespace} implementation.
  */
+@BinaryInterface(reason = PUBLIC_API)
 public final class DefaultObjectNamespace implements ObjectNamespace {
 
     private String service;

--- a/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
@@ -18,11 +18,11 @@ package com.hazelcast.spi;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * Default {@link com.hazelcast.spi.ObjectNamespace} implementation.

--- a/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
@@ -20,9 +20,9 @@ import com.hazelcast.cluster.MemberAttributeOperationType;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.instance.MemberImpl;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * This service event is fired to inform services about a change in a member's attributes collection

--- a/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
@@ -20,10 +20,14 @@ import com.hazelcast.cluster.MemberAttributeOperationType;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * This service event is fired to inform services about a change in a member's attributes collection
  */
+@BinaryInterface(reason = PUBLIC_API)
 public class MemberAttributeServiceEvent extends MemberAttributeEvent {
 
     public MemberAttributeServiceEvent() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/MembershipServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MembershipServiceEvent.java
@@ -18,6 +18,9 @@ package com.hazelcast.spi;
 
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Membership event fired when a new member is added
@@ -25,6 +28,7 @@ import com.hazelcast.instance.MemberImpl;
  *
  * @see com.hazelcast.spi.MembershipAwareService
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class MembershipServiceEvent extends MembershipEvent {
 
     public MembershipServiceEvent(MembershipEvent e) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/MembershipServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MembershipServiceEvent.java
@@ -18,9 +18,9 @@ package com.hazelcast.spi;
 
 import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.instance.MemberImpl;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Membership event fired when a new member is added

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionMigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionMigrationEvent.java
@@ -16,14 +16,18 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 
 import java.util.EventObject;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An {@link java.util.EventObject} for a partition migration. Can be used by SPI services to get a callback
  * to listen to partition migration.  See {@link com.hazelcast.spi.MigrationAwareService} for more info.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class PartitionMigrationEvent extends EventObject {
 
     private final MigrationEndpoint migrationEndpoint;

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionMigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionMigrationEvent.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.spi;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 
 import java.util.EventObject;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An {@link java.util.EventObject} for a partition migration. Can be used by SPI services to get a callback

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionReplicationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionReplicationEvent.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.spi;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.EventObject;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An event send to {@link com.hazelcast.spi.MigrationAwareService} when partition changes happen.

--- a/hazelcast/src/main/java/com/hazelcast/spi/PartitionReplicationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/PartitionReplicationEvent.java
@@ -16,11 +16,16 @@
 
 package com.hazelcast.spi;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.util.EventObject;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * An event send to {@link com.hazelcast.spi.MigrationAwareService} when partition changes happen.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class PartitionReplicationEvent extends EventObject {
 
     private final int partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spi.discovery.multicast.impl;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/CallerNotMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/CallerNotMemberException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link RetryableHazelcastException} that indicates that an operation was send by a machine which isn't member

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/CallerNotMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/CallerNotMemberException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link RetryableHazelcastException} that indicates that an operation was send by a machine which isn't member
  * in the cluster when the operation is executed.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class CallerNotMemberException extends RetryableHazelcastException {
 
     public CallerNotMemberException(Address thisAddress, Address caller, int partitionId,

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/DistributedObjectDestroyedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/DistributedObjectDestroyedException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.core.HazelcastException} that indicates that a {@link com.hazelcast.core.DistributedObject}
  * access was attempted, but the object is destroyed.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class DistributedObjectDestroyedException extends HazelcastException {
 
     public DistributedObjectDestroyedException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/DistributedObjectDestroyedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/DistributedObjectDestroyedException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.core.HazelcastException} that indicates that a {@link com.hazelcast.core.DistributedObject}

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/PartitionMigratingException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/PartitionMigratingException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that is thrown when an operation is executed
  * on a partition, but that partition is currently being moved around.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class PartitionMigratingException extends RetryableHazelcastException {
 
     public PartitionMigratingException(Address thisAddress, int partitionId, String operationName, String serviceName) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/PartitionMigratingException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/PartitionMigratingException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that is thrown when an operation is executed

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/ResponseAlreadySentException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/ResponseAlreadySentException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A HazelcastException indicating that there is some kind of system error causing a response to be send

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/ResponseAlreadySentException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/ResponseAlreadySentException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A HazelcastException indicating that there is some kind of system error causing a response to be send
  * multiple times for some operation.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ResponseAlreadySentException extends HazelcastException {
 
     public ResponseAlreadySentException() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableHazelcastException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableHazelcastException.java
@@ -17,12 +17,16 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A 'marker' exception that indicates that an operation can be retried. E.g. if map.get is send to a partition that
  * is currently migrating, a subclass of this exception is thrown, so the caller can deal with it (e.g. sending the
  * request to the new partition owner).
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class RetryableHazelcastException extends HazelcastException implements RetryableException {
 
     public RetryableHazelcastException() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableHazelcastException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableHazelcastException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A 'marker' exception that indicates that an operation can be retried. E.g. if map.get is send to a partition that

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableIOException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableIOException.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.spi.exception;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link java.io.IOException} indicating that there was a IO failure, but it can be retried.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableIOException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/RetryableIOException.java
@@ -16,11 +16,16 @@
 
 package com.hazelcast.spi.exception;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link java.io.IOException} indicating that there was a IO failure, but it can be retried.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class RetryableIOException extends IOException implements RetryableException {
 
     public RetryableIOException() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/ServiceNotFoundException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/ServiceNotFoundException.java
@@ -17,10 +17,14 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.core.HazelcastException} that indicates that a requested service is not exist.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ServiceNotFoundException extends HazelcastException {
 
     public ServiceNotFoundException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/ServiceNotFoundException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/ServiceNotFoundException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.core.HazelcastException} that indicates that a requested service is not exist.

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
@@ -16,10 +16,15 @@
 
 package com.hazelcast.spi.exception;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that indicates that an operation is about to
  * be send to a non existing machine.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class TargetDisconnectedException extends RetryableHazelcastException {
 
     public TargetDisconnectedException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetDisconnectedException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.spi.exception;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that indicates that an operation is about to

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetNotMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetNotMemberException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that indicates operation is send to a
  * machine that isn't member of the cluster.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class TargetNotMemberException extends RetryableHazelcastException {
 
     public TargetNotMemberException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetNotMemberException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/TargetNotMemberException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} that indicates operation is send to a

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/WrongTargetException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/WrongTargetException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} indicating that an operation is executed on

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/WrongTargetException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/WrongTargetException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.spi.exception;
 
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} indicating that an operation is executed on
  * the wrong machine.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class WrongTargetException extends RetryableHazelcastException {
 
     private transient Address target;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.impl.eventservice.impl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.impl.proxyservice.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionLostEvent.java
@@ -20,11 +20,11 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * Internal event that is dispatched to {@link com.hazelcast.spi.PartitionAwareService#onPartitionLost}

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionLostEvent.java
@@ -20,14 +20,18 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * Internal event that is dispatched to {@link com.hazelcast.spi.PartitionAwareService#onPartitionLost}
  * <p/>
  * It contains the partition id, number of replicas that is lost and the address of node that detects the partition lost
  */
+@BinaryInterface(reason = PUBLIC_API)
 public class IPartitionLostEvent
         implements DataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadException.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadException.java
@@ -17,6 +17,9 @@
 package com.hazelcast.topic;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} thrown when a publisher wants to write to a topic, but there is not sufficient storage
@@ -24,6 +27,7 @@ import com.hazelcast.core.HazelcastException;
  *
  * This exception is only thrown in combination with the reliable topic.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class TopicOverloadException extends HazelcastException {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadException.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/TopicOverloadException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.topic;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} thrown when a publisher wants to write to a topic, but there is not sufficient storage

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
@@ -19,12 +19,16 @@ package com.hazelcast.topic.impl;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Message;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class DataAwareMessage extends Message<Object> {
 
     private static final long serialVersionUID = 1;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/DataAwareMessage.java
@@ -19,14 +19,14 @@ package com.hazelcast.topic.impl;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Message;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 @BinaryInterface(reason = OTHER_CONVENTION)
 public class DataAwareMessage extends Message<Object> {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionException.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.transaction;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} that is thrown when something goes wrong while dealing with transactions and transactional

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionException.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionException.java
@@ -17,11 +17,15 @@
 package com.hazelcast.transaction;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} that is thrown when something goes wrong while dealing with transactions and transactional
  * data-structures.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class TransactionException extends HazelcastException {
 
     public TransactionException() {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionNotActiveException.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionNotActiveException.java
@@ -17,10 +17,14 @@
 package com.hazelcast.transaction;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} thrown when an a transactional operation is executed without an active transaction.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class TransactionNotActiveException extends HazelcastException {
 
     public TransactionNotActiveException() {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionNotActiveException.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionNotActiveException.java
@@ -17,9 +17,9 @@
 package com.hazelcast.transaction;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link HazelcastException} thrown when an a transactional operation is executed without an active transaction.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
@@ -19,12 +19,12 @@ package com.hazelcast.transaction;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.PUBLIC_API;
 
 /**
  * Contains the configuration for a Hazelcast transaction.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
@@ -19,13 +19,17 @@ package com.hazelcast.transaction;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.PUBLIC_API;
+
 /**
  * Contains the configuration for a Hazelcast transaction.
  */
+@BinaryInterface(reason = PUBLIC_API)
 public final class TransactionOptions implements DataSerializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionTimedOutException.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionTimedOutException.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.transaction;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Thrown when a transaction has timed out.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionTimedOutException.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionTimedOutException.java
@@ -16,9 +16,14 @@
 
 package com.hazelcast.transaction;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * Thrown when a transaction has timed out.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class TransactionTimedOutException extends TransactionException {
 
     public TransactionTimedOutException() {

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/SerializableXID.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/SerializableXID.java
@@ -19,7 +19,7 @@ package com.hazelcast.transaction.impl.xa;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.transaction.xa.Xid;
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.util;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.io.IOException;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -30,6 +32,8 @@ import java.util.Deque;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedList;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * AddressUtil contains Address helper methods.
@@ -634,6 +638,7 @@ public final class AddressUtil {
     /**
      * Thrown when given address is not valid.
      */
+    @BinaryInterface(reason = OTHER_CONVENTION)
     public static class InvalidAddressException extends IllegalArgumentException {
 
         public InvalidAddressException(final String message) {

--- a/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.util;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -33,7 +33,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedList;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * AddressUtil contains Address helper methods.

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
@@ -24,6 +24,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.core.IBiFunction;
 import com.hazelcast.core.IFunction;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -48,6 +49,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -148,6 +150,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * @author Jason T. Greene
  */
 @SuppressWarnings("all")
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
         implements com.hazelcast.util.IConcurrentMap<K, V>, Serializable {
 
@@ -469,6 +472,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
      * subclasses from ReentrantLock opportunistically, just to
      * simplify some locking and avoid separate construction.
      */
+    @BinaryInterface(reason = OTHER_CONVENTION)
     static final class Segment<K, V> extends ReentrantLock implements Serializable {
         /*
          * Segments maintain a table of entry lists that are ALWAYS
@@ -1720,6 +1724,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
     /*
      * This class is needed for JDK5 compatibility.
      */
+    @BinaryInterface(reason = OTHER_CONVENTION)
     protected static class SimpleEntry<K, V> implements Entry<K, V>, java.io.Serializable {
         private static final long serialVersionUID = -8499721149061103585L;
 
@@ -1777,6 +1782,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
      * Custom Entry class used by EntryIterator.next(), that relays setValue
      * changes to the underlying map.
      */
+    @BinaryInterface(reason = OTHER_CONVENTION)
     protected class WriteThroughEntry extends SimpleEntry<K, V> {
         private static final long serialVersionUID = -7900634345345313646L;
 

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
@@ -24,7 +24,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.core.IBiFunction;
 import com.hazelcast.core.IFunction;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -49,7 +49,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
@@ -18,6 +18,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.internal.eviction.Expirable;
 import com.hazelcast.internal.util.ThreadLocalRandomProvider;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.AbstractMap;
 import java.util.Collections;
@@ -27,12 +28,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+
 /**
  * ConcurrentHashMap to extend iterator capability.
  *
  * @param <K> Type of the key
  * @param <V> Type of the value
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMap<K, V> {
 
     private static final float LOAD_FACTOR = 0.91f;

--- a/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
@@ -18,7 +18,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.internal.eviction.Expirable;
 import com.hazelcast.internal.util.ThreadLocalRandomProvider;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.AbstractMap;
 import java.util.Collections;
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * ConcurrentHashMap to extend iterator capability.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.util.collection;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.Serializable;
@@ -28,7 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.util.collection;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.Serializable;
@@ -27,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -52,6 +54,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  *
  * @param <T> the type of elements maintained by this set
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Serializable, Cloneable {
 
     private static final long serialVersionUID = 0L;

--- a/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
@@ -16,12 +16,17 @@
 
 package com.hazelcast.version;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.io.Serializable;
 import java.util.Comparator;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Version comparator that disregards patch version, comparing versions on their major & minor versions only.
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 @SuppressWarnings("checkstyle:magicnumber")
 class MajorMinorVersionComparator implements Comparator<MemberVersion>, Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.version;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 import java.util.Comparator;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * Version comparator that disregards patch version, comparing versions on their major & minor versions only.

--- a/hazelcast/src/main/java/com/hazelcast/wan/WANReplicationQueueFullException.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WANReplicationQueueFullException.java
@@ -18,6 +18,9 @@ package com.hazelcast.wan;
 
 import com.hazelcast.config.WANQueueFullBehavior;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
+import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.core.HazelcastException} that is thrown when the wan replication queues are full
@@ -25,6 +28,7 @@ import com.hazelcast.core.HazelcastException;
  * This exception is only thrown when WAN is configured with
  * {@link WANQueueFullBehavior#THROW_EXCEPTION}
  */
+@BinaryInterface(reason = OTHER_CONVENTION)
 public class WANReplicationQueueFullException extends HazelcastException {
 
     public WANReplicationQueueFullException(String message) {

--- a/hazelcast/src/main/java/com/hazelcast/wan/WANReplicationQueueFullException.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WANReplicationQueueFullException.java
@@ -18,9 +18,9 @@ package com.hazelcast.wan;
 
 import com.hazelcast.config.WANQueueFullBehavior;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
-import static com.hazelcast.nio.serialization.impl.BinaryInterface.Reason.OTHER_CONVENTION;
+import static com.hazelcast.nio.serialization.BinaryInterface.Reason.OTHER_CONVENTION;
 
 /**
  * A {@link com.hazelcast.core.HazelcastException} that is thrown when the wan replication queues are full

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -35,7 +35,6 @@ import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -48,7 +47,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Tests for classes which are used as Data in the client protocol
+ * Tests to verify serializable classes conventions are observed. Each conventions test scans the classpath (excluding test classes)
+ * and tests <b>concrete</b> classes which implement (directly or transitively) {@code Serializable} or
+ * {@code DataSerializable} interface, then verifies that it's either annotated with {@code @BinaryInterface} or
+ * they also implement {@code IdentifiedDataSerializable}. Additionally, tests whether IDS instanced obtained from DS factories
+ * have the same ID as the one reported by their `getId` method and that F_ID/ID combinations are unique.
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class})
@@ -67,21 +70,12 @@ public class DataSerializableConventionsTest {
         dataSerializableClasses.removeAll(allIdDataSerializableClasses);
         // also remove IdentifiedDataSerializable itself
         dataSerializableClasses.remove(IdentifiedDataSerializable.class);
+        // do not check abstract classes & interfaces
+        filterNonConcreteClasses(dataSerializableClasses);
 
         // locate all classes annotated with BinaryInterface (and their subclasses) and remove those as well
-        Set<?> allAnnotatedClasses = REFLECTIONS.getTypesAnnotatedWith(BinaryInterface.class, false);
+        Set<?> allAnnotatedClasses = REFLECTIONS.getTypesAnnotatedWith(BinaryInterface.class, true);
         dataSerializableClasses.removeAll(allAnnotatedClasses);
-
-        // filter out public classes from public packages (i.e. not "impl" nor "internal" and not annotated with @PrivateApi)
-        Set<Class> publicClasses = new HashSet<Class>();
-        for (Object o : dataSerializableClasses) {
-            Class klass = (Class) o;
-            // if in public packages and not @PrivateApi ==> exclude from checks
-            if (isPublicClass(klass)) {
-                publicClasses.add(klass);
-            }
-        }
-        dataSerializableClasses.removeAll(publicClasses);
 
         if (dataSerializableClasses.size() > 0) {
             SortedSet<String> nonCompliantClassNames = new TreeSet<String>();
@@ -109,27 +103,12 @@ public class DataSerializableConventionsTest {
                 = REFLECTIONS.getSubTypesOf(IdentifiedDataSerializable.class);
 
         serializableClasses.removeAll(allIdDataSerializableClasses);
+        // do not check abstract classes & interfaces
+        filterNonConcreteClasses(serializableClasses);
 
         // locate all classes annotated with BinaryInterface (and their subclasses) and remove those as well
-        Set<?> allAnnotatedClasses = REFLECTIONS.getTypesAnnotatedWith(BinaryInterface.class, false);
+        Set<?> allAnnotatedClasses = REFLECTIONS.getTypesAnnotatedWith(BinaryInterface.class, true);
         serializableClasses.removeAll(allAnnotatedClasses);
-
-        // filter out public classes from public packages (i.e. not "impl" nor "internal" and not annotated with @PrivateApi)
-        Set<Class> publicClasses = new HashSet<Class>();
-        for (Object o : serializableClasses) {
-            Class klass = (Class) o;
-            // if in public packages and not @PrivateApi ==> exclude from checks
-            if (isPublicClass(klass)) {
-                publicClasses.add(klass);
-            }
-            else {
-                // if not a public class but inherits Serializable from a public class, also exclude
-                if (inheritsClassFromPublicClass(klass, Serializable.class)) {
-                    publicClasses.add(klass);
-                }
-            }
-        }
-        serializableClasses.removeAll(publicClasses);
 
         if (serializableClasses.size() > 0) {
             SortedSet<String> nonCompliantClassNames = new TreeSet<String>();
@@ -260,14 +239,22 @@ public class DataSerializableConventionsTest {
     private Set<Class<? extends IdentifiedDataSerializable>> getIDSConcreteClasses() {
         Set<Class<? extends IdentifiedDataSerializable>> identifiedDataSerializables
                 = REFLECTIONS.getSubTypesOf(IdentifiedDataSerializable.class);
-        Iterator<Class<? extends IdentifiedDataSerializable>> iterator = identifiedDataSerializables.iterator();
+        filterNonConcreteClasses(identifiedDataSerializables);
+        return identifiedDataSerializables;
+    }
+
+    /**
+     * Removes abstract classes and interfaces from given Set in-place.
+     * @param classes
+     */
+    private void filterNonConcreteClasses(Set classes) {
+        Iterator<Class> iterator = classes.iterator();
         while (iterator.hasNext()) {
-            Class<? extends IdentifiedDataSerializable> klass = iterator.next();
+            Class<?> klass = iterator.next();
             if (klass.isInterface() || Modifier.isAbstract(klass.getModifiers())) {
                 iterator.remove();
             }
         }
-        return identifiedDataSerializables;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.AbstractLocalOperation;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/HigherHitsReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/HigherHitsReplicatedMapMergePolicyTest.java
@@ -29,7 +29,7 @@ public class HigherHitsReplicatedMapMergePolicyTest extends AbstractReplicatedMa
 
     @Before
     public void given() {
-        policy = new HigherHitsMapMergePolicy();
+        policy = HigherHitsMapMergePolicy.INSTANCE;
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LatestUpdateReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LatestUpdateReplicatedMapMergePolicyTest.java
@@ -29,7 +29,7 @@ public class LatestUpdateReplicatedMapMergePolicyTest extends AbstractReplicated
 
     @Before
     public void given() {
-        policy = new LatestUpdateMapMergePolicy();
+        policy = LatestUpdateMapMergePolicy.INSTANCE;
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
@@ -40,7 +40,7 @@ public class PassThroughMapMergePolicyTest {
 
     @Before
     public void given() {
-        policy = new PassThroughMergePolicy();
+        policy = PassThroughMergePolicy.INSTANCE;
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicyTest.java
@@ -41,7 +41,7 @@ public class PutIfAbsentMapMergePolicyTest {
 
     @Before
     public void given() {
-        policy = new PutIfAbsentMapMergePolicy();
+        policy = PutIfAbsentMapMergePolicy.INSTANCE;
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
@@ -16,15 +16,27 @@
 
 package com.hazelcast.test;
 
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import org.reflections.Configuration;
+import org.reflections.ReflectionUtils;
 import org.reflections.Reflections;
+import org.reflections.adapters.JavaReflectionAdapter;
+import org.reflections.scanners.AbstractScanner;
 import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 
 import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Initialize once org.reflections library to avoid duplicate work scanning the classpath from individual tests.
@@ -44,7 +56,77 @@ public class ReflectionsHelper {
                 iterator.remove();
             }
         }
-        REFLECTIONS = new Reflections(new ConfigurationBuilder().addUrls(comHazelcastPackageURLs)
-                .addScanners(new SubTypesScanner()).addScanners(new TypeAnnotationsScanner()));
+        HierarchyTraversingSubtypesScanner subtypesScanner = new HierarchyTraversingSubtypesScanner();
+        subtypesScanner.setResultFilter(new FilterBuilder().exclude("java\\.lang\\.(Object|Enum)"));
+        REFLECTIONS = new ReflectionsTransitive(new ConfigurationBuilder().addUrls(comHazelcastPackageURLs)
+                .addScanners(subtypesScanner, new TypeAnnotationsScanner())
+                .setMetadataAdapter(new JavaReflectionAdapter()));
+    }
+
+    // Overrides default implementation of getSubTypesOf to obtain also transitive subtypes of given class
+    public static class ReflectionsTransitive extends Reflections {
+
+        public ReflectionsTransitive(Configuration configuration) {
+            super(configuration);
+        }
+
+        @Override
+        public <T> Set<Class<? extends T>> getSubTypesOf(Class<T> type) {
+            return Sets.newHashSet(ReflectionUtils.<T>forNames(
+                    store.getAll(
+                            HierarchyTraversingSubtypesScanner.class.getSimpleName(),
+                            Arrays.asList(type.getName())),
+                            configuration.getClassLoaders()));
+        }
+    }
+
+    public static class HierarchyTraversingSubtypesScanner extends AbstractScanner{
+        /**
+         * creates new HierarchyTraversingSubtypesScanner. will exclude direct Object subtypes
+         */
+        public HierarchyTraversingSubtypesScanner() {
+            this(true); //exclude direct Object subtypes by default
+        }
+
+        /**
+         * creates new HierarchyTraversingSubtypesScanner.
+         * @param excludeObjectClass if false, include direct {@link Object} subtypes in results.
+         */
+        public HierarchyTraversingSubtypesScanner(boolean excludeObjectClass) {
+            if (excludeObjectClass) {
+                filterResultsBy(new FilterBuilder().exclude(Object.class.getName())); //exclude direct Object subtypes
+            }
+        }
+
+        // depending on Reflections configuration, cls is either a regular Class or a javassist ClassFile
+        @SuppressWarnings({"unchecked"})
+        public void scan(final Object cls) {
+            String className = getMetadataAdapter().getClassName(cls);
+
+            for (String anInterface : (List<String>) getMetadataAdapter().getInterfacesNames(cls)) {
+                if (acceptResult(anInterface)) {
+                    getStore().put(anInterface, className);
+                }
+            }
+
+            // apart from this class' direct supertype and directly declared interfaces, also scan the class
+            // hierarchy up until Object class
+            Class superKlass = ((Class)cls).getSuperclass();
+            while (superKlass != null) {
+                scanClassAndInterfaces(superKlass, className);
+                superKlass = superKlass.getSuperclass();
+            }
+        }
+
+        private void scanClassAndInterfaces(Class klass, String className) {
+            if (acceptResult(klass.getName())) {
+                getStore().put(klass.getName(), className);
+                for (String anInterface : (List<String>) getMetadataAdapter().getInterfacesNames(klass)) {
+                    if (acceptResult(anInterface)) {
+                        getStore().put(anInterface, className);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
* `DataSerializableConventionsTest` has been updated to reflect the following conventions:
 - classes in public packages are now checked for compliance (while they were previously excluded)
 - only concrete classes are checked for compliance. It is OK to annotate interfaces or abstract classes with `@BinaryInterface` as an indication to implementers, however each implementation has to be considered separately.
 - as a consequence of the above `@BinaryInterface` is not considered as inherited.
* `@BinaryInterface` has been extended with a `reason` method to indicate why a class is annotated as such

This PR's first commit includes the changes in the test itself and updates `DataSerializable` classes (either annotated or converted to `IdentifiedDataSerializable`); the second commit updates `Serializable` classes. The third commit moves `BinaryInterface` from `com.hazelcast.nio.serialization.impl` package to `com.hazelcast.nio.serialization`.

An EE counterpart is required.
