### PR TITLE
Small cleanup of SymmetricEncryptionConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/SymmetricEncryptionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SymmetricEncryptionConfig.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import java.util.Arrays;
+import static java.util.Arrays.copyOf;
 
 /**
  * Contains configuration for symmetric encryption
@@ -26,10 +26,10 @@ public class SymmetricEncryptionConfig {
     private static final int ITERATION_COUNT = 19;
 
     private boolean enabled;
-    private String salt = "thesalt";
-    private String password = "thepassword";
-    private int iterationCount = ITERATION_COUNT;
     private String algorithm = "PBEWithMD5AndDES";
+    private String password = "thepassword";
+    private String salt = "thesalt";
+    private int iterationCount = ITERATION_COUNT;
     private byte[] key;
 
     public boolean isEnabled() {
@@ -38,33 +38,6 @@ public class SymmetricEncryptionConfig {
 
     public SymmetricEncryptionConfig setEnabled(boolean enabled) {
         this.enabled = enabled;
-        return this;
-    }
-
-    public String getSalt() {
-        return salt;
-    }
-
-    public SymmetricEncryptionConfig setSalt(String salt) {
-        this.salt = salt;
-        return this;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public SymmetricEncryptionConfig setPassword(String password) {
-        this.password = password;
-        return this;
-    }
-
-    public int getIterationCount() {
-        return iterationCount;
-    }
-
-    public SymmetricEncryptionConfig setIterationCount(int iterationCount) {
-        this.iterationCount = iterationCount;
         return this;
     }
 
@@ -77,23 +50,55 @@ public class SymmetricEncryptionConfig {
         return this;
     }
 
+    public String getPassword() {
+        return password;
+    }
+
+    public SymmetricEncryptionConfig setPassword(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+
+    public SymmetricEncryptionConfig setSalt(String salt) {
+        this.salt = salt;
+        return this;
+    }
+
+    public int getIterationCount() {
+        return iterationCount;
+    }
+
+    public SymmetricEncryptionConfig setIterationCount(int iterationCount) {
+        this.iterationCount = iterationCount;
+        return this;
+    }
+
     public byte[] getKey() {
-        return key != null ? Arrays.copyOf(key, key.length) : null;
+        return cloneKey(key);
     }
 
     public SymmetricEncryptionConfig setKey(byte[] key) {
-        this.key = key != null ? Arrays.copyOf(key, key.length) : null;
+        this.key = cloneKey(key);
         return this;
+    }
+
+    private byte[] cloneKey(byte[] key) {
+        return key != null ? copyOf(key, key.length) : null;
     }
 
     @Override
     public String toString() {
         return "SymmetricEncryptionConfig{"
                 + "enabled=" + enabled
-                + ", iterationCount=" + iterationCount
                 + ", algorithm='" + algorithm + '\''
-                + ", key=" + Arrays.toString(key)
+                + ", password='***'"
+                + ", salt='***'"
+                + ", iterationCount=***"
+                + ", key=***"
                 + '}';
     }
-
 }

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -1794,17 +1794,17 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="password" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        Passphrase to use when generating the secret key.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="salt" type="xs:string" default="thesalt">
                 <xs:annotation>
                     <xs:documentation>
                         Salt value to use when generating the secret key.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="password" type="xs:string">
-                <xs:annotation>
-                    <xs:documentation>
-                        Pass phrase to use when generating the secret key.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/test/java/com/hazelcast/config/SymmetricEncryptionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SymmetricEncryptionConfigTest.java
@@ -1,0 +1,68 @@
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SymmetricEncryptionConfigTest extends HazelcastTestSupport {
+
+    private SymmetricEncryptionConfig config = new SymmetricEncryptionConfig();
+
+    @Test
+    public void testSetEnabled() {
+        config.setEnabled(true);
+
+        assertTrue(config.isEnabled());
+    }
+
+    @Test
+    public void testSetAlgorithm() {
+        config.setAlgorithm("myAlgorithm");
+
+        assertEquals("myAlgorithm", config.getAlgorithm());
+    }
+
+    @Test
+    public void testSetPassword() {
+        config.setPassword("myPassword");
+
+        assertEquals("myPassword", config.getPassword());
+    }
+
+    @Test
+    public void testSetSalt() {
+        config.setSalt("mySalt");
+
+        assertEquals("mySalt", config.getSalt());
+    }
+
+    @Test
+    public void testSetIterationCount() {
+        config.setIterationCount(23);
+
+        assertEquals(23, config.getIterationCount());
+    }
+
+    @Test
+    public void testSetKey() {
+        byte[] key = new byte[] {23, 42};
+        config.setKey(key);
+
+        assertEquals(key[0], config.getKey()[0]);
+        assertEquals(key[1], config.getKey()[1]);
+    }
+
+    @Test
+    public void testToString() {
+        assertContains(config.toString(), "SymmetricEncryptionConfig");
+    }
+}


### PR DESCRIPTION
* Increased code coverage of `SymmetricEncryptionConfig`
* Re-ordered fields in `SymmetricEncryptionConfig` and XSD to usage in code

The original plan was to add the `key` field to the XSD, but since this could be either
* a filename (which would be more convenient for usres)
* or a base64 encoded key (which would match the `SymmectricEncryptionConfig.setKey(byte[] key)`)

we decided to postpone that step to 3.8.1 or later. So the leftover is a small cleanup PR of the config and XSD, with the benefit of increased code coverage on that class.