### PR TITLE
Don't cache null values in jcache near cache

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -747,7 +747,8 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         }
     }
 
-    protected void storeInNearCache(Data key, Data valueData, V value, long reservationId, boolean cacheOnUpdate) {
+    protected void storeInNearCache(Data key, Data valueData, V value,
+                                    long reservationId, boolean cacheOnUpdate) {
         if (nearCache == null) {
             return;
         }
@@ -759,8 +760,13 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         }
 
         if (reservationId != NOT_RESERVED) {
-            Object valueToStore = nearCache.selectToSave(value, valueData);
-            nearCache.tryPublishReserved(key, valueToStore, reservationId, false);
+            if (valueData == null) {
+                // we are not caching nulls in near cache for jcache
+                nearCache.remove(key);
+            } else {
+                Object valueToStore = nearCache.selectToSave(value, valueData);
+                nearCache.tryPublishReserved(key, valueToStore, reservationId, false);
+            }
         }
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -152,6 +152,16 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
         });
         threads.add(putFromMember);
 
+        Thread clearFromMember = new Thread(new Runnable() {
+            public void run() {
+                while (!stopTest.get()) {
+                    memberCache.clear();
+                    sleepSeconds(3);
+                }
+            }
+        });
+        threads.add(clearFromMember);
+
         // start threads
         for (Thread thread : threads) {
             thread.start();


### PR DESCRIPTION
This was a regression only in 3.8, fixing it.