### PR TITLE
Client Map aggregate removed AggregateResult from client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -110,7 +110,6 @@ import com.hazelcast.map.impl.DataAwareEntryEvent;
 import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.ListenerAdapter;
 import com.hazelcast.map.impl.SimpleEntryView;
-import com.hazelcast.map.impl.query.AggregationResult;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.impl.querycache.subscriber.InternalQueryCache;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
@@ -1348,10 +1347,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         ClientMessage request = MapAggregateCodec.encodeRequest(name, toData(aggregator));
         ClientMessage response = invoke(request);
 
-        MapAggregateCodec.ResponseParameters resultParameters =
-                MapAggregateCodec.decodeResponse(response);
-        AggregationResult result = toObject(resultParameters.response);
-        return (R) result.getAggregator().aggregate();
+        MapAggregateCodec.ResponseParameters resultParameters = MapAggregateCodec.decodeResponse(response);
+        return toObject(resultParameters.response);
     }
 
     @Override
@@ -1364,8 +1361,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
 
         MapAggregateWithPredicateCodec.ResponseParameters resultParameters =
                 MapAggregateWithPredicateCodec.decodeResponse(response);
-        AggregationResult result = toObject(resultParameters.response);
-        return (R) result.getAggregator().aggregate();
+        return toObject(resultParameters.response);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapAggregateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapAggregateMessageTask.java
@@ -29,9 +29,8 @@ import java.util.Collection;
 
 public abstract class DefaultMapAggregateMessageTask<P>
         extends AbstractMapQueryMessageTask<P,
-        AggregationResult, AggregationResult, AggregationResult> {
+        AggregationResult, AggregationResult, Object> {
 
-    private static final AggregationResult EMPTY_AGGREGATION_RESULT = new AggregationResult();
 
     public DefaultMapAggregateMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -58,9 +57,9 @@ public abstract class DefaultMapAggregateMessageTask<P>
     }
 
     @Override
-    protected AggregationResult reduce(Collection<AggregationResult> results) {
+    protected Object reduce(Collection<AggregationResult> results) {
         if (results.isEmpty()) {
-            return EMPTY_AGGREGATION_RESULT;
+            return null;
         }
 
         AggregationResult combinedResult = null;
@@ -77,6 +76,6 @@ public abstract class DefaultMapAggregateMessageTask<P>
                 combinedResult.onCombineFinished();
             }
         }
-        return combinedResult;
+        return combinedResult != null ? combinedResult.getAggregator().aggregate() : null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAggregateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAggregateMessageTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAggregateCodec;
-import com.hazelcast.client.impl.protocol.codec.MapAggregateWithPredicateCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -48,7 +47,7 @@ public class MapAggregateMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         Data data = nodeEngine.getSerializationService().toData(response);
-        return MapAggregateWithPredicateCodec.encodeResponse(data);
+        return MapAggregateCodec.encodeResponse(data);
     }
 
     public Permission getRequiredPermission() {

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MapAggregateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MapAggregateTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static com.hazelcast.query.Predicates.greaterThan;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -136,6 +137,16 @@ public class MapAggregateTest extends HazelcastTestSupport {
 
         Double avg = map.aggregate(new DoubleAverageAggregator<Map.Entry<String, Person>>("age"), greaterThan("age", 2.0d));
         assertEquals(Double.valueOf(5.5d), avg);
+    }
+
+    @Test
+    public void doubleAvg_1Node_objectValue_withEmptyResultPredicate() {
+        IMap<String, Person> map = getMapWithNodeCount(1);
+        populateMapWithPersons(map);
+
+        Double avg = map.aggregate(new DoubleAverageAggregator<Map.Entry<String, Person>>("age"),
+                greaterThan("age", 30.0d));
+        assertNull(avg);
     }
 
     @Test


### PR DESCRIPTION
Client Map aggregate removed `AggregateResult` from client, 
server will send aggregated values.

fixes #9845 