### PR TITLE
Added convenience methods to ILogger

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcher.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcher.java
@@ -46,7 +46,6 @@ import static com.hazelcast.client.impl.protocol.codec.CacheFetchNearCacheInvali
 import static com.hazelcast.client.impl.protocol.codec.CacheFetchNearCacheInvalidationMetadataCodec.encodeRequest;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.logging.Level.WARNING;
 
 /**
  * {@code MetaDataFetcher} for client side usage
@@ -76,9 +75,8 @@ public class ClientCacheMetaDataFetcher extends MetaDataFetcher {
             try {
                 futures.add(invocation.invoke());
             } catch (Exception e) {
-                if (logger.isLoggable(WARNING)) {
-                    logger.log(WARNING, "Cant fetch invalidation meta-data from address + " + address
-                            + " + [" + e.getMessage() + "]");
+                if (logger.isWarningEnabled()) {
+                    logger.warning("Cant fetch invalidation meta-data from address + " + address + " + [" + e.getMessage() + "]");
                 }
             }
         }
@@ -93,8 +91,8 @@ public class ClientCacheMetaDataFetcher extends MetaDataFetcher {
             repairUuids(response.partitionUuidList, handlers);
             repairSequences(response.namePartitionSequenceList, handlers);
         } catch (Exception e) {
-            if (logger.isLoggable(WARNING)) {
-                logger.log(WARNING, "Cant fetch invalidation meta-data [" + e.getMessage() + "]");
+            if (logger.isWarningEnabled()) {
+                logger.warning("Cant fetch invalidation meta-data [" + e.getMessage() + "]");
             }
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientConnectionManagerFactory.java
@@ -30,8 +30,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
-import java.util.logging.Level;
-
 public class DefaultClientConnectionManagerFactory implements ClientConnectionManagerFactory {
 
     public DefaultClientConnectionManagerFactory() {
@@ -49,7 +47,7 @@ public class DefaultClientConnectionManagerFactory implements ClientConnectionMa
             try {
                 addressTranslator = new AwsAddressTranslator(awsConfig, loggingService);
             } catch (NoClassDefFoundError e) {
-                logger.log(Level.WARNING, "hazelcast-aws.jar might be missing!");
+                logger.warning("hazelcast-aws.jar might be missing!");
                 throw e;
             }
         } else if (discoveryService != null) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -154,7 +154,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 
 import static java.lang.System.currentTimeMillis;
 
@@ -277,7 +276,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
                 addressProviders.add(new AwsAddressProvider(awsConfig, loggingService));
             } catch (NoClassDefFoundError e) {
                 ILogger logger = loggingService.getLogger(HazelcastClient.class);
-                logger.log(Level.WARNING, "hazelcast-aws.jar might be missing!");
+                logger.warning("hazelcast-aws.jar might be missing!");
                 throw e;
             }
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcher.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcher.java
@@ -45,7 +45,6 @@ import static com.hazelcast.client.impl.protocol.codec.MapFetchNearCacheInvalida
 import static com.hazelcast.client.impl.protocol.codec.MapFetchNearCacheInvalidationMetadataCodec.encodeRequest;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.logging.Level.WARNING;
 
 /**
  * {@code MetaDataFetcher} for client side usage
@@ -76,9 +75,8 @@ public class ClientMapMetaDataFetcher extends MetaDataFetcher {
             try {
                 futures.add(invocation.invoke());
             } catch (Exception e) {
-                if (logger.isLoggable(WARNING)) {
-                    logger.log(WARNING, "Cant fetch invalidation meta-data from address + " + address
-                            + " + [" + e.getMessage() + "]");
+                if (logger.isWarningEnabled()) {
+                    logger.warning("Cant fetch invalidation meta-data from address + " + address + " + [" + e.getMessage() + "]");
                 }
             }
         }
@@ -94,8 +92,8 @@ public class ClientMapMetaDataFetcher extends MetaDataFetcher {
             repairUuids(response.partitionUuidList, handlers);
             repairSequences(response.namePartitionSequenceList, handlers);
         } catch (Exception e) {
-            if (logger.isLoggable(WARNING)) {
-                logger.log(WARNING, "Cant fetch invalidation meta-data [" + e.getMessage() + "]");
+            if (logger.isWarningEnabled()) {
+                logger.warning("Cant fetch invalidation meta-data [" + e.getMessage() + "]");
             }
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AwsAddressProvider.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.logging.Level;
 
 /**
  * Calls the AWS API to load ip addresses related to given credentials.
@@ -65,7 +64,7 @@ public class AwsAddressProvider implements AddressProvider {
         try {
             privateToPublic = awsClient.getAddresses();
         } catch (Exception e) {
-            logger.log(Level.WARNING, "Aws addresses are failed to load : " + e.getMessage());
+            logger.warning("Aws addresses are failed to load : " + e.getMessage());
         }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientListenerServiceImpl.java
@@ -39,7 +39,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
-import java.util.logging.Level;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 
@@ -101,7 +100,7 @@ public abstract class ClientListenerServiceImpl implements ClientListenerService
         try {
             eventExecutor.execute(new ClientEventProcessor(clientMessage, (ClientConnection) connection));
         } catch (RejectedExecutionException e) {
-            logger.log(Level.WARNING, " event clientMessage could not be handled ", e);
+            logger.warning("Event clientMessage could not be handled", e);
         }
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/MapMemoryUsageStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/MapMemoryUsageStressTest.java
@@ -17,7 +17,6 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -68,6 +67,7 @@ public class MapMemoryUsageStressTest extends HazelcastTestSupport {
             this.errors = errors;
         }
 
+        @Override
         public void run() {
             try {
                 for (; ; ) {
@@ -82,7 +82,7 @@ public class MapMemoryUsageStressTest extends HazelcastTestSupport {
                     map.destroy();
 
                     if (index % 1000 == 0) {
-                        logger.log(Level.INFO, "At: " + index);
+                        logger.info("At: " + index);
                     }
                 }
             } catch (Throwable t) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -57,7 +57,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.logging.Level;
 
 class TestClientRegistry {
 
@@ -92,7 +91,7 @@ class TestClientRegistry {
                 try {
                     addressTranslator = new AwsAddressTranslator(awsConfig, client.getLoggingService());
                 } catch (NoClassDefFoundError e) {
-                    LOGGER.log(Level.WARNING, "hazelcast-aws.jar might be missing!");
+                    LOGGER.warning("hazelcast-aws.jar might be missing!");
                     throw e;
                 }
             } else if (discoveryService != null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -35,7 +35,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.security.Permission;
-import java.util.logging.Level;
 
 /**
  * Base Message task.
@@ -148,11 +147,11 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
     }
 
     private void logProcessingFailure(Throwable throwable) {
-        if (logger.isLoggable(Level.FINEST)) {
+        if (logger.isFinestEnabled()) {
             if (parameters == null) {
-                logger.log(Level.FINEST, throwable.getMessage(), throwable);
+                logger.finest(throwable.getMessage(), throwable);
             } else {
-                logger.log(Level.FINEST, "While executing request: " + parameters + " -> " + throwable.getMessage(), throwable);
+                logger.finest("While executing request: " + parameters + " -> " + throwable.getMessage(), throwable);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 
 import static java.util.Collections.synchronizedList;
 
@@ -198,8 +197,7 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractMultiTarg
     private ClientMessage prepareUnauthenticatedClientMessage() {
         Connection connection = endpoint.getConnection();
         ILogger logger = clientEngine.getLogger(getClass());
-        logger.log(Level.WARNING,
-                "Received auth from " + connection + " with principal " + principal + " , authentication failed");
+        logger.warning("Received auth from " + connection + " with principal " + principal + " , authentication failed");
         byte status = AuthenticationStatus.CREDENTIALS_FAILED.getId();
         return encodeAuth(status, null, null, null, serializationService.getVersion(), null);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/AbstractMapQueryMessageTask.java
@@ -44,7 +44,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.logging.Level;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
@@ -125,12 +124,12 @@ public abstract class AbstractMapQueryMessageTask<P, QueryResult extends Result,
                 futures.add(future);
             } catch (Throwable t) {
                 if (t.getCause() instanceof QueryResultSizeExceededException) {
-                    rethrow(t);
+                    throw rethrow(t);
                 } else {
                     // log failure to invoke query on member at fine level
                     // the missing partition IDs will be queried anyway, so it's not a terminal failure
                     if (logger.isFineEnabled()) {
-                        logger.log(Level.FINE, "Query invocation failed on member " + member, t);
+                        logger.fine("Query invocation failed on member " + member, t);
                     }
                 }
             }
@@ -175,12 +174,12 @@ public abstract class AbstractMapQueryMessageTask<P, QueryResult extends Result,
                 }
             } catch (Throwable t) {
                 if (t.getCause() instanceof QueryResultSizeExceededException) {
-                    rethrow(t);
+                    throw rethrow(t);
                 } else {
                     // log failure to invoke query on member at fine level
                     // the missing partition IDs will be queried anyway, so it's not a terminal failure
                     if (logger.isFineEnabled()) {
-                        logger.log(Level.FINE, "Query on member failed with exception", t);
+                        logger.fine("Query on member failed with exception", t);
                     }
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -43,7 +43,6 @@ import java.util.LinkedList;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 import static com.hazelcast.util.AddressUtil.AddressHolder;
 
@@ -444,7 +443,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                 logger.warning("Cannot resolve hostname '" + addressHolder.getAddress()
                         + "'. Please make sure host is valid and reachable.");
                 if (logger.isFineEnabled()) {
-                    logger.log(Level.FINE, "Error during resolving possible target!", e);
+                    logger.fine("Error during resolving possible target!", e);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -42,7 +42,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.logging.Level;
 
 public abstract class CollectionService implements ManagedService, RemoteService,
         EventPublishingService<CollectionEvent, ItemListener>, TransactionalService, MigrationAwareService {
@@ -88,7 +87,7 @@ public abstract class CollectionService implements ManagedService, RemoteService
         ItemEvent itemEvent = new DataAwareItemEvent(event.getName(), event.getEventType(), event.getData(),
                 member, nodeEngine.getSerializationService());
         if (member == null) {
-            if (logger.isLoggable(Level.INFO)) {
+            if (logger.isInfoEnabled()) {
                 logger.info("Dropping event " + itemEvent + " from unknown address:" + event.getCaller());
             }
             return;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -66,7 +66,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.logging.Level;
 
 /**
  * Provides important services via methods for the the Queue
@@ -215,7 +214,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         ItemEvent itemEvent = new DataAwareItemEvent(event.name, event.eventType, event.data,
                 member, nodeEngine.getSerializationService());
         if (member == null) {
-            if (logger.isLoggable(Level.INFO)) {
+            if (logger.isInfoEnabled()) {
                 logger.info("Dropping event " + itemEvent + " from unknown address:" + event.caller);
             }
             return;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -47,7 +47,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.Level;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
@@ -284,7 +283,7 @@ public abstract class AbstractJoiner implements Joiner {
                 return false;
             }
         } catch (Exception e) {
-            logger.log(Level.FINE, "failure during validating join message", e);
+            logger.fine("failure during validating join message", e);
             return false;
         }
         return true;
@@ -399,7 +398,7 @@ public abstract class AbstractJoiner implements Joiner {
         try {
             return (SplitBrainJoinMessage) future.get(SPLIT_BRAIN_JOIN_CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         } catch (TimeoutException e) {
-            logger.log(Level.FINE, "Timeout during join check!", e);
+            logger.fine("Timeout during join check!", e);
         } catch (Exception e) {
             logger.warning("Error during join check!", e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -45,7 +45,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
-import java.util.logging.Level;
 
 import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.SERVICE_NAME;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
@@ -462,7 +461,7 @@ public class ClusterStateManager {
 
         private void log(Throwable cause) {
             if (logger.isFineEnabled()) {
-                logger.log(Level.FINE, "failure during cluster state change", cause);
+                logger.fine("failure during cluster state change", cause);
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PostJoinOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PostJoinOperation.java
@@ -28,7 +28,6 @@ import com.hazelcast.spi.UrgentSystemOperation;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.logging.Level;
 
 import static com.hazelcast.util.Preconditions.checkNegative;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -67,7 +66,7 @@ public class PostJoinOperation extends AbstractJoinOperation implements UrgentSy
                                     + t.getClass().getSimpleName() + ": " + t.getMessage());
 
                             if (logger.isFineEnabled()) {
-                                logger.log(Level.FINE, "Error while running post-join operation: ", t);
+                                logger.fine("Error while running post-join operation: ", t);
                             }
                         }
                     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -26,8 +26,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.memory.MemoryStats;
 import com.hazelcast.spi.properties.GroupProperty;
 
-import java.util.logging.Level;
-
 import static com.hazelcast.internal.diagnostics.HealthMonitorLevel.OFF;
 import static com.hazelcast.internal.diagnostics.HealthMonitorLevel.valueOf;
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
@@ -133,12 +131,12 @@ public class HealthMonitor {
                             if (healthMetrics.exceedsThreshold()) {
                                 logDiagnosticsHint();
                             }
-                            logger.log(Level.INFO, healthMetrics.render());
+                            logger.info(healthMetrics.render());
                             break;
                         case SILENT:
                             if (healthMetrics.exceedsThreshold()) {
                                 logDiagnosticsHint();
-                                logger.log(Level.INFO, healthMetrics.render());
+                                logger.info(healthMetrics.render());
                             }
                             break;
                         default:

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingIOThreadingModel.java
@@ -141,8 +141,7 @@ public class NonBlockingIOThreadingModel
                     + outputThreads.length + " output threads");
         }
 
-        logger.log(getSelectorMode() != SelectorMode.SELECT ? INFO : FINE,
-                "IO threads selector mode is " + getSelectorMode());
+        logger.log(getSelectorMode() != SelectorMode.SELECT ? INFO : FINE, "IO threads selector mode is " + getSelectorMode());
 
         for (int i = 0; i < inputThreads.length; i++) {
             NonBlockingIOThread thread = new NonBlockingIOThread(

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningSocketWriter.java
@@ -33,7 +33,6 @@ import java.nio.ByteBuffer;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.logging.Level;
 
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 import static com.hazelcast.nio.Protocols.CLUSTER;
@@ -199,7 +198,7 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
         }
 
         if (writeHandler == null) {
-            logger.log(Level.WARNING, "SocketWriter is not set, creating SocketWriter with CLUSTER protocol!");
+            logger.warning("SocketWriter is not set, creating SocketWriter with CLUSTER protocol!");
             initializer.init(connection, this, CLUSTER);
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -689,7 +689,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     private void logUnknownAddressesInPartitionTable(Address sender, Set<Address> unknownAddresses) {
-        if (!unknownAddresses.isEmpty() && logger.isLoggable(Level.WARNING)) {
+        if (!unknownAddresses.isEmpty() && logger.isWarningEnabled()) {
             StringBuilder s = new StringBuilder("Following unknown addresses are found in partition table")
                     .append(" sent from master[").append(sender).append("].")
                     .append(" (Probably they have recently joined or left the cluster.)")

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -41,7 +41,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
-import java.util.logging.Level;
 
 abstract class BaseMigrationOperation extends AbstractPartitionOperation
         implements MigrationCycleOperation, PartitionAwareOperation {
@@ -200,7 +199,7 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
         if (e instanceof PartitionStateVersionMismatchException) {
             ILogger logger = getLogger();
             if (logger.isFineEnabled()) {
-                logger.log(Level.FINE, e.getMessage(), e);
+                logger.fine(e.getMessage(), e);
             }
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/logging/AbstractLogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/AbstractLogger.java
@@ -41,13 +41,23 @@ public abstract class AbstractLogger implements ILogger {
     }
 
     @Override
+    public boolean isFinestEnabled() {
+        return isLoggable(Level.FINEST);
+    }
+
+    @Override
     public void fine(String message) {
         log(Level.FINE, message);
     }
 
     @Override
-    public boolean isFinestEnabled() {
-        return isLoggable(Level.FINEST);
+    public void fine(String message, Throwable thrown) {
+        log(Level.FINE, message, thrown);
+    }
+
+    @Override
+    public void fine(Throwable thrown) {
+        log(Level.FINE, thrown.getMessage(), thrown);
     }
 
     @Override
@@ -61,18 +71,8 @@ public abstract class AbstractLogger implements ILogger {
     }
 
     @Override
-    public void severe(String message) {
-        log(Level.SEVERE, message);
-    }
-
-    @Override
-    public void severe(Throwable thrown) {
-        log(Level.SEVERE, thrown.getMessage(), thrown);
-    }
-
-    @Override
-    public void severe(String message, Throwable thrown) {
-        log(Level.SEVERE, message, thrown);
+    public boolean isInfoEnabled() {
+        return isLoggable(Level.INFO);
     }
 
     @Override
@@ -88,5 +88,25 @@ public abstract class AbstractLogger implements ILogger {
     @Override
     public void warning(String message, Throwable thrown) {
         log(Level.WARNING, message, thrown);
+    }
+
+    @Override
+    public boolean isWarningEnabled() {
+        return isLoggable(Level.WARNING);
+    }
+
+    @Override
+    public void severe(String message) {
+        log(Level.SEVERE, message);
+    }
+
+    @Override
+    public void severe(Throwable thrown) {
+        log(Level.SEVERE, thrown.getMessage(), thrown);
+    }
+
+    @Override
+    public void severe(String message, Throwable thrown) {
+        log(Level.SEVERE, message, thrown);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/ILogger.java
@@ -18,7 +18,6 @@ package com.hazelcast.logging;
 
 import java.util.logging.Level;
 
-
 /**
  * The Hazelcast logging interface. The reason if its existence is that Hazelcast doesn't want any dependencies
  * on concrete logging frameworks so it creates it own meta logging framework where existing logging frameworks can
@@ -34,7 +33,7 @@ public interface ILogger {
     void finest(String message);
 
     /**
-     * Logs a throwable at {@link Level#FINEST}.  The message of the Throwable will be the message.
+     * Logs a throwable at {@link Level#FINEST}. The message of the Throwable will be the message.
      *
      * @param thrown the Throwable to log.
      */
@@ -63,6 +62,21 @@ public interface ILogger {
     void fine(String message);
 
     /**
+     * Logs a throwable at {@link Level#FINE}. The message of the Throwable will be the message.
+     *
+     * @param thrown the Throwable to log.
+     */
+    void fine(Throwable thrown);
+
+    /**
+     * Logs message with associated throwable information at {@link Level#FINE}.
+     *
+     * @param message the message to log
+     * @param thrown  the Throwable associated to the message.
+     */
+    void fine(String message, Throwable thrown);
+
+    /**
      * Checks if the {@link Level#FINE} is enabled.
      *
      * @return true if enabled, false otherwise.
@@ -77,6 +91,13 @@ public interface ILogger {
     void info(String message);
 
     /**
+     * Checks if the {@link Level#INFO} is enabled.
+     *
+     * @return true if enabled, false otherwise.
+     */
+    boolean isInfoEnabled();
+
+    /**
      * Logs a message at {@link Level#WARNING}.
      *
      * @param message the message to log.
@@ -84,7 +105,7 @@ public interface ILogger {
     void warning(String message);
 
     /**
-     * Logs a throwable at {@link Level#WARNING}.  The message of the Throwable will be the message.
+     * Logs a throwable at {@link Level#WARNING}. The message of the Throwable will be the message.
      *
      * @param thrown the Throwable to log.
      */
@@ -99,6 +120,13 @@ public interface ILogger {
     void warning(String message, Throwable thrown);
 
     /**
+     * Checks if the {@link Level#WARNING} is enabled.
+     *
+     * @return true if enabled, false otherwise.
+     */
+    boolean isWarningEnabled();
+
+    /**
      * Logs a message at {@link Level#SEVERE}.
      *
      * @param message the message to log.
@@ -106,7 +134,7 @@ public interface ILogger {
     void severe(String message);
 
     /**
-     * Logs a throwable at {@link Level#SEVERE}.  The message of the Throwable will be the message.
+     * Logs a throwable at {@link Level#SEVERE}. The message of the Throwable will be the message.
      *
      * @param thrown the Throwable to log.
      */

--- a/hazelcast/src/main/java/com/hazelcast/logging/NoLogFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/NoLogFactory.java
@@ -19,7 +19,8 @@ package com.hazelcast.logging;
 import java.util.logging.Level;
 
 public class NoLogFactory implements LoggerFactory {
-    final ILogger noLogger = new NoLogger();
+
+    private final ILogger noLogger = new NoLogger();
 
     @Override
     public ILogger getLogger(String name) {
@@ -27,60 +28,98 @@ public class NoLogFactory implements LoggerFactory {
     }
 
     static class NoLogger implements ILogger {
-        @Override public void finest(String message) {
+
+        @Override
+        public void finest(String message) {
         }
 
-        @Override public void finest(String message, Throwable thrown) {
+        @Override
+        public void finest(Throwable thrown) {
         }
 
-        @Override public void finest(Throwable thrown) {
+        @Override
+        public void finest(String message, Throwable thrown) {
         }
 
-        @Override public boolean isFinestEnabled() {
+        @Override
+        public boolean isFinestEnabled() {
             return false;
         }
 
-        @Override public void fine(String message) {
+        @Override
+        public void fine(String message) {
         }
 
-        @Override public boolean isFineEnabled() {
+        @Override
+        public void fine(Throwable thrown) {
+        }
+
+        @Override
+        public void fine(String message, Throwable thrown) {
+        }
+
+        @Override
+        public boolean isFineEnabled() {
             return false;
         }
 
-        @Override public void info(String message) {
+        @Override
+        public void info(String message) {
         }
 
-        @Override public void severe(String message) {
+        @Override
+        public boolean isInfoEnabled() {
+            return false;
         }
 
-        @Override public void severe(Throwable thrown) {
+        @Override
+        public void warning(String message) {
         }
 
-        @Override public void severe(String message, Throwable thrown) {
+        @Override
+        public void warning(Throwable thrown) {
         }
 
-        @Override public void warning(String message) {
+        @Override
+        public void warning(String message, Throwable thrown) {
         }
 
-        @Override public void warning(Throwable thrown) {
+        @Override
+        public boolean isWarningEnabled() {
+            return false;
         }
 
-        @Override public void warning(String message, Throwable thrown) {
+        @Override
+        public void severe(String message) {
         }
 
-        @Override public void log(Level level, String message) {
+        @Override
+        public void severe(Throwable thrown) {
         }
 
-        @Override public void log(Level level, String message, Throwable thrown) {
+        @Override
+        public void severe(String message, Throwable thrown) {
         }
 
-        @Override public void log(LogEvent logEvent) {
+        @Override
+        public void log(Level level, String message) {
         }
 
-        @Override public Level getLevel() {
+        @Override
+        public void log(Level level, String message, Throwable thrown) {
+        }
+
+        @Override
+        public void log(LogEvent logEvent) {
+        }
+
+        @Override
+        public Level getLevel() {
             return Level.OFF;
         }
-        @Override public boolean isLoggable(Level level) {
+
+        @Override
+        public boolean isLoggable(Level level) {
             return false;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapMetaDataFetcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapMetaDataFetcher.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeoutException;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.logging.Level.WARNING;
 
 /**
  * {@code MetaDataFetcher} for member side usage
@@ -67,9 +66,8 @@ public class MemberMapMetaDataFetcher extends MetaDataFetcher {
             try {
                 futures.add(operationService.invokeOnTarget(SERVICE_NAME, operation, address));
             } catch (Exception e) {
-                if (logger.isLoggable(WARNING)) {
-                    logger.log(WARNING,
-                            "Cant fetch invalidation meta-data from address + " + address + " + [" + e.getMessage() + "]");
+                if (logger.isWarningEnabled()) {
+                    logger.warning("Cant fetch invalidation meta-data from address + " + address + " + [" + e.getMessage() + "]");
                 }
             }
         }
@@ -83,8 +81,8 @@ public class MemberMapMetaDataFetcher extends MetaDataFetcher {
             repairUuids(response.getPartitionUuidList().entrySet(), handlers);
             repairSequences(response.getNamePartitionSequenceList().entrySet(), handlers);
         } catch (Exception e) {
-            if (logger.isLoggable(WARNING)) {
-                logger.log(WARNING, "Cant fetch invalidation meta-data [" + e.getMessage() + "]");
+            if (logger.isWarningEnabled()) {
+                logger.warning("Cant fetch invalidation meta-data [" + e.getMessage() + "]");
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.logging.Level;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
@@ -156,7 +155,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
             if (t.getCause() instanceof QueryResultSizeExceededException) {
                 throw rethrow(t);
             }
-            logger.log(Level.FINE, "Could not get results", t);
+            logger.fine("Could not get results", t);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.map.impl.querycache.subscriber.EventPublisherHelper.publishEventLost;
 import static java.lang.String.format;
-import static java.util.logging.Level.WARNING;
 
 /**
  * If all incoming events are in the correct sequence order, this accumulator applies those events to
@@ -154,7 +153,7 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
         boolean isNextSequence = foundSequence == expectedSequence;
 
         if (!isNextSequence) {
-            if (logger.isLoggable(WARNING)) {
+            if (logger.isWarningEnabled()) {
                 logger.warning(format("Event lost detected for partitionId=%d, expectedSequence=%d "
                                 + "but foundSequence=%d, cacheSize=%d",
                         partitionId, expectedSequence, foundSequence, getQueryCache().size()));

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapEventsDispatcher.java
@@ -29,8 +29,6 @@ import com.hazelcast.map.impl.event.EntryEventData;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.map.impl.event.MapEventData;
 
-import java.util.logging.Level;
-
 /**
  * Dispatches multiMapEvents to appropriate methods of given listener
  */
@@ -88,7 +86,7 @@ class MultiMapEventsDispatcher {
     private Member getMemberOrNull(EventData eventData) {
         final Member member = clusterService.getMember(eventData.getCaller());
         if (member == null) {
-            if (logger.isLoggable(Level.INFO)) {
+            if (logger.isInfoEnabled()) {
                 logger.info("Dropping event " + eventData + " from unknown address:" + eventData.getCaller());
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -495,7 +495,7 @@ public abstract class Operation implements DataSerializable {
             }
         } else if (e instanceof OutOfMemoryError) {
             try {
-                logger.log(Level.SEVERE, e.getMessage(), e);
+                logger.severe(e.getMessage(), e);
             } catch (Throwable ignored) {
                 ignore(ignored);
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/ParkedOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/ParkedOperation.java
@@ -32,7 +32,6 @@ import com.hazelcast.util.Clock;
 import java.util.Queue;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 import static com.hazelcast.util.EmptyStatement.ignore;
 
@@ -167,7 +166,7 @@ class ParkedOperation extends AbstractLocalOperation implements Delayed, Partiti
             logger.warning("Op: " + op + ", " + e.getClass().getName() + ": " + e.getMessage());
         } else if (e instanceof OutOfMemoryError) {
             try {
-                logger.log(Level.SEVERE, e.getMessage(), e);
+                logger.severe(e.getMessage(), e);
             } catch (Throwable ignored) {
                 ignore(ignored);
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -470,9 +470,9 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
             }
         } else if (t instanceof OutOfMemoryError) {
             try {
-                logger.log(SEVERE, t.getMessage(), t);
+                logger.severe(t.getMessage(), t);
             } catch (Throwable ignored) {
-                logger.log(SEVERE, ignored.getMessage(), t);
+                logger.severe(ignored.getMessage(), t);
             }
         } else {
             final Level level = nodeEngine.isRunning() ? SEVERE : FINEST;

--- a/hazelcast/src/test/java/com/hazelcast/test/TestLoggerFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestLoggerFactory.java
@@ -27,6 +27,7 @@ public class TestLoggerFactory implements LoggerFactory {
     }
 
     private static class DelegatingTestLogger implements ILogger {
+
         private ILogger delegate;
 
         private DelegatingTestLogger(ILogger delegate) {
@@ -59,6 +60,16 @@ public class TestLoggerFactory implements LoggerFactory {
         }
 
         @Override
+        public void fine(Throwable thrown) {
+            delegate.fine(thrown);
+        }
+
+        @Override
+        public void fine(String message, Throwable thrown) {
+            delegate.fine(message, thrown);
+        }
+
+        @Override
         public boolean isFineEnabled() {
             return true;
         }
@@ -66,6 +77,11 @@ public class TestLoggerFactory implements LoggerFactory {
         @Override
         public void info(String message) {
             delegate.info(message);
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return true;
         }
 
         @Override
@@ -81,6 +97,11 @@ public class TestLoggerFactory implements LoggerFactory {
         @Override
         public void warning(String message, Throwable thrown) {
             delegate.warning(message, thrown);
+        }
+
+        @Override
+        public boolean isWarningEnabled() {
+            return true;
         }
 
         @Override
@@ -123,5 +144,4 @@ public class TestLoggerFactory implements LoggerFactory {
             return true;
         }
     }
-
 }


### PR DESCRIPTION
I saw that we were missing some convenience methods in `ILogger`, so we had to use `logger.log(Level.XXX, ...)` and `logger.isLoggable(Level.XXX)` in a lot of places.

Less imports, shorted code, happy developers :)