### PR TITLE
Fixes testListenersSmartRoutingTerminateRandomNode

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -39,7 +39,10 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -51,12 +54,14 @@ import static org.junit.Assert.assertTrue;
 public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport {
 
     protected HazelcastInstance client;
-    protected AtomicInteger eventCount;
+    private AtomicInteger eventCount;
     private String registrationId;
     private int clusterSize;
 
     private static final int EVENT_COUNT = 10;
     private TestHazelcastFactory factory = new TestHazelcastFactory();
+    private Set<String> events = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+    private CountDownLatch eventsLatch = new CountDownLatch(1);
 
     @After
     public void tearDown() {
@@ -502,28 +507,31 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
     }
 
     private void validateListenerFunctionality() {
-        for (int i = 0; i < EVENT_COUNT; i++) {
-            produceEvent();
-        }
-
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                int count = eventCount.get();
-                assertTrue("Received event count is " + count + " but it is expected to be at least " + EVENT_COUNT,
-                        count >= EVENT_COUNT);
+                events.clear();
+                eventCount.set(0);
+                for (int i = 0; i < EVENT_COUNT; i++) {
+                    events.add(randomString());
+                }
+
+                for (String event : events) {
+                    produceEvent(event);
+                }
+
+                assertTrueAllTheTime(new AssertTask() {
+                    @Override
+                    public void run()
+                            throws Exception {
+                        int count = eventCount.get();
+                        assertEquals("Received event count is " + count + " but it is expected to stay at " + EVENT_COUNT, EVENT_COUNT,
+                                eventCount.get());
+                    }
+                }, 3);
             }
         });
 
-        assertTrueAllTheTime(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                int count = eventCount.get();
-                assertEquals("Received event count is " + count + " but it is expected to stay at " + EVENT_COUNT, EVENT_COUNT,
-                        eventCount.get());
-            }
-        }, 3);
     }
 
     private void terminateRandomNode() {
@@ -570,7 +578,15 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
 
     protected abstract String addListener();
 
-    protected abstract void produceEvent();
+    protected abstract void produceEvent(String event);
+
+    void onEvent(String event) {
+        events.remove(event);
+        eventCount.incrementAndGet();
+        if (events.isEmpty()) {
+            eventsLatch.countDown();
+        }
+    }
 
     protected abstract boolean removeListener(String registrationId);
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
+public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
     private IMap<String, String> iMap;
 
@@ -35,17 +35,17 @@ public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTe
     protected String addListener() {
         iMap = client.getMap(randomString());
 
-        final EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {
-            public void onEntryEvent(EntryEvent<Object, Object> event) {
-                eventCount.incrementAndGet();
+        final EntryAdapter<String, String> listener = new EntryAdapter<String, String>() {
+            public void onEntryEvent(EntryEvent<String, String> event) {
+                onEvent(event.getKey());
             }
         };
         return iMap.addEntryListener(listener, true);
     }
 
     @Override
-    public void produceEvent() {
-        iMap.put(randomString(), randomString());
+    public void produceEvent(String event) {
+        iMap.put(event, randomString());
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
+public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
     private IList<String> iList;
 
@@ -37,8 +37,8 @@ public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnec
 
         ItemListener<String> listener = new ItemListener<String>() {
             @Override
-            public void itemAdded(ItemEvent item) {
-                eventCount.incrementAndGet();
+            public void itemAdded(ItemEvent<String> item) {
+                onEvent(item.getItem());
             }
 
             @Override
@@ -50,8 +50,8 @@ public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnec
     }
 
     @Override
-    public void produceEvent() {
-        iList.add(randomString());
+    public void produceEvent(String event) {
+        iList.add(event);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
+public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
     private MultiMap<String, String> multiMap;
 
@@ -22,15 +22,15 @@ public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnRec
         EntryAdapter<String, String> listener = new EntryAdapter<String, String>() {
             @Override
             public void onEntryEvent(EntryEvent<String, String> event) {
-                eventCount.incrementAndGet();
+                onEvent(event.getKey());
             }
         };
         return multiMap.addEntryListener(listener, true);
     }
 
     @Override
-    public void produceEvent() {
-        multiMap.put(randomString(), randomString());
+    public void produceEvent(String event) {
+        multiMap.put(event, randomString());
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
+public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
     private IQueue<String> iQueue;
 
@@ -37,8 +37,8 @@ public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconne
 
         ItemListener<String> listener = new ItemListener<String>() {
             @Override
-            public void itemAdded(ItemEvent item) {
-                eventCount.incrementAndGet();
+            public void itemAdded(ItemEvent<String> item) {
+                onEvent(item.getItem());
             }
 
             @Override
@@ -50,8 +50,8 @@ public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconne
     }
 
     @Override
-    public void produceEvent() {
-        iQueue.add(randomString());
+    public void produceEvent(String event) {
+        iQueue.add(event);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
@@ -37,15 +37,15 @@ public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListeners
         final EntryAdapter<String, String> listener = new EntryAdapter<String, String>() {
             @Override
             public void onEntryEvent(EntryEvent<String, String> event) {
-                eventCount.incrementAndGet();
+                onEvent(event.getKey());
             }
         };
         return replicatedMap.addEntryListener(listener);
     }
 
     @Override
-    public void produceEvent() {
-        replicatedMap.put(randomString(), randomString());
+    public void produceEvent(String event) {
+        replicatedMap.put(event, randomString());
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
@@ -37,8 +37,8 @@ public class SetItemListenerOnReconnectTest extends AbstractListenersOnReconnect
 
         ItemListener<String> listener = new ItemListener<String>() {
             @Override
-            public void itemAdded(ItemEvent item) {
-                eventCount.incrementAndGet();
+            public void itemAdded(ItemEvent<String> item) {
+                onEvent(item.getItem());
             }
 
             @Override
@@ -49,8 +49,8 @@ public class SetItemListenerOnReconnectTest extends AbstractListenersOnReconnect
     }
 
     @Override
-    public void produceEvent() {
-        iSet.add(randomString());
+    public void produceEvent(String event) {
+        iSet.add(event);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
@@ -21,16 +21,16 @@ public class TopicOnReconnectTest extends AbstractListenersOnReconnectTest {
 
         MessageListener<String> listener = new MessageListener<String>() {
             @Override
-            public void onMessage(Message message) {
-                eventCount.incrementAndGet();
+            public void onMessage(Message<String> message) {
+                onEvent(message.getMessageObject());
             }
         };
         return topic.addMessageListener(listener);
     }
 
     @Override
-    public void produceEvent() {
-        topic.publish(randomString());
+    public void produceEvent(String event) {
+        topic.publish(event);
     }
 
     @Override


### PR DESCRIPTION
Test was failing because we were not giving enough time to listeners
to registered back when a new member is added.

Fixed via giving more change to verification part.
fixes #9803