### PR TITLE
Fixes testListenersSmartRoutingTerminateRandomNode

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/EntryListenerOnReconnectTest.java
@@ -27,24 +27,24 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
+public class EntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
-    private IMap iMap;
+    private IMap<String, String> iMap;
 
     @Override
     protected String addListener() {
         iMap = client.getMap(randomString());
-        final EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {
-            public void onEntryEvent(EntryEvent<Object, Object> event) {
-                eventCount.incrementAndGet();
+        final EntryAdapter<String, String> listener = new EntryAdapter<String, String>() {
+            public void onEntryEvent(EntryEvent<String, String> event) {
+                onEvent(event.getKey());
             }
         };
         return iMap.addEntryListener(listener, true);
     }
 
     @Override
-    public void produceEvent() {
-        iMap.put(randomString(), randomString());
+    public void produceEvent(String event) {
+        iMap.put(event, randomString());
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListItemListenerOnReconnectTest.java
@@ -27,17 +27,17 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
+public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
-    private IList iList;
+    private IList<String> iList;
 
     @Override
     protected String addListener() {
         iList = client.getList(randomString());
-        ItemListener listener = new ItemListener() {
+        ItemListener<String> listener = new ItemListener<String>() {
             @Override
-            public void itemAdded(ItemEvent item) {
-                eventCount.incrementAndGet();
+            public void itemAdded(ItemEvent<String> item) {
+                onEvent(item.getItem());
             }
 
             @Override
@@ -49,8 +49,8 @@ public class ListItemListenerOnReconnectTest extends AbstractListenersOnReconnec
     }
 
     @Override
-    public void produceEvent() {
-        iList.add(randomString());
+    public void produceEvent(String event) {
+        iList.add(event);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/MultiMapEntryListenerOnReconnectTest.java
@@ -11,24 +11,25 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
+public class MultiMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
-    private MultiMap multiMap;
+    private MultiMap<String, String> multiMap;
 
     @Override
     protected String addListener() {
         multiMap = client.getMultiMap(randomString());
-        final EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {
-            public void onEntryEvent(EntryEvent<Object, Object> event) {
-                eventCount.incrementAndGet();
+        EntryAdapter<String, String> listener = new EntryAdapter<String, String>() {
+            @Override
+            public void onEntryEvent(EntryEvent<String, String> event) {
+                onEvent(event.getKey());
             }
         };
         return multiMap.addEntryListener(listener, true);
     }
 
     @Override
-    public void produceEvent() {
-        multiMap.put(randomString(), randomString());
+    public void produceEvent(String event) {
+        multiMap.put(event, randomString());
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/QueueItemListenerOnReconnectTest.java
@@ -27,21 +27,21 @@ import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
+public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest{
 
-    private IQueue iQueue;
+    private IQueue<String> iQueue;
 
     @Override
     protected String addListener() {
         iQueue = client.getQueue(randomString());
-        ItemListener listener = new ItemListener() {
+        ItemListener<String> listener = new ItemListener<String>() {
             @Override
-            public void itemAdded(ItemEvent item) {
-                eventCount.incrementAndGet();
+            public void itemAdded(ItemEvent<String> item) {
+                onEvent(item.getItem());
             }
 
             @Override
-            public void itemRemoved(ItemEvent item) {
+            public void itemRemoved(ItemEvent<String> item) {
 
             }
         };
@@ -49,8 +49,8 @@ public class QueueItemListenerOnReconnectTest extends AbstractListenersOnReconne
     }
 
     @Override
-    public void produceEvent() {
-        iQueue.add(randomString());
+    public void produceEvent(String event) {
+        iQueue.add(event);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ReplicatedMapEntryListenerOnReconnectTest.java
@@ -29,22 +29,23 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapEntryListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
 
-    private ReplicatedMap replicatedMap;
+    private ReplicatedMap<String, String> replicatedMap;
 
     @Override
     protected String addListener() {
         replicatedMap = client.getReplicatedMap(randomString());
-        final EntryAdapter<Object, Object> listener = new EntryAdapter<Object, Object>() {
-            public void onEntryEvent(EntryEvent<Object, Object> event) {
-                eventCount.incrementAndGet();
+        final EntryAdapter<String, String> listener = new EntryAdapter<String, String>() {
+            @Override
+            public void onEntryEvent(EntryEvent<String, String> event) {
+                onEvent(event.getKey());
             }
         };
         return replicatedMap.addEntryListener(listener);
     }
 
     @Override
-    public void produceEvent() {
-        replicatedMap.put(randomString(), randomString());
+    public void produceEvent(String event) {
+        replicatedMap.put(event, randomString());
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/SetItemListenerOnReconnectTest.java
@@ -29,19 +29,19 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelTest.class})
 public class SetItemListenerOnReconnectTest extends AbstractListenersOnReconnectTest {
 
-    private ISet iSet;
+    private ISet<String> iSet;
 
     @Override
     protected String addListener() {
         iSet = client.getSet(randomString());
-        ItemListener listener = new ItemListener() {
+        ItemListener<String> listener = new ItemListener<String>() {
             @Override
-            public void itemAdded(ItemEvent item) {
-                eventCount.incrementAndGet();
+            public void itemAdded(ItemEvent<String> item) {
+                onEvent(item.getItem());
             }
 
             @Override
-            public void itemRemoved(ItemEvent item) {
+            public void itemRemoved(ItemEvent<String> item) {
 
             }
         };
@@ -49,8 +49,8 @@ public class SetItemListenerOnReconnectTest extends AbstractListenersOnReconnect
     }
 
     @Override
-    public void produceEvent() {
-        iSet.add(randomString());
+    public void produceEvent(String event) {
+        iSet.add(event);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/TopicOnReconnectTest.java
@@ -13,23 +13,23 @@ import org.junit.runner.RunWith;
 @Category({QuickTest.class, ParallelTest.class})
 public class TopicOnReconnectTest extends AbstractListenersOnReconnectTest {
 
-    private ITopic topic;
+    private ITopic<String> topic;
 
     @Override
     protected String addListener() {
         topic = client.getTopic(randomString());
-        MessageListener listener = new MessageListener() {
+        MessageListener<String> listener = new MessageListener<String>() {
             @Override
-            public void onMessage(Message message) {
-                eventCount.incrementAndGet();
+            public void onMessage(Message<String> message) {
+                onEvent(message.getMessageObject());
             }
         };
         return topic.addMessageListener(listener);
     }
 
     @Override
-    public void produceEvent() {
-        topic.publish(randomString());
+    public void produceEvent(String event) {
+        topic.publish(event);
     }
 
     @Override


### PR DESCRIPTION
Test was failing because we were not giving enough time to listeners
to registered back when a new member is added.

Fixed via giving more change to verification part.
fixes #9803