### PR TITLE
Fire MERGE_FAILED when node fails to merge to discovered cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
@@ -42,6 +42,7 @@ public final class LifecycleEvent {
         SHUTDOWN,
         MERGING,
         MERGED,
+        MERGE_FAILED,
         CLIENT_CONNECTED,
         CLIENT_DISCONNECTED
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -335,7 +335,7 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
         }
     }
 
-    private static void blockCommunicationBetween(HazelcastInstance h1, HazelcastInstance h2) {
+    public static void blockCommunicationBetween(HazelcastInstance h1, HazelcastInstance h2) {
         FirewallingMockConnectionManager h1CM = getFireWalledConnectionManager(h1);
         FirewallingMockConnectionManager h2CM = getFireWalledConnectionManager(h2);
         Node h1Node = getNode(h1);
@@ -344,7 +344,7 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
         h2CM.block(h1Node.getThisAddress());
     }
 
-    private static void unblockCommunicationBetween(HazelcastInstance h1, HazelcastInstance h2) {
+    public static void unblockCommunicationBetween(HazelcastInstance h1, HazelcastInstance h2) {
         FirewallingMockConnectionManager h1CM = getFireWalledConnectionManager(h1);
         FirewallingMockConnectionManager h2CM = getFireWalledConnectionManager(h2);
         Node h1Node = getNode(h1);


### PR DESCRIPTION
Currently there are only `MERGING`, `MERGED` events, but no event fired for a failed merge.

Fixes #9856