### PR TITLE
Updates in Serializable & DataSerializable conventions test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.cache;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 import java.io.Serializable;
 
 /**
@@ -29,6 +31,7 @@ import java.io.Serializable;
  * (s)he should use {@link StorageTypeAwareCacheMergePolicy} which is sub-type of this interface.
  * </p>
  */
+@BinaryInterface
 public interface CacheMergePolicy extends Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheMergePolicy.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.cache;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/HazelcastExpiryPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/HazelcastExpiryPolicy.java
@@ -20,7 +20,7 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
@@ -19,7 +19,7 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventDataImpl.java
@@ -19,6 +19,7 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
@@ -27,6 +28,7 @@ import java.io.IOException;
  *
  * @see com.hazelcast.cache.impl.CacheEventData
  */
+@BinaryInterface
 public class CacheEventDataImpl
         implements CacheEventData {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CachePartitionEventData.java
@@ -19,9 +19,11 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public class CachePartitionEventData extends CacheEventDataImpl implements CacheEventData {
 
     private int partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.eviction.Evictable;
 import com.hazelcast.internal.eviction.EvictionCandidate;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+@SerializableByConvention
 public class CacheRecordHashMap
         extends SampleableConcurrentHashMap<Data, CacheRecord>
         implements SampleableCacheRecordMap<Data, CacheRecord> {

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
@@ -18,11 +18,13 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * `HigherHitsCacheMergePolicy` merges cache entry from source to destination cache
  * if source entry has more hits than the destination one.
  */
+@BinaryInterface
 public class HigherHitsCacheMergePolicy
         implements StorageTypeAwareCacheMergePolicy {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/HigherHitsCacheMergePolicy.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * `HigherHitsCacheMergePolicy` merges cache entry from source to destination cache

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
@@ -18,11 +18,13 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * `LatestAccessCacheMergePolicy` merges cache entry from source to destination cache
  * if source entry has been accessed more recently than the destination entry.
  */
+@BinaryInterface
 public class LatestAccessCacheMergePolicy
         implements StorageTypeAwareCacheMergePolicy {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/LatestAccessCacheMergePolicy.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * `LatestAccessCacheMergePolicy` merges cache entry from source to destination cache

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination directly.

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PassThroughCacheMergePolicy.java
@@ -18,10 +18,12 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination directly.
  */
+@BinaryInterface
 public class PassThroughCacheMergePolicy
         implements StorageTypeAwareCacheMergePolicy {
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
@@ -18,7 +18,7 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination

--- a/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/merge/PutIfAbsentCacheMergePolicy.java
@@ -18,11 +18,13 @@ package com.hazelcast.cache.merge;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.StorageTypeAwareCacheMergePolicy;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * `PassThroughCacheMergePolicy` policy merges cache entry from source to destination
  * if it does not exist in the destination cache.
  */
+@BinaryInterface
 public class PutIfAbsentCacheMergePolicy
         implements StorageTypeAwareCacheMergePolicy {
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.version.MemberVersion;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/InternalLockNamespace.java
@@ -18,10 +18,13 @@ package com.hazelcast.concurrent.lock;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.impl.operationparker.impl.OperationParkerImpl;
 
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 
 /**
  * A specialization of {@link ObjectNamespace} intended to be used by ILock proxies.
@@ -47,6 +50,7 @@ import java.io.IOException;
  * @see OperationParkerImpl#cancelParkedOperations(String, Object, Throwable)
  *
  */
+@SerializableByConvention(PUBLIC_API)
 public final class InternalLockNamespace implements ObjectNamespace {
 
     private String name;

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.CompleteConfiguration;

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -22,7 +22,7 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExp
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.CompleteConfiguration;

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfigReadOnly.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.Factory;

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfig.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheEvictionConfigReadOnly.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * Read only version of {@link CacheEvictionConfig}.

--- a/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfig.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CachePartitionLostListenerConfigReadOnly.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.EventListener;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -23,7 +23,7 @@ import com.hazelcast.internal.eviction.EvictionStrategyType;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfigReadOnly.java
@@ -17,7 +17,7 @@
 package com.hazelcast.config;
 
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * Read only version of {@link com.hazelcast.config.EvictionConfig}.

--- a/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheConfig.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.TypedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.Factory;

--- a/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheEvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LegacyCacheEvictionConfig.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.TypedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
@@ -19,7 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * Contains the configuration for a size of Map.

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -19,7 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRefReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRefReadOnly.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.List;
 

--- a/hazelcast/src/main/java/com/hazelcast/console/Echo.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/Echo.java
@@ -21,7 +21,7 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;

--- a/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
@@ -18,7 +18,7 @@ package com.hazelcast.console;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 import java.util.concurrent.Callable;

--- a/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
@@ -18,6 +18,7 @@ package com.hazelcast.console;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.Serializable;
 import java.util.concurrent.Callable;
@@ -25,6 +26,7 @@ import java.util.concurrent.Callable;
 /**
  * A simulated load test.
  */
+@BinaryInterface
 public final class SimulateLoadTask implements Callable, Serializable, HazelcastInstanceAware {
 
     private static final long serialVersionUID = 1;

--- a/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
@@ -22,14 +22,17 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 
 import static com.hazelcast.cluster.MemberAttributeOperationType.PUT;
+import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 import static java.util.Collections.EMPTY_SET;
 
 @SuppressFBWarnings("SE_BAD_FIELD")
+@SerializableByConvention(PUBLIC_API)
 public class MemberAttributeEvent extends MembershipEvent implements DataSerializable {
 
     private MemberAttributeOperationType operationType;

--- a/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MigrationEvent.java
@@ -19,11 +19,14 @@ package com.hazelcast.core;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.partition.PartitionEvent;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 
 /**
  * An event fired when a partition migration starts, completes or fails.
@@ -32,6 +35,7 @@ import java.io.IOException;
  * @see PartitionService
  * @see MigrationListener
  */
+@SerializableByConvention(PUBLIC_API)
 public class MigrationEvent implements DataSerializable, PartitionEvent {
 
     private int partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/core/PartitionAwareKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/PartitionAwareKey.java
@@ -19,7 +19,7 @@ package com.hazelcast.core;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.version.MemberVersion;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.internal.eviction;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 import java.util.Comparator;
 
@@ -25,7 +23,6 @@ import java.util.Comparator;
  * A kind of {@link java.util.Comparator} to be used while comparing
  * entries to be evicted.
  */
-@BinaryInterface
 public abstract class EvictionPolicyComparator<K, V, E extends EvictableEntryView<K, V>>
         implements Comparator<E>, Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LFUEvictionPolicyComparator.java
@@ -18,14 +18,12 @@ package com.hazelcast.internal.eviction.impl.comparator;
 
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#LFU} policy based {@link EvictionPolicyComparator}.
  */
-@SuppressFBWarnings(
-        value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE",
-        justification = "No need to serializable since its instance is not serialized")
+@SerializableByConvention
 public class LFUEvictionPolicyComparator extends EvictionPolicyComparator {
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/LRUEvictionPolicyComparator.java
@@ -18,14 +18,12 @@ package com.hazelcast.internal.eviction.impl.comparator;
 
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#LRU} policy based {@link EvictionPolicyComparator}.
  */
-@SuppressFBWarnings(
-        value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE",
-        justification = "No need to serializable since its instance is not serialized")
+@SerializableByConvention
 public class LRUEvictionPolicyComparator extends EvictionPolicyComparator {
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/comparator/RandomEvictionPolicyComparator.java
@@ -18,14 +18,12 @@ package com.hazelcast.internal.eviction.impl.comparator;
 
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
 /**
  * {@link com.hazelcast.config.EvictionPolicy#RANDOM} policy based {@link EvictionPolicyComparator}.
  */
-@SuppressFBWarnings(
-        value = "SE_COMPARATOR_SHOULD_BE_SERIALIZABLE",
-        justification = "No need to serializable since its instance is not serialized")
+@SerializableByConvention
 public class RandomEvictionPolicyComparator extends EvictionPolicyComparator {
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/BatchInvalidator.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.IFunction;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.LifecycleService;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
@@ -225,6 +226,7 @@ public class BatchInvalidator extends Invalidator {
         super.reset();
     }
 
+    @SerializableByConvention
     public static class InvalidationQueue extends ConcurrentLinkedQueue<Invalidation> {
         private final AtomicInteger elementCount = new AtomicInteger(0);
         private final AtomicBoolean flushingInProgress = new AtomicBoolean(false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.nearcache.impl.invalidation;
 
 import com.hazelcast.core.IFunction;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.EventRegistration;
 
 import static java.lang.Boolean.TRUE;
@@ -27,12 +28,15 @@ import static java.lang.Boolean.TRUE;
 public final class InvalidationUtils {
 
     public static final long NO_SEQUENCE = -1L;
-    public static final IFunction<EventRegistration, Boolean> TRUE_FILTER = new IFunction<EventRegistration, Boolean>() {
+    public static final IFunction<EventRegistration, Boolean> TRUE_FILTER = new TrueFilter();
+
+    @SerializableByConvention
+    public static class TrueFilter implements IFunction<EventRegistration, Boolean> {
         @Override
         public Boolean apply(EventRegistration eventRegistration) {
             return TRUE;
         }
-    };
+    }
 
     private InvalidationUtils() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/InvalidationUtils.java
@@ -30,14 +30,14 @@ public final class InvalidationUtils {
     public static final long NO_SEQUENCE = -1L;
     public static final IFunction<EventRegistration, Boolean> TRUE_FILTER = new TrueFilter();
 
+    private InvalidationUtils() {
+    }
+
     @SerializableByConvention
-    public static class TrueFilter implements IFunction<EventRegistration, Boolean> {
+    private static class TrueFilter implements IFunction<EventRegistration, Boolean> {
         @Override
         public Boolean apply(EventRegistration eventRegistration) {
             return TRUE;
         }
-    }
-
-    private InvalidationUtils() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/HeapNearCacheRecordMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/HeapNearCacheRecordMap.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.eviction.EvictionCandidate;
 import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.nearcache.NearCacheRecord;
 import com.hazelcast.internal.nearcache.impl.SampleableNearCacheRecordMap;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
@@ -29,6 +30,7 @@ import com.hazelcast.util.SampleableConcurrentHashMap;
  * @param <K> the type of the key stored in Near Cache
  * @param <V> the type of the value stored in Near Cache
  */
+@SerializableByConvention
 public class HeapNearCacheRecordMap<K, V extends NearCacheRecord>
         extends SampleableConcurrentHashMap<K, V>
         implements SampleableNearCacheRecordMap<K, V> {

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.ByteArraySerializer;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.serialization.VersionedPortable;
@@ -34,11 +35,7 @@ import java.util.Set;
 
 public final class SerializationUtil {
 
-    static final PartitioningStrategy EMPTY_PARTITIONING_STRATEGY = new PartitioningStrategy() {
-        public Object getPartitionKey(Object key) {
-            return null;
-        }
-    };
+    static final PartitioningStrategy EMPTY_PARTITIONING_STRATEGY = new EmptyPartitioningStrategy();
 
     private SerializationUtil() {
     }
@@ -120,4 +117,10 @@ public final class SerializationUtil {
         return new ObjectDataInputStream(in, ss);
     }
 
+    @SerializableByConvention
+    private static class EmptyPartitioningStrategy implements PartitioningStrategy {
+        public Object getPartitionKey(Object key) {
+            return null;
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
@@ -16,11 +16,13 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
+
+import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 
 /**
  * An abstract {@link EntryProcessor} that already has implemented the {@link #getBackupProcessor()}. In a most cases you
@@ -37,7 +39,6 @@ import java.util.Map;
  * @see com.hazelcast.map.EntryProcessor
  * @see com.hazelcast.map.EntryBackupProcessor
  */
-@BinaryInterface
 public abstract class AbstractEntryProcessor<K, V> implements EntryProcessor<K, V> {
 
     private final EntryBackupProcessor<K, V> entryBackupProcessor;
@@ -67,6 +68,7 @@ public abstract class AbstractEntryProcessor<K, V> implements EntryProcessor<K, 
         return entryBackupProcessor;
     }
 
+    @SerializableByConvention(PUBLIC_API)
     private class EntryBackupProcessorImpl implements EntryBackupProcessor<K, V>, HazelcastInstanceAware {
         // to fix https://github.com/hazelcast/hazelcast/issues/10083 we need to add the HazelcastInstanceAware
         // interface on the EntryBackupProcessorImpl. Unfortunately this changes the generated serialVersionUID

--- a/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -35,6 +35,7 @@ import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
@@ -70,13 +71,7 @@ public class MapContainer {
     protected final SerializationService serializationService;
     protected final QueryEntryFactory queryEntryFactory;
     protected final InterceptorRegistry interceptorRegistry = new InterceptorRegistry();
-    protected final IFunction<Object, Data> toDataFunction = new IFunction<Object, Data>() {
-        @Override
-        public Data apply(Object input) {
-            SerializationService ss = mapStoreContext.getSerializationService();
-            return ss.toData(input, partitioningStrategy);
-        }
-    };
+    protected final IFunction<Object, Data> toDataFunction = new ObjectToData();
     protected final ConstructorFunction<Void, RecordFactory> recordFactoryConstructor;
     /**
      * Holds number of registered {@link InvalidationListener} from clients.
@@ -289,6 +284,15 @@ public class MapContainer {
 
     public boolean shouldCloneOnEntryProcessing() {
         return getIndexes().hasIndex() && OBJECT.equals(mapConfig.getInMemoryFormat());
+    }
+
+    @SerializableByConvention
+    private class ObjectToData implements IFunction<Object, Data> {
+        @Override
+        public Data apply(Object input) {
+            SerializationService ss = mapStoreContext.getSerializationService();
+            return ss.toData(input, partitioningStrategy);
+        }
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntrySimple.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapEntrySimple.java
@@ -16,8 +16,11 @@
 
 package com.hazelcast.map.impl;
 
+import com.hazelcast.nio.serialization.SerializableByConvention;
+
 import java.util.AbstractMap;
 
+@SerializableByConvention
 public class MapEntrySimple<K, V> extends AbstractMap.SimpleEntry<K, V> {
 
     private boolean modified;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.event;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.event;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * General contract for map event data.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.event;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.event;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -35,6 +35,7 @@ import com.hazelcast.map.impl.MapManagedService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.nearcache.invalidation.MemberMapMetaDataFetcher;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.ExecutionService;
@@ -88,6 +89,7 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
     /**
      * Filters out listeners other than invalidation related ones.
      */
+    @SerializableByConvention
     private static class InvalidationAcceptorFilter implements IFunction<EventRegistration, Boolean> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -61,6 +61,7 @@ import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.DefaultObjectNamespace;
@@ -492,11 +493,7 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
     }
 
     protected <K> Iterable<Data> convertToData(Iterable<K> keys) {
-        return IterableUtil.map(nullToEmpty(keys), new IFunction<K, Data>() {
-            public Data apply(K key) {
-                return toData(key);
-            }
-        });
+        return IterableUtil.map(nullToEmpty(keys), new KeyToData<K>());
     }
 
     private Operation createLoadAllOperation(List<Data> keys, boolean replaceExistingValues) {
@@ -1198,5 +1195,12 @@ abstract class MapProxySupport extends AbstractDistributedObject<MapService> imp
 
     public int getTotalBackupCount() {
         return mapConfig.getBackupCount() + mapConfig.getAsyncBackupCount();
+    }
+
+    @SerializableByConvention
+    private class KeyToData<K> implements IFunction<K, Data> {
+        public Data apply(K key) {
+            return toData(key);
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/NodeQueryCacheContext.java
@@ -36,6 +36,7 @@ import com.hazelcast.map.impl.querycache.subscriber.NodeSubscriberContext;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
@@ -73,12 +74,7 @@ public class NodeQueryCacheContext implements QueryCacheContext {
         this.invokerWrapper = new NodeInvokerWrapper(nodeEngine.getOperationService());
         // init these in the end
         this.subscriberContext = new NodeSubscriberContext(this);
-        this.publisherContext = new DefaultPublisherContext(this, nodeEngine, new IFunction<String, String>() {
-            @Override
-            public String apply(String mapName) {
-                return registerLocalIMapListener(mapName);
-            }
-        });
+        this.publisherContext = new DefaultPublisherContext(this, nodeEngine, new RegisterMapListenerFunction());
         flushPublishersOnNodeShutdown();
     }
 
@@ -180,4 +176,12 @@ public class NodeQueryCacheContext implements QueryCacheContext {
             }
         }, mapName);
     }
+
+    @SerializableByConvention
+    private class RegisterMapListenerFunction implements IFunction<String, String> {
+        @Override
+        public String apply(String mapName) {
+            return registerLocalIMapListener(mapName);
+        }
+    };
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
@@ -21,7 +21,7 @@ import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
@@ -20,7 +20,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventData.java
@@ -20,7 +20,7 @@ import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventData.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.querycache.event;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordHashMap.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.eviction.EvictionListener;
 import com.hazelcast.internal.eviction.impl.strategy.sampling.SampleableEvictableStore;
 import com.hazelcast.map.impl.querycache.subscriber.record.QueryCacheRecord;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
 import com.hazelcast.util.SampleableConcurrentHashMap;
@@ -34,6 +35,7 @@ import java.util.EnumSet;
  * @see SampleableConcurrentHashMap
  * @see SampleableEvictableStore
  */
+@SerializableByConvention
 public class QueryCacheRecordHashMap extends SampleableConcurrentHashMap<Data, QueryCacheRecord>
         implements SampleableEvictableStore<Data, QueryCacheRecord> {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageSCHM.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageSCHM.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
@@ -26,6 +27,7 @@ import com.hazelcast.util.SampleableConcurrentHashMap;
  *
  * @param <R> Type of records in this CHM
  */
+@SerializableByConvention
 public class StorageSCHM<R extends Record> extends SampleableConcurrentHashMap<Data, R> {
 
     private static final int DEFAULT_INITIAL_CAPACITY = 256;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/CombinerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/CombinerFactory.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/JobPartitionState.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/JobPartitionState.java
@@ -17,7 +17,7 @@
 package com.hazelcast.mapreduce;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * An implementation of this interface contains current information about

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyPredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
@@ -24,7 +24,7 @@ import com.hazelcast.mapreduce.impl.ListKeyValueSource;
 import com.hazelcast.mapreduce.impl.MapKeyValueSource;
 import com.hazelcast.mapreduce.impl.MultiMapKeyValueSource;
 import com.hazelcast.mapreduce.impl.SetKeyValueSource;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 
 import java.io.Closeable;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapper.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * <p>The LifecycleMapper interface is a more sophisticated version of {@link Mapper} normally used for more complex

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapperAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapperAdapter.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 /**
  * <p>

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Mapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Mapper.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducerFactory.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationCombinerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationCombinerFactory.java
@@ -20,7 +20,7 @@ import com.hazelcast.mapreduce.CombinerFactory;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationReducerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationReducerFactory.java
@@ -20,7 +20,7 @@ import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/CountAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/CountAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
@@ -28,7 +28,7 @@ import com.hazelcast.mapreduce.impl.task.DefaultContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongAvgAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMinAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongSumAggregation.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.Map;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
@@ -23,7 +23,7 @@ import com.hazelcast.mapreduce.impl.task.DefaultContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
@@ -25,7 +25,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
@@ -26,7 +26,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionService;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MultiMapKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MultiMapKeyValueSource.java
@@ -27,7 +27,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionService;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
@@ -26,7 +26,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
@@ -25,7 +25,7 @@ import com.hazelcast.mapreduce.impl.CombinerResultList;
 import com.hazelcast.mapreduce.impl.HashMapAdapter;
 import com.hazelcast.mapreduce.impl.MapReduceUtil;
 import com.hazelcast.nio.serialization.SerializableByConvention;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
 import com.hazelcast.util.IConcurrentMap;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
@@ -24,6 +24,7 @@ import com.hazelcast.mapreduce.Context;
 import com.hazelcast.mapreduce.impl.CombinerResultList;
 import com.hazelcast.mapreduce.impl.HashMapAdapter;
 import com.hazelcast.mapreduce.impl.MapReduceUtil;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
 import com.hazelcast.util.IConcurrentMap;
@@ -56,14 +57,7 @@ public class DefaultContext<KeyIn, ValueIn>
     private final CombinerFactory<KeyIn, ValueIn, ?> combinerFactory;
     private final MapCombineTask mapCombineTask;
 
-    private final IFunction<KeyIn, Combiner<ValueIn, ?>> combinerFunction = new IFunction<KeyIn, Combiner<ValueIn, ?>>() {
-        @Override
-        public Combiner<ValueIn, ?> apply(KeyIn keyIn) {
-            Combiner<ValueIn, ?> combiner = combinerFactory.newCombiner(keyIn);
-            combiner.beginCombine();
-            return combiner;
-        }
-    };
+    private final IFunction<KeyIn, Combiner<ValueIn, ?>> combinerFunction = new CombinerFunction();
 
     // This field is only accessed through the updater
     private volatile int collected;
@@ -163,4 +157,13 @@ public class DefaultContext<KeyIn, ValueIn>
         }
     }
 
+    @SerializableByConvention
+    private class CombinerFunction implements IFunction<KeyIn, Combiner<ValueIn, ?>> {
+        @Override
+        public Combiner<ValueIn, ?> apply(KeyIn keyIn) {
+            Combiner<ValueIn, ?> combiner = combinerFactory.newCombiner(keyIn);
+            combiner.beginCombine();
+            return combiner;
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImpl.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceFacade.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceFacade.java
@@ -21,7 +21,7 @@ import com.hazelcast.mapreduce.KeyValueSource;
 import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.mapreduce.impl.operation.ProcessStatsUpdateOperation;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -18,7 +18,7 @@ package com.hazelcast.nio;
 
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.util.AddressUtil;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/BinaryInterface.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/BinaryInterface.java
@@ -14,7 +14,23 @@
  * limitations under the License.
  */
 
-package com.hazelcast.nio.serialization.impl;
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializableByConvention.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializableByConvention.java
@@ -23,7 +23,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Indicates that the annotated class cannot be converted to {@code IdentifiedDataSerializable} due to other conventions.
+ * Indicates that the annotated class cannot be converted to {@link IdentifiedDataSerializable} due to other conventions.
  * The annotation's {@link #value()} provides reasoning why class cannot be converted. Classes annotated with
  * {@code SerializableByConvention} are excluded from compliance tests by {@code DataSerializableConventionsTest}.
  */
@@ -34,17 +34,19 @@ public @interface SerializableByConvention {
 
     enum Reason {
         /**
-         * Class definition is part of public API so cannot be migrated to {@code IdentifiedDataSerializable}.
+         * Class definition is part of public API so cannot be migrated to {@link IdentifiedDataSerializable} in
+         * minor or patch releases.
          */
         PUBLIC_API,
         /**
          * Class is {@code Serializable} due to conventions and cannot be converted to {@code IdentifiedDataSerializable}.
          * Examples:
          * <ul>
-         *     <li>inheritance from a class external to Hazelcast e.g. {@code CacheEntryEvent}, which imposes
-         *     serializability even when not required</li>
-         *     <li>inheritance from a class external to Hazelcast, however {@code IdentifiedDataSerializable} requires a
-         *     default no-args constructor and non-final fields which  is not always possible (e.g. subclasses of
+         *     <li>inheritance from a class external to Hazelcast e.g. {@link javax.cache.event.CacheEntryEvent} imposes
+         *     serializability to its implementation in {@link com.hazelcast.cache.impl.CacheEntryEventImpl} even though
+         *     the latter is never serialized</li>
+         *     <li>inheritance from a class external to Hazelcast, however {@link IdentifiedDataSerializable} requires a
+         *     default no-args constructor and non-final fields which is not always possible (e.g. subclasses of
          *     {@code java.util.EventObject} & {@code java.lang.Exception})</li>
          *     <li>a {@code Comparator} which should by convention also implement {@code Serializable}.</li>
          * </ul>

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializableByConvention.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializableByConvention.java
@@ -39,17 +39,23 @@ public @interface SerializableByConvention {
          */
         PUBLIC_API,
         /**
-         * Class is {@code Serializable} due to conventions and cannot be converted to {@code IdentifiedDataSerializable}.
+         * Class is {@code Serializable} due to inheritance or other coding conventions and cannot or is not desirable
+         * to have it converted to {@link IdentifiedDataSerializable}.
          * Examples:
          * <ul>
-         *     <li>inheritance from a class external to Hazelcast e.g. {@link javax.cache.event.CacheEntryEvent} imposes
-         *     serializability to its implementation in {@link com.hazelcast.cache.impl.CacheEntryEventImpl} even though
-         *     the latter is never serialized</li>
-         *     <li>inheritance from a class external to Hazelcast, however {@link IdentifiedDataSerializable} requires a
-         *     default no-args constructor and non-final fields which is not always possible (e.g. subclasses of
-         *     {@code java.util.EventObject} & {@code java.lang.Exception})</li>
+         *     <li>inheritance from a {@code Serializable} class external to Hazelcast e.g.
+         *     {@link javax.cache.event.CacheEntryEvent} is serializable however its implementation in
+         *     {@link com.hazelcast.cache.impl.CacheEntryEventImpl} is never used in serialized form, so there
+         *     is no interest in converting this class to {@link IdentifiedDataSerializable}</li>
          *     <li>a {@code Comparator} which should by convention also implement {@code Serializable}.</li>
          * </ul>
+         *
+         * Classes whose superclasses are {@link java.io.Serializable} without a default constructor or with private
+         * final fields, such as {@link Throwable} or {@link java.util.EventObject}, cannot be converted to
+         * {@link IdentifiedDataSerializable}, so these are not annotated with {@code SerializableByConvention}.
+         * Instead these classes are white-listed in
+         * {@code com.hazelcast.internal.serialization.impl.DataSerializableConventionsTest#SERIALIZABLE_WHITE_LIST}
+         * and are excluded from conventions testing.
          */
         INHERITANCE,
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializableByConvention.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/SerializableByConvention.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Indicates that the annotated class cannot be converted to {@code IdentifiedDataSerializable} due to other conventions.
+ * The annotation's {@link #value()} provides reasoning why class cannot be converted. Classes annotated with
+ * {@code SerializableByConvention} are excluded from compliance tests by {@code DataSerializableConventionsTest}.
+ */
+@Target(TYPE)
+@Retention(RUNTIME)
+public @interface SerializableByConvention {
+    Reason value() default Reason.INHERITANCE;
+
+    enum Reason {
+        /**
+         * Class definition is part of public API so cannot be migrated to {@code IdentifiedDataSerializable}.
+         */
+        PUBLIC_API,
+        /**
+         * Class is {@code Serializable} due to conventions and cannot be converted to {@code IdentifiedDataSerializable}.
+         * Examples:
+         * <ul>
+         *     <li>inheritance from a class external to Hazelcast e.g. {@code CacheEntryEvent}, which imposes
+         *     serializability even when not required</li>
+         *     <li>inheritance from a class external to Hazelcast, however {@code IdentifiedDataSerializable} requires a
+         *     default no-args constructor and non-final fields which  is not always possible (e.g. subclasses of
+         *     {@code java.util.EventObject} & {@code java.lang.Exception})</li>
+         *     <li>a {@code Comparator} which should by convention also implement {@code Serializable}.</li>
+         * </ul>
+         */
+        INHERITANCE,
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/BinaryInterface.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/impl/BinaryInterface.java
@@ -30,6 +30,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * - NEVER CHANGE THEM
  * - NEVER MAKE THEM IMPLEMENT THE VERSIONED INTERFACE
+ *
+ * For the purposes of serializable classes conventions testing, this annotation is only taken into account when
+ * used on concrete classes; it does not make sense to annotate an interface or an abstract class, because serialized form
+ * is only relevant in the context of a concrete class. However, it may be informative to use this annotation also on
+ * interfaces or abstract classes, as a warning to implementers.
  */
 @Target(TYPE)
 @Retention(RUNTIME)

--- a/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/PartitionLostEvent.java
@@ -23,8 +23,11 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 
 /**
  * The event that is fired when a partition lost its owner and all backups.
@@ -33,6 +36,7 @@ import java.io.IOException;
  * @see PartitionService
  * @see PartitionLostListener
  */
+@SerializableByConvention(PUBLIC_API)
 public class PartitionLostEvent
         implements DataSerializable, PartitionEvent {
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/DefaultPartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/DefaultPartitioningStrategy.java
@@ -18,12 +18,13 @@ package com.hazelcast.partition.strategy;
 
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.core.PartitioningStrategy;
-
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
 /**
  * A {@link PartitioningStrategy} that checks if the key implements {@link PartitionAware}.
  * If so, the {@link PartitionAware#getPartitionKey()} is called. Otherwise null is returned.
  */
+@SerializableByConvention
 public class DefaultPartitioningStrategy implements PartitioningStrategy {
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringAndPartitionAwarePartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringAndPartitionAwarePartitioningStrategy.java
@@ -18,7 +18,9 @@ package com.hazelcast.partition.strategy;
 
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
+@SerializableByConvention
 public final class StringAndPartitionAwarePartitioningStrategy implements PartitioningStrategy {
 
     //since the StringAndPartitionAwarePartitioningStrategy is stateless, we can just create an instance up front

--- a/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringPartitioningStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/strategy/StringPartitioningStrategy.java
@@ -17,7 +17,9 @@
 package com.hazelcast.partition.strategy;
 
 import com.hazelcast.core.PartitioningStrategy;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
+@SerializableByConvention
 public class StringPartitioningStrategy implements PartitioningStrategy {
 
     public static final StringPartitioningStrategy INSTANCE = new StringPartitioningStrategy();

--- a/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 

--- a/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;

--- a/hazelcast/src/main/java/com/hazelcast/query/PartitionPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PartitionPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/query/Predicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Predicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;

--- a/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/FalsePredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.AttributeType;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.IndexImpl;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.ComparisonType;
 import com.hazelcast.query.impl.Index;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.util.regex.Pattern;
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InstanceOfPredicate.java
@@ -21,7 +21,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotEqualPredicate.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/NotPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;
 import com.hazelcast.query.impl.Indexes;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/OrPredicate.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RegexPredicate.java
@@ -18,7 +18,7 @@ package com.hazelcast.query.impl.predicates;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 import java.util.Map;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Contains classes related to cluster quorum.
+ * Classes for replicated map.
  */
 package com.hazelcast.replicatedmap;

--- a/hazelcast/src/main/java/com/hazelcast/security/AbstractCredentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/AbstractCredentials.java
@@ -19,7 +19,7 @@ package com.hazelcast.security;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/security/Credentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/Credentials.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.security;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/UsernamePasswordCredentials.java
@@ -18,7 +18,7 @@ package com.hazelcast.security;
 
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.impl.SpiPortableHook;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/DefaultObjectNamespace.java
@@ -18,12 +18,16 @@ package com.hazelcast.spi;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 
 /**
  * Default {@link com.hazelcast.spi.ObjectNamespace} implementation.
  */
+@SerializableByConvention(PUBLIC_API)
 public final class DefaultObjectNamespace implements ObjectNamespace {
 
     private String service;

--- a/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/MemberAttributeServiceEvent.java
@@ -20,10 +20,14 @@ import com.hazelcast.cluster.MemberAttributeOperationType;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.MemberAttributeEvent;
 import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.nio.serialization.SerializableByConvention;
+
+import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 
 /**
  * This service event is fired to inform services about a change in a member's attributes collection
  */
+@SerializableByConvention(PUBLIC_API)
 public class MemberAttributeServiceEvent extends MemberAttributeEvent {
 
     public MemberAttributeServiceEvent() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spi.discovery.multicast.impl;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.Serializable;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.impl.eventservice.impl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
@@ -19,7 +19,7 @@ package com.hazelcast.spi.impl.proxyservice.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import java.io.IOException;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/partition/IPartitionLostEvent.java
@@ -20,14 +20,18 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
 import java.io.IOException;
+
+import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 
 /**
  * Internal event that is dispatched to {@link com.hazelcast.spi.PartitionAwareService#onPartitionLost}
  * <p/>
  * It contains the partition id, number of replicas that is lost and the address of node that detects the partition lost
  */
+@SerializableByConvention(PUBLIC_API)
 public class IPartitionLostEvent
         implements DataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicMessage.java
@@ -19,6 +19,7 @@ package com.hazelcast.topic.impl.reliable;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.util.Clock;
@@ -31,6 +32,7 @@ import static com.hazelcast.topic.impl.TopicDataSerializerHook.RELIABLE_TOPIC_ME
 /**
  * The Object that is going to be stored in the Ringbuffer. It contains the actual message payload and some metadata.
  */
+@BinaryInterface
 public class ReliableTopicMessage implements IdentifiedDataSerializable {
     private long publishTime;
     private Address publisherAddress;

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionOptions.java
@@ -19,13 +19,17 @@ package com.hazelcast.transaction;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
+
 /**
  * Contains the configuration for a Hazelcast transaction.
  */
+@SerializableByConvention(PUBLIC_API)
 public final class TransactionOptions implements DataSerializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/SerializableXID.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/SerializableXID.java
@@ -19,7 +19,7 @@ package com.hazelcast.transaction.impl.xa;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 
 import javax.transaction.xa.Xid;
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrentReferenceHashMap.java
@@ -24,6 +24,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.core.IBiFunction;
 import com.hazelcast.core.IFunction;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -148,6 +149,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * @author Jason T. Greene
  */
 @SuppressWarnings("all")
+@SerializableByConvention
 public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
         implements com.hazelcast.util.IConcurrentMap<K, V>, Serializable {
 
@@ -469,6 +471,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
      * subclasses from ReentrantLock opportunistically, just to
      * simplify some locking and avoid separate construction.
      */
+    @SerializableByConvention
     static final class Segment<K, V> extends ReentrantLock implements Serializable {
         /*
          * Segments maintain a table of entry lists that are ALWAYS
@@ -1720,6 +1723,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
     /*
      * This class is needed for JDK5 compatibility.
      */
+    @SerializableByConvention
     protected static class SimpleEntry<K, V> implements Entry<K, V>, java.io.Serializable {
         private static final long serialVersionUID = -8499721149061103585L;
 
@@ -1777,6 +1781,7 @@ public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
      * Custom Entry class used by EntryIterator.next(), that relays setValue
      * changes to the underlying map.
      */
+    @SerializableByConvention
     protected class WriteThroughEntry extends SimpleEntry<K, V> {
         private static final long serialVersionUID = -7900634345345313646L;
 

--- a/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
@@ -18,6 +18,7 @@ package com.hazelcast.util;
 
 import com.hazelcast.internal.eviction.Expirable;
 import com.hazelcast.internal.util.ThreadLocalRandomProvider;
+import com.hazelcast.nio.serialization.SerializableByConvention;
 
 import java.util.AbstractMap;
 import java.util.Collections;
@@ -33,6 +34,7 @@ import java.util.NoSuchElementException;
  * @param <K> Type of the key
  * @param <V> Type of the value
  */
+@SerializableByConvention
 public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMap<K, V> {
 
     private static final float LOAD_FACTOR = 0.91f;

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/InflatableSet.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.util.collection;
 
+import com.hazelcast.nio.serialization.SerializableByConvention;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.Serializable;
@@ -52,6 +53,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  *
  * @param <T> the type of elements maintained by this set
  */
+@SerializableByConvention
 public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Serializable, Cloneable {
 
     private static final long serialVersionUID = 0L;

--- a/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MajorMinorVersionComparator.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.version;
 
+import com.hazelcast.nio.serialization.SerializableByConvention;
+
 import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * Version comparator that disregards patch version, comparing versions on their major & minor versions only.
  */
+@SerializableByConvention
 @SuppressWarnings("checkstyle:magicnumber")
 class MajorMinorVersionComparator implements Comparator<MemberVersion>, Serializable {
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -255,7 +255,6 @@ public class DataSerializableConventionsTest {
 
     /**
      * Removes abstract classes and interfaces from given Set in-place.
-     * @param classes
      */
     private void filterNonConcreteClasses(Set classes) {
         Iterator<Class> iterator = classes.iterator();

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.SerializableByConvention;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.AbstractLocalOperation;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
@@ -48,7 +48,9 @@ public class ReflectionsHelper {
         for (Iterator<URL> iterator = comHazelcastPackageURLs.iterator(); iterator.hasNext(); ) {
             URL url = iterator.next();
             // detect hazelcast-VERSION-tests.jar & $SOMEPATH/hazelcast/target/test-classes/ and exclude it from classpath
-            if (url.toString().contains("-tests.jar") || url.toString().contains("target/test-classes")) {
+            // also exclude hazelcast-license-extractor artifact
+            if (url.toString().contains("-tests.jar") || url.toString().contains("target/test-classes") ||
+                    url.toString().contains("hazelcast-license-extractor")) {
                 iterator.remove();
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
@@ -16,15 +16,23 @@
 
 package com.hazelcast.test;
 
+import com.google.common.collect.Sets;
+import org.reflections.Configuration;
+import org.reflections.ReflectionUtils;
 import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
+import org.reflections.adapters.JavaReflectionAdapter;
+import org.reflections.scanners.AbstractScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Initialize once org.reflections library to avoid duplicate work scanning the classpath from individual tests.
@@ -44,7 +52,77 @@ public class ReflectionsHelper {
                 iterator.remove();
             }
         }
-        REFLECTIONS = new Reflections(new ConfigurationBuilder().addUrls(comHazelcastPackageURLs)
-                .addScanners(new SubTypesScanner()).addScanners(new TypeAnnotationsScanner()));
+        HierarchyTraversingSubtypesScanner subtypesScanner = new HierarchyTraversingSubtypesScanner();
+        subtypesScanner.setResultFilter(new FilterBuilder().exclude("java\\.lang\\.(Object|Enum)"));
+        REFLECTIONS = new ReflectionsTransitive(new ConfigurationBuilder().addUrls(comHazelcastPackageURLs)
+                .addScanners(subtypesScanner, new TypeAnnotationsScanner())
+                .setMetadataAdapter(new JavaReflectionAdapter()));
+    }
+
+    // Overrides default implementation of getSubTypesOf to obtain also transitive subtypes of given class
+    public static class ReflectionsTransitive extends Reflections {
+
+        public ReflectionsTransitive(Configuration configuration) {
+            super(configuration);
+        }
+
+        @Override
+        public <T> Set<Class<? extends T>> getSubTypesOf(Class<T> type) {
+            return Sets.newHashSet(ReflectionUtils.<T>forNames(
+                    store.getAll(
+                            HierarchyTraversingSubtypesScanner.class.getSimpleName(),
+                            Arrays.asList(type.getName())),
+                            configuration.getClassLoaders()));
+        }
+    }
+
+    public static class HierarchyTraversingSubtypesScanner extends AbstractScanner{
+        /**
+         * creates new HierarchyTraversingSubtypesScanner. will exclude direct Object subtypes
+         */
+        public HierarchyTraversingSubtypesScanner() {
+            this(true); //exclude direct Object subtypes by default
+        }
+
+        /**
+         * creates new HierarchyTraversingSubtypesScanner.
+         * @param excludeObjectClass if false, include direct {@link Object} subtypes in results.
+         */
+        public HierarchyTraversingSubtypesScanner(boolean excludeObjectClass) {
+            if (excludeObjectClass) {
+                filterResultsBy(new FilterBuilder().exclude(Object.class.getName())); //exclude direct Object subtypes
+            }
+        }
+
+        // depending on Reflections configuration, cls is either a regular Class or a javassist ClassFile
+        @SuppressWarnings({"unchecked"})
+        public void scan(final Object cls) {
+            String className = getMetadataAdapter().getClassName(cls);
+
+            for (String anInterface : (List<String>) getMetadataAdapter().getInterfacesNames(cls)) {
+                if (acceptResult(anInterface)) {
+                    getStore().put(anInterface, className);
+                }
+            }
+
+            // apart from this class' direct supertype and directly declared interfaces, also scan the class
+            // hierarchy up until Object class
+            Class superKlass = ((Class)cls).getSuperclass();
+            while (superKlass != null) {
+                scanClassAndInterfaces(superKlass, className);
+                superKlass = superKlass.getSuperclass();
+            }
+        }
+
+        private void scanClassAndInterfaces(Class klass, String className) {
+            if (acceptResult(klass.getName())) {
+                getStore().put(klass.getName(), className);
+                for (String anInterface : (List<String>) getMetadataAdapter().getInterfacesNames(klass)) {
+                    if (acceptResult(anInterface)) {
+                        getStore().put(anInterface, className);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
DataSerializableConventionsTest has been updated to reflect the following conventions:
- classes in public packages are now checked for compliance (while they were previously excluded)
- only concrete classes are checked for compliance. It is OK to annotate interfaces or abstract classes with @BinaryInterface as an indication to implementers, however each implementation has to be considered separately.
- as a consequence of the above `@BinaryInterface` is not considered as inherited.
- introduces a separate `@SerializableByConvention` annotation to mark classes which implement `Serializable` or `DataSerializable` and:
    * are not used in serialized form, however extend from a `Serializable` class
    * are used in serialized form, however cannot be converted due to extending from a superclass with no default constructor or fields which cannot be set after construction  (e.g. subclasses of `Throwable`, `java.util.EventObject`, `java.security.Permission`)

Due to the large number of classes affected, this PR is split in several commits, see commit messages for details.
An EE counterpart is required