### PR TITLE
Classes converted to IdentifiedDataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.serialization.DataSerializerHook;
+import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
+import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
+import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.util.ConstructorFunction;
+
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.CONFIG_DS_FACTORY;
+import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.CONFIG_DS_FACTORY_ID;
+
+/**
+ * DataSerializerHook for com.hazelcast.config classes
+ */
+@SuppressWarnings("checkstyle:javadocvariable")
+public final class ConfigDataSerializerHook implements DataSerializerHook {
+
+    public static final int F_ID = FactoryIdHelper.getFactoryId(CONFIG_DS_FACTORY, CONFIG_DS_FACTORY_ID);
+
+    public static final int WAN_REPLICATION_CONFIG = 0;
+    public static final int WAN_CONSUMER_CONFIG = 1;
+    public static final int WAN_PUBLISHER_CONFIG = 2;
+    public static final int NEAR_CACHE_CONFIG = 3;
+    public static final int NEAR_CACHE_PRELOADER_CONFIG = 4;
+
+    private static final int LEN = NEAR_CACHE_PRELOADER_CONFIG + 1;
+
+    @Override
+    public int getFactoryId() {
+        return F_ID;
+    }
+
+    @Override
+    public DataSerializableFactory createFactory() {
+        ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
+
+        constructors[WAN_REPLICATION_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new WanReplicationConfig();
+            }
+        };
+        constructors[WAN_CONSUMER_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new WanConsumerConfig();
+            }
+        };
+        constructors[WAN_PUBLISHER_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new WanPublisherConfig();
+            }
+        };
+        constructors[NEAR_CACHE_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new NearCacheConfig();
+            }
+        };
+        constructors[NEAR_CACHE_PRELOADER_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new NearCachePreloaderConfig();
+            }
+        };
+
+        return new ArrayDataSerializableFactory(constructors);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -18,8 +18,7 @@ package com.hazelcast.config;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -32,8 +31,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 /**
  * Contains the configuration for a Near Cache.
  */
-@BinaryInterface
-public class NearCacheConfig implements DataSerializable, Serializable {
+public class NearCacheConfig implements IdentifiedDataSerializable, Serializable {
 
     /**
      * Default value of the time to live in seconds.
@@ -452,6 +450,16 @@ public class NearCacheConfig implements DataSerializable, Serializable {
     public NearCacheConfig setPreloaderConfig(NearCachePreloaderConfig preloaderConfig) {
         this.preloaderConfig = checkNotNull(preloaderConfig, "NearCachePreloaderConfig cannot be null!");
         return this;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.NEAR_CACHE_CONFIG;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfigReadOnly.java
@@ -16,15 +16,15 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 /**
  * Contains configuration for a Near Cache (read-only).
  *
  * @deprecated this class will be removed in 3.8; it is meant for internal usage only.
  */
-@BinaryInterface
 public class NearCacheConfigReadOnly extends NearCacheConfig {
+
+    public NearCacheConfigReadOnly() {
+    }
 
     public NearCacheConfigReadOnly(NearCacheConfig config) {
         super(config);
@@ -98,5 +98,10 @@ public class NearCacheConfigReadOnly extends NearCacheConfig {
     @Override
     public NearCachePreloaderConfig getPreloaderConfig() {
         return super.getPreloaderConfig().getAsReadOnly();
+    }
+
+    @Override
+    public int getId() {
+        throw new UnsupportedOperationException("NearCacheConfigReadOnly is not serializable");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
@@ -18,8 +18,7 @@ package com.hazelcast.config;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.annotation.PrivateApi;
 
@@ -34,8 +33,7 @@ import static com.hazelcast.util.Preconditions.checkPositive;
  * You can set a limit for number of entries or total memory cost of entries.
  */
 @Beta
-@BinaryInterface
-public class NearCachePreloaderConfig implements DataSerializable, Serializable {
+public class NearCachePreloaderConfig implements IdentifiedDataSerializable, Serializable {
 
     /**
      * Default initial delay for the Near Cache key storage.
@@ -130,6 +128,16 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
     }
 
     @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.NEAR_CACHE_PRELOADER_CONFIG;
+    }
+
+    @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeBoolean(enabled);
         out.writeUTF(directory);
@@ -167,8 +175,10 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
      */
     @Beta
     @PrivateApi
-    @BinaryInterface
     private static class NearCachePreloaderConfigReadOnly extends NearCachePreloaderConfig {
+
+        public NearCachePreloaderConfigReadOnly() {
+        }
 
         NearCachePreloaderConfigReadOnly(NearCachePreloaderConfig nearCachePreloaderConfig) {
             super(nearCachePreloaderConfig);
@@ -192,6 +202,11 @@ public class NearCachePreloaderConfig implements DataSerializable, Serializable 
         @Override
         public NearCachePreloaderConfig setStoreIntervalSeconds(int storeIntervalSeconds) {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getId() {
+            throw new UnsupportedOperationException("NearCachePreloaderConfigReadOnly is not serializable");
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
@@ -18,7 +18,7 @@ package com.hazelcast.config;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -27,7 +27,7 @@ import java.util.Map;
 /**
  * Config to be used by WanReplicationConsumer instances (EE only).
  */
-public class WanConsumerConfig implements DataSerializable {
+public class WanConsumerConfig implements IdentifiedDataSerializable {
 
     private Map<String, Comparable> properties = new HashMap<String, Comparable>();
     private String className;
@@ -67,6 +67,16 @@ public class WanConsumerConfig implements DataSerializable {
                 + ", className='" + className + '\''
                 + ", implementation=" + implementation
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.WAN_CONSUMER_CONFIG;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -18,7 +18,7 @@ package com.hazelcast.config;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -27,7 +27,7 @@ import java.util.Map;
 /**
  * Configuration object for WAN publishers.
  */
-public class WanPublisherConfig implements DataSerializable {
+public class WanPublisherConfig implements IdentifiedDataSerializable {
 
     private static final int DEFAULT_QUEUE_CAPACITY = 10000;
     private static final WANQueueFullBehavior DEFAULT_QUEUE_FULL_BEHAVIOR = WANQueueFullBehavior.DISCARD_AFTER_MUTATION;
@@ -136,6 +136,16 @@ public class WanPublisherConfig implements DataSerializable {
                 + ", queueCapacity=" + queueCapacity
                 + ", queueFullBehavior=" + queueFullBehavior
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.WAN_PUBLISHER_CONFIG;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -18,7 +18,7 @@ package com.hazelcast.config;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * Configuration for wan replication.
  */
-public class WanReplicationConfig implements DataSerializable {
+public class WanReplicationConfig implements IdentifiedDataSerializable {
 
     private String name;
     private WanConsumerConfig wanConsumerConfig;
@@ -72,6 +72,16 @@ public class WanReplicationConfig implements DataSerializable {
                 + "{name='" + name + '\''
                 + ", wanPublisherConfigs=" + wanPublisherConfigs
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.WAN_REPLICATION_CONFIG;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/FactoryIdHelper.java
@@ -131,6 +131,12 @@ public final class FactoryIdHelper {
     public static final String PROJECTION_DS_FACTORY = "hazelcast.serialization.ds.projection";
     public static final int PROJECTION_DS_FACTORY_ID = -42;
 
+    public static final String CONFIG_DS_FACTORY = "hazelcast.serialization.ds.config";
+    public static final int CONFIG_DS_FACTORY_ID = -43;
+
+    public static final String ENTERPRISE_SECURITY_DS_FACTORY = "hazelcast.serialization.ds.security";
+    public static final int ENTERPRISE_SECURITY_DS_FACTORY_ID = -44;
+
     // =========================== portables =============================================
 
     public static final String SPI_PORTABLE_FACTORY = "hazelcast.serialization.portable.spi";

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryRemovingProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryRemovingProcessor.java
@@ -17,10 +17,14 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
+import java.io.IOException;
 import java.util.Map;
 
-public class EntryRemovingProcessor extends AbstractEntryProcessor {
+public class EntryRemovingProcessor extends AbstractEntryProcessor implements IdentifiedDataSerializable {
 
     public static final EntryRemovingProcessor ENTRY_REMOVING_PROCESSOR = new EntryRemovingProcessor();
 
@@ -30,5 +34,23 @@ public class EntryRemovingProcessor extends AbstractEntryProcessor {
     public Object process(Map.Entry entry) {
         ((LazyMapEntry) entry).remove();
         return null;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.ENTRY_REMOVING_PROCESSOR;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -282,8 +282,9 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int TRIGGER_LOAD_IF_NEEDED = 132;
     public static final int IS_KEYLOAD_FINISHED = 133;
     public static final int REMOVE_FROM_LOAD_ALL = 134;
+    public static final int ENTRY_REMOVING_PROCESSOR = 135;
 
-    private static final int LEN = REMOVE_FROM_LOAD_ALL + 1;
+    private static final int LEN = ENTRY_REMOVING_PROCESSOR + 1;
 
     @Override
     public int getFactoryId() {
@@ -947,6 +948,11 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[REMOVE_FROM_LOAD_ALL] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new RemoveFromLoadAllOperation();
+            }
+        };
+        constructors[ENTRY_REMOVING_PROCESSOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return EntryRemovingProcessor.ENTRY_REMOVING_PROCESSOR;
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
@@ -23,6 +23,10 @@ import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.replicatedmap.impl.record.RecordMigrationInfo;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
+import com.hazelcast.replicatedmap.merge.HigherHitsMapMergePolicy;
+import com.hazelcast.replicatedmap.merge.LatestUpdateMapMergePolicy;
+import com.hazelcast.replicatedmap.merge.PassThroughMergePolicy;
+import com.hazelcast.replicatedmap.merge.PutIfAbsentMapMergePolicy;
 import com.hazelcast.util.ConstructorFunction;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.REPLICATED_MAP_DS_FACTORY;
@@ -62,8 +66,12 @@ public class ReplicatedMapDataSerializerHook implements DataSerializerHook {
     public static final int CLEAR_OP_FACTORY = 23;
     public static final int PUT_ALL_OP_FACTORY = 24;
     public static final int RECORD_MIGRATION_INFO = 25;
+    public static final int HIGHER_HITS_MERGE_POLICY = 26;
+    public static final int LATEST_UPDATE_MERGE_POLICY = 27;
+    public static final int PASS_THROUGH_MERGE_POLICY = 28;
+    public static final int PUT_IF_ABSENT_MERGE_POLICY = 29;
 
-    private static final int LEN = RECORD_MIGRATION_INFO + 1;
+    private static final int LEN = PUT_IF_ABSENT_MERGE_POLICY + 1;
 
     private static final DataSerializableFactory FACTORY = createFactoryInternal();
 
@@ -227,6 +235,30 @@ public class ReplicatedMapDataSerializerHook implements DataSerializerHook {
             @Override
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new RecordMigrationInfo();
+            }
+        };
+        constructors[HIGHER_HITS_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return HigherHitsMapMergePolicy.INSTANCE;
+            }
+        };
+        constructors[LATEST_UPDATE_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return LatestUpdateMapMergePolicy.INSTANCE;
+            }
+        };
+        constructors[PASS_THROUGH_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return PassThroughMergePolicy.INSTANCE;
+            }
+        };
+        constructors[PUT_IF_ABSENT_MERGE_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return PutIfAbsentMapMergePolicy.INSTANCE;
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/HigherHitsMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/HigherHitsMapMergePolicy.java
@@ -16,14 +16,27 @@
 
 package com.hazelcast.replicatedmap.merge;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
+import java.io.IOException;
 
 /**
  * HigherHitsMapMergePolicy causes the merging entry to be merged from source to destination map
  * if source entry has more hits than the destination one.
  */
-public class HigherHitsMapMergePolicy implements ReplicatedMapMergePolicy {
+public final class HigherHitsMapMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
+
+    /**
+     * Single instance of this class
+     */
+    public static final HigherHitsMapMergePolicy INSTANCE = new HigherHitsMapMergePolicy();
+
+    private HigherHitsMapMergePolicy() {
+    }
 
     @Override
     public Object merge(String mapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
@@ -33,4 +46,25 @@ public class HigherHitsMapMergePolicy implements ReplicatedMapMergePolicy {
         return existingEntry.getValue();
     }
 
+    @Override
+    public int getFactoryId() {
+        return ReplicatedMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.HIGHER_HITS_MERGE_POLICY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    private Object readResolve() {
+        return INSTANCE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/LatestUpdateMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/LatestUpdateMapMergePolicy.java
@@ -16,7 +16,13 @@
 
 package com.hazelcast.replicatedmap.merge;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
+
+import java.io.IOException;
 
 /**
  * LatestUpdateMapMergePolicy causes the merging entry to be merged from source to destination map
@@ -24,7 +30,15 @@ import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
  * <p/>
  * This policy can only be used of the clocks of the machines are in sync.
  */
-public class LatestUpdateMapMergePolicy implements ReplicatedMapMergePolicy {
+public final class LatestUpdateMapMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
+
+    /**
+     * Single instance of this class
+     */
+    public static final LatestUpdateMapMergePolicy INSTANCE = new LatestUpdateMapMergePolicy();
+
+    private LatestUpdateMapMergePolicy() {
+    }
 
     @Override
     public Object merge(String mapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
@@ -32,5 +46,27 @@ public class LatestUpdateMapMergePolicy implements ReplicatedMapMergePolicy {
             return mergingEntry.getValue();
         }
         return existingEntry.getValue();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ReplicatedMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.LATEST_UPDATE_MERGE_POLICY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    private Object readResolve() {
+        return INSTANCE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/MergePolicyProvider.java
@@ -56,10 +56,10 @@ public final class MergePolicyProvider {
     }
 
     private void addOutOfBoxPolicies() {
-        mergePolicyMap.put(PutIfAbsentMapMergePolicy.class.getName(), new PutIfAbsentMapMergePolicy());
-        mergePolicyMap.put(HigherHitsMapMergePolicy.class.getName(), new HigherHitsMapMergePolicy());
-        mergePolicyMap.put(PassThroughMergePolicy.class.getName(), new PassThroughMergePolicy());
-        mergePolicyMap.put(LatestUpdateMapMergePolicy.class.getName(), new LatestUpdateMapMergePolicy());
+        mergePolicyMap.put(PutIfAbsentMapMergePolicy.class.getName(), PutIfAbsentMapMergePolicy.INSTANCE);
+        mergePolicyMap.put(HigherHitsMapMergePolicy.class.getName(), HigherHitsMapMergePolicy.INSTANCE);
+        mergePolicyMap.put(PassThroughMergePolicy.class.getName(), PassThroughMergePolicy.INSTANCE);
+        mergePolicyMap.put(LatestUpdateMapMergePolicy.class.getName(), LatestUpdateMapMergePolicy.INSTANCE);
     }
 
     public ReplicatedMapMergePolicy getMergePolicy(String className) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PassThroughMergePolicy.java
@@ -16,18 +16,52 @@
 
 package com.hazelcast.replicatedmap.merge;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
+import java.io.IOException;
 
 /**
  * PassThroughMergePolicy causes the merging entry to be merged from source to destination map
  * unless merging entry is null.
  */
-public class PassThroughMergePolicy implements ReplicatedMapMergePolicy {
+public final class PassThroughMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
+
+    /**
+     * Single instance of this class
+     */
+    public static final PassThroughMergePolicy INSTANCE = new PassThroughMergePolicy();
+
+    private PassThroughMergePolicy() {
+    }
 
     @Override
     public Object merge(String mapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
         return mergingEntry == null ? existingEntry.getValue() : mergingEntry.getValue();
     }
 
+    @Override
+    public int getFactoryId() {
+        return ReplicatedMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.PASS_THROUGH_MERGE_POLICY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    private Object readResolve() {
+        return INSTANCE;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicy.java
@@ -16,14 +16,27 @@
 
 package com.hazelcast.replicatedmap.merge;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedMapEntryView;
 
+import java.io.IOException;
 
 /**
  * PutIfAbsentMapMergePolicy causes the merging entry to be merged from source to destination map
  * if it does not exist in the destination map.
  */
-public class PutIfAbsentMapMergePolicy implements ReplicatedMapMergePolicy {
+public final class PutIfAbsentMapMergePolicy implements ReplicatedMapMergePolicy, IdentifiedDataSerializable {
+
+    /**
+     * Single instance of this class
+     */
+    public static final PutIfAbsentMapMergePolicy INSTANCE = new PutIfAbsentMapMergePolicy();
+
+    private PutIfAbsentMapMergePolicy() {
+    }
 
     @Override
     public Object merge(String mapName, ReplicatedMapEntryView mergingEntry, ReplicatedMapEntryView existingEntry) {
@@ -31,5 +44,27 @@ public class PutIfAbsentMapMergePolicy implements ReplicatedMapMergePolicy {
             return mergingEntry.getValue();
         }
         return existingEntry.getValue();
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ReplicatedMapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ReplicatedMapDataSerializerHook.PUT_IF_ABSENT_MERGE_POLICY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+    }
+
+    private Object readResolve() {
+        return INSTANCE;
     }
 }

--- a/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
+++ b/hazelcast/src/main/resources/META-INF/services/com.hazelcast.DataSerializerHook
@@ -29,3 +29,4 @@ com.hazelcast.scheduledexecutor.impl.ScheduledExecutorDataSerializerHook
 com.hazelcast.internal.usercodedeployment.impl.UserCodeDeploymentSerializerHook
 com.hazelcast.aggregation.impl.AggregatorDataSerializerHook
 com.hazelcast.projection.impl.ProjectionDataSerializerHook
+com.hazelcast.config.ConfigDataSerializerHook

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/HigherHitsReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/HigherHitsReplicatedMapMergePolicyTest.java
@@ -29,7 +29,7 @@ public class HigherHitsReplicatedMapMergePolicyTest extends AbstractReplicatedMa
 
     @Before
     public void given() {
-        policy = new HigherHitsMapMergePolicy();
+        policy = HigherHitsMapMergePolicy.INSTANCE;
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LatestUpdateReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/LatestUpdateReplicatedMapMergePolicyTest.java
@@ -29,7 +29,7 @@ public class LatestUpdateReplicatedMapMergePolicyTest extends AbstractReplicated
 
     @Before
     public void given() {
-        policy = new LatestUpdateMapMergePolicy();
+        policy = LatestUpdateMapMergePolicy.INSTANCE;
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PassThroughMapMergePolicyTest.java
@@ -40,7 +40,7 @@ public class PassThroughMapMergePolicyTest {
 
     @Before
     public void given() {
-        policy = new PassThroughMergePolicy();
+        policy = PassThroughMergePolicy.INSTANCE;
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/merge/PutIfAbsentMapMergePolicyTest.java
@@ -41,7 +41,7 @@ public class PutIfAbsentMapMergePolicyTest {
 
     @Before
     public void given() {
-        policy = new PutIfAbsentMapMergePolicy();
+        policy = PutIfAbsentMapMergePolicy.INSTANCE;
     }
 
     @Test


### PR DESCRIPTION
Converts to `IdentifiedDataSerializable`:
* `NearCacheConfig`, `WanPublisherConfig`, `WanConsumerConfig` and `WanReplicationConfig` 
* `ReplicatedMap` built-in merge policies
* `EntryRemovingProcessor`

Also adds factory ID constants required for EE-side to convert security-related classes to `IdentifiedDataSerializable`.