### PR TITLE
Allow UnlockIfLeaseExpiredOperation to be executed remotely

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockDataSerializerHook.java
@@ -29,6 +29,7 @@ import com.hazelcast.concurrent.lock.operations.LockReplicationOperation;
 import com.hazelcast.concurrent.lock.operations.SignalBackupOperation;
 import com.hazelcast.concurrent.lock.operations.SignalOperation;
 import com.hazelcast.concurrent.lock.operations.UnlockBackupOperation;
+import com.hazelcast.concurrent.lock.operations.UnlockIfLeaseExpiredOperation;
 import com.hazelcast.concurrent.lock.operations.UnlockOperation;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
@@ -59,6 +60,7 @@ public final class LockDataSerializerHook implements DataSerializerHook {
     public static final int SIGNAL = 14;
     public static final int UNLOCK_BACKUP = 15;
     public static final int UNLOCK = 16;
+    public static final int UNLOCK_IF_LEASE_EXPIRED = 17;
 
 
     @Override
@@ -106,6 +108,8 @@ public final class LockDataSerializerHook implements DataSerializerHook {
                         return new WaitersInfo();
                     case LOCK_RESOURCE:
                         return new LockResourceImpl();
+                    case UNLOCK_IF_LEASE_EXPIRED:
+                        return new UnlockIfLeaseExpiredOperation();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.concurrent.lock.operations;
 
+import com.hazelcast.concurrent.lock.LockDataSerializerHook;
 import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
@@ -31,7 +32,7 @@ import java.io.IOException;
 
 public final class UnlockIfLeaseExpiredOperation extends UnlockOperation {
 
-    private final int version;
+    private int version;
 
     /**
      * This constructor should not be used to obtain an instance of this class; it exists to fulfill IdentifiedDataSerializable
@@ -83,16 +84,18 @@ public final class UnlockIfLeaseExpiredOperation extends UnlockOperation {
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        throw new UnsupportedOperationException("This operation is intended to be executed on local member only!");
+        super.writeInternal(out);
+        out.writeInt(version);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        throw new UnsupportedOperationException("This operation is intended to be executed on local member only!");
+        super.readInternal(in);
+        version = in.readInt();
     }
 
     @Override
     public int getId() {
-        throw new UnsupportedOperationException("This operation is intended to be executed on local member only!");
+        return LockDataSerializerHook.UNLOCK_IF_LEASE_EXPIRED;
     }
 }


### PR DESCRIPTION
We allow the operation to be executed remotely as groundwork for further lock lease issue fixes.

The lock lease fixes will be added later to 3.8 or a 3.8.x patch release.