### PR TITLE
De-duplicated dependency configuration in pom.xml of Spring module

### DIFF
--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -35,7 +35,7 @@
 
         <org.springframework.version>4.3.0.RELEASE</org.springframework.version>
         <jsr250.api.version>1.0</jsr250.api.version>
-        <hazelcast.latest.version>3.6</hazelcast.latest.version>
+        <hazelcast.latest.version>3.8</hazelcast.latest.version>
     </properties>
 
     <build>
@@ -136,60 +136,11 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <dependencies>
-                <dependency>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast</artifactId>
-                    <version>${project.parent.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast-client</artifactId>
-                    <version>${project.parent.version}</version>
-                    <optional>true</optional>
-                </dependency>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>jsr250-api</artifactId>
-                    <version>${jsr250.api.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-tx</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-
                 <!--TEST DEPENDENCIES-->
-                <dependency>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast</artifactId>
-                    <scope>test</scope>
-                    <version>${project.parent.version}</version>
-                    <classifier>tests</classifier>
-                </dependency>
                 <dependency>
                     <groupId>com.hazelcast</groupId>
                     <artifactId>hazelcast-hibernate4</artifactId>
                     <version>${hazelcast.latest.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-test</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context-support</artifactId>
-                    <version>${org.springframework.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -204,66 +155,11 @@
         <profile>
             <id>hibernate-3</id>
             <dependencies>
-                <dependency>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast</artifactId>
-                    <version>${project.parent.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast-client</artifactId>
-                    <version>${project.parent.version}</version>
-                    <optional>true</optional>
-                </dependency>
-                <dependency>
-                    <groupId>javax.annotation</groupId>
-                    <artifactId>jsr250-api</artifactId>
-                    <version>${jsr250.api.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-tx</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>provided</scope>
-                </dependency>
-
                 <!--TEST DEPENDENCIES-->
                 <dependency>
                     <groupId>com.hazelcast</groupId>
                     <artifactId>hazelcast-hibernate3</artifactId>
                     <version>${hazelcast.latest.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast</artifactId>
-                    <scope>test</scope>
-                    <version>${project.parent.version}</version>
-                    <classifier>tests</classifier>
-                </dependency>
-                <dependency>
-                    <groupId>javax.cache</groupId>
-                    <artifactId>cache-api</artifactId>
-                    <version>${jsr107.api.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-test</artifactId>
-                    <version>${org.springframework.version}</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context-support</artifactId>
-                    <version>${org.springframework.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>
@@ -275,4 +171,57 @@
             </dependencies>
         </profile>
     </profiles>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-client</artifactId>
+            <version>${project.parent.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>jsr250-api</artifactId>
+            <version>${jsr250.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${org.springframework.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <version>${org.springframework.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!--TEST DEPENDENCIES-->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <scope>test</scope>
+            <version>${project.parent.version}</version>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${org.springframework.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>${org.springframework.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
* pulled out shared Hazelcast and Spring dependencies
* removed JSR 107 dependency, which is already defined in parent pom.xml
* updated Hazelcast dependency to 3.8

This makes it easier to read the dependency layout for the Spring module, since each dependency is just once in the `pom.xml`.

It also helps debugging if you accidentally disable the `hibernate-4` and `hibernate-3` profile in IDEA. Before this PR the whole module failed to compile, due to the missing dependencies. The first class IDEA jumps to is `SpringHazelcastCachingProvider` with missing imports for Hazelcast and Spring. It's not very obvious, that this error is related to the deactivated `hibernate-x` profile:
![broken-spring-module-old](https://cloud.githubusercontent.com/assets/4196298/22959713/b6f4b03a-f338-11e6-965b-44302b85e645.png)

After this PR just `TestHibernateApplicationContext` fails to compile. It's much easier to get the connection to the `hibernate-x` profiles now, than from missing Hazelcast and Spring imports.
![broken-spring-module-new](https://cloud.githubusercontent.com/assets/4196298/23406569/db4b97aa-fdbf-11e6-8946-8c9f0074b30d.png)