### PR TITLE
adding identified predicate builder (CompositePredicate)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/AbstractPredicateBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/AbstractPredicateBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.query.impl.QueryContext;
+import com.hazelcast.query.impl.QueryableEntry;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class contains server side implementation of PredicateBuilder.
+ */
+@BinaryInterface
+public class AbstractPredicateBuilder implements IndexAwarePredicate {
+
+    protected List<Predicate> lsPredicates = new ArrayList<Predicate>();
+    protected String attribute;
+
+    @Override
+    public boolean apply(Map.Entry mapEntry) {
+        return lsPredicates.get(0).apply(mapEntry);
+    }
+
+    @Override
+    public Set<QueryableEntry> filter(QueryContext queryContext) {
+        Predicate p = lsPredicates.get(0);
+        if (p instanceof IndexAwarePredicate) {
+            return ((IndexAwarePredicate) p).filter(queryContext);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isIndexed(QueryContext queryContext) {
+        Predicate p = lsPredicates.get(0);
+        if (p instanceof IndexAwarePredicate) {
+            return ((IndexAwarePredicate) p).isIndexed(queryContext);
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "PredicateBuilder{\n" + (lsPredicates.size() == 0 ? "" : lsPredicates.get(0)) + "\n}";
+    }
+
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(attribute);
+        out.writeInt(lsPredicates.size());
+        for (Predicate predicate : lsPredicates) {
+            out.writeObject(predicate);
+        }
+    }
+
+    public void readData(ObjectDataInput in) throws IOException {
+        attribute = in.readUTF();
+        int size = in.readInt();
+        lsPredicates = new ArrayList<Predicate>(size);
+        for (int i = 0; i < size; i++) {
+            lsPredicates.add((Predicate) in.readObject());
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/CompositePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/CompositePredicate.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query;
+
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
+
+/**
+ * Identified version of AbstractPredicateBuilder or non-java clients to be able to
+ * support predicate builder.
+ */
+@BinaryInterface
+public class CompositePredicate extends AbstractPredicateBuilder implements IdentifiedDataSerializable {
+
+    public CompositePredicate() {
+
+    }
+
+    public CompositePredicate(PredicateBuilder predicateBuilder) {
+        this.lsPredicates = predicateBuilder.lsPredicates;
+        this.attribute = predicateBuilder.attribute;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return PredicateDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return PredicateDataSerializerHook.COMPOSITE_PREDICATE;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PredicateBuilder.java
@@ -16,27 +16,14 @@
 
 package com.hazelcast.query;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.impl.BinaryInterface;
-import com.hazelcast.query.impl.QueryContext;
-import com.hazelcast.query.impl.QueryableEntry;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 /**
  * This class provides functionality to build predicate.
  */
 @BinaryInterface
-public class PredicateBuilder implements IndexAwarePredicate, DataSerializable {
-
-    List<Predicate> lsPredicates = new ArrayList<Predicate>();
-
-    private String attribute;
+public class PredicateBuilder extends AbstractPredicateBuilder implements DataSerializable {
 
     public String getAttribute() {
         return attribute;
@@ -44,11 +31,6 @@ public class PredicateBuilder implements IndexAwarePredicate, DataSerializable {
 
     public void setAttribute(String attribute) {
         this.attribute = attribute;
-    }
-
-    @Override
-    public boolean apply(Map.Entry mapEntry) {
-        return lsPredicates.get(0).apply(mapEntry);
     }
 
     public EntryObject getEntryObject() {
@@ -79,47 +61,5 @@ public class PredicateBuilder implements IndexAwarePredicate, DataSerializable {
         Predicate second = lsPredicates.remove(index);
         lsPredicates.add(Predicates.or(first, second));
         return this;
-    }
-
-    @Override
-    public Set<QueryableEntry> filter(QueryContext queryContext) {
-        Predicate p = lsPredicates.get(0);
-        if (p instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) p).filter(queryContext);
-        }
-        return null;
-    }
-
-    @Override
-    public boolean isIndexed(QueryContext queryContext) {
-        Predicate p = lsPredicates.get(0);
-        if (p instanceof IndexAwarePredicate) {
-            return ((IndexAwarePredicate) p).isIndexed(queryContext);
-        }
-        return false;
-    }
-
-    @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(attribute);
-        out.writeInt(lsPredicates.size());
-        for (Predicate predicate : lsPredicates) {
-            out.writeObject(predicate);
-        }
-    }
-
-    @Override
-    public void readData(ObjectDataInput in) throws IOException {
-        attribute = in.readUTF();
-        int size = in.readInt();
-        lsPredicates = new ArrayList<Predicate>(size);
-        for (int i = 0; i < size; i++) {
-            lsPredicates.add((Predicate) in.readObject());
-        }
-    }
-
-    @Override
-    public String toString() {
-        return "PredicateBuilder{\n" + (lsPredicates.size() == 0 ? "" : lsPredicates.get(0)) + "\n}";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateDataSerializerHook.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.query.CompositePredicate;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.PartitionPredicate;
 import com.hazelcast.query.SqlPredicate;
@@ -55,8 +56,8 @@ public class PredicateDataSerializerHook
     public static final int PAGING_PREDICATE = 15;
     public static final int PARTITION_PREDICATE = 16;
     public static final int NULL_OBJECT = 17;
-
-    public static final int LEN = NULL_OBJECT + 1;
+    public static final int COMPOSITE_PREDICATE = 18;
+    public static final int LEN = COMPOSITE_PREDICATE + 1;
 
     @Override
     public int getFactoryId() {
@@ -155,6 +156,11 @@ public class PredicateDataSerializerHook
         constructors[NULL_OBJECT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new IndexImpl.NullObject();
+            }
+        };
+        constructors[COMPOSITE_PREDICATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CompositePredicate();
             }
         };
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
@@ -11,6 +11,7 @@ import com.hazelcast.nio.serialization.PortableFactory;
 import com.hazelcast.nio.serialization.PortableTest.ChildPortableObject;
 import com.hazelcast.nio.serialization.PortableTest.GrandParentPortableObject;
 import com.hazelcast.nio.serialization.PortableTest.ParentPortableObject;
+import com.hazelcast.query.CompositePredicate;
 import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.PredicateBuilder;
@@ -291,6 +292,21 @@ public class QueryBasicTest extends HazelcastTestSupport {
             map.put("" + i, "" + i);
         }
         Predicate predicate = new PredicateBuilder().getEntryObject().get("this").equal("10");
+        Collection<String> set = map.values(predicate);
+        assertEquals(1, set.size());
+        assertEquals(1, map.values(new SqlPredicate("this=15")).size());
+    }
+
+    @Test(timeout = 1000 * 60)
+    public void queryWithThis_compositePredicate() {
+        HazelcastInstance instance = createHazelcastInstance(getConfig());
+        IMap<String, String> map = instance.getMap("queryWithThis");
+        map.addIndex("this", false);
+        for (int i = 0; i < 1000; i++) {
+            map.put("" + i, "" + i);
+        }
+        PredicateBuilder predicateBuilder = new PredicateBuilder().getEntryObject().get("this").equal("10");
+        Predicate predicate = new CompositePredicate(predicateBuilder);
         Collection<String> set = map.values(predicate);
         assertEquals(1, set.size());
         assertEquals(1, map.values(new SqlPredicate("this=15")).size());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.query.impl;
 
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.query.CompositePredicate;
 import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.PredicateBuilder;
 import com.hazelcast.query.SampleObjects.Employee;
@@ -63,6 +64,9 @@ public class IndexesTest {
                 .and(entryObject.get("age").in(ages.toArray(new String[count])));
         Set<QueryableEntry> results = indexes.query(predicate);
         assertEquals(1, results.size());
+
+        Set<QueryableEntry> results1 = indexes.query(new CompositePredicate(predicate));
+        assertEquals(1, results1.size());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.CompositePredicate;
 import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.Predicate;
@@ -275,6 +276,18 @@ public class PredicatesTest extends HazelcastTestSupport {
         assertTrue(predicate.apply(createEntry("1", value)));
         e = new PredicateBuilder().getEntryObject();
         assertTrue(e.get("id").equal(12).apply(createEntry("1", value)));
+    }
+
+    @Test
+    public void testCriteriaAPI_compositePredicate() {
+        Object value = new Employee(12, "abc-123-xvz", 34, true, 10D);
+        EntryObject e = new PredicateBuilder().getEntryObject();
+        EntryObject e2 = e.get("age");
+        Predicate predicate = new CompositePredicate(e2.greaterEqual(29).and(e2.lessEqual(36)));
+        assertTrue(predicate.apply(createEntry("1", value)));
+        e = new PredicateBuilder().getEntryObject();
+        Predicate compositePredicate = new CompositePredicate(e.get("id").equal(12));
+        assertTrue(compositePredicate.apply(createEntry("1", value)));
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Adding identified predicate builder (CompositePredicate) for non java clients to be able to support predicate builder. 
PredicateBuilder was only DataSerializable before. Our other clients(c++ , nodejs , csharp ..) do not support DataSerializable.
