### PR TITLE
Execute member bouncing statement when no @Before exists

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockLeaseMemberBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockLeaseMemberBounceTest.java
@@ -9,7 +9,6 @@ import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
 import com.hazelcast.test.jitter.JitterRule;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,11 +43,6 @@ public class LockLeaseMemberBounceTest {
                                                                .driverCount(DRIVER_COUNT).build();
     @Rule
     public JitterRule jitterRule = new JitterRule();
-
-    @Before
-    public void setup() {
-        // Needed because BounceMemberRule expects a before method or otherwise won't bounce, will be fixed
-    }
 
     @Test
     public void leaseShouldExpireWhenMemberBouncing() {

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -188,16 +188,15 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         List<FrameworkMethod> befores = getTestClass().getAnnotatedMethods(
                 Before.class);
         List<TestRule> testRules = getTestRules(target);
+        Statement nextStatement = statement;
         if (!testRules.isEmpty()) {
             for (TestRule rule : testRules) {
                 if (rule instanceof BounceMemberRule) {
-                    Statement bounceMembersAfterBefores = ((BounceMemberRule) rule).startBouncing(statement);
-                    return befores.isEmpty() ? statement : new RunBefores(bounceMembersAfterBefores,
-                            befores, target);
+                    nextStatement = ((BounceMemberRule) rule).startBouncing(statement);
                 }
             }
         }
-        return befores.isEmpty() ? statement : new RunBefores(statement,
+        return befores.isEmpty() ? nextStatement : new RunBefores(nextStatement,
                 befores, target);
     }
 


### PR DESCRIPTION
Fixes `BounceMemberRule` to start member bouncing thread even when no `@Before` methods exist in the test.