### PR TITLE
Fire migration events only for 0th replica

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionEventManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionEventManager.java
@@ -54,6 +54,12 @@ public class PartitionEventManager {
     }
 
     void sendMigrationEvent(final MigrationInfo migrationInfo, final MigrationEvent.MigrationStatus status) {
+        if (migrationInfo.getSourceCurrentReplicaIndex() != 0
+                && migrationInfo.getDestinationNewReplicaIndex() != 0) {
+            // only fire events for 0th replica migrations
+            return;
+        }
+
         ClusterServiceImpl clusterService = node.getClusterService();
         MemberImpl current = clusterService.getMember(migrationInfo.getSource());
         MemberImpl newOwner = clusterService.getMember(migrationInfo.getDestination());


### PR DESCRIPTION
Before changes in migration system in 3.7, migration events were fired for primary replica migrations. 

Fixes #9919