### PR TITLE
SSL and SocketInterceptor classes should be public

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/MemberSocketInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/MemberSocketInterceptor.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.nio;
 
-import com.hazelcast.spi.annotation.PrivateApi;
-
 import java.io.IOException;
 import java.net.Socket;
 
@@ -25,7 +23,6 @@ import java.net.Socket;
  * Member Socket Interceptor can be registered via
  * see {@link com.hazelcast.config.SocketInterceptorConfig}
  */
-@PrivateApi
 public interface MemberSocketInterceptor extends SocketInterceptor {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketInterceptor.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.nio;
 
-import com.hazelcast.spi.annotation.PrivateApi;
-
 import java.io.IOException;
 import java.net.Socket;
 import java.util.Properties;
@@ -28,7 +26,6 @@ import java.util.Properties;
  * For members see {@link com.hazelcast.nio.MemberSocketInterceptor}
  * see {@link com.hazelcast.config.SocketInterceptorConfig}
  */
-@PrivateApi
 public interface SocketInterceptor {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/BasicSSLContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/BasicSSLContextFactory.java
@@ -17,7 +17,6 @@
 package com.hazelcast.nio.ssl;
 
 import com.hazelcast.nio.IOUtil;
-import com.hazelcast.spi.annotation.PrivateApi;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -32,7 +31,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.Properties;
 
-@PrivateApi
 public class BasicSSLContextFactory implements SSLContextFactory {
 
     private static final String JAVA_NET_SSL_PREFIX = "javax.net.ssl.";

--- a/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLContextFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ssl/SSLContextFactory.java
@@ -16,15 +16,12 @@
 
 package com.hazelcast.nio.ssl;
 
-import com.hazelcast.spi.annotation.PrivateApi;
-
 import javax.net.ssl.SSLContext;
 import java.util.Properties;
 
 /**
  * Factory class for creating {@link javax.net.ssl.SSLContext}
  */
-@PrivateApi
 public interface SSLContextFactory {
 
     /**


### PR DESCRIPTION
`SSLContextFactory` and `SocketInterceptor` were marked as `@PrivateAPI`
in commit 843af4e9330a6a90f9afa28d273734c6a3294fe9.
But they are part of public api.