### PR TITLE
Backport of #6702 and #7162

### DIFF
--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -58,6 +58,7 @@ public class ClientConnection implements Connection, Closeable {
 
     private volatile Address remoteEndpoint;
     private volatile boolean heartBeating = true;
+    private volatile boolean isAuthenticatedAsOwner;
 
     public ClientConnection(HazelcastClientInstanceImpl client, IOSelector in, IOSelector out,
                             int connectionId, SocketChannelWrapper socketChannelWrapper) throws IOException {
@@ -69,6 +70,7 @@ public class ClientConnection implements Connection, Closeable {
         this.connectionId = connectionId;
         this.readHandler = new ClientReadHandler(this, in, socket.getReceiveBufferSize());
         this.writeHandler = new ClientWriteHandler(this, out, socket.getSendBufferSize());
+        init();
     }
 
     public ClientConnection(HazelcastClientInstanceImpl client,
@@ -110,12 +112,20 @@ public class ClientConnection implements Connection, Closeable {
         return true;
     }
 
-    public void init() throws IOException {
+    private void init() throws IOException {
         final ByteBuffer buffer = ByteBuffer.allocate(6);
         buffer.put(stringToBytes(Protocols.CLIENT_BINARY_NEW));
         buffer.put(stringToBytes(ClientTypes.JAVA));
         buffer.flip();
         socketChannelWrapper.write(buffer);
+    }
+
+    public boolean isAuthenticatedAsOwner() {
+        return isAuthenticatedAsOwner;
+    }
+
+    public void setAuthenticatedAsOwner() {
+        isAuthenticatedAsOwner = true;
     }
 
     @Override

--- a/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
+++ b/hazelcast-client-new/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
@@ -66,7 +66,6 @@ public class ClusterAuthenticator implements Authenticator {
             clientMessage = ClientAuthenticationCustomCodec.encodeRequest(data, uuid, ownerUuid, false);
 
         }
-        connection.init();
 
         ClientMessage response;
         final ClientInvocation clientInvocation = new ClientInvocation(client, clientMessage, connection);

--- a/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client-new/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -179,11 +179,6 @@ public class TestClientRegistry {
         }
 
         @Override
-        public void init() throws IOException {
-
-        }
-
-        @Override
         public long lastReadTime() {
             return lastReadTime;
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -58,6 +58,7 @@ public class ClientConnection implements Connection, Closeable {
 
     private volatile Address remoteEndpoint;
     private volatile boolean heartBeating = true;
+    private volatile boolean isAuthenticatedAsOwner;
 
     public ClientConnection(HazelcastClientInstanceImpl client, IOSelector in, IOSelector out,
                             int connectionId, SocketChannelWrapper socketChannelWrapper) throws IOException {
@@ -69,6 +70,7 @@ public class ClientConnection implements Connection, Closeable {
         this.connectionId = connectionId;
         this.readHandler = new ClientReadHandler(this, in, socket.getReceiveBufferSize());
         this.writeHandler = new ClientWriteHandler(this, out, socket.getSendBufferSize());
+        init();
     }
 
     public ClientConnection(HazelcastClientInstanceImpl client,
@@ -110,12 +112,20 @@ public class ClientConnection implements Connection, Closeable {
         return true;
     }
 
-    public void init() throws IOException {
+    private void init() throws IOException {
         final ByteBuffer buffer = ByteBuffer.allocate(6);
         buffer.put(stringToBytes(Protocols.CLIENT_BINARY));
         buffer.put(stringToBytes(ClientTypes.JAVA));
         buffer.flip();
         socketChannelWrapper.write(buffer);
+    }
+
+    public boolean isAuthenticatedAsOwner() {
+        return isAuthenticatedAsOwner;
+    }
+
+    public void setAuthenticatedAsOwner() {
+        isAuthenticatedAsOwner = true;
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClusterAuthenticator.java
@@ -56,7 +56,6 @@ public class ClusterAuthenticator implements Authenticator {
         final ClientPrincipal principal = clusterService.getPrincipal();
         final SerializationService ss = client.getSerializationService();
         AuthenticationRequest auth = new AuthenticationRequest(credentials, principal);
-        connection.init();
         //contains remoteAddress and principal
         SerializableCollection collectionWrapper;
         final ClientInvocation clientInvocation = new ClientInvocation(client, auth, connection);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -200,11 +200,6 @@ public class TestClientRegistry {
         }
 
         @Override
-        public void init() throws IOException {
-
-        }
-
-        @Override
         public long lastReadTime() {
             return lastReadTime;
         }


### PR DESCRIPTION
Invocation timeout handling is fixed. # of times an
invocation made is used to be count with 1 second sleeps. Since
invocation itself can take time, user configured timeout was
used to be violated. It is now checked by comparing
System.currentTimeMillis and starting time.
Half backport of #6702

Reauthenticate as owner to an old connection when owner dead
When client searching for a new owner connection, if it come accross
already established one, it will resend authentication
request to change the owner connection info on the cluster.
backport of #7162