### PR TITLE
Followup to listener fix in 9866

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/AbstractListenersOnReconnectTest.java
@@ -520,6 +520,8 @@ public abstract class AbstractListenersOnReconnectTest extends ClientTestSupport
                     produceEvent(event);
                 }
 
+                assertOpenEventually(eventsLatch);
+
                 assertTrueAllTheTime(new AssertTask() {
                     @Override
                     public void run()


### PR DESCRIPTION
Fix in #9866 accidenttally send broken.
The new added latch should have been waited in the test.

fixes #9937