### PR TITLE
[BACKPORT] Making clusterVersion non-null all the time.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -173,19 +173,19 @@ public interface Cluster {
     /**
      * The cluster version indicates the operating version of the cluster. It is separate from each node's codebase version,
      * as it may be acceptable for a node to operate at a different compatibility version than its codebase version. This method
-     * may return {@code null} if invoked after the ClusterService is constructed and before the node forms a cluster, either
+     * may return Version.UNKNOWN if invoked after the ClusterService is constructed and before the node forms a cluster, either
      * by joining existing members or becoming master of its standalone cluster if it is the first node on the cluster.
      * Importantly, this is the time during which a lifecycle event with state
      * {@link com.hazelcast.core.LifecycleEvent.LifecycleState#STARTING} is triggered.
      *
-     * For example, consider a cluster comprised of nodes running on {@code hazelcast-3.8.jar}. Each node's codebase version
+     * For example, consider a cluster comprised of nodes running on {@code hazelcast-3.8.0.jar}. Each node's codebase version
      * is 3.8.0 and on startup the cluster version is 3.8. After a while, another node joins, running on
-     * {@code hazelcast-3.9.jar}; this node's codebase version is 3.9.0. If deemed compatible, it is allowed to join the cluster.
+     * {@code hazelcast-3.9.0jar}; this node's codebase version is 3.9.0. If deemed compatible, it is allowed to join the cluster.
      * At this point, the cluster version is still 3.8 and the 3.9.0 member should be able to adapt its behaviour to be compatible
      * with the other 3.8.0 members. Once all 3.8.0 members have been shutdown and replaced by other members on codebase
      * version 3.9.0, still the cluster version will be 3.8. At this point, it is possible to update the cluster version to
      * 3.9, since all cluster members will be compatible with the new cluster version. Once cluster version
-     * is updated to 3.9.0, further communication among members will take place in 3.9 and all new features and functionality
+     * is updated to 3.9, further communication among members will take place in 3.9 and all new features and functionality
      * of version 3.9 will be available.
      *
      * @return the version at which this cluster operates.

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -307,7 +307,7 @@ public class DefaultNodeExtension implements NodeExtension {
     // otherwise, if overridden with GroupProperty#INIT_CLUSTER_VERSION, use this one
     // otherwise, if not overridden, use current node's codebase version
     private Version getClusterOrNodeVersion() {
-        if (node.getClusterService() != null && node.getClusterService().getClusterVersion() != null) {
+        if (node.getClusterService() != null && !node.getClusterService().getClusterVersion().isUnknown()) {
             return node.getClusterService().getClusterVersion();
         } else {
             String overriddenClusterVersion = node.getProperties().getString(GroupProperty.INIT_CLUSTER_VERSION);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -501,7 +501,7 @@ public class ClusterJoinManager {
 
             node.setMasterAddress(thisAddress);
 
-            if (clusterService.getClusterVersion() == null) {
+            if (clusterService.getClusterVersion().isUnknown()) {
                 clusterService.getClusterStateManager().setClusterVersion(version.asVersion());
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateChange.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateChange.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 
@@ -55,6 +56,12 @@ public class ClusterStateChange<T> implements IdentifiedDataSerializable {
     public void validate() {
         if (type == null || newState == null) {
             throw new IllegalArgumentException("Invalid null state");
+        }
+
+        if (isOfType(Version.class)) {
+            if (((Version) newState).isUnknown()) {
+                throw new IllegalArgumentException("Cannot change Version to UNKNOWN!");
+            }
         }
 
         if (isOfType(ClusterState.class)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -68,7 +68,7 @@ public class ClusterStateManager {
     private static final long LOCK_LEASE_EXTENSION_MILLIS = TimeUnit.SECONDS.toMillis(20);
 
     // this is the version at which the cluster operates. see Cluster#getClusterVersion
-    volatile Version clusterVersion;
+    volatile Version clusterVersion = Version.UNKNOWN;
 
     private final Node node;
     private final ILogger logger;
@@ -166,16 +166,16 @@ public class ClusterStateManager {
         clusterServiceLock.lock();
         try {
             state = ClusterState.ACTIVE;
-            // not notifying cluster version listeners about change to null. consider for example the following scenario:
+            // not notifying cluster version listeners about change to UNKNOWN. consider for example the following scenario:
             // - node starts with codebase version 3.9, overrides init cluster version via group property to 3.8
             // - node joins an existing 3.8 cluster which is undergoing rolling-upgrade to 3.9
             // - once all cluster members are on 3.9, cluster version is upgraded to 3.9.0
-            // - clusterVersion is reset to null
+            // - clusterVersion is reset to UNKNOWN
             // - if cluster version listener is notified of null cluster version, it should receive the overridden one (3.8)
             // - if 3.8 discovery & join messages are incompatible, node will not be able to join 3.9 cluster
             // Instead, not notifying cluster version listeners will let the node use its last set cluster version for discovery &
             // join messages and join the cluster.
-            clusterVersion = null;
+            clusterVersion = Version.UNKNOWN;
             stateLockRef.set(LockGuard.NOT_LOCKED);
         } finally {
             clusterServiceLock.unlock();
@@ -238,7 +238,7 @@ public class ClusterStateManager {
 
     // validate transition from current to newClusterVersion is allowed
     private void validateClusterVersionChange(Version newClusterVersion) {
-        if (clusterVersion != null && clusterVersion.getMajor() != newClusterVersion.getMajor()) {
+        if (!clusterVersion.isUnknown() && clusterVersion.getMajor() != newClusterVersion.getMajor()) {
             throw new IllegalArgumentException("Transition to requested version " + newClusterVersion
                     + " not allowed for current cluster version " + clusterVersion);
         }

--- a/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
@@ -88,7 +88,7 @@ public final class MemberVersion
     }
 
     public boolean isUnknown() {
-        return this.equals(UNKNOWN);
+        return this.major == 0 && this.minor == 0 && this.patch == 0;
     }
 
     @Override


### PR DESCRIPTION
Backport of https://github.com/hazelcast/hazelcast/pull/9929