### PR TITLE
Metric Registry: Auto convert getter name into a property name

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
@@ -38,7 +38,7 @@ public class ClusterClockImpl implements ClusterClock {
         this.logger = logger;
     }
 
-    @Probe(name = "clusterTime")
+    @Probe
     @Override
     public long getClusterTime() {
         return Clock.currentTimeMillis() + clusterTimeDiff;
@@ -67,12 +67,12 @@ public class ClusterClockImpl implements ClusterClock {
         this.clusterTimeDiff = diff;
     }
 
-    @Probe(name = "clusterTimeDiff", level = MANDATORY)
+    @Probe(level = MANDATORY)
     long getClusterTimeDiff() {
         return clusterTimeDiff;
     }
 
-    @Probe(name = "clusterUpTime")
+    @Probe
     @Override
     public long getClusterUpTime() {
         return Clock.currentTimeMillis() - clusterStartTime;
@@ -84,12 +84,12 @@ public class ClusterClockImpl implements ClusterClock {
         }
     }
 
-    @Probe(name = "localClockTime")
+    @Probe
     private long getLocalClockTime() {
         return Clock.currentTimeMillis();
     }
 
-    @Probe(name = "clusterStartTime")
+    @Probe
     public long getClusterStartTime() {
         return clusterStartTime;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -860,7 +860,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         return node.getLocalMember();
     }
 
-    @Probe(name = "size")
+    @Probe
     @Override
     public int getSize() {
         return getMembers().size();

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -37,6 +37,7 @@ import static com.hazelcast.internal.metrics.impl.ProbeUtils.TYPE_PRIMITIVE_LONG
 import static com.hazelcast.internal.metrics.impl.ProbeUtils.TYPE_SEMAPHORE;
 import static com.hazelcast.internal.metrics.impl.ProbeUtils.getType;
 import static com.hazelcast.internal.metrics.impl.ProbeUtils.isDouble;
+import static com.hazelcast.util.StringUtil.getterIntoProperty;
 import static java.lang.String.format;
 
 /**
@@ -63,8 +64,10 @@ abstract class MethodProbe implements ProbeFunction {
     }
 
     private String getName(String namePrefix) {
-        String name = method.getName();
-        if (!probe.name().equals("")) {
+        String name;
+        if (probe.name().equals("")) {
+            name = getterIntoProperty(method.getName());
+        } else {
             name = probe.name();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingSocketWriter.java
@@ -125,12 +125,12 @@ public final class NonBlockingSocketWriter
         return bytesPending;
     }
 
-    @Probe(name = "idleTimeMs")
+    @Probe
     private long idleTimeMs() {
         return max(currentTimeMillis() - lastWriteTime, 0);
     }
 
-    @Probe(name = "isScheduled", level = DEBUG)
+    @Probe(level = DEBUG)
     private long isScheduled() {
         return scheduled.get() ? 1 : 0;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningSocketWriter.java
@@ -90,7 +90,7 @@ public class SpinningSocketWriter extends AbstractHandler implements SocketWrite
         return bytesPending(urgentWriteQueue);
     }
 
-    @Probe(name = "idleTimeMs")
+    @Probe
     private long idleTimeMs() {
         return Math.max(currentTimeMillis() - lastWriteTime, 0);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -951,7 +951,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     @Override
-    @Probe(name = "migrationQueueSize")
+    @Probe
     public long getMigrationQueueSize() {
         return migrationManager.getMigrationQueueSize();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -293,24 +293,24 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
         return size;
     }
 
-    @Probe(name = "genericQueueSize")
+    @Probe
     private int getGenericQueueSize() {
         return genericQueue.normalSize();
     }
 
-    @Probe(name = "genericPriorityQueueSize")
+    @Probe
     private int getGenericPriorityQueueSize() {
         return genericQueue.prioritySize();
     }
 
     @Override
-    @Probe(name = "partitionThreadCount")
+    @Probe
     public int getPartitionThreadCount() {
         return partitionThreads.length;
     }
 
     @Override
-    @Probe(name = "genericThreadCount")
+    @Probe
     public int getGenericThreadCount() {
         return genericThreads.length;
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -24,6 +24,10 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.lang.Character.isLetter;
+import static java.lang.Character.isLowerCase;
+import static java.lang.Character.toLowerCase;
+
 /**
  * Utility class for Strings.
  */
@@ -50,6 +54,8 @@ public final class StringUtil {
      */
     private static final Pattern VERSION_PATTERN
             = Pattern.compile("^([\\d]+)\\.([\\d]+)(\\.([\\d]+))?(-[\\w]+)?(-SNAPSHOT)?$");
+
+    private static final String GETTER_PREFIX = "get";
 
     private StringUtil() {
     }
@@ -246,5 +252,39 @@ public final class StringUtil {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Convert getter into a property name
+     * Example: 'getFoo' is converted into 'foo'
+     *
+     * It's written defensively, when output is not a getter then it
+     * return the original name.
+     *
+     * It converters name starting with the get- prefix only. When a getter
+     * starts with is- prefix (=boolean) then it does not convert it.
+     *
+     * @param getterName
+     * @return property matching the given getter
+     */
+    public static String getterIntoProperty(String getterName) {
+        if (getterName == null) {
+            return getterName;
+        }
+        int length = getterName.length();
+        if (!getterName.startsWith(GETTER_PREFIX) || length <= GETTER_PREFIX.length()) {
+            return getterName;
+        }
+
+        String propertyName = getterName.substring(GETTER_PREFIX.length(), length);
+        char firstChar = propertyName.charAt(0);
+        if (isLetter(firstChar)) {
+            if (isLowerCase(firstChar)) {
+                //ok, apparently this is not a JavaBean getter, better leave it untouched
+                return getterName;
+            }
+            propertyName = toLowerCase(firstChar) + propertyName.substring(1, propertyName.length());
+        }
+        return propertyName;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/ManagedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/ManagedExecutorService.java
@@ -26,18 +26,18 @@ public interface ManagedExecutorService extends ExecutorService {
 
     String getName();
 
-    @Probe(name = "completedTaskCount")
+    @Probe
     long getCompletedTaskCount();
 
-    @Probe(name = "maximumPoolSize")
+    @Probe
     int getMaximumPoolSize();
 
-    @Probe(name = "poolSize")
+    @Probe
     int getPoolSize();
 
-    @Probe(name = "queueSize", level = MANDATORY)
+    @Probe(level = MANDATORY)
     int getQueueSize();
 
-    @Probe(name = "remainingQueueCapacity")
+    @Probe
     int getRemainingQueueCapacity();
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
@@ -1,0 +1,53 @@
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class StringUtilTest extends HazelcastTestSupport {
+
+    @Test
+    public void getterIntoProperty_whenNull_returnNull() throws Exception {
+        assertEquals("", StringUtil.getterIntoProperty(""));
+    }
+
+    @Test
+    public void getterIntoProperty_whenEmpty_returnEmptyString() throws Exception {
+        assertEquals("", StringUtil.getterIntoProperty(""));
+    }
+
+    @Test
+    public void getterIntoProperty_whenGet_returnUnchanged() throws Exception {
+        assertEquals("get", StringUtil.getterIntoProperty("get"));
+    }
+
+    @Test
+    public void getterIntoProperty_whenGetFoo_returnFoo() throws Exception {
+        assertEquals("foo", StringUtil.getterIntoProperty("getFoo"));
+    }
+
+    @Test
+    public void getterIntoProperty_whenGetF_returnF() throws Exception {
+        assertEquals("f", StringUtil.getterIntoProperty("getF"));
+    }
+
+
+    @Test
+    public void getterIntoProperty_whenGetNumber_returnNumber() throws Exception {
+        assertEquals("8", StringUtil.getterIntoProperty("get8"));
+    }
+
+    @Test
+    public void getterIntoProperty_whenPropertyIsLowerCase_DoNotChange() throws Exception {
+        assertEquals("getfoo", StringUtil.getterIntoProperty("getfoo"));
+    }
+
+}


### PR DESCRIPTION
Example
```java
@Probe
public int getFoo() {
 [...]
}
```

Now generates a probe named `foo` instead of `getFoo`

This increases usefulness of implicit probe names and does not force
you to use explicit names only to remove the get- prefix.