### PR TITLE
Split-Brain handler listener throws away messages from non-trusted hosts

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessageTrustChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessageTrustChecker.java
@@ -1,0 +1,30 @@
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.config.MulticastConfig;
+
+import java.util.Set;
+
+import static com.hazelcast.util.AddressUtil.matchAnyInterface;
+
+/**
+ * Check if a received join message is to be trusted.
+ *
+ * To be precise it's checking if IP of the JoinMessage sender
+ * is among configured {@link MulticastConfig#getTrustedInterfaces()}
+ *
+ * When no trusted interfaces were explicitly configured then all messages are deemed
+ * as trusted.
+ *
+ */
+final class JoinMessageTrustChecker {
+    private final Set<String> trustedInterfaces;
+
+    JoinMessageTrustChecker(Set<String> trustedInterfaces) {
+        this.trustedInterfaces = trustedInterfaces;
+    }
+
+    boolean isTrusted(JoinMessage joinMessage) {
+        String host = joinMessage.getAddress().getHost();
+        return trustedInterfaces.isEmpty() || matchAnyInterface(host, trustedInterfaces);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -24,6 +24,7 @@ import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.RandomPicker;
 
+import java.util.Set;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
@@ -47,7 +48,9 @@ public class MulticastJoiner extends AbstractJoiner {
     public MulticastJoiner(Node node) {
         super(node);
         maxTryCount = new AtomicInteger(calculateTryCount());
-        node.multicastService.addMulticastListener(new SplitBrainMulticastListener(node, splitBrainJoinMessages));
+        Set<String> trustedInterfaces = node.getConfig().getNetworkConfig().getJoin().getMulticastConfig().getTrustedInterfaces();
+        JoinMessageTrustChecker trustChecker = new JoinMessageTrustChecker(trustedInterfaces);
+        node.multicastService.addMulticastListener(new SplitBrainMulticastListener(node, splitBrainJoinMessages, trustChecker));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
@@ -6,6 +6,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastTestSupport;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -80,5 +81,24 @@ public class AbstractJoinTest extends HazelcastTestSupport {
 
         assertTrue(hz2.getLifecycleService().isRunning());
         assertClusterSize(1, hz2);
+    }
+
+    protected static void assertIndependentClustersAndDoNotMergedEventually(Config config1, Config config2, int durationSeconds) {
+        HazelcastInstance hz1 = Hazelcast.newHazelcastInstance(config1);
+        HazelcastInstance hz2 = Hazelcast.newHazelcastInstance(config2);
+
+        assertTrue(hz1.getLifecycleService().isRunning());
+        assertClusterSize(1, hz1);
+
+        assertTrue(hz2.getLifecycleService().isRunning());
+        assertClusterSize(1, hz2);
+
+        long deadLine = System.currentTimeMillis() + SECONDS.toMillis(durationSeconds);
+        while (System.currentTimeMillis() < deadLine) {
+            assertClusterSize(1, hz1);
+            assertClusterSize(1, hz2);
+
+            sleepAtLeastMillis(100);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SlowMulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SlowMulticastJoinTest.java
@@ -1,0 +1,43 @@
+package com.hazelcast.cluster;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class SlowMulticastJoinTest extends AbstractJoinTest {
+
+    @Before
+    @After
+    public void killAllHazelcastInstances() throws IOException {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testMembersStaysIndependentWhenHostIsNotTrusted() {
+        Config config1 = newConfig();
+        Config config2 = newConfig();
+
+        int testDurationSeconds = 30;
+        assertIndependentClustersAndDoNotMergedEventually(config1, config2, testDurationSeconds);
+    }
+
+    private Config newConfig() {
+        Config config = new Config();
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "3");
+        config.getNetworkConfig().getJoin().getMulticastConfig().addTrustedInterface("8.8.8.8");
+        return config;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/JoinMessageTrustCheckerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/JoinMessageTrustCheckerTest.java
@@ -1,0 +1,68 @@
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.MemberVersion;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static java.util.Collections.EMPTY_SET;
+import static java.util.Collections.singleton;
+import static org.junit.Assert.*;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class JoinMessageTrustCheckerTest extends HazelcastTestSupport {
+
+    @Test
+    public void givenNoInterfaceIsConfigured_whenMessageArrives_thenTrust() throws UnknownHostException {
+        JoinMessageTrustChecker joinMessageTrustChecker = new JoinMessageTrustChecker(EMPTY_SET);
+        JoinMessage message = createJoinMessage("127.0.0.1");
+        assertTrue(joinMessageTrustChecker.isTrusted(message));
+    }
+
+    @Test
+    public void givenInterfaceIsConfigured_whenMessageWithMatchingHost_thenTrust() throws UnknownHostException {
+        JoinMessageTrustChecker joinMessageTrustChecker = new JoinMessageTrustChecker(singleton("127.0.0.1"));
+        JoinMessage message = createJoinMessage("127.0.0.1");
+        assertTrue(joinMessageTrustChecker.isTrusted(message));
+    }
+
+    @Test
+    public void givenInterfaceIsConfigured_whenMessageWithNonMatchingHost_thenDoNotTrust() throws UnknownHostException {
+        JoinMessageTrustChecker joinMessageTrustChecker = new JoinMessageTrustChecker(singleton("127.0.0.2"));
+        JoinMessage message = createJoinMessage("127.0.0.1");
+        assertFalse(joinMessageTrustChecker.isTrusted(message));
+    }
+
+    @Test
+    public void givenInterfaceRangeIsConfigured_whenMessageWithMatchingHost_thenTrust() throws UnknownHostException {
+        JoinMessageTrustChecker joinMessageTrustChecker = new JoinMessageTrustChecker(singleton("127.0.0.1-100"));
+        JoinMessage message = createJoinMessage("127.0.0.2");
+        assertTrue(joinMessageTrustChecker.isTrusted(message));
+    }
+
+    @Test
+    public void givenInterfaceRangeIsConfigured_whenMessageWithNonMatchingHost_thenDoNotTrust() throws UnknownHostException {
+        JoinMessageTrustChecker joinMessageTrustChecker = new JoinMessageTrustChecker(singleton("127.0.0.1-100"));
+        JoinMessage message = createJoinMessage("127.0.0.101");
+        assertFalse(joinMessageTrustChecker.isTrusted(message));
+    }
+
+    private JoinMessage createJoinMessage(String ip) throws UnknownHostException {
+        InetAddress inetAddress = InetAddress.getByName(ip);
+        Address address = new Address(inetAddress, 5701);
+        ConfigCheck configCheck = new ConfigCheck();
+        return new JoinMessage(Packet.VERSION, 0, MemberVersion.UNKNOWN, address, "uuid", false, configCheck);
+    }
+
+}


### PR DESCRIPTION
Fixes #9953

Also introduced JoinMessageTrustChecker to use the same trust-checking
in both SplitBrainMulticastListener and NodeMulticastListener