### PR TITLE
Peel exceptions before rethrowing from ReliableTopic.publish

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.config.ClientReliableTopicConfig;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.ITopic;
@@ -51,6 +50,7 @@ import java.util.concurrent.Executor;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferService.TOPIC_RB_PREFIX;
 import static com.hazelcast.topic.impl.reliable.ReliableTopicService.SERVICE_NAME;
+import static com.hazelcast.util.ExceptionUtil.peel;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -114,10 +114,9 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
                 default:
                     throw new IllegalArgumentException("Unknown overloadPolicy:" + overloadPolicy);
             }
-        } catch (RuntimeException e) {
-            throw e;
         } catch (Exception e) {
-            throw new HazelcastException("Failed to publish message: " + payload + " to topic:" + name, e);
+            throw (RuntimeException) peel(e, null,
+                    "Failed to publish message: " + payload + " to topic:" + getName());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -43,6 +43,7 @@ import java.util.concurrent.Executor;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferService.TOPIC_RB_PREFIX;
 import static com.hazelcast.spi.ExecutionService.ASYNC_EXECUTOR;
+import static com.hazelcast.util.ExceptionUtil.peel;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -166,10 +167,9 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
             }
 
             localTopicStats.incrementPublishes();
-        } catch (RuntimeException e) {
-            throw e;
         } catch (Exception e) {
-            throw new HazelcastException("Failed to publish message: " + payload + " to topic:" + getName(), e);
+            throw (RuntimeException) peel(e, null,
+                    "Failed to publish message: " + payload + " to topic:" + getName());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ExceptionUtil.java
@@ -53,6 +53,24 @@ public final class ExceptionUtil {
     }
 
     public static <T extends Throwable> Throwable peel(final Throwable t, Class<T> allowedType) {
+        return peel(t, allowedType, null);
+    }
+
+    /**
+     * Processes {@code Throwable t} so that the returned {@code Throwable}'s type matches {@code allowedType} or
+     * {@code RuntimeException}. Processing may include unwrapping {@code t}'s cause hierarchy, wrapping it in a
+     * {@code HazelcastException} or just returning the same instance {@code t} if it is already an instance of
+     * {@code RuntimeException}.
+     *
+     * @param t             {@code Throwable} to be peeled
+     * @param allowedType   the type expected to be returned; when {@code null}, this method returns instances
+     *                      of {@code RuntimeException}
+     * @param message       if not {@code null}, used as the message in the {@code HazelcastException} that
+     *                      may wrap the peeled {@code Throwable}
+     * @param <T>           expected type of {@code Throwable}
+     * @return              the peeled {@code Throwable}
+     */
+    public static <T extends Throwable> Throwable peel(final Throwable t, Class<T> allowedType, String message) {
         if (t instanceof RuntimeException) {
             return t;
         }
@@ -70,7 +88,11 @@ public final class ExceptionUtil {
             return t;
         }
 
-        return new HazelcastException(t);
+        if (message != null) {
+            return new HazelcastException(message, t);
+        } else {
+            return new HazelcastException(t);
+        }
     }
 
     public static RuntimeException rethrow(final Throwable t) {


### PR DESCRIPTION
Also adds a `peel` method variant in `ExceptionUtil` to provide a custom message when wrapping with a `HazelcastException`.

Fixes #9960 