### PR TITLE
[WIP]BinaryInterface annotated classes updated 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalAverageAggregator.java
@@ -20,10 +20,12 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 
+@BinaryInterface
 public final class BigDecimalAverageAggregator<I> extends AbstractAggregator<I, BigDecimal, BigDecimal>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigDecimalSumAggregator.java
@@ -20,10 +20,12 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 
+@BinaryInterface
 public final class BigDecimalSumAggregator<I> extends AbstractAggregator<I, BigDecimal, BigDecimal>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerAverageAggregator.java
@@ -20,11 +20,13 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+@BinaryInterface
 public final class BigIntegerAverageAggregator<I> extends AbstractAggregator<I, BigInteger, BigDecimal>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/BigIntegerSumAggregator.java
@@ -20,10 +20,12 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.math.BigInteger;
 
+@BinaryInterface
 public final class BigIntegerSumAggregator<I> extends AbstractAggregator<I, BigInteger, BigInteger>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/CountAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class CountAggregator<I> extends AbstractAggregator<I, Object, Long> implements IdentifiedDataSerializable {
     private long count;
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DistinctValuesAggregator.java
@@ -20,11 +20,13 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+@BinaryInterface
 public final class DistinctValuesAggregator<I, R> extends AbstractAggregator<I, R, Set<R>> implements IdentifiedDataSerializable {
     Set<R> values = new HashSet<R>();
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleAverageAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class DoubleAverageAggregator<I> extends AbstractAggregator<I, Double, Double>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/DoubleSumAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class DoubleSumAggregator<I> extends AbstractAggregator<I, Double, Double>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FixedSumAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class FixedSumAggregator<I> extends AbstractAggregator<I, Number, Long> implements IdentifiedDataSerializable {
 
     private long sum;

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/FloatingPointSumAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class FloatingPointSumAggregator<I> extends AbstractAggregator<I, Number, Double>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerAverageAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class IntegerAverageAggregator<I> extends AbstractAggregator<I, Integer, Double>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/IntegerSumAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class IntegerSumAggregator<I> extends AbstractAggregator<I, Integer, Long>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongAverageAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class LongAverageAggregator<I> extends AbstractAggregator<I, Long, Double> implements IdentifiedDataSerializable {
 
     private long sum;

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/LongSumAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class LongSumAggregator<I> extends AbstractAggregator<I, Long, Long> implements IdentifiedDataSerializable {
 
     private long sum;

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MaxAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class MaxAggregator<I, R extends Comparable> extends AbstractAggregator<I, R, R>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/MinAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class MinAggregator<I, R extends Comparable> extends AbstractAggregator<I, R, R>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/NumberAverageAggregator.java
@@ -20,9 +20,11 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
+@BinaryInterface
 public final class NumberAverageAggregator<I> extends AbstractAggregator<I, Number, Double>
         implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.AbstractMember;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.version.MemberVersion;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -32,7 +31,6 @@ import java.util.Map;
  * <p>Caution: This class is required by protocol encoder/decoder which are on the Hazelcast module.
  * So this implementation also stays in the same module, although it is totally client side specific.</p>
  */
-@BinaryInterface
 public final class MemberImpl extends AbstractMember implements Member {
 
     public MemberImpl() {

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractCacheConfig.java
@@ -17,7 +17,6 @@
 package com.hazelcast.config;
 
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.configuration.CompleteConfiguration;
@@ -35,7 +34,6 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 /**
  * Base class for {@link CacheConfig}
  */
-@BinaryInterface
 abstract class AbstractCacheConfig<K, V> implements CacheConfiguration<K, V>, DataSerializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -143,6 +143,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
     /**
      * Maximum Size Policy
      */
+    @BinaryInterface
     public enum MaxSizePolicy {
         /**
          * Policy based on maximum number of entries stored per data structure (map, cache etc)

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionPolicy.java
@@ -15,9 +15,13 @@
  */
 
 package com.hazelcast.config;
+
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 /**
  * Eviction Policy enum.
  */
+@BinaryInterface
 public enum EvictionPolicy {
     /**
      * Least Recently Used

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryFormat.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryFormat.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+
 /**
  * Storage format type of values stored in cluster
 */
+@BinaryInterface
 public enum InMemoryFormat {
     /**
      * As Binary

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfig.java
@@ -19,7 +19,6 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -28,7 +27,6 @@ import java.io.Serializable;
  * Configuration for map's capacity.
  * You can set a limit for number of entries or total memory cost of entries.
  */
-@BinaryInterface
 public class MaxSizeConfig implements DataSerializable, Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MaxSizeConfigReadOnly.java
@@ -16,14 +16,11 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 /**
  * Contains the configuration for a size of Map.
  *
  * @deprecated this class will be removed in 4.0; it is meant for internal usage only.
  */
-@BinaryInterface
 public class MaxSizeConfigReadOnly extends MaxSizeConfig {
 
     public MaxSizeConfigReadOnly(MaxSizeConfig config) {

--- a/hazelcast/src/main/java/com/hazelcast/console/Echo.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/Echo.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
@@ -29,7 +28,6 @@ import java.util.concurrent.Callable;
 /**
  * Echoes to screen.
  */
-@BinaryInterface
 public class Echo implements Callable<String>, DataSerializable, HazelcastInstanceAware {
 
     String input;

--- a/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.core;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
 /**
@@ -33,7 +31,6 @@ import java.io.Serializable;
  * @since 3.2
  */
 
-@BinaryInterface
 public interface IFunction<T, R> extends Serializable {
 
     R apply(T input);

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/RunnableAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/RunnableAdapter.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.PartitionAware;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
@@ -31,6 +32,7 @@ import java.util.concurrent.Callable;
  *
  * @param <V>
  */
+@BinaryInterface
 public final class RunnableAdapter<V> implements IdentifiedDataSerializable, Callable<V>,
         HazelcastInstanceAware, PartitionAware {
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.version.MemberVersion;
 
@@ -37,7 +36,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @PrivateApi
-@BinaryInterface
 public abstract class AbstractMember implements Member {
 
     protected final Map<String, Object> attributes = new ConcurrentHashMap<String, Object>();

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyComparator.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.internal.eviction;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 import java.util.Comparator;
 
@@ -25,7 +23,6 @@ import java.util.Comparator;
  * A kind of {@link java.util.Comparator} to be used while comparing
  * entries to be evicted.
  */
-@BinaryInterface
 public abstract class EvictionPolicyComparator<K, V, E extends EvictableEntryView<K, V>>
         implements Comparator<E>, Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.util.Map;
 
 /**
@@ -35,7 +33,6 @@ import java.util.Map;
  * @see com.hazelcast.map.EntryProcessor
  * @see com.hazelcast.map.EntryBackupProcessor
  */
-@BinaryInterface
 public abstract class AbstractEntryProcessor<K, V> implements EntryProcessor<K, V> {
 
     private final EntryBackupProcessor<K, V> entryBackupProcessor;

--- a/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EntryProcessor.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 import java.util.Map;
 
@@ -64,7 +62,6 @@ import java.util.Map;
  * @param <V> Type of value of a {@link java.util.Map.Entry}
  * @see AbstractEntryProcessor
  */
-@BinaryInterface
 public interface EntryProcessor<K, V> extends Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
 /**
@@ -31,7 +29,6 @@ import java.io.Serializable;
  * Serialized instances of this interface are used in client-member communication, so changing an implementation's binary format
  * will render it incompatible with its previous versions.
  */
-@BinaryInterface
 public interface MapInterceptor extends Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
@@ -21,7 +21,6 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
@@ -31,7 +30,6 @@ import java.io.IOException;
  * @param <K> the type of key.
  * @param <V> the type of value.
  */
-@BinaryInterface
 @SuppressWarnings("checkstyle:methodcount")
 public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
@@ -19,14 +19,12 @@ package com.hazelcast.map.impl.event;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
 /**
  * Abstract event data.
  */
-@BinaryInterface
 abstract class AbstractEventData implements EventData {
 
     protected String source;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EntryEventData.java
@@ -20,14 +20,12 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
 /**
  * An entry's event data.
  */
-@BinaryInterface
 public class EntryEventData extends AbstractEventData {
 
     protected Data dataKey;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/EventData.java
@@ -18,12 +18,10 @@ package com.hazelcast.map.impl.event;
 
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * General contract for map event data.
  */
-@BinaryInterface
 public interface EventData extends DataSerializable {
 
     String getSource();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventData.java
@@ -19,14 +19,12 @@ package com.hazelcast.map.impl.event;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
 /**
  * Map wide event's data.
  */
-@BinaryInterface
 public class MapEventData extends AbstractEventData {
 
     protected int numberOfEntries;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapPartitionEventData.java
@@ -19,14 +19,12 @@ package com.hazelcast.map.impl.event;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
 /**
  * Contains the data related to a map partition event
  */
-@BinaryInterface
 public class MapPartitionEventData extends AbstractEventData {
 
     private int partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/BatchEventData.java
@@ -21,7 +21,6 @@ import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,7 +35,6 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  *
  * @see QueryCacheEventData
  */
-@BinaryInterface
 public class BatchEventData implements Sequenced, EventData {
 
     private String source;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventData.java
@@ -20,7 +20,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 
@@ -29,7 +28,6 @@ import java.io.IOException;
 /**
  * Default implementation of {@link QueryCacheEventData} which is sent to subscriber.
  */
-@BinaryInterface
 public class DefaultQueryCacheEventData implements QueryCacheEventData {
 
     private Object key;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalCacheWideEventData.java
@@ -20,7 +20,6 @@ import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
@@ -32,7 +31,6 @@ import java.io.IOException;
  *
  * Throws {@link UnsupportedOperationException} if one tries to serialize an instance of this class.
  */
-@BinaryInterface
 public class LocalCacheWideEventData implements EventData {
 
     private final String source;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/LocalEntryEventData.java
@@ -21,7 +21,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
@@ -36,7 +35,6 @@ import java.io.IOException;
  * @param <K> the key type.
  * @param <V> the value type.
  */
-@BinaryInterface
 public class LocalEntryEventData<K, V> implements EventData {
 
     private K key;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/QueryCacheEventData.java
@@ -19,13 +19,11 @@ package com.hazelcast.map.impl.querycache.event;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.serialization.SerializationService;
 
 /**
  * Event data contract which is sent to subscriber side.
  */
-@BinaryInterface
 public interface QueryCacheEventData extends Sequenced, EventData {
 
     Object getKey();

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/CombinerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/CombinerFactory.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
 /**
@@ -36,7 +34,6 @@ import java.io.Serializable;
  * For general data processing, it is superseded by <a href="http://jet.hazelcast.org">Hazelcast Jet</a>.
  */
 @Deprecated
-@BinaryInterface
 public interface CombinerFactory<KeyIn, ValueIn, ValueOut>
         extends Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/JobPartitionState.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/JobPartitionState.java
@@ -17,7 +17,6 @@
 package com.hazelcast.mapreduce;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 /**
  * An implementation of this interface contains current information about
@@ -29,7 +28,6 @@ import com.hazelcast.nio.serialization.impl.BinaryInterface;
  * For general data processing, it is superseded by <a href="http://jet.hazelcast.org">Hazelcast Jet</a>.
  */
 @Deprecated
-@BinaryInterface
 public interface JobPartitionState {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyPredicate.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
 /**
@@ -31,7 +29,6 @@ import java.io.Serializable;
  * For general data processing, it is superseded by <a href="http://jet.hazelcast.org">Hazelcast Jet</a>.
  */
 @Deprecated
-@BinaryInterface
 public interface KeyPredicate<Key>
         extends Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/KeyValueSource.java
@@ -24,7 +24,6 @@ import com.hazelcast.mapreduce.impl.ListKeyValueSource;
 import com.hazelcast.mapreduce.impl.MapKeyValueSource;
 import com.hazelcast.mapreduce.impl.MultiMapKeyValueSource;
 import com.hazelcast.mapreduce.impl.SetKeyValueSource;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 
 import java.io.Closeable;
@@ -46,7 +45,6 @@ import java.util.Map;
  * For general data processing, it is superseded by <a href="http://jet.hazelcast.org">Hazelcast Jet</a>.
  */
 @Deprecated
-@BinaryInterface
 public abstract class KeyValueSource<K, V>
         implements Closeable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapper.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 /**
  * <p>The LifecycleMapper interface is a more sophisticated version of {@link Mapper} normally used for more complex
  * algorithms with a need for initialization and finalization.</p>
@@ -36,7 +34,6 @@ import com.hazelcast.nio.serialization.impl.BinaryInterface;
  * For general data processing, it is superseded by <a href="http://jet.hazelcast.org">Hazelcast Jet</a>.
  */
 @Deprecated
-@BinaryInterface
 public interface LifecycleMapper<KeyIn, ValueIn, KeyOut, ValueOut>
         extends Mapper<KeyIn, ValueIn, KeyOut, ValueOut> {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapperAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/LifecycleMapperAdapter.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 /**
  * <p>
  * The abstract LifecycleMapperAdapter superclass is used to ease building mappers for the {@link Job}.
@@ -54,7 +52,6 @@ import com.hazelcast.nio.serialization.impl.BinaryInterface;
  * For general data processing, it is superseded by <a href="http://jet.hazelcast.org">Hazelcast Jet</a>.
  */
 @Deprecated
-@BinaryInterface
 public abstract class LifecycleMapperAdapter<KeyIn, ValueIn, KeyOut, ValueOut>
         implements LifecycleMapper<KeyIn, ValueIn, KeyOut, ValueOut> {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/Mapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/Mapper.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
 /**
@@ -55,7 +53,6 @@ import java.io.Serializable;
  * For general data processing, it is superseded by <a href="http://jet.hazelcast.org">Hazelcast Jet</a>.
  */
 @Deprecated
-@BinaryInterface
 public interface Mapper<KeyIn, ValueIn, KeyOut, ValueOut>
         extends Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/ReducerFactory.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.mapreduce;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
 /**
@@ -34,7 +32,6 @@ import java.io.Serializable;
  * For general data processing, it is superseded by <a href="http://jet.hazelcast.org">Hazelcast Jet</a>.
  */
 @Deprecated
-@BinaryInterface
 public interface ReducerFactory<KeyIn, ValueIn, ValueOut>
         extends Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationCombinerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationCombinerFactory.java
@@ -20,7 +20,6 @@ import com.hazelcast.mapreduce.CombinerFactory;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
@@ -32,7 +31,6 @@ import java.io.IOException;
  * @param <ValueIn>  the input value type
  * @param <ValueOut> the output value type
  */
-@BinaryInterface
 abstract class AbstractAggregationCombinerFactory<KeyIn, ValueIn, ValueOut>
         implements CombinerFactory<KeyIn, ValueIn, ValueOut>, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationReducerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/AbstractAggregationReducerFactory.java
@@ -20,7 +20,6 @@ import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
@@ -32,7 +31,6 @@ import java.io.IOException;
  * @param <ValueIn>  the input value type
  * @param <ValueOut> the output value type
  */
-@BinaryInterface
 abstract class AbstractAggregationReducerFactory<KeyIn, ValueIn, ValueOut>
         implements ReducerFactory<KeyIn, ValueIn, ValueOut>, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalAvgAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -74,8 +73,7 @@ public class BigDecimalAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigDecimalAvgCombinerFactory<Key>
+        static final class BigDecimalAvgCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, BigDecimal, AvgTuple<Long, BigDecimal>> {
 
         @Override
@@ -94,8 +92,7 @@ public class BigDecimalAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigDecimalAvgReducerFactory<Key>
+        static final class BigDecimalAvgReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, AvgTuple<Long, BigDecimal>, AvgTuple<Long, BigDecimal>> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMaxAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -72,8 +71,7 @@ public class BigDecimalMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigDecimalMaxCombinerFactory<Key>
+        static final class BigDecimalMaxCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, BigDecimal, BigDecimal> {
 
         @Override
@@ -92,8 +90,7 @@ public class BigDecimalMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigDecimalMaxReducerFactory<Key>
+        static final class BigDecimalMaxReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, BigDecimal, BigDecimal> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalMinAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -72,8 +71,7 @@ public class BigDecimalMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigDecimalMinCombinerFactory<Key>
+        static final class BigDecimalMinCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, BigDecimal, BigDecimal> {
 
         @Override
@@ -92,8 +90,7 @@ public class BigDecimalMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigDecimalMinReducerFactory<Key>
+        static final class BigDecimalMinReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, BigDecimal, BigDecimal> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigDecimalSumAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -71,8 +70,7 @@ public class BigDecimalSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigDecimalSumCombinerFactory<Key>
+        static final class BigDecimalSumCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, BigDecimal, BigDecimal> {
 
         @Override
@@ -91,8 +89,7 @@ public class BigDecimalSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigDecimalSumReducerFactory<Key>
+        static final class BigDecimalSumReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, BigDecimal, BigDecimal> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerAvgAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -74,8 +73,7 @@ public class BigIntegerAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigIntegerAvgCombinerFactory<Key>
+        static final class BigIntegerAvgCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, BigInteger, AvgTuple<Long, BigInteger>> {
 
         @Override
@@ -94,8 +92,7 @@ public class BigIntegerAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigIntegerAvgReducerFactory<Key>
+        static final class BigIntegerAvgReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, AvgTuple<Long, BigInteger>, AvgTuple<Long, BigInteger>> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMaxAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -72,8 +71,7 @@ public class BigIntegerMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigIntegerMaxCombinerFactory<Key>
+        static final class BigIntegerMaxCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, BigInteger, BigInteger> {
 
         @Override
@@ -92,8 +90,7 @@ public class BigIntegerMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigIntegerMaxReducerFactory<Key>
+        static final class BigIntegerMaxReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, BigInteger, BigInteger> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerMinAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -72,8 +71,7 @@ public class BigIntegerMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigIntegerMinCombinerFactory<Key>
+        static final class BigIntegerMinCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, BigInteger, BigInteger> {
 
         @Override
@@ -92,8 +90,7 @@ public class BigIntegerMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigIntegerMinReducerFactory<Key>
+        static final class BigIntegerMinReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, BigInteger, BigInteger> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/BigIntegerSumAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -71,8 +70,7 @@ public class BigIntegerSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigIntegerSumCombinerFactory<Key>
+        static final class BigIntegerSumCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, BigInteger, BigInteger> {
 
         @Override
@@ -91,8 +89,7 @@ public class BigIntegerSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class BigIntegerSumReducerFactory<Key>
+        static final class BigIntegerSumReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, BigInteger, BigInteger> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMaxAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class ComparableMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class ComparableMaxCombinerFactory<Key>
+        static final class ComparableMaxCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Comparable, Comparable> {
 
         @Override
@@ -93,8 +91,7 @@ public class ComparableMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class ComparableMaxReducerFactory<Key>
+        static final class ComparableMaxReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Comparable, Comparable> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/ComparableMinAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class ComparableMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class ComparableMinCombinerFactory<Key>
+        static final class ComparableMinCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Comparable, Comparable> {
 
         @Override
@@ -93,8 +91,7 @@ public class ComparableMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class ComparableMinReducerFactory<Key>
+        static final class ComparableMinReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Comparable, Comparable> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/CountAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/CountAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -70,8 +69,7 @@ public class CountAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class CountCombinerFactory<Key>
+        static final class CountCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Object, Long> {
 
         @Override
@@ -90,8 +88,7 @@ public class CountAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class CountReducerFactory<Key>
+        static final class CountReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Long, Long> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
@@ -28,7 +28,6 @@ import com.hazelcast.mapreduce.impl.task.DefaultContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -84,8 +83,7 @@ public class DistinctValuesAggregation<Key, Value, DistinctType>
      *
      * @param <DistinctType> the distinct values type
      */
-    @BinaryInterface
-    static class DistinctValuesCombinerFactory<DistinctType>
+        static class DistinctValuesCombinerFactory<DistinctType>
             extends AbstractAggregationCombinerFactory<Integer, DistinctType, Set<DistinctType>> {
 
         @Override
@@ -104,8 +102,7 @@ public class DistinctValuesAggregation<Key, Value, DistinctType>
      *
      * @param <DistinctType> the distinct values type
      */
-    @BinaryInterface
-    private static class DistinctValuesCombiner<DistinctType>
+        private static class DistinctValuesCombiner<DistinctType>
             extends Combiner<DistinctType, Set<DistinctType>> {
 
         private final Set<DistinctType> distinctValues = new HashSet<DistinctType>();
@@ -129,8 +126,7 @@ public class DistinctValuesAggregation<Key, Value, DistinctType>
      *
      * @param <DistinctType> the distinct values type
      */
-    @BinaryInterface
-    static class DistinctValuesReducerFactory<DistinctType>
+        static class DistinctValuesReducerFactory<DistinctType>
             extends AbstractAggregationReducerFactory<Integer, Set<DistinctType>, Set<DistinctType>> {
 
         @Override
@@ -173,8 +169,7 @@ public class DistinctValuesAggregation<Key, Value, DistinctType>
      * @param <DistinctType> the type of distinct values
      */
     @SuppressFBWarnings("SE_NO_SERIALVERSIONID")
-    @BinaryInterface
-    static class DistinctValueMapper<Key, Value, DistinctType>
+        static class DistinctValueMapper<Key, Value, DistinctType>
             implements Mapper<Key, Value, Integer, DistinctType>, IdentifiedDataSerializable {
 
         // These keys are used to distribute reducer steps around the cluster

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleAvgAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class DoubleAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class DoubleAvgCombinerFactory<Key>
+        static final class DoubleAvgCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Double, AvgTuple<Long, Double>> {
 
         @Override
@@ -93,8 +91,7 @@ public class DoubleAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class DoubleAvgReducerFactory<Key>
+        static final class DoubleAvgReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, AvgTuple<Long, Double>, AvgTuple<Long, Double>> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMaxAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class DoubleMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class DoubleMaxCombinerFactory<Key>
+        static final class DoubleMaxCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Double, Double> {
 
         @Override
@@ -93,8 +91,7 @@ public class DoubleMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class DoubleMaxReducerFactory<Key>
+        static final class DoubleMaxReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Double, Double> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleMinAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class DoubleMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class DoubleMinCombinerFactory<Key>
+        static final class DoubleMinCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Double, Double> {
 
         @Override
@@ -93,8 +91,7 @@ public class DoubleMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class DoubleMinReducerFactory<Key>
+        static final class DoubleMinReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Double, Double> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DoubleSumAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -70,8 +69,7 @@ public class DoubleSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class DoubleSumCombinerFactory<Key>
+        static final class DoubleSumCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Double, Double> {
 
         @Override
@@ -90,8 +88,7 @@ public class DoubleSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class DoubleSumReducerFactory<Key>
+        static final class DoubleSumReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Double, Double> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerAvgAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class IntegerAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class IntegerAvgCombinerFactory<Key>
+        static final class IntegerAvgCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Integer, AvgTuple<Integer, Integer>> {
 
         @Override
@@ -93,8 +91,7 @@ public class IntegerAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class IntegerAvgReducerFactory<Key>
+        static final class IntegerAvgReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, AvgTuple<Integer, Integer>, AvgTuple<Integer, Integer>> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMaxAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class IntegerMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class IntegerMaxCombinerFactory<Key>
+        static final class IntegerMaxCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Integer, Integer> {
 
         @Override
@@ -93,8 +91,7 @@ public class IntegerMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class IntegerMaxReducerFactory<Key>
+        static final class IntegerMaxReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Integer, Integer> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerMinAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class IntegerMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class IntegerMinCombinerFactory<Key>
+        static final class IntegerMinCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Integer, Integer> {
 
         @Override
@@ -93,8 +91,7 @@ public class IntegerMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class IntegerMinReducerFactory<Key>
+        static final class IntegerMinReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Integer, Integer> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/IntegerSumAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -70,8 +69,7 @@ public class IntegerSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class IntegerSumCombinerFactory<Key>
+        static final class IntegerSumCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Integer, Integer> {
 
         @Override
@@ -90,8 +88,7 @@ public class IntegerSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class IntegerSumReducerFactory<Key>
+        static final class IntegerSumReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Integer, Integer> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongAvgAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongAvgAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class LongAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class LongAvgCombinerFactory<Key>
+        static final class LongAvgCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Long, AvgTuple<Long, Long>> {
 
         @Override
@@ -93,8 +91,7 @@ public class LongAvgAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class LongAvgReducerFactory<Key>
+        static final class LongAvgReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, AvgTuple<Long, Long>, AvgTuple<Long, Long>> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMaxAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class LongMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class LongMaxCombinerFactory<Key>
+        static final class LongMaxCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Long, Long> {
 
         @Override
@@ -93,8 +91,7 @@ public class LongMaxAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class LongMaxReducerFactory<Key>
+        static final class LongMaxReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Long, Long> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMinAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongMinAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -73,8 +72,7 @@ public class LongMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class LongMinCombinerFactory<Key>
+        static final class LongMinCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Long, Long> {
 
         @Override
@@ -93,8 +91,7 @@ public class LongMinAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class LongMinReducerFactory<Key>
+        static final class LongMinReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Long, Long> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongSumAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/LongSumAggregation.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.Mapper;
 import com.hazelcast.mapreduce.Reducer;
 import com.hazelcast.mapreduce.ReducerFactory;
 import com.hazelcast.mapreduce.aggregation.Supplier;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
 
@@ -70,8 +69,7 @@ public class LongSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class LongSumCombinerFactory<Key>
+        static final class LongSumCombinerFactory<Key>
             extends AbstractAggregationCombinerFactory<Key, Long, Long> {
 
         @Override
@@ -90,8 +88,7 @@ public class LongSumAggregation<Key, Value>
      *
      * @param <Key> the key type
      */
-    @BinaryInterface
-    static final class LongSumReducerFactory<Key>
+        static final class LongSumReducerFactory<Key>
             extends AbstractAggregationReducerFactory<Key, Long, Long> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
@@ -23,7 +23,6 @@ import com.hazelcast.mapreduce.impl.task.DefaultContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -36,7 +35,6 @@ import java.io.IOException;
  * @param <ValueOut> the output value type
  */
 @SuppressFBWarnings("SE_NO_SERIALVERSIONID")
-@BinaryInterface
 class SupplierConsumingMapper<Key, ValueIn, ValueOut>
         implements Mapper<Key, ValueIn, Key, ValueOut>, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/ListKeyValueSource.java
@@ -25,7 +25,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -45,7 +44,6 @@ import java.util.Map;
  *
  * @param <V> type of the values inside the IList
  */
-@BinaryInterface
 public class ListKeyValueSource<V>
         extends KeyValueSource<String, V>
         implements IdentifiedDataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapKeyValueSource.java
@@ -26,7 +26,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionService;
@@ -44,7 +43,6 @@ import java.util.Map;
  * @param <K> type of the key of the IMap
  * @param <V> type of the value of the IMap
  */
-@BinaryInterface
 public class MapKeyValueSource<K, V>
         extends KeyValueSource<K, V>
         implements IdentifiedDataSerializable, PartitionIdAware {

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MultiMapKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MultiMapKeyValueSource.java
@@ -27,7 +27,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionService;
@@ -45,7 +44,6 @@ import java.util.Map;
  * @param <K> type of the key of the MultiMap
  * @param <V> type of the value of the MultiMap
  */
-@BinaryInterface
 public class MultiMapKeyValueSource<K, V>
         extends KeyValueSource<K, V>
         implements IdentifiedDataSerializable, PartitionIdAware {

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/SetKeyValueSource.java
@@ -26,7 +26,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -45,7 +44,6 @@ import java.util.Map;
  *
  * @param <V> type of the values inside the ISet
  */
-@BinaryInterface
 public class SetKeyValueSource<V>
         extends KeyValueSource<String, V>
         implements IdentifiedDataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/DefaultContext.java
@@ -24,7 +24,6 @@ import com.hazelcast.mapreduce.Context;
 import com.hazelcast.mapreduce.impl.CombinerResultList;
 import com.hazelcast.mapreduce.impl.HashMapAdapter;
 import com.hazelcast.mapreduce.impl.MapReduceUtil;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
 import com.hazelcast.util.IConcurrentMap;
 
@@ -135,8 +134,7 @@ public class DefaultContext<KeyIn, ValueIn>
      * @param <KeyIn>   type of the key
      * @param <ValueIn> type of the value
      */
-    @BinaryInterface
-    private static class CollectingCombinerFactory<KeyIn, ValueIn>
+        private static class CollectingCombinerFactory<KeyIn, ValueIn>
             implements CombinerFactory<KeyIn, ValueIn, List<ValueIn>> {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImpl.java
@@ -21,14 +21,12 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
 /**
  * This class holds information about the current processing state and the owner of a partition.
  */
-@BinaryInterface
 public class JobPartitionStateImpl implements JobPartitionState, DataSerializable {
 
     private Address address;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceFacade.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/KeyValueSourceFacade.java
@@ -21,7 +21,6 @@ import com.hazelcast.mapreduce.KeyValueSource;
 import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.mapreduce.impl.operation.ProcessStatsUpdateOperation;
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.NodeEngine;
 
 import java.io.IOException;
@@ -36,7 +35,6 @@ import java.util.Map;
  * @param <K> type of the key
  * @param <V> type of the value
  */
-@BinaryInterface
 class KeyValueSourceFacade<K, V>
         extends KeyValueSource<K, V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/Address.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Address.java
@@ -18,7 +18,6 @@ package com.hazelcast.nio;
 
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.util.AddressUtil;
 
 import java.io.IOException;
@@ -34,7 +33,6 @@ import static com.hazelcast.util.StringUtil.stringToBytes;
 /**
  * Represents an address of a member in the cluster.
  */
-@BinaryInterface
 public final class Address implements IdentifiedDataSerializable {
 
     private static final byte IPV4 = 4;

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/MultiAttributeProjection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/MultiAttributeProjection.java
@@ -19,6 +19,7 @@ package com.hazelcast.projection.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.impl.Extractable;
 
@@ -35,6 +36,7 @@ import static com.hazelcast.util.Preconditions.checkHasText;
  *
  * @param <I> type of the input
  */
+@BinaryInterface
 public final class MultiAttributeProjection<I> extends Projection<I, Object[]> implements IdentifiedDataSerializable {
 
     private String[] attributePaths;

--- a/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
+++ b/hazelcast/src/main/java/com/hazelcast/projection/impl/SingleAttributeProjection.java
@@ -19,6 +19,7 @@ package com.hazelcast.projection.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.impl.Extractable;
 
@@ -35,6 +36,7 @@ import static com.hazelcast.util.Preconditions.checkHasText;
  *
  * @param <I> type of the input
  */
+@BinaryInterface
 public final class SingleAttributeProjection<I, O> extends Projection<I, O> implements IdentifiedDataSerializable {
 
     private String attributePath;

--- a/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/IndexAwarePredicate.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.query;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
@@ -27,7 +26,6 @@ import java.util.Set;
  * @param <K>
  * @param <V>
  */
-@BinaryInterface
 public interface IndexAwarePredicate<K, V> extends Predicate<K, V> {
 
     Set<QueryableEntry<K, V>> filter(QueryContext queryContext);

--- a/hazelcast/src/main/java/com/hazelcast/query/Predicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Predicate.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.query;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 import java.util.Map;
 
@@ -28,7 +26,6 @@ import java.util.Map;
  * @param <K>
  * @param <V>
  */
-@BinaryInterface
 public interface Predicate<K, V> extends Serializable {
 
     boolean apply(Map.Entry<K, V> mapEntry);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractIndexAwarePredicate.java
@@ -16,12 +16,10 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.query.IndexAwarePredicate;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.QueryContext;
 
-@BinaryInterface
 public abstract class AbstractIndexAwarePredicate<K, V> extends AbstractPredicate<K, V> implements IndexAwarePredicate<K, V> {
 
     protected AbstractIndexAwarePredicate() {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AbstractPredicate.java
@@ -19,7 +19,6 @@ package com.hazelcast.query.impl.predicates;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.AttributeType;
@@ -38,7 +37,6 @@ import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICAT
  * Provides base features for predicates, such as extraction and convertion of the attribute's value.
  * It also handles apply() on MultiResult.
  */
-@BinaryInterface
 public abstract class AbstractPredicate<K, V>
         implements Predicate<K, V>, IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/security/AbstractCredentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/AbstractCredentials.java
@@ -19,14 +19,12 @@ package com.hazelcast.security;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.nio.serialization.PortableWriter;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
 /**
  * Abstract implementation of {@link Credentials}
  */
-@BinaryInterface
 public abstract class AbstractCredentials implements Credentials, Portable {
 
     private static final long serialVersionUID = 3587995040707072446L;

--- a/hazelcast/src/main/java/com/hazelcast/security/Credentials.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/Credentials.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.security;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
 /**
@@ -26,7 +24,6 @@ import java.io.Serializable;
  * <p/>
  * It is used on authentication process by {@link javax.security.auth.spi.LoginModule}s.
  */
-@BinaryInterface
 public interface Credentials extends Serializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastMemberInfo.java
@@ -16,11 +16,8 @@
 
 package com.hazelcast.spi.discovery.multicast.impl;
 
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
-
 import java.io.Serializable;
 
-@BinaryInterface
 public class MulticastMemberInfo implements Serializable {
 
     private String host;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -19,7 +19,6 @@ package com.hazelcast.spi.impl.eventservice.impl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
 
@@ -29,7 +28,6 @@ import java.io.IOException;
 // cannot implement IdentifiedDataSerializable (both EventRegistration and IdentifiedDataSerializable interfaces define a
 // method {@code getId()} which differ in return type).
 // Since this class is still DataSerializable it should not be moved/renamed in 3.9, otherwise upgradability will be compromised.
-@BinaryInterface
 public class Registration implements EventRegistration {
 
     private String id;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectEventPacket.java
@@ -19,13 +19,11 @@ package com.hazelcast.spi.impl.proxyservice.impl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.io.IOException;
 
 import static com.hazelcast.core.DistributedObjectEvent.EventType;
 
-@BinaryInterface
 public final class DistributedObjectEventPacket implements DataSerializable {
 
     private EventType eventType;

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicMessage.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
 import com.hazelcast.util.Clock;
 
 import java.io.IOException;
@@ -31,6 +32,7 @@ import static com.hazelcast.topic.impl.TopicDataSerializerHook.RELIABLE_TOPIC_ME
 /**
  * The Object that is going to be stored in the Ringbuffer. It contains the actual message payload and some metadata.
  */
+@BinaryInterface
 public class ReliableTopicMessage implements IdentifiedDataSerializable {
     private long publishTime;
     private Address publisherAddress;

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ClientSerializationBuiltinsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ClientSerializationBuiltinsTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2008-2015, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.nio.serialization.impl.BinaryInterface;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.hazelcast.test.ReflectionsHelper.REFLECTIONS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for classes which are used as Data in the client protocol. Changing these tests may break client compatibility.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class})
+public class ClientSerializationBuiltinsTest {
+
+    //This list should reflect the builtin classes that client depend on.
+    // New builtin classes can be added but cannot be removed.
+    private static List<String> BuiltinClasses = Arrays.asList(
+    "com.hazelcast.aggregation.impl.BigDecimalAverageAggregator",
+    "com.hazelcast.aggregation.impl.BigDecimalSumAggregator",
+    "com.hazelcast.aggregation.impl.BigIntegerAverageAggregator",
+    "com.hazelcast.aggregation.impl.BigIntegerSumAggregator",
+    "com.hazelcast.aggregation.impl.CountAggregator",
+    "com.hazelcast.aggregation.impl.DistinctValuesAggregator",
+    "com.hazelcast.aggregation.impl.DoubleAverageAggregator",
+    "com.hazelcast.aggregation.impl.DoubleSumAggregator",
+    "com.hazelcast.aggregation.impl.FixedSumAggregator",
+    "com.hazelcast.aggregation.impl.FloatingPointSumAggregator",
+    "com.hazelcast.aggregation.impl.IntegerAverageAggregator",
+    "com.hazelcast.aggregation.impl.IntegerSumAggregator",
+    "com.hazelcast.aggregation.impl.LongAverageAggregator",
+    "com.hazelcast.aggregation.impl.LongSumAggregator",
+    "com.hazelcast.aggregation.impl.MaxAggregator",
+    "com.hazelcast.aggregation.impl.MinAggregator",
+    "com.hazelcast.aggregation.impl.NumberAverageAggregator",
+
+    "com.hazelcast.projection.impl.SingleAttributeProjection",
+    "com.hazelcast.projection.impl.MultiAttributeProjection",
+
+    "com.hazelcast.query.SqlPredicate",
+    "com.hazelcast.query.impl.predicates.AndPredicate",
+    "com.hazelcast.query.impl.predicates.BetweenPredicate",
+    "com.hazelcast.query.impl.predicates.EqualPredicate",
+    "com.hazelcast.query.impl.predicates.GreaterLessPredicate",
+    "com.hazelcast.query.impl.predicates.LikePredicate",
+    "com.hazelcast.query.impl.predicates.ILikePredicate",
+    "com.hazelcast.query.impl.predicates.InPredicate",
+    "com.hazelcast.query.impl.predicates.InstanceOfPredicate",
+    "com.hazelcast.query.impl.predicates.NotEqualPredicate",
+    "com.hazelcast.query.impl.predicates.NotPredicate",
+    "com.hazelcast.query.impl.predicates.OrPredicate",
+    "com.hazelcast.query.impl.predicates.RegexPredicate",
+    "com.hazelcast.query.impl.FalsePredicate",
+    "com.hazelcast.query.TruePredicate",
+    "com.hazelcast.query.PagingPredicate",
+    "com.hazelcast.query.PartitionPredicate",
+    "com.hazelcast.query.PredicateBuilder",
+
+    "com.hazelcast.config.CacheConfig",
+    "com.hazelcast.config.CacheConfigReadOnly",
+    "com.hazelcast.config.CacheEvictionConfig",
+    "com.hazelcast.config.CacheEvictionConfigReadOnly",
+    "com.hazelcast.config.WanReplicationRef",
+    "com.hazelcast.config.WanReplicationRefReadOnly",
+    "com.hazelcast.config.CachePartitionLostListenerConfig",
+    "com.hazelcast.config.CachePartitionLostListenerConfigReadOnly",
+    "com.hazelcast.config.InMemoryFormat",
+    "com.hazelcast.config.EvictionConfig",
+    "com.hazelcast.config.EvictionConfigReadOnly",
+    "com.hazelcast.config.EvictionConfig$MaxSizePolicy",
+    "com.hazelcast.config.EvictionPolicy",
+
+    "com.hazelcast.config.LegacyCacheConfig",
+    "com.hazelcast.config.LegacyCacheEvictionConfig",
+
+    "com.hazelcast.cache.HazelcastExpiryPolicy",
+
+    "com.hazelcast.security.UsernamePasswordCredentials",
+    "com.hazelcast.topic.impl.reliable.ReliableTopicMessage",
+    "com.hazelcast.transaction.impl.xa.SerializableXID",
+    "com.hazelcast.executor.impl.RunnableAdapter",
+    "com.hazelcast.core.PartitionAwareKey"
+    );
+
+    //NEVER CHANGE THESE THREE LIST. CLIENT COMPATIBILITY TESTS WILL BE BROKEN!!!
+    //These enum values shouldn't add or remove new enum values.
+    private static List<String> MaxSizePolicyNames = Arrays.asList("ENTRY_COUNT","USED_NATIVE_MEMORY_SIZE",
+            "USED_NATIVE_MEMORY_PERCENTAGE","FREE_NATIVE_MEMORY_SIZE","FREE_NATIVE_MEMORY_PERCENTAGE");
+    private static List<String> EvictionPolicyNames = Arrays.asList("LRU","LFU","NONE","RANDOM");
+    private static List<String> InMemoryFormatNames = Arrays.asList("BINARY","OBJECT","NATIVE");
+
+
+    @Test
+    public void BinaryInterfaceListTest() {
+        Set<Class<?>> allAnnotatedClasses = REFLECTIONS.getTypesAnnotatedWith(BinaryInterface.class, false);
+        for (Class clazz : allAnnotatedClasses) {
+            assertTrue("Annotated class is not in the list: " + clazz.getName(), BuiltinClasses.contains(clazz.getName()));
+        }
+        List<String> list = new ArrayList<String>(BuiltinClasses);
+        for(Class clazz : allAnnotatedClasses) {
+            list.remove(clazz.getName());
+        }
+        for(String clazz:list){
+            fail("Class should be BinaryInterface annotated: " + clazz);
+        }
+        assertEquals(BuiltinClasses.size(), allAnnotatedClasses.size());
+    }
+
+    @Test
+    public void MaxSizePolicyEnumTest() {
+        EnumTest(EvictionConfig.MaxSizePolicy.values(), MaxSizePolicyNames);
+    }
+
+    @Test
+    public void EvictionPolicyEnumTest() {
+        EnumTest(EvictionPolicy.values(), EvictionPolicyNames);
+    }
+
+    @Test
+    public void InMemoryFormatEnumTest() {
+        EnumTest(InMemoryFormat.values(), InMemoryFormatNames);
+    }
+
+    private <E extends Enum> void EnumTest(E[] values, List<String> names) {
+        assertEquals(values.length, names.size());
+        for (E enumVal : values) {
+            assertTrue(names.contains(enumVal.name()));
+        }
+    }
+}


### PR DESCRIPTION
Client compatibility related builtin classes require binary compatibility between versions. In order achieve this, builtin classes used by client is marked with `@BinaryInterface`. There is a well known class list and related tests added.