### PR TITLE
wrong ClientExecutionService usages restored.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -141,7 +141,7 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
                     public void onFailure(Throwable t) {
                         invalidateNearCache(keyData);
                     }
-                });
+                }, false);
             }
             return delegatingFuture;
         } else {
@@ -165,7 +165,7 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
     private Object asCompletedFutureOrValue(Object value, boolean async) {
         if (async) {
             return new CompletedFuture(clientContext.getSerializationService(), value,
-                    clientContext.getExecutionService().getAsyncExecutor());
+                    clientContext.getExecutionService().getUserExecutor());
         }
 
         return value;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -329,16 +329,15 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         ClientDelegatingFuture<T> delegatingFuture =
                 new ClientDelegatingFuture<T>(future, clientContext.getSerializationService(), GET_AND_REMOVE_RESPONSE_DECODER);
         if (async && statisticsEnabled) {
-            delegatingFuture.andThen(new ExecutionCallback<T>() {
-                public void onResponse(T responseData) {
-                    Object response = clientContext.getSerializationService().toObject(responseData);
+            delegatingFuture.andThenInternal(new ExecutionCallback<T>() {
+                public void onResponse(T response) {
                     handleStatisticsOnRemove(true, start, response);
                 }
 
                 public void onFailure(Throwable t) {
 
                 }
-            });
+            }, true);
         }
         return delegatingFuture;
     }
@@ -368,15 +367,14 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         ClientDelegatingFuture<T> delegatingFuture =
                 new ClientDelegatingFuture<T>(future, clientContext.getSerializationService(), REMOVE_RESPONSE_DECODER);
         if (async && statisticsEnabled) {
-            delegatingFuture.andThen(new ExecutionCallback<T>() {
-                public void onResponse(T responseData) {
-                    Object response = clientContext.getSerializationService().toObject(responseData);
+            delegatingFuture.andThenInternal(new ExecutionCallback<T>() {
+                public void onResponse(T response) {
                     handleStatisticsOnRemove(false, start, response);
                 }
 
                 public void onFailure(Throwable t) {
                 }
-            });
+            }, true);
         }
         return delegatingFuture;
     }
@@ -429,15 +427,14 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         ClientDelegatingFuture<T> delegatingFuture =
                 new ClientDelegatingFuture<T>(future, clientContext.getSerializationService(), REPLACE_RESPONSE_DECODER);
         if (async && statisticsEnabled) {
-            delegatingFuture.andThen(new ExecutionCallback<T>() {
-                public void onResponse(T responseData) {
-                    Object response = clientContext.getSerializationService().toObject(responseData);
+            delegatingFuture.andThenInternal(new ExecutionCallback<T>() {
+                public void onResponse(T response) {
                     handleStatisticsOnReplace(false, start, response);
                 }
 
                 public void onFailure(Throwable t) {
                 }
-            });
+            }, true);
         }
         return delegatingFuture;
     }
@@ -472,15 +469,14 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         ClientDelegatingFuture<T> delegatingFuture =
                 new ClientDelegatingFuture<T>(future, clientContext.getSerializationService(), GET_AND_REPLACE_RESPONSE_DECODER);
         if (async && statisticsEnabled) {
-            delegatingFuture.andThen(new ExecutionCallback<T>() {
-                public void onResponse(T responseData) {
-                    Object response = clientContext.getSerializationService().toObject(responseData);
+            delegatingFuture.andThenInternal(new ExecutionCallback<T>() {
+                public void onResponse(T response) {
                     handleStatisticsOnReplace(true, start, response);
                 }
 
                 public void onFailure(Throwable t) {
                 }
-            });
+            }, true);
         }
         return delegatingFuture;
     }
@@ -581,7 +577,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         }
         ClientDelegatingFuture<V> delegatingFuture = new CallbackAwareClientDelegatingFuture<V>(future,
                 serializationService, PUT_RESPONSE_DECODER, oneShotExecutionCallback);
-        delegatingFuture.andThen(oneShotExecutionCallback);
+        delegatingFuture.andThenInternal(oneShotExecutionCallback, true);
         return delegatingFuture;
     }
 
@@ -653,7 +649,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
     private Object putIfAbsentInternalAsync(final V value, final long start, final Data keyData, final Data valueData,
                                             ClientDelegatingFuture<Boolean> delegatingFuture) {
         if (nearCache != null || statisticsEnabled) {
-            delegatingFuture.andThen(new ExecutionCallback<Boolean>() {
+            delegatingFuture.andThenInternal(new ExecutionCallback<Boolean>() {
                 @Override
                 public void onResponse(Boolean responseData) {
                     if (nearCache != null) {
@@ -672,7 +668,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
                 @Override
                 public void onFailure(Throwable t) {
                 }
-            });
+            }, true);
         }
         return delegatingFuture;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -341,7 +341,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         AuthenticationFuture callback = new AuthenticationFuture();
         AuthenticationFuture firstCallback = connectionsInProgress.putIfAbsent(target, callback);
         if (firstCallback == null) {
-            executionService.executeInternal(new InitConnectionTask(target, asOwner, callback));
+            executionService.execute(new InitConnectionTask(target, asOwner, callback));
             return callback;
         }
         return firstCallback;
@@ -481,7 +481,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                                 logger.warning("Error receiving heartbeat for connection: " + connection, t);
                             }
                         }
-                    }, executionService.getInternalExecutor());
+                    });
                 } else {
                     if (!connection.isHeartBeating()) {
                         logger.warning("Heartbeat is back to healthy for connection : " + connection);
@@ -573,7 +573,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                 onAuthenticationFailed(target, connection, t);
                 callback.onFailure(t);
             }
-        }, executionService.getInternalExecutor());
+        });
     }
 
     private ClientMessage encodeAuthenticationRequest(boolean asOwner, SerializationService ss, byte serializationVersion,

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
@@ -45,7 +45,6 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -215,7 +214,7 @@ public final class ClientDurableExecutorServiceProxy extends ClientProxy impleme
             ClientMessage response = invokeOnPartition(request, partitionId);
             sequence = DurableExecutorSubmitToPartitionCodec.decodeResponse(response).response;
         } catch (Throwable t) {
-            return new ClientDurableExecutorServiceCompletedFuture<T>(t, getAsyncExecutor());
+            return new ClientDurableExecutorServiceCompletedFuture<T>(t, getUserExecutor());
         }
         ClientMessage clientMessage = DurableExecutorRetrieveResultCodec.encodeRequest(name, sequence);
         ClientInvocationFuture future = new ClientInvocation(getClient(), clientMessage, partitionId).invoke();
@@ -223,8 +222,8 @@ public final class ClientDurableExecutorServiceProxy extends ClientProxy impleme
         return new ClientDurableExecutorServiceDelegatingFuture<T>(future, serService, RETRIEVE_RESPONSE_DECODER, result, taskId);
     }
 
-    private ExecutorService getAsyncExecutor() {
-        return getContext().getExecutionService().getAsyncExecutor();
+    private Executor getUserExecutor() {
+        return getContext().getExecutionService().getUserExecutor();
     }
 
     private <T> RunnableAdapter<T> createRunnableAdapter(Runnable command) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -55,7 +55,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -381,10 +381,10 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         for (Callable<T> task : tasks) {
             futures.add(submitToRandomInternal(task, null, true));
         }
-        ExecutorService asyncExecutor = getContext().getExecutionService().getAsyncExecutor();
+        Executor userExecutor = getContext().getExecutionService().getUserExecutor();
         for (Future<T> future : futures) {
             Object value = retrieveResult(future);
-            result.add(new CompletedFuture<T>(getContext().getSerializationService(), value, asyncExecutor));
+            result.add(new CompletedFuture<T>(getContext().getSerializationService(), value, userExecutor));
         }
         return result;
     }
@@ -505,8 +505,8 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         boolean sync = isSyncComputation(preventSync);
         if (sync) {
             Object response = retrieveResultFromMessage(f);
-            ExecutorService asyncExecutor = getContext().getExecutionService().getAsyncExecutor();
-            return new CompletedFuture<T>(getContext().getSerializationService(), response, asyncExecutor);
+            Executor userExecutor = getContext().getExecutionService().getUserExecutor();
+            return new CompletedFuture<T>(getContext().getSerializationService(), response, userExecutor);
         } else {
             return new ClientAddressCancellableDelegatingFuture<T>(f, getContext(), uuid, address, defaultValue
                     , SUBMIT_TO_ADDRESS_DECODER);
@@ -518,8 +518,8 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         boolean sync = isSyncComputation(preventSync);
         if (sync) {
             Object response = retrieveResultFromMessage(f);
-            ExecutorService asyncExecutor = getContext().getExecutionService().getAsyncExecutor();
-            return new CompletedFuture<T>(getContext().getSerializationService(), response, asyncExecutor);
+            Executor userExecutor = getContext().getExecutionService().getUserExecutor();
+            return new CompletedFuture<T>(getContext().getSerializationService(), response, userExecutor);
         } else {
             return new ClientPartitionCancellableDelegatingFuture<T>(f, getContext(), uuid, partitionId, defaultValue
                     , SUBMIT_TO_PARTITION_DECODER);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -132,10 +132,10 @@ public class ClientMapReduceProxy
                 final ClientInvocation clientInvocation = new ClientInvocation(getClient(), request);
                 final ClientInvocationFuture future = clientInvocation.invoke();
 
-                future.andThen(new ExecutionCallback() {
+                future.andThen(new ExecutionCallback<ClientMessage>() {
                     @Override
-                    public void onResponse(Object res) {
-                        Map map = toObjectMap((ClientMessage) res);
+                    public void onResponse(ClientMessage res) {
+                        Map map = toObjectMap(res);
 
                         Object response = map;
                         try {
@@ -235,7 +235,7 @@ public class ClientMapReduceProxy
         private final String jobId;
 
         protected ClientCompletableFuture(String jobId) {
-            super(getContext().getExecutionService().getAsyncExecutor(),
+            super(getContext().getExecutionService().getUserExecutor(),
                     getContext().getLoggingService().getLogger(ClientCompletableFuture.class));
             this.jobId = jobId;
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -88,7 +88,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
     private Executor getExecutor(ClientReliableTopicConfig config, HazelcastClientInstanceImpl client) {
         Executor executor = config.getExecutor();
         if (executor == null) {
-            executor = client.getClientExecutionService();
+            executor = client.getClientExecutionService().getUserExecutor();
         }
         return executor;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -147,7 +147,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         Object value = getCachedValue(key, false);
         if (value != NOT_CACHED) {
             return new CompletedFuture<V>(getContext().getSerializationService(),
-                    value, getContext().getExecutionService().getAsyncExecutor());
+                    value, getContext().getExecutionService().getUserExecutor());
         }
 
         final long reservationId = nearCache.tryReserveForUpdate(key);
@@ -169,7 +169,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
             public void onFailure(Throwable t) {
                 invalidateNearCache(key);
             }
-        });
+        }, false);
 
         return future;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.spi;
 
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.spi.ExecutionService;
 
 import java.util.concurrent.Callable;
@@ -25,25 +24,17 @@ import java.util.concurrent.ExecutorService;
 
 /**
  * Executor service for Hazelcast clients.
- *
+ * <p>
  * Allows asynchronous execution and scheduling of {@link Runnable} and {@link Callable} commands.
+ * <p>
+ * Any schedule submit or execute operation runs on internal executors.
+ * When user code needs to run getUserExecutor() should be utilized
  */
 public interface ClientExecutionService extends ExecutionService, Executor {
 
     /**
-     * Execute alien (user code) on execution service
-     *
-     * @param command to run
-     */
-    @Override
-    void execute(Runnable command);
-
-    ICompletableFuture<?> submit(Runnable task);
-
-    <T> ICompletableFuture<T> submit(Callable<T> task);
-
-    /**
      * @return executorService that alien (user code) runs on
      */
-    ExecutorService getAsyncExecutor();
+    ExecutorService getUserExecutor();
+
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.client.spi.impl;
 
-import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.AbstractInvocationFuture;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -33,9 +33,9 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
     protected final ClientMessage request;
     private final ClientInvocation invocation;
 
-    public ClientInvocationFuture(ClientInvocation invocation, HazelcastClientInstanceImpl client,
+    public ClientInvocationFuture(ClientInvocation invocation, Executor internalExecutor,
                                   ClientMessage request, ILogger logger) {
-        super(client.getClientExecutionService(), logger);
+        super(internalExecutor, logger);
         this.request = request;
         this.invocation = invocation;
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImplTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImplTest.java
@@ -52,7 +52,7 @@ public class ClientExecutionServiceImplTest {
     public void testExecuteInternal() {
         TestRunnable runnable = new TestRunnable();
 
-        executionService.executeInternal(runnable);
+        executionService.execute(runnable);
 
         runnable.await();
     }
@@ -61,7 +61,7 @@ public class ClientExecutionServiceImplTest {
     public void testSubmitInternal() throws Exception {
         TestRunnable runnable = new TestRunnable();
 
-        Future<?> future = executionService.submitInternal(runnable);
+        Future<?> future = executionService.submit(null, runnable);
         future.get();
 
         assertTrue(runnable.isExecuted());
@@ -80,7 +80,7 @@ public class ClientExecutionServiceImplTest {
     public void testSubmit_withRunnable() throws Exception {
         TestRunnable runnable = new TestRunnable();
 
-        Future<?> future = executionService.submit(runnable);
+        Future<?> future = executionService.submit(null, runnable);
         future.get();
 
         assertTrue(runnable.isExecuted());
@@ -90,7 +90,7 @@ public class ClientExecutionServiceImplTest {
     public void testSubmit_withCallable() throws Exception {
         TestCallable callable = new TestCallable();
 
-        Future<Integer> future = executionService.submit(callable);
+        Future<Integer> future = executionService.submit(null, callable);
         int result = future.get();
 
         assertTrue(callable.isExecuted());
@@ -203,12 +203,7 @@ public class ClientExecutionServiceImplTest {
 
     @Test
     public void testGetAsyncExecutor() {
-        assertNotNull(executionService.getAsyncExecutor());
-    }
-
-    @Test
-    public void testGetInternalExecutor() {
-        assertNotNull(executionService.getInternalExecutor());
+        assertNotNull(executionService.getUserExecutor());
     }
 
     private static class TestRunnable implements Runnable {

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
@@ -23,7 +23,6 @@ import com.hazelcast.spi.serialization.SerializationService;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -32,12 +31,12 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
 public final class CompletedFuture<V> implements InternalCompletableFuture<V> {
 
     private final SerializationService serializationService;
-    private final ExecutorService asyncExecutor;
+    private final Executor userExecutor;
     private final Object value;
 
-    public CompletedFuture(SerializationService serializationService, Object value, ExecutorService asyncExecutor) {
+    public CompletedFuture(SerializationService serializationService, Object value, Executor userExecutor) {
         this.serializationService = serializationService;
-        this.asyncExecutor = asyncExecutor;
+        this.userExecutor = userExecutor;
         this.value = value;
     }
 
@@ -97,7 +96,7 @@ public final class CompletedFuture<V> implements InternalCompletableFuture<V> {
 
     @Override
     public void andThen(ExecutionCallback<V> callback) {
-        andThen(callback, asyncExecutor);
+        andThen(callback, userExecutor);
     }
 
     @Override


### PR DESCRIPTION
Parts that violates following rules are fixed.
User code (listener and callback) runs on userExecutor
Other internals runs on internalExecutor

To avoid further confusion about usages made the following changes
1. Made ClientExecutionService to use only internalExecutor when used over its methods.
2. Removed getInternalExecutor to avoid doing same thing two different ways.
3. Renamed getAsyncExecutor to getUserExecutor to avoid confusion
4. Used getUserExecutor where needed to fix current wrong usages.

fixes https://github.com/hazelcast/hazelcast/issues/8651