### PR TITLE
Cleanup of ClientReplicatedMapProxy related files

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapPortableHook.java
@@ -31,7 +31,7 @@ import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.REPLICAT
 /**
  * This class registers all Portable serializers that are needed for communication between nodes and clients
  */
-//CHECKSTYLE:OFF
+@SuppressWarnings("checkstyle:anoninnerlength")
 public class ReplicatedMapPortableHook implements PortableHook {
 
     public static final int F_ID = FactoryIdHelper.getFactoryId(REPLICATED_PORTABLE_FACTORY, REPLICATED_PORTABLE_FACTORY_ID);
@@ -41,7 +41,7 @@ public class ReplicatedMapPortableHook implements PortableHook {
     public static final int VALUES_COLLECTION = 14;
     public static final int MAP_ENTRY_EVENT = 18;
 
-    private static final int LENGTH = 21;
+    private static final int LENGTH = MAP_ENTRY_EVENT + 1;
 
     @Override
     public int getFactoryId() {
@@ -51,7 +51,9 @@ public class ReplicatedMapPortableHook implements PortableHook {
     @Override
     public PortableFactory createFactory() {
         return new PortableFactory() {
-            final ConstructorFunction<Integer, Portable> constructors[] = new ConstructorFunction[LENGTH];
+
+            @SuppressWarnings("unchecked")
+            private final ConstructorFunction<Integer, Portable>[] constructors = new ConstructorFunction[LENGTH];
 
             {
                 constructors[MAP_ENTRIES] = new ConstructorFunction<Integer, Portable>() {
@@ -91,4 +93,3 @@ public class ReplicatedMapPortableHook implements PortableHook {
         return null;
     }
 }
-//CHECKSTYLE:ON

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapValueCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/client/ReplicatedMapValueCollection.java
@@ -58,7 +58,7 @@ public class ReplicatedMapValueCollection implements Portable {
     public void readPortable(PortableReader reader) throws IOException {
         int size = reader.readInt("size");
         ObjectDataInput in = reader.getRawDataInput();
-        values = new ArrayList(size);
+        values = new ArrayList<Data>(size);
         for (int i = 0; i < size; i++) {
             values.add(in.readData());
         }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/PutOperation.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 public class PutOperation extends AbstractReplicatedMapOperation implements PartitionAwareOperation {
 
     private transient ReplicatedMapService service;
-    private transient ReplicatedRecordStore store;
     private transient Data oldValue;
 
     public PutOperation() {
@@ -56,11 +55,11 @@ public class PutOperation extends AbstractReplicatedMapOperation implements Part
     @Override
     public void run() throws Exception {
         service = getService();
-        store = service.getReplicatedRecordStore(name, true, getPartitionId());
+        ReplicatedRecordStore store = service.getReplicatedRecordStore(name, true, getPartitionId());
         Address thisAddress = getNodeEngine().getThisAddress();
         boolean isLocal = getCallerAddress().equals(thisAddress);
         Object putResult = store.put(key, value, ttl, TimeUnit.MILLISECONDS, isLocal);
-        this.oldValue = getNodeEngine().toData(putResult);
+        oldValue = getNodeEngine().toData(putResult);
         response = new VersionResponsePair(putResult, store.getVersion());
         if (!isLocal) {
             sendUpdateCallerOperation(false);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/RemoveOperation.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 public class RemoveOperation extends AbstractReplicatedMapOperation implements PartitionAwareOperation {
 
     private transient ReplicatedMapService service;
-    private transient ReplicatedRecordStore store;
     private transient Data oldValue;
 
     public RemoveOperation() {
@@ -47,7 +46,7 @@ public class RemoveOperation extends AbstractReplicatedMapOperation implements P
     @Override
     public void run() throws Exception {
         service = getService();
-        store = service.getReplicatedRecordStore(name, true, getPartitionId());
+        ReplicatedRecordStore store = service.getReplicatedRecordStore(name, true, getPartitionId());
         Object removed = store.remove(key);
         this.oldValue = getNodeEngine().toData(removed);
         response = new VersionResponsePair(removed, store.getVersion());

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ReplicatedMapDataSerializerHook.java
@@ -35,8 +35,6 @@ import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.REPLICAT
 /**
  * This class contains all the ID hooks for IdentifiedDataSerializable classes used inside the replicated map.
  */
-//Deactivated all checkstyle rules because those classes will never comply
-//CHECKSTYLE:OFF
 public class ReplicatedMapDataSerializerHook implements DataSerializerHook {
 
     public static final int F_ID = FactoryIdHelper.getFactoryId(REPLICATED_MAP_DS_FACTORY, REPLICATED_MAP_DS_FACTORY_ID);

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecord.java
@@ -125,9 +125,8 @@ public class ReplicatedRecord<K, V> {
         lastAccessTime = Clock.currentTimeMillis();
     }
 
-    // CheckStyle is deactivated due to complexity of the equals method
-    //CHECKSTYLE:OFF
     @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -150,7 +149,6 @@ public class ReplicatedRecord<K, V> {
 
         return true;
     }
-    //CHECKSTYLE:ON
 
     @Override
     public int hashCode() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ValuesIteratorFactory.java
@@ -41,7 +41,7 @@ class ValuesIteratorFactory<K, V> implements IteratorFactory<K, V, V> {
 
         private Map.Entry<K, ReplicatedRecord<K, V>> entry;
 
-        public ValuesIterator(Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
+        ValuesIterator(Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
             this.iterator = iterator;
         }
 


### PR DESCRIPTION
* Added missing generics in `ReplicatedMapSplitBrainHandlerService`
* Added missing generics in `ReplicatedMapValueCollection`
* Made `ReplicatedRecordStore` in `PutOperation` and `RemoveOperation`
  a local variable
* Made remaining CheckStyle suppressions more granular
