### PR TITLE
[BACKPORT] Fix re-execution of completed task when killing the owner node

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/PutResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/PutResultOperation.java
@@ -20,12 +20,16 @@ import com.hazelcast.durableexecutor.impl.DurableExecutorDataSerializerHook;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Notifier;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
 
 import java.io.IOException;
 
-public class PutResultOperation extends AbstractDurableExecutorOperation implements Notifier {
+public class PutResultOperation
+        extends AbstractDurableExecutorOperation
+        implements Notifier, BackupAwareOperation {
 
     private int sequence;
 
@@ -55,6 +59,11 @@ public class PutResultOperation extends AbstractDurableExecutorOperation impleme
     public WaitNotifyKey getNotifiedKey() {
         long uniqueId = Bits.combineToLong(getPartitionId(), sequence);
         return new DurableExecutorWaitNotifyKey(name, uniqueId);
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return new PutResultOperation(name, sequence, result);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableRetrieveResultTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableRetrieveResultTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.durableexecutor;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.executor.ExecutorServiceTestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -30,6 +31,7 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -151,6 +153,33 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
         executorService = instance2.getDurableExecutorService(name);
         Future<Boolean> future = executorService.retrieveResult(taskId);
         assertTrue(future.get());
+    }
+
+    @Test
+    public void testSingleExecution_WhenMigratedAfterCompletion_WhenOwnerMemberKilled() throws Exception {
+        String name = randomString();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance instance1 = factory.newHazelcastInstance();
+        HazelcastInstance instance2 = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+        String key = generateKeyOwnedBy(instance1);
+
+        String runCounterName = "runCount";
+        IAtomicLong runCount = instance2.getAtomicLong(runCounterName);
+
+        DurableExecutorService executorService = instance1.getDurableExecutorService(name);
+        IncrementAtomicLongRunnable task = new IncrementAtomicLongRunnable(runCounterName);
+        DurableExecutorServiceFuture future = executorService.submitToKeyOwner(task, key);
+
+        future.get(); // Wait for it to finish
+
+        instance1.getLifecycleService().terminate();
+
+        executorService = instance2.getDurableExecutorService(name);
+        Future<Object> newFuture = executorService.retrieveResult(future.getTaskId());
+        newFuture.get(); // Make sure its completed
+
+        assertEquals(1, runCount.get());
     }
 
     @Test


### PR DESCRIPTION
When a task is submitted to a key owner, and the task completes, we replace the runnable
with the result in the internal ring buffer. However, there is no backup-operation to sync
the result with the backup nodes. If the node shuts down gracefully then the replication
will properly handle it, but when the node is killed, the backup nodes still have the task
in their ring-buffer rather than the result, thus, we re-execute it.

Fix #9965 