### PR TITLE
Removed duplicate implements in proxy hierarchies

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.cache.impl;
 
 import com.hazelcast.cache.CacheStatistics;
-import com.hazelcast.cache.impl.ICacheInternal;
 import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
@@ -70,7 +69,7 @@ import static java.util.Collections.emptyMap;
  * @param <V> the type of value
  */
 @SuppressWarnings("checkstyle:npathcomplexity")
-abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCacheProxy<K, V> implements ICacheInternal<K, V> {
+abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCacheProxy<K, V> {
 
     @SuppressWarnings("unchecked")
     private static ClientMessageDecoder cacheGetResponseDecoder = new ClientMessageDecoder() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -62,7 +62,6 @@ import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.PartitionPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -100,7 +99,7 @@ import static java.util.Collections.emptyMap;
  * @param <V> the value type of map.
  */
 @SuppressWarnings("checkstyle:classfanoutcomplexity")
-public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V>, InitializingObject {
+public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V> {
 
     public MapProxyImpl(String name, MapService mapService, NodeEngine nodeEngine, MapConfig mapConfig) {
         super(name, mapService, nodeEngine, mapConfig);


### PR DESCRIPTION
* `IMap` is already implemented in `MapProxySupport`
* `ICacheInternal` is already implemented in `AbstractClientCacheProxyBase`

This makes the class hierarchy easier to document, since some double inheritance are removed. It is still complex enough...
![proxies](https://cloud.githubusercontent.com/assets/4196298/23551526/61ecc334-0017-11e7-835c-eb0db597ae9d.png)
