### PR TITLE
Small cleanup of Cache related proxy classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -30,7 +30,6 @@ import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.executor.CompletableFutureTask;
 
 import javax.cache.CacheException;
@@ -39,7 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
@@ -47,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateResults;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 /**
  * Abstract class providing cache open/close operations and {@link NodeEngine}, {@link CacheService} and
@@ -59,9 +58,9 @@ import static com.hazelcast.cache.impl.CacheProxyUtil.validateResults;
  */
 abstract class AbstractCacheProxyBase<K, V>
         extends AbstractDistributedObject<ICacheService>
-        implements PrefixedDistributedObject {
+        implements ICacheInternal<K, V>, PrefixedDistributedObject {
 
-    static final int TIMEOUT = 10;
+    private static final int TIMEOUT = 10;
 
     protected final ILogger logger;
     protected final CacheConfig<K, V> cacheConfig;
@@ -78,7 +77,7 @@ abstract class AbstractCacheProxyBase<K, V>
     private final AtomicBoolean isClosed = new AtomicBoolean(false);
     private final AtomicBoolean isDestroyed = new AtomicBoolean(false);
 
-    protected AbstractCacheProxyBase(CacheConfig cacheConfig, NodeEngine nodeEngine, ICacheService cacheService) {
+    AbstractCacheProxyBase(CacheConfig<K, V> cacheConfig, NodeEngine nodeEngine, ICacheService cacheService) {
         super(nodeEngine, cacheService);
         this.name = cacheConfig.getName();
         this.nameWithPrefix = cacheConfig.getNameWithPrefix();
@@ -92,20 +91,10 @@ abstract class AbstractCacheProxyBase<K, V>
                 cacheService.getCacheOperationProvider(nameWithPrefix, cacheConfig.getInMemoryFormat());
     }
 
-    protected void injectDependencies(Object obj) {
+    void injectDependencies(Object obj) {
         if (obj instanceof HazelcastInstanceAware) {
             ((HazelcastInstanceAware) obj).setHazelcastInstance(nodeEngine.getHazelcastInstance());
         }
-    }
-
-    @Override
-    public String getServiceName() {
-        return ICacheService.SERVICE_NAME;
-    }
-
-    @Override
-    protected String getDistributedObjectName() {
-        return nameWithPrefix;
     }
 
     @Override
@@ -114,16 +103,29 @@ abstract class AbstractCacheProxyBase<K, V>
     }
 
     @Override
+    protected String getDistributedObjectName() {
+        return nameWithPrefix;
+    }
+
+    @Override
     public String getPrefixedName() {
         return nameWithPrefix;
     }
 
-    protected void ensureOpen() {
-        if (isClosed()) {
-            throw new IllegalStateException("Cache operations can not be performed. The cache closed");
-        }
+    @Override
+    public String getServiceName() {
+        return ICacheService.SERVICE_NAME;
     }
 
+    @Override
+    public void open() {
+        if (isDestroyed.get()) {
+            throw new IllegalStateException("Cache is already destroyed! Cannot be reopened");
+        }
+        isClosed.compareAndSet(true, false);
+    }
+
+    @Override
     public void close() {
         if (!isClosed.compareAndSet(false, true)) {
             return;
@@ -157,29 +159,29 @@ abstract class AbstractCacheProxyBase<K, V>
         return true;
     }
 
+    @Override
     public boolean isClosed() {
         return isClosed.get();
     }
 
+    @Override
     public boolean isDestroyed() {
         return isDestroyed.get();
     }
 
-    public void open() {
-        if (isDestroyed.get()) {
-            throw new IllegalStateException("Cache is already destroyed! Cannot be reopened");
-        }
-        if (!isClosed.compareAndSet(true, false)) {
-            return;
+    abstract void closeListeners();
+
+    void ensureOpen() {
+        if (isClosed()) {
+            throw new IllegalStateException("Cache operations can not be performed. The cache closed");
         }
     }
 
-    protected abstract void closeListeners();
-
-    protected void submitLoadAllTask(LoadAllTask loadAllTask) {
-        final ExecutionService executionService = nodeEngine.getExecutionService();
-        final CompletableFutureTask<?> future =
-                (CompletableFutureTask<?>) executionService.submit("loadAll-" + nameWithPrefix, loadAllTask);
+    @SuppressWarnings("unchecked")
+    void submitLoadAllTask(LoadAllTask loadAllTask) {
+        ExecutionService executionService = nodeEngine.getExecutionService();
+        final CompletableFutureTask<Object> future =
+                (CompletableFutureTask<Object>) executionService.submit("loadAll-" + nameWithPrefix, loadAllTask);
         loadAllTasks.add(future);
         future.andThen(new ExecutionCallback() {
             @Override
@@ -195,16 +197,41 @@ abstract class AbstractCacheProxyBase<K, V>
         });
     }
 
-    protected final class LoadAllTask
-            implements Runnable {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AbstractCacheProxyBase that = (AbstractCacheProxyBase) o;
+        if (nameWithPrefix != null ? !nameWithPrefix.equals(that.nameWithPrefix) : that.nameWithPrefix != null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return nameWithPrefix != null ? nameWithPrefix.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + '{' + "name=" + name + ", nameWithPrefix=" + nameWithPrefix + '}';
+    }
+
+    final class LoadAllTask implements Runnable {
 
         private final CompletionListener completionListener;
         private final CacheOperationProvider operationProvider;
         private final Set<Data> keysData;
         private final boolean replaceExistingValues;
 
-        public LoadAllTask(CacheOperationProvider operationProvider, Set<Data> keysData,
-                           boolean replaceExistingValues, CompletionListener completionListener) {
+        LoadAllTask(CacheOperationProvider operationProvider, Set<Data> keysData,
+                    boolean replaceExistingValues, CompletionListener completionListener) {
             this.operationProvider = operationProvider;
             this.keysData = keysData;
             this.replaceExistingValues = replaceExistingValues;
@@ -223,7 +250,7 @@ abstract class AbstractCacheProxyBase<K, V>
                 Map<Address, List<Integer>> memberPartitionsMap = partitionService.getMemberPartitionsMap();
                 Map<Integer, Object> results = new HashMap<Integer, Object>();
 
-                for (Entry<Address, List<Integer>> memberPartitions : memberPartitionsMap.entrySet()) {
+                for (Map.Entry<Address, List<Integer>> memberPartitions : memberPartitionsMap.entrySet()) {
                     Set<Integer> partitions = new HashSet<Integer>(memberPartitions.getValue());
                     Set<Data> ownerKeys = filterOwnerKeys(partitionService, partitions);
                     operationFactory = operationProvider.createLoadAllOperationFactory(ownerKeys, replaceExistingValues);
@@ -242,7 +269,7 @@ abstract class AbstractCacheProxyBase<K, V>
                 }
             } catch (Throwable t) {
                 if (t instanceof OutOfMemoryError) {
-                    ExceptionUtil.rethrow(t);
+                    throw rethrow(t);
                 } else {
                     if (completionListener != null) {
                         completionListener.onException(new CacheException(t));
@@ -253,7 +280,7 @@ abstract class AbstractCacheProxyBase<K, V>
 
         private Set<Data> filterOwnerKeys(IPartitionService partitionService, Set<Integer> partitions) {
             Set<Data> ownerKeys = new HashSet<Data>();
-            for (Data key: keysData) {
+            for (Data key : keysData) {
                 int keyPartitionId = partitionService.getPartitionId(key);
                 if (partitions.contains(keyPartitionId)) {
                     ownerKeys.add(key);
@@ -261,34 +288,5 @@ abstract class AbstractCacheProxyBase<K, V>
             }
             return ownerKeys;
         }
-
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        AbstractCacheProxyBase that = (AbstractCacheProxyBase) o;
-        if (nameWithPrefix != null ? !nameWithPrefix.equals(that.nameWithPrefix) : that.nameWithPrefix != null) {
-            return false;
-        }
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return nameWithPrefix != null ? nameWithPrefix.hashCode() : 0;
-    }
-
-    @Override
-    public String toString() {
-        return getClass().getName() + '{' + "name=" + name + ", nameWithPrefix=" + nameWithPrefix + '}';
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -54,6 +54,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
 import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLETION;
+import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
 
 /**
  * Abstract {@link com.hazelcast.cache.ICache} implementation which provides shared internal implementations
@@ -69,36 +70,32 @@ import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLET
  */
 abstract class AbstractInternalCacheProxy<K, V>
         extends AbstractCacheProxyBase<K, V>
-        implements ICacheInternal<K, V>, CacheSyncListenerCompleter {
+        implements CacheSyncListenerCompleter {
 
     private static final long MAX_COMPLETION_LATCH_WAIT_TIME = TimeUnit.MINUTES.toMillis(5);
-
     private static final long COMPLETION_LATCH_WAIT_TIME_STEP = TimeUnit.SECONDS.toMillis(1);
-    private final ConcurrentMap<CacheEntryListenerConfiguration, String> asyncListenerRegistrations;
-
-    private final ConcurrentMap<CacheEntryListenerConfiguration, String> syncListenerRegistrations;
-    private final ConcurrentMap<Integer, CountDownLatch> syncLocks;
 
     private final AtomicInteger completionIdCounter = new AtomicInteger();
 
+    private final ConcurrentMap<CacheEntryListenerConfiguration, String> asyncListenerRegistrations;
+    private final ConcurrentMap<CacheEntryListenerConfiguration, String> syncListenerRegistrations;
+    private final ConcurrentMap<Integer, CountDownLatch> syncLocks;
+
     private HazelcastServerCacheManager cacheManager;
 
-    protected AbstractInternalCacheProxy(CacheConfig cacheConfig, NodeEngine nodeEngine,
-                                         ICacheService cacheService) {
+    AbstractInternalCacheProxy(CacheConfig<K, V> cacheConfig, NodeEngine nodeEngine, ICacheService cacheService) {
         super(cacheConfig, nodeEngine, cacheService);
         asyncListenerRegistrations = new ConcurrentHashMap<CacheEntryListenerConfiguration, String>();
         syncListenerRegistrations = new ConcurrentHashMap<CacheEntryListenerConfiguration, String>();
         syncLocks = new ConcurrentHashMap<Integer, CountDownLatch>();
 
-        final List<CachePartitionLostListenerConfig> configs = cacheConfig.getPartitionLostListenerConfigs();
+        List<CachePartitionLostListenerConfig> configs = cacheConfig.getPartitionLostListenerConfigs();
         for (CachePartitionLostListenerConfig listenerConfig : configs) {
-            final CachePartitionLostListener listener = initializeListener(listenerConfig);
+            CachePartitionLostListener listener = initializeListener(listenerConfig);
             if (listener != null) {
-                final InternalCachePartitionLostListenerAdapter listenerAdapter =
-                        new InternalCachePartitionLostListenerAdapter(listener);
-                final EventFilter filter = new CachePartitionLostEventFilter();
-                final ICacheService service = getService();
-                service.getNodeEngine().getEventService()
+                EventFilter filter = new CachePartitionLostEventFilter();
+                CacheEventListener listenerAdapter = new InternalCachePartitionLostListenerAdapter(listener);
+                getService().getNodeEngine().getEventService()
                         .registerListener(AbstractCacheService.SERVICE_NAME, name, filter, listenerAdapter);
             }
         }
@@ -120,200 +117,17 @@ abstract class AbstractInternalCacheProxy<K, V>
         }
     }
 
-    protected <T> InternalCompletableFuture<T> invoke(Operation op, int partitionId, boolean completionOperation) {
-        Integer completionId = null;
-        if (completionOperation) {
-            completionId = registerCompletionLatch(1);
-            if (op instanceof MutableOperation) {
-                ((MutableOperation) op).setCompletionId(completionId);
+    @Override
+    public void countDownCompletionLatch(int countDownLatchId) {
+        if (countDownLatchId != IGNORE_COMPLETION) {
+            CountDownLatch countDownLatch = syncLocks.get(countDownLatchId);
+            if (countDownLatch == null) {
+                return;
             }
-        }
-        try {
-            final InternalCompletableFuture<T> f =
-                    getNodeEngine().getOperationService()
-                            .invokeOnPartition(getServiceName(), op, partitionId);
-            if (completionOperation) {
-                waitCompletionLatch(completionId);
+            countDownLatch.countDown();
+            if (countDownLatch.getCount() == 0) {
+                deregisterCompletionLatch(countDownLatchId);
             }
-            return f;
-        } catch (Throwable e) {
-            if (e instanceof IllegalStateException) {
-                close();
-            }
-            throw ExceptionUtil.rethrowAllowedTypeFirst(e, CacheException.class);
-        } finally {
-            if (completionOperation) {
-                deregisterCompletionLatch(completionId);
-            }
-        }
-    }
-
-    protected <T> InternalCompletableFuture<T> invoke(Operation op, Data keyData, boolean completionOperation) {
-        final int partitionId = getPartitionId(keyData);
-        return invoke(op, partitionId, completionOperation);
-    }
-
-    protected <T> InternalCompletableFuture<T> removeAsyncInternal(K key, V oldValue, boolean hasOldValue,
-                                                                   boolean isGet, boolean withCompletionEvent) {
-        ensureOpen();
-        if (hasOldValue) {
-            validateNotNull(key, oldValue);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, oldValue);
-        } else {
-            validateNotNull(key);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key);
-        }
-        final Data keyData = serializationService.toData(key);
-        final Data valueData = serializationService.toData(oldValue);
-        final Operation operation;
-        if (isGet) {
-            operation = operationProvider.createGetAndRemoveOperation(keyData, IGNORE_COMPLETION);
-        } else {
-            operation = operationProvider.createRemoveOperation(keyData, valueData, IGNORE_COMPLETION);
-        }
-        return invoke(operation, keyData, withCompletionEvent);
-    }
-
-    protected <T> InternalCompletableFuture<T> replaceAsyncInternal(K key, V oldValue, V newValue,
-                                                                    ExpiryPolicy expiryPolicy,
-                                                                    boolean hasOldValue, boolean isGet,
-                                                                    boolean withCompletionEvent) {
-        ensureOpen();
-        if (hasOldValue) {
-            validateNotNull(key, oldValue, newValue);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, oldValue, newValue);
-        } else {
-            validateNotNull(key, newValue);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, newValue);
-        }
-        final Data keyData = serializationService.toData(key);
-        final Data oldValueData = serializationService.toData(oldValue);
-        final Data newValueData = serializationService.toData(newValue);
-        final Operation operation;
-        if (isGet) {
-            operation = operationProvider.createGetAndReplaceOperation(keyData, newValueData,
-                    expiryPolicy, IGNORE_COMPLETION);
-        } else {
-            operation = operationProvider.createReplaceOperation(keyData, oldValueData, newValueData,
-                    expiryPolicy, IGNORE_COMPLETION);
-        }
-        return invoke(operation, keyData, withCompletionEvent);
-    }
-
-    protected <T> InternalCompletableFuture<T> putAsyncInternal(K key, V value, ExpiryPolicy expiryPolicy,
-                                                                boolean isGet, boolean withCompletionEvent) {
-        ensureOpen();
-        validateNotNull(key, value);
-        CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, value);
-        final Data keyData = serializationService.toData(key);
-        final Data valueData = serializationService.toData(value);
-        final Operation op = operationProvider.createPutOperation(keyData, valueData, expiryPolicy,
-                isGet, IGNORE_COMPLETION);
-        return invoke(op, keyData, withCompletionEvent);
-    }
-
-    protected InternalCompletableFuture<Boolean> putIfAbsentAsyncInternal(K key, V value,
-                                                                          ExpiryPolicy expiryPolicy,
-                                                                          boolean withCompletionEvent) {
-        ensureOpen();
-        validateNotNull(key, value);
-        CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, value);
-        final Data keyData = serializationService.toData(key);
-        final Data valueData = serializationService.toData(value);
-        Operation operation = operationProvider.createPutIfAbsentOperation(keyData, valueData,
-                expiryPolicy, IGNORE_COMPLETION);
-        return invoke(operation, keyData, withCompletionEvent);
-    }
-
-    protected void clearInternal() {
-        final OperationService operationService = getNodeEngine().getOperationService();
-        OperationFactory operationFactory = operationProvider.createClearOperationFactory();
-        try {
-            final Map<Integer, Object> results =
-                    operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
-            for (Object result : results.values()) {
-                if (result != null && result instanceof CacheClearResponse) {
-                    final Object response = ((CacheClearResponse) result).getResponse();
-                    if (response instanceof Throwable) {
-                        throw (Throwable) response;
-                    }
-                }
-            }
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrowAllowedTypeFirst(t, CacheException.class);
-        }
-    }
-
-    protected void removeAllInternal(Set<? extends K> keys) {
-        final Set<Data> keysData;
-        if (keys != null) {
-            keysData = new HashSet<Data>();
-            for (K key : keys) {
-                keysData.add(serializationService.toData(key));
-            }
-        } else {
-            keysData = null;
-        }
-        final int partitionCount = getNodeEngine().getPartitionService().getPartitionCount();
-        final Integer completionId = registerCompletionLatch(partitionCount);
-        final OperationService operationService = getNodeEngine().getOperationService();
-        OperationFactory operationFactory =
-                operationProvider.createRemoveAllOperationFactory(keysData, completionId);
-        try {
-            final Map<Integer, Object> results =
-                    operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
-            int completionCount = 0;
-            for (Object result : results.values()) {
-                if (result != null && result instanceof CacheClearResponse) {
-                    final Object response = ((CacheClearResponse) result).getResponse();
-                    if (response instanceof Boolean) {
-                        completionCount++;
-                    }
-                    if (response instanceof Throwable) {
-                        throw (Throwable) response;
-                    }
-                }
-            }
-            waitCompletionLatch(completionId, partitionCount - completionCount);
-        } catch (Throwable t) {
-            deregisterCompletionLatch(completionId);
-            throw ExceptionUtil.rethrowAllowedTypeFirst(t, CacheException.class);
-        }
-    }
-
-    protected void addListenerLocally(String regId,
-                                      CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
-        if (cacheEntryListenerConfiguration.isSynchronous()) {
-            syncListenerRegistrations.putIfAbsent(cacheEntryListenerConfiguration, regId);
-        } else {
-            asyncListenerRegistrations.putIfAbsent(cacheEntryListenerConfiguration, regId);
-        }
-    }
-
-    protected String removeListenerLocally(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
-        final ConcurrentMap<CacheEntryListenerConfiguration, String> regs;
-        if (cacheEntryListenerConfiguration.isSynchronous()) {
-            regs = syncListenerRegistrations;
-        } else {
-            regs = asyncListenerRegistrations;
-        }
-        return regs.remove(cacheEntryListenerConfiguration);
-    }
-
-    protected String getListenerIdLocal(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
-        final ConcurrentMap<CacheEntryListenerConfiguration, String> regs;
-        if (cacheEntryListenerConfiguration.isSynchronous()) {
-            regs = syncListenerRegistrations;
-        } else {
-            regs = asyncListenerRegistrations;
-        }
-        return regs.get(cacheEntryListenerConfiguration);
-    }
-
-    private void deregisterAllCacheEntryListener(Collection<String> listenerRegistrations) {
-        final ICacheService service = getService();
-        for (String regId : listenerRegistrations) {
-            service.deregisterListener(nameWithPrefix, regId);
         }
     }
 
@@ -325,6 +139,196 @@ abstract class AbstractInternalCacheProxy<K, V>
         syncListenerRegistrations.clear();
         asyncListenerRegistrations.clear();
         notifyAndClearSyncListenerLatches();
+    }
+
+    @Override
+    public CacheStatistics getLocalCacheStatistics() {
+        // TODO: throw UnsupportedOperationException if cache statistics are not enabled (but it breaks backward compatibility)
+        return getService().createCacheStatIfAbsent(cacheConfig.getNameWithPrefix());
+    }
+
+    <T> InternalCompletableFuture<T> invoke(Operation op, int partitionId, boolean completionOperation) {
+        Integer completionId = null;
+        if (completionOperation) {
+            completionId = registerCompletionLatch(1);
+            if (op instanceof MutableOperation) {
+                ((MutableOperation) op).setCompletionId(completionId);
+            }
+        }
+        try {
+            InternalCompletableFuture<T> future = getNodeEngine().getOperationService()
+                    .invokeOnPartition(getServiceName(), op, partitionId);
+            if (completionOperation) {
+                waitCompletionLatch(completionId);
+            }
+            return future;
+        } catch (Throwable e) {
+            if (e instanceof IllegalStateException) {
+                close();
+            }
+            throw rethrowAllowedTypeFirst(e, CacheException.class);
+        } finally {
+            if (completionOperation) {
+                deregisterCompletionLatch(completionId);
+            }
+        }
+    }
+
+    <T> InternalCompletableFuture<T> invoke(Operation op, Data keyData, boolean completionOperation) {
+        int partitionId = getPartitionId(keyData);
+        return invoke(op, partitionId, completionOperation);
+    }
+
+    <T> InternalCompletableFuture<T> removeAsyncInternal(K key, V oldValue, boolean hasOldValue,
+                                                         boolean isGet, boolean withCompletionEvent) {
+        ensureOpen();
+        if (hasOldValue) {
+            validateNotNull(key, oldValue);
+            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, oldValue);
+        } else {
+            validateNotNull(key);
+            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key);
+        }
+        Data keyData = serializationService.toData(key);
+        Data valueData = serializationService.toData(oldValue);
+        Operation operation;
+        if (isGet) {
+            operation = operationProvider.createGetAndRemoveOperation(keyData, IGNORE_COMPLETION);
+        } else {
+            operation = operationProvider.createRemoveOperation(keyData, valueData, IGNORE_COMPLETION);
+        }
+        return invoke(operation, keyData, withCompletionEvent);
+    }
+
+    <T> InternalCompletableFuture<T> replaceAsyncInternal(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy,
+                                                          boolean hasOldValue, boolean isGet, boolean withCompletionEvent) {
+        ensureOpen();
+        if (hasOldValue) {
+            validateNotNull(key, oldValue, newValue);
+            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, oldValue, newValue);
+        } else {
+            validateNotNull(key, newValue);
+            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, newValue);
+        }
+        Data keyData = serializationService.toData(key);
+        Data oldValueData = serializationService.toData(oldValue);
+        Data newValueData = serializationService.toData(newValue);
+        Operation operation;
+        if (isGet) {
+            operation = operationProvider.createGetAndReplaceOperation(keyData, newValueData, expiryPolicy, IGNORE_COMPLETION);
+        } else {
+            operation = operationProvider.createReplaceOperation(keyData, oldValueData, newValueData, expiryPolicy,
+                    IGNORE_COMPLETION);
+        }
+        return invoke(operation, keyData, withCompletionEvent);
+    }
+
+    <T> InternalCompletableFuture<T> putAsyncInternal(K key, V value, ExpiryPolicy expiryPolicy,
+                                                      boolean isGet, boolean withCompletionEvent) {
+        ensureOpen();
+        validateNotNull(key, value);
+        CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, value);
+        Data keyData = serializationService.toData(key);
+        Data valueData = serializationService.toData(value);
+        Operation op = operationProvider.createPutOperation(keyData, valueData, expiryPolicy, isGet, IGNORE_COMPLETION);
+        return invoke(op, keyData, withCompletionEvent);
+    }
+
+    InternalCompletableFuture<Boolean> putIfAbsentAsyncInternal(K key, V value, ExpiryPolicy expiryPolicy,
+                                                                boolean withCompletionEvent) {
+        ensureOpen();
+        validateNotNull(key, value);
+        CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, value);
+        Data keyData = serializationService.toData(key);
+        Data valueData = serializationService.toData(value);
+        Operation operation = operationProvider.createPutIfAbsentOperation(keyData, valueData, expiryPolicy, IGNORE_COMPLETION);
+        return invoke(operation, keyData, withCompletionEvent);
+    }
+
+    void clearInternal() {
+        try {
+            OperationService operationService = getNodeEngine().getOperationService();
+            OperationFactory operationFactory = operationProvider.createClearOperationFactory();
+            Map<Integer, Object> results = operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
+            for (Object result : results.values()) {
+                if (result != null && result instanceof CacheClearResponse) {
+                    Object response = ((CacheClearResponse) result).getResponse();
+                    if (response instanceof Throwable) {
+                        throw (Throwable) response;
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            throw rethrowAllowedTypeFirst(t, CacheException.class);
+        }
+    }
+
+    void removeAllInternal(Set<? extends K> keys) {
+        Set<Data> keysData = null;
+        if (keys != null) {
+            keysData = new HashSet<Data>();
+            for (K key : keys) {
+                keysData.add(serializationService.toData(key));
+            }
+        }
+        int partitionCount = getNodeEngine().getPartitionService().getPartitionCount();
+        Integer completionId = registerCompletionLatch(partitionCount);
+        OperationService operationService = getNodeEngine().getOperationService();
+        OperationFactory operationFactory = operationProvider.createRemoveAllOperationFactory(keysData, completionId);
+        try {
+            Map<Integer, Object> results = operationService.invokeOnAllPartitions(getServiceName(), operationFactory);
+            int completionCount = 0;
+            for (Object result : results.values()) {
+                if (result != null && result instanceof CacheClearResponse) {
+                    Object response = ((CacheClearResponse) result).getResponse();
+                    if (response instanceof Boolean) {
+                        completionCount++;
+                    }
+                    if (response instanceof Throwable) {
+                        throw (Throwable) response;
+                    }
+                }
+            }
+            waitCompletionLatch(completionId, partitionCount - completionCount);
+        } catch (Throwable t) {
+            deregisterCompletionLatch(completionId);
+            throw rethrowAllowedTypeFirst(t, CacheException.class);
+        }
+    }
+
+    void addListenerLocally(String regId, CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
+        if (cacheEntryListenerConfiguration.isSynchronous()) {
+            syncListenerRegistrations.putIfAbsent(cacheEntryListenerConfiguration, regId);
+        } else {
+            asyncListenerRegistrations.putIfAbsent(cacheEntryListenerConfiguration, regId);
+        }
+    }
+
+    String removeListenerLocally(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
+        ConcurrentMap<CacheEntryListenerConfiguration, String> regs;
+        if (cacheEntryListenerConfiguration.isSynchronous()) {
+            regs = syncListenerRegistrations;
+        } else {
+            regs = asyncListenerRegistrations;
+        }
+        return regs.remove(cacheEntryListenerConfiguration);
+    }
+
+    String getListenerIdLocal(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
+        ConcurrentMap<CacheEntryListenerConfiguration, String> regs;
+        if (cacheEntryListenerConfiguration.isSynchronous()) {
+            regs = syncListenerRegistrations;
+        } else {
+            regs = asyncListenerRegistrations;
+        }
+        return regs.get(cacheEntryListenerConfiguration);
+    }
+
+    private void deregisterAllCacheEntryListener(Collection<String> listenerRegistrations) {
+        ICacheService service = getService();
+        for (String regId : listenerRegistrations) {
+            service.deregisterListener(nameWithPrefix, regId);
+        }
     }
 
     private void notifyAndClearSyncListenerLatches() {
@@ -340,22 +344,9 @@ abstract class AbstractInternalCacheProxy<K, V>
         }
     }
 
-    public void countDownCompletionLatch(int countDownLatchId) {
-        if (countDownLatchId != IGNORE_COMPLETION) {
-            final CountDownLatch countDownLatch = syncLocks.get(countDownLatchId);
-            if (countDownLatch == null) {
-                return;
-            }
-            countDownLatch.countDown();
-            if (countDownLatch.getCount() == 0) {
-                deregisterCompletionLatch(countDownLatchId);
-            }
-        }
-    }
-
-    protected Integer registerCompletionLatch(int count) {
+    Integer registerCompletionLatch(int count) {
         if (!syncListenerRegistrations.isEmpty()) {
-            final int id = completionIdCounter.incrementAndGet();
+            int id = completionIdCounter.incrementAndGet();
             int size = syncListenerRegistrations.size();
             CountDownLatch countDownLatch = new CountDownLatch(count * size);
             syncLocks.put(id, countDownLatch);
@@ -364,24 +355,24 @@ abstract class AbstractInternalCacheProxy<K, V>
         return IGNORE_COMPLETION;
     }
 
-    protected void deregisterCompletionLatch(Integer countDownLatchId) {
+    void deregisterCompletionLatch(Integer countDownLatchId) {
         if (countDownLatchId != IGNORE_COMPLETION) {
             syncLocks.remove(countDownLatchId);
         }
     }
 
-    protected void waitCompletionLatch(Integer countDownLatchId) {
+    void waitCompletionLatch(Integer countDownLatchId) {
         if (countDownLatchId != IGNORE_COMPLETION) {
-            final CountDownLatch countDownLatch = syncLocks.get(countDownLatchId);
+            CountDownLatch countDownLatch = syncLocks.get(countDownLatchId);
             if (countDownLatch != null) {
                 awaitLatch(countDownLatch);
             }
         }
     }
 
-    protected void waitCompletionLatch(Integer countDownLatchId, int offset) {
+    private void waitCompletionLatch(Integer countDownLatchId, int offset) {
         if (countDownLatchId != IGNORE_COMPLETION) {
-            final CountDownLatch countDownLatch = syncLocks.get(countDownLatchId);
+            CountDownLatch countDownLatch = syncLocks.get(countDownLatchId);
             if (countDownLatch != null) {
                 for (int i = 0; i < offset; i++) {
                     countDownLatch.countDown();
@@ -417,6 +408,7 @@ abstract class AbstractInternalCacheProxy<K, V>
         }
     }
 
+    @SuppressWarnings("unchecked")
     private <T extends EventListener> T initializeListener(ListenerConfig listenerConfig) {
         T listener = null;
         if (listenerConfig.getImplementation() != null) {
@@ -431,13 +423,4 @@ abstract class AbstractInternalCacheProxy<K, V>
         }
         return listener;
     }
-
-    @Override
-    public CacheStatistics getLocalCacheStatistics() {
-        // TODO Throw `UnsupportedOperationException` if cache statistics are not enabled
-        // but it breaks backward compatibility.
-        final ICacheService service = getService();
-        return service.createCacheStatIfAbsent(cacheConfig.getNameWithPrefix());
-    }
-
 }


### PR DESCRIPTION
* `AbstractCacheProxyBase` already implements methods from the interface `ICacheInterna`, so it should implement it
* Added generics to reduce warnings
* Added static imports
* Made methods more private if applicable
* Added missing `@Override` annotations
* Got rid of single letter variables
* Improved formatting

First step to simplify the Cache proxies on the member side.