### PR TITLE
Small cleanup of Transactional related proxy classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txncollection/AbstractTransactionalCollectionProxy.java
@@ -30,7 +30,6 @@ import com.hazelcast.spi.TransactionalDistributedObject;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.impl.Transaction;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -38,19 +37,22 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public abstract class AbstractTransactionalCollectionProxy<S extends RemoteService, E>
         extends TransactionalDistributedObject<S> {
 
+    protected final Set<Long> itemIdSet = new HashSet<Long>();
     protected final String name;
     protected final int partitionId;
-    protected final Set<Long> itemIdSet = new HashSet<Long>();
+    protected final OperationService operationService;
 
     public AbstractTransactionalCollectionProxy(String name, Transaction tx, NodeEngine nodeEngine, S service) {
         super(nodeEngine, service, tx);
         this.name = name;
         this.partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
+        this.operationService = nodeEngine.getOperationService();
     }
 
     protected abstract Collection<CollectionItem> getCollection();
@@ -64,12 +66,11 @@ public abstract class AbstractTransactionalCollectionProxy<S extends RemoteServi
         checkTransactionActive();
         checkObjectNotNull(e);
 
-        final NodeEngine nodeEngine = getNodeEngine();
-        final Data value = nodeEngine.toData(e);
+        Data value = getNodeEngine().toData(e);
         CollectionReserveAddOperation operation = new CollectionReserveAddOperation(name, tx.getTxnId(), null);
         try {
-            Future<Long> f = nodeEngine.getOperationService().invokeOnPartition(getServiceName(), operation, partitionId);
-            Long itemId = f.get();
+            Future<Long> future = operationService.invokeOnPartition(getServiceName(), operation, partitionId);
+            Long itemId = future.get();
             if (itemId != null) {
                 if (!itemIdSet.add(itemId)) {
                     throw new TransactionException("Duplicate itemId: " + itemId);
@@ -80,7 +81,7 @@ public abstract class AbstractTransactionalCollectionProxy<S extends RemoteServi
                 return true;
             }
         } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
+            throw rethrow(t);
         }
         return false;
     }
@@ -106,26 +107,21 @@ public abstract class AbstractTransactionalCollectionProxy<S extends RemoteServi
         checkTransactionActive();
         checkObjectNotNull(e);
 
-        final NodeEngine nodeEngine = getNodeEngine();
-        final Data value = nodeEngine.toData(e);
-        final Iterator<CollectionItem> iterator = getCollection().iterator();
+        Data value = getNodeEngine().toData(e);
+        Iterator<CollectionItem> iterator = getCollection().iterator();
         long reservedItemId = -1;
         while (iterator.hasNext()) {
-            final CollectionItem item = iterator.next();
+            CollectionItem item = iterator.next();
             if (value.equals(item.getValue())) {
                 reservedItemId = item.getItemId();
                 break;
             }
         }
-        final CollectionReserveRemoveOperation operation = new CollectionReserveRemoveOperation(
-                name,
-                reservedItemId,
-                value,
-                tx.getTxnId());
+        CollectionReserveRemoveOperation operation = new CollectionReserveRemoveOperation(
+                name, reservedItemId, value, tx.getTxnId());
         try {
-            final OperationService operationService = nodeEngine.getOperationService();
-            Future<CollectionItem> f = operationService.invokeOnPartition(getServiceName(), operation, partitionId);
-            CollectionItem item = f.get();
+            Future<CollectionItem> future = operationService.invokeOnPartition(getServiceName(), operation, partitionId);
+            CollectionItem item = future.get();
             if (item != null) {
                 if (reservedItemId == item.getItemId()) {
                     iterator.remove();
@@ -141,7 +137,7 @@ public abstract class AbstractTransactionalCollectionProxy<S extends RemoteServi
                 return true;
             }
         } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
+            throw rethrow(t);
         }
         return false;
     }
@@ -149,13 +145,13 @@ public abstract class AbstractTransactionalCollectionProxy<S extends RemoteServi
     public int size() {
         checkTransactionActive();
 
-        CollectionSizeOperation operation = new CollectionSizeOperation(name);
         try {
-            Future<Integer> f = getNodeEngine().getOperationService().invokeOnPartition(getServiceName(), operation, partitionId);
-            Integer size = f.get();
+            CollectionSizeOperation operation = new CollectionSizeOperation(name);
+            Future<Integer> future = operationService.invokeOnPartition(getServiceName(), operation, partitionId);
+            Integer size = future.get();
             return size + getCollection().size();
         } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
+            throw rethrow(t);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
@@ -17,7 +17,6 @@
 package com.hazelcast.collection.impl.txnqueue;
 
 import com.hazelcast.collection.impl.queue.QueueService;
-import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.transaction.impl.Transaction;
@@ -32,9 +31,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  *
  * @param <E>
  */
-public class TransactionalQueueProxy<E>
-        extends TransactionalQueueProxySupport
-        implements TransactionalQueue<E> {
+public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E> {
 
     public TransactionalQueueProxy(NodeEngine nodeEngine, QueueService service, String name, Transaction tx) {
         super(nodeEngine, service, name, tx);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxySupport.java
@@ -26,6 +26,7 @@ import com.hazelcast.collection.impl.txnqueue.operations.TxnPollOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnReserveOfferOperation;
 import com.hazelcast.collection.impl.txnqueue.operations.TxnReservePollOperation;
 import com.hazelcast.config.QueueConfig;
+import com.hazelcast.core.TransactionalQueue;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
@@ -34,7 +35,6 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.TransactionalDistributedObject;
 import com.hazelcast.transaction.TransactionException;
 import com.hazelcast.transaction.TransactionNotActiveException;
-import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.util.ExceptionUtil;
 
@@ -46,37 +46,60 @@ import java.util.concurrent.Future;
 /**
  * Provides support for proxy of the Transactional Queue.
  */
-public abstract class TransactionalQueueProxySupport
+public abstract class TransactionalQueueProxySupport<E>
         extends TransactionalDistributedObject<QueueService>
-        implements TransactionalObject {
+        implements TransactionalQueue<E> {
 
     protected final String name;
     protected final int partitionId;
     protected final QueueConfig config;
+
     private final LinkedList<QueueItem> offeredQueue = new LinkedList<QueueItem>();
     private final Set<Long> itemIdSet = new HashSet<Long>();
 
-    protected TransactionalQueueProxySupport(NodeEngine nodeEngine, QueueService service, String name,
-                                             Transaction tx) {
+    TransactionalQueueProxySupport(NodeEngine nodeEngine, QueueService service, String name, Transaction tx) {
         super(nodeEngine, service, tx);
         this.name = name;
         partitionId = nodeEngine.getPartitionService().getPartitionId(getNameAsPartitionAwareData());
         config = nodeEngine.getConfig().findQueueConfig(name);
     }
 
-    protected void checkTransactionState() {
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public final String getServiceName() {
+        return QueueService.SERVICE_NAME;
+    }
+
+    @Override
+    public int size() {
+        checkTransactionState();
+        SizeOperation operation = new SizeOperation(name);
+        try {
+            Future<Integer> future = invoke(operation);
+            Integer size = future.get();
+            return size + offeredQueue.size();
+        } catch (Throwable t) {
+            throw ExceptionUtil.rethrow(t);
+        }
+    }
+
+    void checkTransactionState() {
         if (!tx.getState().equals(Transaction.State.ACTIVE)) {
             throw new TransactionNotActiveException("Transaction is not active!");
         }
     }
 
-    public boolean offerInternal(Data data, long timeout) {
+    boolean offerInternal(Data data, long timeout) {
         TxnReserveOfferOperation operation
                 = new TxnReserveOfferOperation(name, timeout, offeredQueue.size(), tx.getTxnId());
         operation.setCallerUuid(tx.getOwnerUuid());
         try {
-            Future<Long> f = invoke(operation);
-            Long itemId = f.get();
+            Future<Long> future = invoke(operation);
+            Long itemId = future.get();
             if (itemId != null) {
                 if (!itemIdSet.add(itemId)) {
                     throw new TransactionException("Duplicate itemId: " + itemId);
@@ -92,31 +115,14 @@ public abstract class TransactionalQueueProxySupport
         return false;
     }
 
-    private void putToRecord(BaseTxnQueueOperation operation) {
-        QueueTransactionLogRecord logRecord = (QueueTransactionLogRecord) tx.get(name);
-        if (logRecord == null) {
-            logRecord = new QueueTransactionLogRecord(tx.getTxnId(), name, partitionId);
-            tx.add(logRecord);
-        }
-        logRecord.addOperation(operation);
-    }
-
-    private void removeFromRecord(long itemId) {
-        QueueTransactionLogRecord logRecord = (QueueTransactionLogRecord) tx.get(name);
-        int size = logRecord.removeOperation(itemId);
-        if (size == 0) {
-            tx.remove(name);
-        }
-    }
-
-    public Data pollInternal(long timeout) {
+    Data pollInternal(long timeout) {
         QueueItem reservedOffer = offeredQueue.peek();
         long itemId = reservedOffer == null ? -1 : reservedOffer.getItemId();
         TxnReservePollOperation operation = new TxnReservePollOperation(name, timeout, itemId, tx.getTxnId());
         operation.setCallerUuid(tx.getOwnerUuid());
         try {
-            Future<QueueItem> f = invoke(operation);
-            QueueItem item = f.get();
+            Future<QueueItem> future = invoke(operation);
+            QueueItem item = future.get();
             if (item != null) {
                 if (reservedOffer != null && item.getItemId() == reservedOffer.getItemId()) {
                     offeredQueue.poll();
@@ -138,13 +144,13 @@ public abstract class TransactionalQueueProxySupport
         return null;
     }
 
-    public Data peekInternal(long timeout) {
-        final QueueItem offer = offeredQueue.peek();
+    Data peekInternal(long timeout) {
+        QueueItem offer = offeredQueue.peek();
         long itemId = offer == null ? -1 : offer.getItemId();
-        final TxnPeekOperation operation = new TxnPeekOperation(name, timeout, itemId, tx.getTxnId());
+        TxnPeekOperation operation = new TxnPeekOperation(name, timeout, itemId, tx.getTxnId());
         try {
-            final Future<QueueItem> f = invoke(operation);
-            final QueueItem item = f.get();
+            Future<QueueItem> future = invoke(operation);
+            QueueItem item = future.get();
             if (item != null) {
                 if (offer != null && item.getItemId() == offer.getItemId()) {
                     return offer.getData();
@@ -157,30 +163,25 @@ public abstract class TransactionalQueueProxySupport
         return null;
     }
 
-    public int size() {
-        checkTransactionState();
-        SizeOperation operation = new SizeOperation(name);
-        try {
-            Future<Integer> f = invoke(operation);
-            Integer size = f.get();
-            return size + offeredQueue.size();
-        } catch (Throwable t) {
-            throw ExceptionUtil.rethrow(t);
+    private void putToRecord(BaseTxnQueueOperation operation) {
+        QueueTransactionLogRecord logRecord = (QueueTransactionLogRecord) tx.get(name);
+        if (logRecord == null) {
+            logRecord = new QueueTransactionLogRecord(tx.getTxnId(), name, partitionId);
+            tx.add(logRecord);
+        }
+        logRecord.addOperation(operation);
+    }
+
+    private void removeFromRecord(long itemId) {
+        QueueTransactionLogRecord logRecord = (QueueTransactionLogRecord) tx.get(name);
+        int size = logRecord.removeOperation(itemId);
+        if (size == 0) {
+            tx.remove(name);
         }
     }
 
-    private <E> InternalCompletableFuture<E> invoke(Operation operation) {
+    private <T> InternalCompletableFuture<T> invoke(Operation operation) {
         OperationService operationService = getNodeEngine().getOperationService();
         return operationService.invokeOnPartition(QueueService.SERVICE_NAME, operation, partitionId);
-    }
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    @Override
-    public final String getServiceName() {
-        return QueueService.SERVICE_NAME;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnset/TransactionalSetProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnset/TransactionalSetProxy.java
@@ -47,16 +47,15 @@ public class TransactionalSetProxy<E>
         checkTransactionActive();
         checkObjectNotNull(e);
 
-        final NodeEngine nodeEngine = getNodeEngine();
-        final Data value = nodeEngine.toData(e);
+        Data value = getNodeEngine().toData(e);
         if (!getCollection().add(new CollectionItem(-1, value))) {
             return false;
         }
 
         CollectionReserveAddOperation operation = new CollectionReserveAddOperation(name, tx.getTxnId(), value);
         try {
-            Future<Long> f = nodeEngine.getOperationService().invokeOnPartition(getServiceName(), operation, partitionId);
-            Long itemId = f.get();
+            Future<Long> future = operationService.invokeOnPartition(getServiceName(), operation, partitionId);
+            Long itemId = future.get();
             if (itemId != null) {
                 if (!itemIdSet.add(itemId)) {
                     throw new TransactionException("Duplicate itemId: " + itemId);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxy.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.multimap.impl.txn;
 
-import com.hazelcast.core.TransactionalMultiMap;
 import com.hazelcast.multimap.impl.MultiMapRecord;
 import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.serialization.Data;
@@ -27,19 +26,13 @@ import com.hazelcast.transaction.impl.Transaction;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class TransactionalMultiMapProxy<K, V> extends TransactionalMultiMapProxySupport
-        implements TransactionalMultiMap<K, V> {
+public class TransactionalMultiMapProxy<K, V> extends TransactionalMultiMapProxySupport<K, V> {
 
     public TransactionalMultiMapProxy(NodeEngine nodeEngine,
                                       MultiMapService service,
                                       String name,
                                       Transaction tx) {
         super(nodeEngine, service, name, tx);
-    }
-
-    @Override
-    public String getName() {
-        return name;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TransactionalDistributedObject.java
@@ -32,7 +32,7 @@ public abstract class TransactionalDistributedObject<S extends RemoteService> ex
         this.tx = tx;
     }
 
-    public Object toObjectIfNeeded(Object data) {
+    protected Object toObjectIfNeeded(Object data) {
         if (tx.isOriginatedFromClient()) {
             return data;
         }


### PR DESCRIPTION
* The `TransactionalQueueProxySupport` already implements methods from the `TransactionalQueue` interface, so it should implement it, so we can have proper `@Override` annotations in that class.
* The `TransactionalMultiMapProxySupport` already implements methods from the `TransactionalMap` interface, so it should implement it, so we can have proper `@Override` annotations in that class.
* Made internal methods package private where possible
* Added some static imports
* Pulled out fields for `OperationService` and `IPartitionService` where they are used frequently in a class
