### PR TITLE
Use ParallelRunner for ReplicatedMapTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTest.java
@@ -25,8 +25,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.replicatedmap.impl.record.ReplicatedRecord;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -53,8 +54,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapTest extends ReplicatedMapAbstractTest {
 
     @Test


### PR DESCRIPTION
 Also the test is moved into the ParallelCategory.
 The serialized runner was added by #8517,
 I assume it was a mistake? There is no held state between tests and  it uses
 a mock network.