### PR TITLE
Test parallelization

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheStaleReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheStaleReadTest.java
@@ -15,6 +15,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -38,7 +39,7 @@ import static org.junit.Assert.fail;
  * @see com.hazelcast.client.map.impl.nearcache.ClientMapNearCacheStaleReadTest
  */
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheNearCacheStaleReadTest extends HazelcastTestSupport {
 
     private static final int NUM_GETTERS = 7;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.cache.impl.nearcache;
 
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -31,7 +32,7 @@ import java.util.Collection;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientNearCacheTest extends ClientNearCacheTestSupport {
 
     @Parameter

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/BasicClientCacheNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/BasicClientCacheNearCacheTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -45,7 +46,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCach
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class BasicClientCacheNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
 
     @Parameter

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/stats/ClientCacheStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/stats/ClientCacheStatsTest.java
@@ -11,6 +11,7 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -21,7 +22,7 @@ import javax.cache.spi.CachingProvider;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class})
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheStatsTest extends CacheStatsTest {
 
     private final TestHazelcastFactory instanceFactory = new TestHazelcastFactory();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/BasicClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/BasicClientMapNearCacheTest.java
@@ -13,6 +13,7 @@ import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -32,7 +33,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCach
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class BasicClientMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
 
     @Parameter

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheStaleReadTest.java
@@ -13,6 +13,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -37,7 +38,7 @@ import static org.junit.Assert.fail;
  * Thanks Lukas Blunschi for this test (https://github.com/lukasblu).
  */
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientMapNearCacheStaleReadTest extends HazelcastTestSupport {
 
     private static final int NUM_GETTERS = 7;

--- a/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/BasicCacheLiteMemberTest.java
@@ -21,9 +21,10 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -51,8 +52,8 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.fail;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class BasicCacheLiteMemberTest
         extends HazelcastTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheManagementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheManagementTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheManagementTest extends CacheTestSupport {
 
     private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);

--- a/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
@@ -8,6 +8,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -21,7 +22,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class})
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheStatsTest extends CacheTestSupport {
 
     protected TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceMigrationTest.java
@@ -6,9 +6,10 @@ import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -19,8 +20,8 @@ import java.io.Serializable;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class AtomicReferenceMigrationTest extends HazelcastTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
@@ -12,6 +12,7 @@ import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,7 +25,7 @@ import static org.junit.Assert.assertEquals;
  * This test can't run with test-hazelcast instances since we rely on a real TcpIpConnectionManager.
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class OverloadedConnectionsPluginTest extends AbstractDiagnosticsPluginTest {
 
     private OverloadedConnectionsPlugin plugin;

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/LocalStatsDelegateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/LocalStatsDelegateTest.java
@@ -8,6 +8,7 @@ import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.UuidUtil;
 import org.junit.Before;
@@ -22,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class LocalStatsDelegateTest extends HazelcastTestSupport {
 
     private AtomicBoolean done;

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTest.java
@@ -6,6 +6,7 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -19,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class NearCacheRecordStoreTest extends NearCacheRecordStoreTestSupport {
 
     @Parameterized.Parameter

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectNow_TcpIpConnectionManager_ConnectMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectNow_TcpIpConnectionManager_ConnectMemberTest.java
@@ -2,13 +2,13 @@ package com.hazelcast.internal.networking.nonblocking;
 
 import com.hazelcast.nio.tcp.TcpIpConnectionManager_ConnectMemberBaseTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class SelectNow_TcpIpConnectionManager_ConnectMemberTest extends TcpIpConnectionManager_ConnectMemberBaseTest {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectWithSelectorFix_TcpIpConnectionManager_ConnectMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectWithSelectorFix_TcpIpConnectionManager_ConnectMemberTest.java
@@ -3,12 +3,13 @@ package com.hazelcast.internal.networking.nonblocking;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager_ConnectMemberBaseTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class SelectWithSelectorFix_TcpIpConnectionManager_ConnectMemberTest
         extends TcpIpConnectionManager_ConnectMemberBaseTest {
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnectionManager_ConnectMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnectionManager_ConnectMemberTest.java
@@ -2,13 +2,13 @@ package com.hazelcast.internal.networking.spinning;
 
 import com.hazelcast.nio.tcp.TcpIpConnectionManager_ConnectMemberBaseTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class Spinning_TcpIpConnectionManager_ConnectMemberTest extends TcpIpConnectionManager_ConnectMemberBaseTest {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnection_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_TcpIpConnection_BasicTest.java
@@ -3,12 +3,13 @@ package com.hazelcast.internal.networking.spinning;
 import com.hazelcast.nio.tcp.TcpIpConnection_BaseTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class Spinning_TcpIpConnection_BasicTest extends TcpIpConnection_BaseTest {
 
     @Before

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -55,7 +56,7 @@ import static org.junit.Assert.assertTrue;
  * the numbers are added in the correct order and also whether there's any data loss as nodes leave or join the cluster.
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
 
     private static final int ENTRIES = 10;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/BasicLiteMemberMapNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/BasicLiteMemberMapNearCacheTest.java
@@ -13,6 +13,7 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -33,7 +34,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCach
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class BasicLiteMemberMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
 
     @Parameter

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/BasicMapNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/BasicMapNearCacheTest.java
@@ -12,6 +12,7 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -32,7 +33,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCach
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(QuickTest.class)
+@Category({ParallelTest.class, QuickTest.class})
 public class BasicMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
 
     @Parameter

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStaleReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStaleReadTest.java
@@ -11,6 +11,7 @@ import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -37,7 +38,7 @@ import static org.junit.Assert.fail;
  * Thansk Lukas Blunschi for this test (https://github.com/lukasblu).
  */
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class NearCacheStaleReadTest extends HazelcastTestSupport {
 
     private static final int NUM_GETTERS = 7;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStalenessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheStalenessTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,7 +41,7 @@ import static com.hazelcast.util.RandomPicker.getInt;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class})
+@Category({QuickTest.class, ParallelTest.class})
 public class NearCacheStalenessTest extends HazelcastTestSupport {
 
     private final int ENTRY_COUNT = 1;

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/BasicTxnMapNearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/BasicTxnMapNearCacheTest.java
@@ -12,6 +12,7 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -35,7 +36,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCach
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class BasicTxnMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
 
     @Parameter

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
@@ -12,6 +12,7 @@ import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.nio.serialization.PortableReader;
 import com.hazelcast.query.impl.getters.MultiResult;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.ExceptionUtil;
 import org.junit.Rule;
@@ -80,7 +81,7 @@ import static org.junit.Assert.assertThat;
  * - check in which method the scenario is generated - narrow down the scope of the tests run
  */
 @RunWith(Parameterized.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class DefaultPortableReaderSpecTest extends HazelcastTestSupport {
 
     private static final PrimitivePortable P_NON_EMPTY = new PrimitivePortable(0, PrimitivePortable.Init.FULL);

--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiServiceTest.java
@@ -7,7 +7,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.osgi.impl.HazelcastInternalOSGiService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class HazelcastOSGiServiceTest extends HazelcastTestSupport {
 
     private TestBundle bundle;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/MapQuorumLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/MapQuorumLiteMemberTest.java
@@ -7,6 +7,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,7 +15,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MapQuorumLiteMemberTest extends HazelcastTestSupport {
 
     private TestHazelcastInstanceFactory factory;

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
@@ -27,9 +27,10 @@ import com.hazelcast.quorum.QuorumEvent;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.QuorumFunction;
 import com.hazelcast.quorum.QuorumListener;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.EmptyStatement;
 import org.junit.Test;
@@ -44,8 +45,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class CacheQuorumListenerTest extends HazelcastTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapListenerTest.java
@@ -30,6 +30,7 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,8 +42,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 
-@Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapListenerTest extends HazelcastTestSupport {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
@@ -27,9 +27,10 @@ import com.hazelcast.core.RingbufferStoreFactory;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.ringbuffer.OverflowPolicy;
 import com.hazelcast.ringbuffer.Ringbuffer;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
@@ -60,8 +61,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class RingbufferStoreTest extends HazelcastTestSupport {
 
     private static Config getConfig(String ringbufferName,

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,7 +40,7 @@ import static com.hazelcast.spi.properties.GroupProperty.SLOW_OPERATION_DETECTOR
 import static java.lang.String.valueOf;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category(SlowTest.class)
 public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstractTest {
 
     private HazelcastInstance instance;

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/TransactionImpl_TwoPhaseIntegrationTest.java
@@ -4,7 +4,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.TransactionException;
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
 public class TransactionImpl_TwoPhaseIntegrationTest extends HazelcastTestSupport {
 


### PR DESCRIPTION
This PR decreases the merge build duration from 1h02m to about 33 minutes. 
10 out of these 33 minutes is caused by too slow test result post-processing - @hasancelik is already dealing with this.

A few tests were moved to a slow category. More info it commit messages. 