### PR TITLE
Fix race conditions in client tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/heartbeat/ClientHeartbeatTest.java
@@ -395,6 +395,8 @@ public class ClientHeartbeatTest extends ClientTestSupport {
 
         HazelcastInstance hazelcastInstance2 = hazelcastFactory.newHazelcastInstance();
 
+        assertSizeEventually(2, clientInstanceImpl.getConnectionManager().getActiveConnections());
+
         blockMessagesFromInstance(hazelcastInstance2, client);
         assertOpenEventually(heartbeatStopped);
         blockIncoming.countDown();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -30,6 +30,7 @@ import com.hazelcast.client.spi.impl.AwsAddressTranslator;
 import com.hazelcast.client.spi.impl.DefaultAddressTranslator;
 import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressTranslator;
 import com.hazelcast.client.spi.properties.ClientProperty;
+import com.hazelcast.client.test.TwoWayBlockableExecutor.LockPair;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
@@ -108,7 +109,7 @@ class TestClientRegistry {
         private final String host;
         private final AtomicInteger ports;
         private final HazelcastClientInstanceImpl client;
-        private final ConcurrentHashMap<Address, TwoWayBlockableExecutor.LockPair> addressBlockMap = new ConcurrentHashMap<Address, TwoWayBlockableExecutor.LockPair>();
+        private final ConcurrentHashMap<Address, LockPair> addressBlockMap = new ConcurrentHashMap<Address, LockPair>();
 
         MockClientConnectionManager(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
                                     String host, AtomicInteger ports) {
@@ -142,13 +143,7 @@ class TestClientRegistry {
                 }
                 Node node = TestUtil.getNode(instance);
                 Address localAddress = new Address(host, ports.incrementAndGet());
-                TwoWayBlockableExecutor.LockPair lockPair = ConcurrencyUtil.getOrPutIfAbsent(addressBlockMap, address,
-                        new ConstructorFunction<Address, TwoWayBlockableExecutor.LockPair>() {
-                            @Override
-                            public TwoWayBlockableExecutor.LockPair createNew(Address arg) {
-                                return new TwoWayBlockableExecutor.LockPair(new ReentrantReadWriteLock(), new ReentrantReadWriteLock());
-                            }
-                        });
+                LockPair lockPair = getLockPair(address);
 
                 MockedClientConnection connection = new MockedClientConnection(client,
                         connectionIdGen.incrementAndGet(), node.nodeEngine, address, localAddress, lockPair);
@@ -159,12 +154,22 @@ class TestClientRegistry {
             }
         }
 
+        private LockPair getLockPair(Address address) {
+            return ConcurrencyUtil.getOrPutIfAbsent(addressBlockMap, address,
+                    new ConstructorFunction<Address, LockPair>() {
+                        @Override
+                        public LockPair createNew(Address arg) {
+                            return new LockPair(new ReentrantReadWriteLock(), new ReentrantReadWriteLock());
+                        }
+                    });
+        }
+
         /**
          * Blocks incoming messages to client from given address
          */
         void blockFrom(Address address) {
             LOGGER.info("Blocked messages from " + address);
-            TwoWayBlockableExecutor.LockPair lockPair = addressBlockMap.get(address);
+            LockPair lockPair = getLockPair(address);
             lockPair.blockIncoming();
         }
 
@@ -173,7 +178,7 @@ class TestClientRegistry {
          */
         void unblockFrom(Address address) {
             LOGGER.info("Unblocked messages from " + address);
-            TwoWayBlockableExecutor.LockPair lockPair = addressBlockMap.get(address);
+            LockPair lockPair = getLockPair(address);
             lockPair.unblockIncoming();
         }
 
@@ -182,7 +187,7 @@ class TestClientRegistry {
          */
         void blockTo(Address address) {
             LOGGER.info("Blocked messages to " + address);
-            TwoWayBlockableExecutor.LockPair lockPair = addressBlockMap.get(address);
+            LockPair lockPair = getLockPair(address);
             lockPair.blockOutgoing();
         }
 
@@ -191,7 +196,7 @@ class TestClientRegistry {
          */
         void unblockTo(Address address) {
             LOGGER.info("Unblocked messages to " + address);
-            TwoWayBlockableExecutor.LockPair lockPair = addressBlockMap.get(address);
+            LockPair lockPair = getLockPair(address);
             lockPair.unblockOutgoing();
         }
 
@@ -209,7 +214,7 @@ class TestClientRegistry {
         MockedClientConnection(HazelcastClientInstanceImpl client,
                                int connectionId, NodeEngineImpl serverNodeEngine,
                                Address address, Address localAddress,
-                               TwoWayBlockableExecutor.LockPair lockPair) throws IOException {
+                               LockPair lockPair) throws IOException {
 
             super(client, connectionId);
             this.serverNodeEngine = serverNodeEngine;


### PR DESCRIPTION
There are two detected race conditions :
- in TestClientRegistry the methods block or unblock are called before the connection to the member is established. This caused a NPE. The new code allows traffic to be blocked before the connection is established
- in ClientHeartbeatTest when the connection is established after the messages are blocked the test client would not send heartbeats to that client and the test would fail. This is changed so that the test waits for the client to connect to all members before blocking the messages

Fixes : https://github.com/hazelcast/hazelcast/issues/10021