### PR TITLE
Fix racy scheduled executor, syncState when task is cancelled.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -201,7 +201,17 @@ public class ScheduledExecutorContainer {
 
         descriptor.setState(newState);
         descriptor.setStats(stats);
-        descriptor.setTaskResult(resolution);
+
+        if (descriptor.getTaskResult() != null) {
+            // Task result previously populated - ie. through cancel
+            // Ignore all subsequent results
+            if (logger.isFineEnabled()) {
+                logger.fine(String.format("[Scheduler: " + name + "][Partition: " + partitionId + "] syncState result skipped. "
+                                        + "Current: %s New: %s", descriptor.getTaskResult(), resolution));
+            }
+        } else {
+            descriptor.setTaskResult(resolution);
+        }
     }
 
     public boolean shouldParkGetResult(String taskName)

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
@@ -41,7 +41,7 @@ public class SyncStateOperation
 
     protected ScheduledTaskResult result;
 
-    protected boolean shouldRun;
+    private boolean shouldRun;
 
     public SyncStateOperation() {
     }


### PR DESCRIPTION
Cancelling an in-flight task (not handling interrupts properly), results in a cancel task state, which is racy with the syncState when the task finally completes execution. This is *only* documenting itself when replication happens, where the result of the task is used as decision mechanism to re-schedule it or not on the new partition owner. 

The patch is gating the result assignment to check whether it was set before. 
If so, the new result is ignored.

Fix #9984 