### PR TITLE
Separate proxy for jcache near cache

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -32,29 +32,26 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.util.executor.CompletedFuture;
 
 import javax.cache.CacheException;
 import javax.cache.expiry.ExpiryPolicy;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.cache.impl.CacheProxyUtil.NULL_KEY_IS_NOT_ALLOWED;
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
-import static com.hazelcast.internal.nearcache.NearCache.CACHED_AS_NULL;
-import static com.hazelcast.internal.nearcache.NearCache.NOT_CACHED;
-import static com.hazelcast.internal.nearcache.NearCacheRecord.NOT_RESERVED;
+import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
 import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.Collections.emptyMap;
 
 /**
@@ -72,7 +69,7 @@ import static java.util.Collections.emptyMap;
 abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCacheProxy<K, V> {
 
     @SuppressWarnings("unchecked")
-    private static ClientMessageDecoder cacheGetResponseDecoder = new ClientMessageDecoder() {
+    private static final ClientMessageDecoder CACHE_GET_RESPONSE_DECODER = new ClientMessageDecoder() {
         @Override
         public <T> T decodeClientMessage(ClientMessage clientMessage) {
             return (T) CacheGetCodec.decodeResponse(clientMessage).response;
@@ -83,101 +80,30 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
         super(cacheConfig);
     }
 
-    protected Object getCachedValue(Data keyData, boolean deserializeValue) {
-        if (nearCache == null) {
-            return NOT_CACHED;
-        }
-
-        Object cached = nearCache.get(keyData);
-        if (cached == null) {
-            return NOT_CACHED;
-        }
-
-        if (cached == CACHED_AS_NULL) {
-            cached = null;
-        }
-
-        return deserializeValue ? toObject(cached) : cached;
-    }
-
-    protected Object getInternal(final K key, ExpiryPolicy expiryPolicy, boolean async) {
-        final long start = System.nanoTime();
-        ensureOpen();
-        validateNotNull(key);
-        final Data keyData = toData(key);
-        Object cached = getCachedValue(keyData, !async);
-        if (cached != NOT_CACHED) {
-            return asCompletedFutureOrValue(cached, async);
-        }
-
-        final long reservationId = tryReserveForUpdate(keyData);
-        final Data expiryPolicyData = toData(expiryPolicy);
-        ClientMessage request = CacheGetCodec.encodeRequest(nameWithPrefix, keyData, expiryPolicyData);
-        ClientInvocationFuture future;
+    protected Object getSyncInternal(Data keyData, ExpiryPolicy expiryPolicy) {
+        long startNanos = nowInNanosOrDefault();
         try {
-            final int partitionId = clientContext.getPartitionService().getPartitionId(keyData);
-            final HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
-            final ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionId);
-            future = clientInvocation.invoke();
-        } catch (Throwable t) {
-            invalidateNearCache(keyData);
-
-            throw rethrow(t);
-        }
-
-        SerializationService serializationService = clientContext.getSerializationService();
-        ClientDelegatingFuture<V> delegatingFuture =
-                new ClientDelegatingFuture<V>(future, serializationService, cacheGetResponseDecoder);
-        if (async) {
-            if (nearCache != null) {
-                delegatingFuture.andThenInternal(new ExecutionCallback<Data>() {
-                    public void onResponse(Data valueData) {
-                        storeInNearCache(keyData, valueData, null, reservationId, false);
-                        if (statisticsEnabled) {
-                            handleStatisticsOnGet(start, valueData);
-                        }
-                    }
-
-                    public void onFailure(Throwable t) {
-                        invalidateNearCache(keyData);
-                    }
-                }, false);
+            ClientDelegatingFuture future = getInternal(keyData, expiryPolicy, false);
+            Object value = future.get();
+            if (statisticsEnabled) {
+                statsHandler.onGet(startNanos, value != null);
             }
-            return delegatingFuture;
-        } else {
-            try {
-                V value = toObject(delegatingFuture.get());
-                if (nearCache != null) {
-                    storeInNearCache(keyData, (Data) delegatingFuture.getResponse(), value, reservationId, false);
-                }
-                if (statisticsEnabled) {
-                    handleStatisticsOnGet(start, value);
-                }
-                return value;
-            } catch (Throwable e) {
-                invalidateNearCache(keyData);
-
-                throw rethrowAllowedTypeFirst(e, CacheException.class);
-            }
+            return value;
+        } catch (Throwable e) {
+            throw rethrowAllowedTypeFirst(e, CacheException.class);
         }
     }
 
-    private Object asCompletedFutureOrValue(Object value, boolean async) {
-        if (async) {
-            return new CompletedFuture(clientContext.getSerializationService(), value,
-                    clientContext.getExecutionService().getUserExecutor());
-        }
+    private ClientDelegatingFuture getInternal(Data keyData, ExpiryPolicy expiryPolicy, boolean deserializeResponse) {
+        Data expiryPolicyData = toData(expiryPolicy);
 
-        return value;
-    }
+        HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
+        ClientMessage request = CacheGetCodec.encodeRequest(nameWithPrefix, keyData, expiryPolicyData);
+        int partitionId = clientContext.getPartitionService().getPartitionId(keyData);
 
-    protected void handleStatisticsOnGet(long start, Object response) {
-        if (response == null) {
-            statistics.increaseCacheMisses();
-        } else {
-            statistics.increaseCacheHits();
-        }
-        statistics.addGetTimeNanos(System.nanoTime() - start);
+        ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionId);
+        ClientInvocationFuture future = clientInvocation.invoke();
+        return newDelegatingFuture(future, CACHE_GET_RESPONSE_DECODER, deserializeResponse);
     }
 
     @Override
@@ -187,7 +113,19 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public ICompletableFuture<V> getAsync(K key, ExpiryPolicy expiryPolicy) {
-        return (ICompletableFuture<V>) getInternal(key, expiryPolicy, true);
+        final long startNanos = nowInNanosOrDefault();
+        ensureOpen();
+        validateNotNull(key);
+
+        Data dataKey = toData(key);
+        ExecutionCallback callback = !statisticsEnabled ? null : statsHandler.newOnGetCallback(startNanos);
+        return getAsyncInternal(dataKey, expiryPolicy, callback);
+    }
+
+    protected ClientDelegatingFuture getAsyncInternal(Data dataKey, ExpiryPolicy expiryPolicy, ExecutionCallback callback) {
+        ClientDelegatingFuture future = getInternal(dataKey, expiryPolicy, true);
+        addCallback(future, callback);
+        return future;
     }
 
     @Override
@@ -197,7 +135,8 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public ICompletableFuture<Void> putAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        return (ICompletableFuture<Void>) putInternal(key, value, expiryPolicy, false, true, true);
+        return (ICompletableFuture<Void>) putAsyncInternal(key, value, expiryPolicy, false, true,
+                newStatsCallbackOrNull(false));
     }
 
     @Override
@@ -217,22 +156,23 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public ICompletableFuture<V> getAndPutAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        return (ICompletableFuture<V>) putInternal(key, value, expiryPolicy, true, false, true);
+        return (ICompletableFuture<V>) putAsyncInternal(key, value, expiryPolicy, true, false,
+                newStatsCallbackOrNull(true));
     }
 
     @Override
     public ICompletableFuture<Boolean> removeAsync(K key) {
-        return removeAsyncInternal(key, null, false, false, true);
+        return (ICompletableFuture<Boolean>) removeAsyncInternal(key, null, false, false, true);
     }
 
     @Override
     public ICompletableFuture<Boolean> removeAsync(K key, V oldValue) {
-        return removeAsyncInternal(key, oldValue, true, false, true);
+        return (ICompletableFuture<Boolean>) removeAsyncInternal(key, oldValue, true, false, true);
     }
 
     @Override
     public ICompletableFuture<V> getAndRemoveAsync(K key) {
-        return getAndRemoveAsyncInternal(key, false, true);
+        return getAndRemoveAsyncInternal(key, false);
     }
 
     @Override
@@ -267,132 +207,95 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public V get(K key, ExpiryPolicy expiryPolicy) {
-        return (V) getInternal(key, expiryPolicy, false);
+        ensureOpen();
+        validateNotNull(key);
+        return (V) toObject(getSyncInternal(toData(key), expiryPolicy));
     }
 
     @Override
     public Map<K, V> getAll(Set<? extends K> keys, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
+        long startNanos = nowInNanosOrDefault();
         ensureOpen();
-        validateNotNull(keys);
-
+        checkNotNull(keys, NULL_KEY_IS_NOT_ALLOWED);
         if (keys.isEmpty()) {
             return emptyMap();
         }
 
-        final Set<Data> keySet = new HashSet<Data>(keys.size());
-        for (K key : keys) {
-            final Data k = toData(key);
-            keySet.add(k);
-        }
+        List<Data> dataKeys = new ArrayList<Data>(keys.size());
+        objectToDataCollection(keys, dataKeys, serializationService, NULL_KEY_IS_NOT_ALLOWED);
+        Map<K, V> resultMap = createHashMap(keys.size());
+        return getAllInternal(dataKeys, expiryPolicy, resultMap, startNanos);
+    }
 
-        Map<K, V> result = createHashMap(keys.size());
-        populateResultFromNearCache(keySet, result);
+    protected Map<K, V> getAllInternal(Collection<Data> binaryKeys, ExpiryPolicy expiryPolicy,
+                                       Map<K, V> resultMap, long startNanos) {
+        Data expiryPolicyData = toData(expiryPolicy);
 
-        if (keySet.isEmpty()) {
-            return result;
-        }
+        ClientMessage request = CacheGetAllCodec.encodeRequest(nameWithPrefix, binaryKeys, expiryPolicyData);
+        ClientMessage responseMessage = invoke(request);
 
-        List<Map.Entry<Data, Data>> entries;
-        Map<Data, Long> reservations = createHashMap(keySet.size());
-        try {
+        List<Map.Entry<Data, Data>> entries = CacheGetAllCodec.decodeResponse(responseMessage).response;
+        for (Map.Entry<Data, Data> dataEntry : entries) {
+            Data keyData = dataEntry.getKey();
+            Data valueData = dataEntry.getValue();
 
-            for (Data key : keySet) {
-                long reservationId = tryReserveForUpdate(key);
-                if (reservationId != NOT_RESERVED) {
-                    reservations.put(key, reservationId);
-                }
-            }
+            K key = toObject(keyData);
+            V value = toObject(valueData);
 
-            Data expiryPolicyData = toData(expiryPolicy);
-            ClientMessage request = CacheGetAllCodec.encodeRequest(nameWithPrefix, keySet, expiryPolicyData);
-            ClientMessage responseMessage = invoke(request);
-            entries = CacheGetAllCodec.decodeResponse(responseMessage).response;
-            for (Map.Entry<Data, Data> dataEntry : entries) {
-                Data keyData = dataEntry.getKey();
-                Data valueData = dataEntry.getValue();
-                K key = toObject(keyData);
-                V value = toObject(valueData);
-                result.put(key, value);
-
-                Long reservationId = reservations.get(keyData);
-                if (reservationId != null) {
-                    storeInNearCache(keyData, valueData, value, reservationId, false);
-                    reservations.remove(keyData);
-                }
-            }
-        } finally {
-            releaseRemainingReservedKeys(reservations);
+            resultMap.put(key, value);
         }
 
         if (statisticsEnabled) {
-            statistics.increaseCacheHits(entries.size());
-            statistics.addGetTimeNanos(System.nanoTime() - start);
+            statsHandler.onBatchGet(startNanos, entries.size());
         }
 
-        return result;
-    }
-
-    private void populateResultFromNearCache(Set<Data> keySet, Map<K, V> result) {
-        if (nearCache == null) {
-            return;
-
-        }
-
-        Iterator<Data> iterator = keySet.iterator();
-        while (iterator.hasNext()) {
-            Data key = iterator.next();
-            Object cached = getCachedValue(key, true);
-            if (cached != NOT_CACHED) {
-                result.put((K) toObject(key), (V) cached);
-                iterator.remove();
-            }
-        }
+        return resultMap;
     }
 
     @Override
     public void put(K key, V value, ExpiryPolicy expiryPolicy) {
-        putInternal(key, value, expiryPolicy, false, true, false);
+        putSyncInternal(key, value, expiryPolicy, false, true);
     }
 
     @Override
     public V getAndPut(K key, V value, ExpiryPolicy expiryPolicy) {
-        return (V) putInternal(key, value, expiryPolicy, true, true, false);
+        return (V) putSyncInternal(key, value, expiryPolicy, true, true);
     }
 
     @Override
     public void putAll(Map<? extends K, ? extends V> map, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
+        long startNanos = nowInNanosOrDefault();
         ensureOpen();
-        validateNotNull(map);
+        checkNotNull(map, "map is null");
+        if (map.isEmpty()) {
+            return;
+        }
 
+        putAllInternal(map, expiryPolicy, new List[partitionCount], startNanos);
+    }
+
+    protected void putAllInternal(Map<? extends K, ? extends V> map,
+                                  ExpiryPolicy expiryPolicy, List<Map.Entry<Data, Data>>[] entriesPerPartition, long startNanos) {
         try {
-            ClientPartitionService partitionService = clientContext.getPartitionService();
-            int partitionCount = partitionService.getPartitionCount();
             // First we fill entry set per partition
-            List<Map.Entry<Data, Data>>[] entriesPerPartition =
-                    groupDataToPartitions(map, partitionService, partitionCount);
-
+            groupDataToPartitions(map, clientContext.getPartitionService(), entriesPerPartition);
             // Then we invoke the operations and sync on completion of these operations
-            putToAllPartitionsAndWaitForCompletion(entriesPerPartition, expiryPolicy, start);
-        } catch (Exception e) {
-            throw ExceptionUtil.rethrow(e);
+            putToAllPartitionsAndWaitForCompletion(entriesPerPartition, expiryPolicy, startNanos);
+        } catch (Exception t) {
+            throw ExceptionUtil.rethrow(t);
         }
     }
 
-    private List<Map.Entry<Data, Data>>[] groupDataToPartitions(Map<? extends K, ? extends V> map,
-                                                                ClientPartitionService partitionService,
-                                                                int partitionCount) {
-        List<Map.Entry<Data, Data>>[] entriesPerPartition = new List[partitionCount];
-        SerializationService serializationService = clientContext.getSerializationService();
-
+    private void groupDataToPartitions(Map<? extends K, ? extends V> map,
+                                       ClientPartitionService partitionService,
+                                       List<Map.Entry<Data, Data>>[] entriesPerPartition) {
         for (Map.Entry<? extends K, ? extends V> entry : map.entrySet()) {
             K key = entry.getKey();
             V value = entry.getValue();
             validateNotNull(key, value);
 
-            Data keyData = serializationService.toData(key);
-            Data valueData = serializationService.toData(value);
+            Data keyData = toData(key);
+            Data valueData = toData(value);
 
             int partitionId = partitionService.getPartitionId(keyData);
             List<Map.Entry<Data, Data>> entries = entriesPerPartition[partitionId];
@@ -403,8 +306,6 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
             entries.add(new AbstractMap.SimpleImmutableEntry<Data, Data>(keyData, valueData));
         }
-
-        return entriesPerPartition;
     }
 
     private static final class FutureEntriesTuple {
@@ -416,11 +317,10 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
             this.future = future;
             this.entries = entries;
         }
-
     }
 
     private void putToAllPartitionsAndWaitForCompletion(List<Map.Entry<Data, Data>>[] entriesPerPartition,
-                                                        ExpiryPolicy expiryPolicy, long start)
+                                                        ExpiryPolicy expiryPolicy, long startNanos)
             throws ExecutionException, InterruptedException {
         Data expiryPolicyData = toData(expiryPolicy);
         List<FutureEntriesTuple> futureEntriesTuples = new ArrayList<FutureEntriesTuple>(entriesPerPartition.length);
@@ -437,29 +337,23 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
             }
         }
 
-        waitResponseFromAllPartitionsForPutAll(futureEntriesTuples, start);
+        waitResponseFromAllPartitionsForPutAll(futureEntriesTuples, startNanos);
     }
 
-    private void waitResponseFromAllPartitionsForPutAll(List<FutureEntriesTuple> futureEntriesTuples, long start) {
+    private void waitResponseFromAllPartitionsForPutAll(List<FutureEntriesTuple> futureEntriesTuples, long startNanos) {
         Throwable error = null;
         for (FutureEntriesTuple tuple : futureEntriesTuples) {
             Future future = tuple.future;
             List<Map.Entry<Data, Data>> entries = tuple.entries;
             try {
                 future.get();
-                if (nearCache != null) {
-                    handleNearCacheOnPutAll(entries);
-                }
                 // Note that we count the batch put only if there is no exception while putting to target partition.
                 // In case of error, some of the entries might have been put and others might fail.
                 // But we simply ignore the actual put count here if there is an error.
                 if (statisticsEnabled) {
-                    statistics.increaseCachePuts(entries.size());
+                    statsHandler.getStatistics().increaseCachePuts(entries.size());
                 }
             } catch (Throwable t) {
-                if (nearCache != null) {
-                    handleNearCacheOnPutAll(entries);
-                }
                 logger.finest("Error occurred while putting entries as batch!", t);
                 if (error == null) {
                     error = t;
@@ -468,7 +362,7 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
         }
 
         if (statisticsEnabled) {
-            statistics.addPutTimeNanos(System.nanoTime() - start);
+            statsHandler.getStatistics().addPutTimeNanos(nowInNanosOrDefault() - startNanos);
         }
 
         if (error != null) {
@@ -490,20 +384,6 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
         }
     }
 
-    private void handleNearCacheOnPutAll(List<Map.Entry<Data, Data>> entries) {
-        if (nearCache == null) {
-            return;
-        }
-
-        for (Map.Entry<Data, Data> entry : entries) {
-            if (cacheOnUpdate) {
-                storeInNearCache(entry.getKey(), entry.getValue(), null, NOT_RESERVED, cacheOnUpdate);
-            } else {
-                invalidateNearCache(entry.getKey());
-            }
-        }
-    }
-
     @Override
     public boolean putIfAbsent(K key, V value, ExpiryPolicy expiryPolicy) {
         return (Boolean) putIfAbsentInternal(key, value, expiryPolicy, true, false);
@@ -511,12 +391,12 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public boolean replace(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
+        final long startNanos = nowInNanosOrDefault();
         final Future<Boolean> f = replaceInternal(key, oldValue, newValue, expiryPolicy, true, true, false);
         try {
             boolean replaced = f.get();
             if (statisticsEnabled) {
-                handleStatisticsOnReplace(false, start, replaced);
+                statsHandler.onReplace(false, startNanos, replaced);
             }
             return replaced;
         } catch (Throwable e) {
@@ -526,12 +406,12 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public boolean replace(K key, V value, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
+        final long startNanos = nowInNanosOrDefault();
         final Future<Boolean> f = replaceInternal(key, null, value, expiryPolicy, false, true, false);
         try {
             boolean replaced = f.get();
             if (statisticsEnabled) {
-                handleStatisticsOnReplace(false, start, replaced);
+                statsHandler.onReplace(false, startNanos, replaced);
             }
             return replaced;
         } catch (Throwable e) {
@@ -541,12 +421,12 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public V getAndReplace(K key, V value, ExpiryPolicy expiryPolicy) {
-        final long start = System.nanoTime();
+        final long startNanos = nowInNanosOrDefault();
         final Future<V> f = replaceAndGetAsyncInternal(key, null, value, expiryPolicy, false, true, false);
         try {
             V oldValue = f.get();
             if (statisticsEnabled) {
-                handleStatisticsOnReplace(true, start, oldValue);
+                statsHandler.onReplace(true, startNanos, oldValue);
             }
             return oldValue;
         } catch (Throwable e) {
@@ -568,6 +448,6 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public CacheStatistics getLocalCacheStatistics() {
-        return statistics;
+        return statsHandler.getStatistics();
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -16,21 +16,15 @@
 
 package com.hazelcast.client.cache.impl;
 
+import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.impl.CacheEventData;
 import com.hazelcast.cache.impl.CacheEventListenerAdaptor;
-import com.hazelcast.cache.impl.CacheProxyUtil;
-import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.CacheSyncListenerCompleter;
 import com.hazelcast.cache.impl.operation.MutableOperation;
-import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.connection.ClientConnectionManager;
-import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheAddEntryListenerCodec;
-import com.hazelcast.client.impl.protocol.codec.CacheAddInvalidationListenerCodec;
-import com.hazelcast.client.impl.protocol.codec.CacheAddNearCacheInvalidationListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheClearCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheGetAndRemoveCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheGetAndReplaceCodec;
@@ -39,44 +33,25 @@ import com.hazelcast.client.impl.protocol.codec.CachePutIfAbsentCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveAllCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveAllKeysCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveCodec;
-import com.hazelcast.client.impl.protocol.codec.CacheRemoveEntryListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheReplaceCodec;
-import com.hazelcast.client.spi.ClientClusterService;
-import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientListenerService;
+import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
-import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.NativeMemoryConfig;
-import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.internal.adapter.ICacheDataStructureAdapter;
-import com.hazelcast.internal.nearcache.NearCache;
-import com.hazelcast.internal.nearcache.NearCacheManager;
-import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
-import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.Address;
-import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
 import javax.cache.CacheException;
 import javax.cache.configuration.CacheEntryListenerConfiguration;
 import javax.cache.expiry.ExpiryPolicy;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
@@ -84,19 +59,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.cache.impl.CacheProxyUtil.validateConfiguredTypes;
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
-import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
 import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLETION;
-import static com.hazelcast.config.InMemoryFormat.NATIVE;
-import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE;
-import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE;
-import static com.hazelcast.instance.BuildInfo.UNKNOWN_HAZELCAST_VERSION;
-import static com.hazelcast.instance.BuildInfo.calculateVersion;
-import static com.hazelcast.internal.nearcache.NearCacheRecord.NOT_RESERVED;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
-import static com.hazelcast.util.Preconditions.checkTrue;
-import static java.lang.String.format;
 
 /**
  * Abstract {@link com.hazelcast.cache.ICache} implementation which provides shared internal implementations
@@ -108,8 +75,7 @@ import static java.lang.String.format;
  * @param <K> the type of key
  * @param <V> the type of value
  */
-@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling",
-        "checkstyle:classfanoutcomplexity", "checkstyle:anoninnerlength"})
+@SuppressWarnings("checkstyle:methodcount")
 abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCacheProxyBase<K, V>
         implements CacheSyncListenerCompleter {
 
@@ -165,23 +131,11 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
     };
 
     protected HazelcastClientCacheManager cacheManager;
-    protected NearCacheManager nearCacheManager;
-    // Object => Data or <V>
-    protected NearCache<Object, Object> nearCache;
-    /**
-     * used when this cache has no near cache configured
-     */
+    protected int partitionCount;
 
-    protected String nearCacheMembershipRegistrationId;
-    protected ClientCacheStatisticsImpl statistics;
-
-    protected boolean statisticsEnabled;
-    protected boolean cacheOnUpdate;
     private final ConcurrentMap<CacheEntryListenerConfiguration, String> asyncListenerRegistrations;
     private final ConcurrentMap<CacheEntryListenerConfiguration, String> syncListenerRegistrations;
     private final ConcurrentMap<Integer, CountDownLatch> syncLocks;
-    // Eventually consistent near cache can only be used with server versions >= 3.8.
-    private final int minConsistentNearCacheSupportingServerVersion = calculateVersion("3.8");
 
     protected AbstractClientInternalCacheProxy(CacheConfig<K, V> cacheConfig) {
         super(cacheConfig);
@@ -194,20 +148,15 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
     protected void onInitialize() {
         super.onInitialize();
 
-        nearCacheManager = clientContext.getNearCacheManager();
-
-        initNearCache();
-
-        if (nearCache != null) {
-            statistics = new ClientCacheStatisticsImpl(System.currentTimeMillis(), nearCache.getNearCacheStats());
-        } else {
-            statistics = new ClientCacheStatisticsImpl(System.currentTimeMillis());
-        }
-        statisticsEnabled = cacheConfig.isStatisticsEnabled();
+        ClientPartitionService partitionService = clientContext.getPartitionService();
+        partitionCount = partitionService.getPartitionCount();
     }
 
-    void setCacheManager(HazelcastClientCacheManager cacheManager) {
-        this.cacheManager = cacheManager;
+    @Override
+    public void setCacheManager(HazelcastCacheManager cacheManager) {
+        assert cacheManager instanceof HazelcastClientCacheManager;
+
+        this.cacheManager = (HazelcastClientCacheManager) cacheManager;
     }
 
     @Override
@@ -217,61 +166,22 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         }
     }
 
-    void initNearCache() {
-        ClientConfig clientConfig = clientContext.getClientConfig();
-        NearCacheConfig nearCacheConfig = clientConfig.getNearCacheConfig(name);
-        if (nearCacheConfig != null) {
-            checkNearCacheConfig(nearCacheConfig, clientConfig.getNativeMemoryConfig());
-            cacheOnUpdate = isCacheOnUpdate(nearCacheConfig, nameWithPrefix, logger);
-            ICacheDataStructureAdapter<K, V> adapter = new ICacheDataStructureAdapter<K, V>(this);
-            nearCache = nearCacheManager.getOrCreateNearCache(nameWithPrefix, nearCacheConfig, adapter);
-            registerInvalidationListener();
-        }
-    }
-
-    private static void checkNearCacheConfig(NearCacheConfig nearCacheConfig, NativeMemoryConfig nativeMemoryConfig) {
-        InMemoryFormat inMemoryFormat = nearCacheConfig.getInMemoryFormat();
-        if (inMemoryFormat != NATIVE) {
-            return;
-        }
-
-        checkTrue(nativeMemoryConfig.isEnabled(), "Enable native memory config to use NATIVE in-memory-format for Near Cache");
-
-    }
-
-    static boolean isCacheOnUpdate(NearCacheConfig nearCacheConfig, String cacheName, ILogger logger) {
-        NearCacheConfig.LocalUpdatePolicy localUpdatePolicy = nearCacheConfig.getLocalUpdatePolicy();
-        if (localUpdatePolicy == CACHE) {
-            logger.warning(format("Deprecated local update policy is found for cache `%s`."
-                            + " The policy `%s` is subject to remove in further releases. Instead you can use `%s`",
-                    cacheName, CACHE, CACHE_ON_UPDATE));
-            return true;
-        }
-
-        return localUpdatePolicy == CACHE_ON_UPDATE;
-    }
-
     @Override
     public void close() {
-        if (nearCache != null) {
-            removeInvalidationListener();
-            nearCacheManager.clearNearCache(nearCache.getName());
-        }
         if (statisticsEnabled) {
-            statistics.clear();
+            statsHandler.clear();
         }
+
         super.close();
     }
 
     @Override
     protected void onDestroy() {
-        if (nearCache != null) {
-            removeInvalidationListener();
-            nearCacheManager.destroyNearCache(nearCache.getName());
-        }
         if (statisticsEnabled) {
-            statistics.clear();
+            statsHandler.clear();
         }
+
+        super.onDestroy();
     }
 
     protected ClientInvocationFuture invoke(ClientMessage req, int partitionId, int completionId) {
@@ -311,102 +221,93 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         }
     }
 
-    protected <T> ICompletableFuture<T> getAndRemoveAsyncInternal(K key, boolean withCompletionEvent, boolean async) {
-        final long start = System.nanoTime();
+    protected <T> ICompletableFuture<T> getAndRemoveAsyncInternal(K key, boolean withCompletionEvent) {
+        final long startNanos = nowInNanosOrDefault();
         ensureOpen();
         validateNotNull(key);
-        CacheProxyUtil.validateConfiguredTypes(cacheConfig, key);
-        final Data keyData = toData(key);
-        final int completionId = withCompletionEvent ? nextCompletionId() : -1;
-        ClientMessage request = CacheGetAndRemoveCodec.encodeRequest(nameWithPrefix, keyData, completionId);
-        ClientInvocationFuture future;
-        try {
-            future = invoke(request, keyData, completionId);
-            invalidateNearCache(keyData);
-        } catch (Exception e) {
-            throw rethrow(e);
-        }
-        ClientDelegatingFuture<T> delegatingFuture =
-                new ClientDelegatingFuture<T>(future, clientContext.getSerializationService(), GET_AND_REMOVE_RESPONSE_DECODER);
-        if (async && statisticsEnabled) {
-            delegatingFuture.andThenInternal(new ExecutionCallback<T>() {
-                public void onResponse(T response) {
-                    handleStatisticsOnRemove(true, start, response);
-                }
+        validateConfiguredTypes(cacheConfig, key);
 
-                public void onFailure(Throwable t) {
-
-                }
-            }, true);
-        }
+        Data keyData = toData(key);
+        ClientDelegatingFuture<T> delegatingFuture = getAndRemoveInternal(keyData, withCompletionEvent);
+        ExecutionCallback<T> callback = !statisticsEnabled ? null : statsHandler.newOnRemoveCallback(true, startNanos);
+        onGetAndRemoveAsyncInternal(delegatingFuture, callback, keyData);
         return delegatingFuture;
     }
 
-    protected <T> ICompletableFuture<T> removeAsyncInternal(K key, V oldValue, boolean hasOldValue, boolean withCompletionEvent,
-                                                            boolean async) {
-        final long start = System.nanoTime();
+    protected <T> ClientDelegatingFuture<T> getAndRemoveSyncInternal(K key, boolean withCompletionEvent) {
+        ensureOpen();
+        validateNotNull(key);
+        validateConfiguredTypes(cacheConfig, key);
+
+        Data keyData = toData(key);
+        return getAndRemoveInternal(keyData, withCompletionEvent);
+    }
+
+    private <T> ClientDelegatingFuture<T> getAndRemoveInternal(Data keyData, boolean withCompletionEvent) {
+        final int completionId = withCompletionEvent ? nextCompletionId() : -1;
+        ClientMessage request = CacheGetAndRemoveCodec.encodeRequest(nameWithPrefix, keyData, completionId);
+        ClientInvocationFuture future = invoke(request, keyData, completionId);
+        return newDelegatingFuture(future, GET_AND_REMOVE_RESPONSE_DECODER);
+    }
+
+    protected <T> void onGetAndRemoveAsyncInternal(ClientDelegatingFuture<T> delegatingFuture,
+                                                   ExecutionCallback<T> callback, Data keyData) {
+        addCallback(delegatingFuture, callback);
+    }
+
+    protected Object removeAsyncInternal(K key, V oldValue, boolean hasOldValue, boolean withCompletionEvent,
+                                         boolean async) {
+        final long startNanos = nowInNanosOrDefault();
         ensureOpen();
         if (hasOldValue) {
             validateNotNull(key, oldValue);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, oldValue);
+            validateConfiguredTypes(cacheConfig, key, oldValue);
         } else {
             validateNotNull(key);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key);
+            validateConfiguredTypes(cacheConfig, key);
         }
+
         Data keyData = toData(key);
         Data oldValueData = toData(oldValue);
+
         int completionId = withCompletionEvent ? nextCompletionId() : -1;
         ClientMessage request = CacheRemoveCodec.encodeRequest(nameWithPrefix, keyData, oldValueData, completionId);
-        ClientInvocationFuture future;
-        try {
-            future = invoke(request, keyData, completionId);
-            invalidateNearCache(keyData);
-        } catch (Exception e) {
-            throw rethrow(e);
+        ClientInvocationFuture future = invoke(request, keyData, completionId);
+        ClientDelegatingFuture delegatingFuture = newDelegatingFuture(future, REMOVE_RESPONSE_DECODER);
+        if (async) {
+            ExecutionCallback callback = !statisticsEnabled ? null : statsHandler.newOnRemoveCallback(false, startNanos);
+            onRemoveAsyncInternal(keyData, delegatingFuture, callback);
+            return delegatingFuture;
+        } else {
+            try {
+                Object result = delegatingFuture.get();
+                onRemoveSyncInternal(keyData);
+                return result;
+            } catch (Throwable t) {
+                throw rethrow(t);
+            }
         }
-        ClientDelegatingFuture<T> delegatingFuture =
-                new ClientDelegatingFuture<T>(future, clientContext.getSerializationService(), REMOVE_RESPONSE_DECODER);
-        if (async && statisticsEnabled) {
-            delegatingFuture.andThenInternal(new ExecutionCallback<T>() {
-                public void onResponse(T response) {
-                    handleStatisticsOnRemove(false, start, response);
-                }
 
-                public void onFailure(Throwable t) {
-                }
-            }, true);
-        }
-        return delegatingFuture;
     }
 
-    protected void handleStatisticsOnRemove(boolean isGet, long start, Object response) {
-        if (isGet) {
-            statistics.addGetTimeNanos(System.nanoTime() - start);
-            if (response != null) {
-                statistics.increaseCacheHits();
-                statistics.increaseCacheRemovals();
-                statistics.addRemoveTimeNanos(System.nanoTime() - start);
-            } else {
-                statistics.increaseCacheMisses();
-            }
-        } else {
-            if (Boolean.TRUE.equals(response)) {
-                statistics.increaseCacheRemovals();
-                statistics.addRemoveTimeNanos(System.nanoTime() - start);
-            }
-        }
+    public void onRemoveSyncInternal(Data keyData) {
+        // NOP
+    }
+
+    protected void onRemoveAsyncInternal(Data keyData, ClientDelegatingFuture future, ExecutionCallback callback) {
+        addCallback(future, callback);
     }
 
     protected <T> ICompletableFuture<T> replaceInternal(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy,
                                                         boolean hasOldValue, boolean withCompletionEvent, boolean async) {
-        final long start = System.nanoTime();
+        final long startNanos = nowInNanosOrDefault();
         ensureOpen();
         if (hasOldValue) {
             validateNotNull(key, oldValue, newValue);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, oldValue, newValue);
+            validateConfiguredTypes(cacheConfig, key, oldValue, newValue);
         } else {
             validateNotNull(key, newValue);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, newValue);
+            validateConfiguredTypes(cacheConfig, key, newValue);
         }
 
         Data keyData = toData(key);
@@ -416,312 +317,211 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         int completionId = withCompletionEvent ? nextCompletionId() : -1;
         ClientMessage request = CacheReplaceCodec.encodeRequest(nameWithPrefix, keyData, oldValueData, newValueData,
                 expiryPolicyData, completionId);
-        ClientInvocationFuture future;
-        try {
-            future = invoke(request, keyData, completionId);
-            invalidateNearCache(keyData);
-        } catch (Exception e) {
-            throw rethrow(e);
-        }
-
-        ClientDelegatingFuture<T> delegatingFuture =
-                new ClientDelegatingFuture<T>(future, clientContext.getSerializationService(), REPLACE_RESPONSE_DECODER);
-        if (async && statisticsEnabled) {
-            delegatingFuture.andThenInternal(new ExecutionCallback<T>() {
-                public void onResponse(T response) {
-                    handleStatisticsOnReplace(false, start, response);
-                }
-
-                public void onFailure(Throwable t) {
-                }
-            }, true);
+        ClientInvocationFuture future = invoke(request, keyData, completionId);
+        ClientDelegatingFuture<T> delegatingFuture = newDelegatingFuture(future, REPLACE_RESPONSE_DECODER);
+        if (async) {
+            ExecutionCallback callback = statisticsEnabled ? new OnReplaceCallback(startNanos, false) : null;
+            onReplaceInternalAsync(keyData, newValueData, newValue, delegatingFuture, callback);
         }
         return delegatingFuture;
     }
 
-    protected <T> ICompletableFuture<T> replaceAndGetAsyncInternal(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy,
+    protected <T> void onReplaceInternalAsync(Data keyData, Data valueData, Object value,
+                                              ClientDelegatingFuture<T> delegatingFuture, ExecutionCallback<T> callback) {
+        addCallback(delegatingFuture, callback);
+    }
+
+    protected <T> ICompletableFuture<T> replaceAndGetAsyncInternal(K key, V oldValue, V newValue, ExpiryPolicy
+            expiryPolicy,
                                                                    boolean hasOldValue, boolean withCompletionEvent,
                                                                    boolean async) {
-        final long start = System.nanoTime();
+        final long startNanos = nowInNanosOrDefault();
         ensureOpen();
         if (hasOldValue) {
             validateNotNull(key, oldValue, newValue);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, oldValue, newValue);
+            validateConfiguredTypes(cacheConfig, key, oldValue, newValue);
         } else {
             validateNotNull(key, newValue);
-            CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, newValue);
+            validateConfiguredTypes(cacheConfig, key, newValue);
         }
 
         Data keyData = toData(key);
         Data newValueData = toData(newValue);
         Data expiryPolicyData = toData(expiryPolicy);
+
         int completionId = withCompletionEvent ? nextCompletionId() : -1;
         ClientMessage request = CacheGetAndReplaceCodec.encodeRequest(nameWithPrefix, keyData, newValueData, expiryPolicyData,
                 completionId);
-        ClientInvocationFuture future;
-        try {
-            future = invoke(request, keyData, completionId);
-            invalidateNearCache(keyData);
-        } catch (Exception e) {
-            throw rethrow(e);
-        }
-
-        ClientDelegatingFuture<T> delegatingFuture =
-                new ClientDelegatingFuture<T>(future, clientContext.getSerializationService(), GET_AND_REPLACE_RESPONSE_DECODER);
-        if (async && statisticsEnabled) {
-            delegatingFuture.andThenInternal(new ExecutionCallback<T>() {
-                public void onResponse(T response) {
-                    handleStatisticsOnReplace(true, start, response);
-                }
-
-                public void onFailure(Throwable t) {
-                }
-            }, true);
+        ClientInvocationFuture future = invoke(request, keyData, completionId);
+        ClientDelegatingFuture<T> delegatingFuture = newDelegatingFuture(future, GET_AND_REPLACE_RESPONSE_DECODER);
+        if (async) {
+            ExecutionCallback callback = statisticsEnabled ? new OnReplaceCallback(startNanos, true) : null;
+            onReplaceAndGetAsync(keyData, newValueData, newValue, delegatingFuture, callback);
         }
         return delegatingFuture;
     }
 
-    protected void handleStatisticsOnReplace(boolean isGet, long start, Object response) {
-        if (isGet) {
-            statistics.addGetTimeNanos(System.nanoTime() - start);
-            if (response != null) {
-                statistics.increaseCacheHits();
-                statistics.increaseCachePuts();
-                statistics.addPutTimeNanos(System.nanoTime() - start);
-            } else {
-                statistics.increaseCacheMisses();
-            }
-        } else {
-            if (Boolean.TRUE.equals(response)) {
-                statistics.increaseCacheHits();
-                statistics.increaseCachePuts();
-                statistics.addPutTimeNanos(System.nanoTime() - start);
-            } else {
-                statistics.increaseCacheMisses();
-            }
-        }
+    protected <T> void onReplaceAndGetAsync(Data keyData, Data valueData, Object value,
+                                            ClientDelegatingFuture<T> delegatingFuture, ExecutionCallback<T> callback) {
+        addCallback(delegatingFuture, callback);
     }
 
-    protected Object putInternal(K key, V value, ExpiryPolicy expiryPolicy, boolean isGet, boolean withCompletionEvent,
-                                 boolean async) {
-        long start = System.nanoTime();
-        ensureOpen();
-        validateNotNull(key, value);
-        CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, value);
-
-        Data keyData = toData(key);
-        Data valueData = toData(value);
-        Data expiryPolicyData = toData(expiryPolicy);
-        int completionId = withCompletionEvent ? nextCompletionId() : -1;
-        ClientMessage request = CachePutCodec.encodeRequest(nameWithPrefix, keyData, valueData, expiryPolicyData, isGet,
-                completionId);
-        ClientInvocationFuture future;
-        try {
-            future = invoke(request, keyData, completionId);
-        } catch (Exception e) {
-            throw rethrow(e);
-        }
-
-        if (async) {
-            return putInternalAsync(value, isGet, start, keyData, valueData, future);
-        }
-        return putInternalSync(value, isGet, start, keyData, valueData, future);
-    }
-
-    protected long tryReserveForUpdate(Data keyData) {
-        if (nearCache == null) {
-            return NOT_RESERVED;
-        }
-        return nearCache.tryReserveForUpdate(keyData);
-    }
-
-    protected void releaseRemainingReservedKeys(Map<Data, Long> reservedKeys) {
-        if (nearCache == null) {
+    protected static <T> void addCallback(ClientDelegatingFuture<T> delegatingFuture, ExecutionCallback<T> callback) {
+        if (callback == null) {
             return;
         }
 
-        for (Data key : reservedKeys.keySet()) {
-            nearCache.remove(key);
+        delegatingFuture.andThenInternal(callback, true);
+    }
+
+    private final class OnReplaceCallback implements ExecutionCallback<V> {
+
+        private final long startNanos;
+        private final boolean isGet;
+
+        private OnReplaceCallback(long startNanos, boolean isGet) {
+            this.startNanos = startNanos;
+            this.isGet = isGet;
+        }
+
+        @Override
+        public void onResponse(V response) {
+            statsHandler.onReplace(isGet, startNanos, toObject(response));
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
         }
     }
 
-    private Object putInternalAsync(final V value, final boolean isGet, final long start, final Data keyData,
-                                    final Data valueData, ClientInvocationFuture future) {
-        OneShotExecutionCallback<V> oneShotExecutionCallback = null;
-        if (nearCache != null || statisticsEnabled) {
-            oneShotExecutionCallback = new OneShotExecutionCallback<V>() {
-                @Override
-                protected void onResponseInternal(V responseData) {
-                    if (nearCache != null) {
-                        if (cacheOnUpdate) {
-                            storeInNearCache(keyData, valueData, value, NOT_RESERVED, cacheOnUpdate);
-                        } else {
-                            invalidateNearCache(keyData);
-                        }
-                    }
-
-                    if (statisticsEnabled) {
-                        handleStatisticsOnPut(isGet, start, responseData);
-                    }
-                }
-
-                @Override
-                protected void onFailureInternal(Throwable t) {
-                }
-            };
-        }
-
-        SerializationService serializationService = clientContext.getSerializationService();
-        if (oneShotExecutionCallback == null) {
-            return new ClientDelegatingFuture<V>(future, serializationService, PUT_RESPONSE_DECODER);
-        }
-        ClientDelegatingFuture<V> delegatingFuture = new CallbackAwareClientDelegatingFuture<V>(future,
-                serializationService, PUT_RESPONSE_DECODER, oneShotExecutionCallback);
-        delegatingFuture.andThenInternal(oneShotExecutionCallback, true);
-        return delegatingFuture;
+    private ClientInvocationFuture putInternal(Data keyData, Data valueData, Data expiryPolicyData,
+                                               boolean isGet, boolean withCompletionEvent) {
+        int completionId = withCompletionEvent ? nextCompletionId() : -1;
+        ClientMessage request = CachePutCodec.encodeRequest(nameWithPrefix, keyData, valueData,
+                expiryPolicyData, isGet, completionId);
+        return invoke(request, keyData, completionId);
     }
 
-    private Object putInternalSync(V value, boolean isGet, long start, Data keyData, Data valueData,
-                                   ClientInvocationFuture future) {
-        try {
-            ClientDelegatingFuture delegatingFuture = new ClientDelegatingFuture(future,
-                    clientContext.getSerializationService(), PUT_RESPONSE_DECODER);
-            Object response = delegatingFuture.get();
-
-            if (statisticsEnabled) {
-                handleStatisticsOnPut(isGet, start, response);
-            }
-            return response;
-        } catch (Throwable e) {
-            throw rethrowAllowedTypeFirst(e, CacheException.class);
-        } finally {
-            if (nearCache != null) {
-                if (cacheOnUpdate) {
-                    storeInNearCache(keyData, valueData, value, NOT_RESERVED, cacheOnUpdate);
-                } else {
-                    invalidateNearCache(keyData);
-                }
-            }
-        }
-    }
-
-    protected void handleStatisticsOnPut(boolean isGet, long start, Object response) {
-        statistics.increaseCachePuts();
-        statistics.addPutTimeNanos(System.nanoTime() - start);
-        if (isGet) {
-            Object resp = clientContext.getSerializationService().toObject(response);
-            statistics.addGetTimeNanos(System.nanoTime() - start);
-            if (resp == null) {
-                statistics.increaseCacheMisses();
-            } else {
-                statistics.increaseCacheHits();
-            }
-        }
-    }
-
-    protected Object putIfAbsentInternal(K key, V value, ExpiryPolicy expiryPolicy, boolean withCompletionEvent,
-                                         boolean async) {
-        long start = System.nanoTime();
+    protected Object putSyncInternal(K key, V value, ExpiryPolicy expiryPolicy, boolean isGet, boolean withCompletionEvent) {
+        long startNanos = nowInNanosOrDefault();
         ensureOpen();
         validateNotNull(key, value);
-        CacheProxyUtil.validateConfiguredTypes(cacheConfig, key, value);
+        validateConfiguredTypes(cacheConfig, key, value);
+
         Data keyData = toData(key);
         Data valueData = toData(value);
         Data expiryPolicyData = toData(expiryPolicy);
-        int completionId = withCompletionEvent ? nextCompletionId() : -1;
-        ClientMessage request = CachePutIfAbsentCodec.encodeRequest(nameWithPrefix, keyData, valueData,
-                expiryPolicyData, completionId);
-        ClientInvocationFuture future;
+
         try {
-            future = invoke(request, keyData, completionId);
-        } catch (Throwable t) {
-            throw rethrow(t);
-        }
-        ClientDelegatingFuture<Boolean> delegatingFuture = new ClientDelegatingFuture<Boolean>(future,
-                clientContext.getSerializationService(), PUT_IF_ABSENT_RESPONSE_DECODER);
-
-        if (async) {
-            return putIfAbsentInternalAsync(value, start, keyData, valueData, delegatingFuture);
-        }
-        return putIfAbsentInternalSync(value, start, keyData, valueData, delegatingFuture);
-    }
-
-    private Object putIfAbsentInternalAsync(final V value, final long start, final Data keyData, final Data valueData,
-                                            ClientDelegatingFuture<Boolean> delegatingFuture) {
-        if (nearCache != null || statisticsEnabled) {
-            delegatingFuture.andThenInternal(new ExecutionCallback<Boolean>() {
-                @Override
-                public void onResponse(Boolean responseData) {
-                    if (nearCache != null) {
-                        if (cacheOnUpdate) {
-                            storeInNearCache(keyData, valueData, value, NOT_RESERVED, cacheOnUpdate);
-                        } else {
-                            invalidateNearCache(keyData);
-                        }
-                    }
-                    if (statisticsEnabled) {
-                        Object response = clientContext.getSerializationService().toObject(responseData);
-                        handleStatisticsOnPutIfAbsent(start, (Boolean) response);
-                    }
-                }
-
-                @Override
-                public void onFailure(Throwable t) {
-                }
-            }, true);
-        }
-        return delegatingFuture;
-    }
-
-    private Object putIfAbsentInternalSync(V value, long start, Data keyData, Data valueData,
-                                           ClientDelegatingFuture<Boolean> delegatingFuture) {
-        try {
+            ClientInvocationFuture invocationFuture = putInternal(keyData, valueData,
+                    expiryPolicyData, isGet, withCompletionEvent);
+            ClientDelegatingFuture delegatingFuture = newDelegatingFuture(invocationFuture, PUT_RESPONSE_DECODER);
             Object response = delegatingFuture.get();
 
             if (statisticsEnabled) {
-                handleStatisticsOnPutIfAbsent(start, (Boolean) response);
+                statsHandler.onPut(isGet, startNanos, response != null);
             }
             return response;
         } catch (Throwable e) {
             throw rethrowAllowedTypeFirst(e, CacheException.class);
         } finally {
-            if (nearCache != null) {
-                if (cacheOnUpdate) {
-                    storeInNearCache(keyData, valueData, value, NOT_RESERVED, cacheOnUpdate);
-                } else {
-                    invalidateNearCache(keyData);
+            onPutSyncInternal(keyData, valueData, value);
+        }
+    }
+
+    protected void onPutSyncInternal(Data keyData, Data valueData, V value) {
+        // NOP.
+    }
+
+    protected ClientDelegatingFuture putAsyncInternal(K key, V value, ExpiryPolicy expiryPolicy,
+                                                      boolean isGet, boolean withCompletionEvent,
+                                                      OneShotExecutionCallback<V> callback) {
+        ensureOpen();
+        validateNotNull(key, value);
+        validateConfiguredTypes(cacheConfig, key, value);
+
+        Data keyData = toData(key);
+        Data valueData = toData(value);
+        Data expiryPolicyData = toData(expiryPolicy);
+
+        ClientInvocationFuture invocationFuture = putInternal(keyData, valueData, expiryPolicyData, isGet, withCompletionEvent);
+        return wrapPutAsyncFuture(keyData, valueData, value, invocationFuture, callback);
+    }
+
+    protected ClientDelegatingFuture<V> wrapPutAsyncFuture(Data keyData, Data valueData, V value,
+                                                           ClientInvocationFuture invocationFuture,
+                                                           OneShotExecutionCallback<V> callback) {
+        if (callback == null) {
+            return newDelegatingFuture(invocationFuture, PUT_RESPONSE_DECODER);
+        }
+
+        CallbackAwareClientDelegatingFuture<V> future = new CallbackAwareClientDelegatingFuture<V>(invocationFuture,
+                serializationService, PUT_RESPONSE_DECODER, callback);
+        future.andThenInternal(callback, true);
+
+        return future;
+    }
+
+    protected OneShotExecutionCallback<V> newStatsCallbackOrNull(boolean isGet) {
+        if (!statisticsEnabled) {
+            return null;
+        }
+        return statsHandler.newOnPutCallback(isGet, System.nanoTime());
+    }
+
+    protected Object putIfAbsentInternal(K key, V value, ExpiryPolicy expiryPolicy, boolean withCompletionEvent, boolean async) {
+        final long startNanos = nowInNanosOrDefault();
+        ensureOpen();
+        validateNotNull(key, value);
+        validateConfiguredTypes(cacheConfig, key, value);
+
+        Data keyData = toData(key);
+        Data valueData = toData(value);
+        Data expiryPolicyData = toData(expiryPolicy);
+
+        int completionId = withCompletionEvent ? nextCompletionId() : -1;
+        ClientMessage request = CachePutIfAbsentCodec.encodeRequest(nameWithPrefix, keyData, valueData,
+                expiryPolicyData, completionId);
+        ClientInvocationFuture future = invoke(request, keyData, completionId);
+        ClientDelegatingFuture<Boolean> delegatingFuture = newDelegatingFuture(future, PUT_IF_ABSENT_RESPONSE_DECODER);
+        if (async) {
+            ExecutionCallback<Boolean> callback = !statisticsEnabled ? null : statsHandler.newOnPutIfAbsentCallback(startNanos);
+            onPutIfAbsentAsyncInternal(keyData, valueData, value, delegatingFuture, callback);
+            return delegatingFuture;
+        } else {
+            try {
+                Object response = delegatingFuture.get();
+
+                if (statisticsEnabled) {
+                    statsHandler.onPutIfAbsent(startNanos, (Boolean) response);
                 }
+                onPutIfAbsentSyncInternal(keyData, valueData, value);
+                return response;
+            } catch (Throwable e) {
+                throw rethrowAllowedTypeFirst(e, CacheException.class);
             }
         }
     }
 
-    protected void handleStatisticsOnPutIfAbsent(long start, boolean saved) {
-        if (saved) {
-            statistics.increaseCachePuts();
-            statistics.addPutTimeNanos(System.nanoTime() - start);
-        }
+    protected void onPutIfAbsentAsyncInternal(Data keyData, Data valueData, V value,
+                                              ClientDelegatingFuture<Boolean> delegatingFuture, ExecutionCallback callback) {
+        addCallback(delegatingFuture, callback);
     }
 
-    protected void removeAllKeysInternal(Set<? extends K> keys) {
-        long start = System.nanoTime();
-        Set<Data> keysData;
-        keysData = new HashSet<Data>();
-        for (K key : keys) {
-            keysData.add(toData(key));
-        }
+    protected void onPutIfAbsentSyncInternal(Data keyData, Data valueData, V value) {
+        // NOP.
+    }
+
+    protected void removeAllKeysInternal(Collection<Data> dataKeys, long startNanos) {
         int partitionCount = clientContext.getPartitionService().getPartitionCount();
         int completionId = nextCompletionId();
         registerCompletionLatch(completionId, partitionCount);
-        ClientMessage request = CacheRemoveAllKeysCodec.encodeRequest(nameWithPrefix, keysData, completionId);
+        ClientMessage request = CacheRemoveAllKeysCodec.encodeRequest(nameWithPrefix, dataKeys, completionId);
         try {
             invoke(request);
             waitCompletionLatch(completionId, null);
             if (statisticsEnabled) {
-                // Actually we don't know how many of them are really removed or not.
-                // We just assume that if there is no exception, all of them are removed.
-                // Otherwise (if there is an exception), we don't update any cache stats about remove.
-                statistics.increaseCacheRemovals(keysData.size());
-                statistics.addRemoveTimeNanos(System.nanoTime() - start);
+                statsHandler.onBatchRemove(startNanos, dataKeys.size());
             }
         } catch (Throwable t) {
             deregisterCompletionLatch(completionId);
@@ -738,7 +538,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
             invoke(request);
             waitCompletionLatch(completionId, null);
             if (statisticsEnabled) {
-                statistics.setLastUpdateTime(System.currentTimeMillis());
+                statsHandler.getStatistics().setLastUpdateTime(System.currentTimeMillis());
                 // We don't support count stats of removing all entries.
             }
         } catch (Throwable t) {
@@ -752,43 +552,12 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         try {
             invoke(request);
             if (statisticsEnabled) {
-                statistics.setLastUpdateTime(System.currentTimeMillis());
+                statsHandler.getStatistics().setLastUpdateTime(System.currentTimeMillis());
                 // We don't support count stats of removing all entries.
             }
         } catch (Throwable t) {
             throw rethrowAllowedTypeFirst(t, CacheException.class);
         }
-    }
-
-    protected void storeInNearCache(Data key, Data valueData, V value,
-                                    long reservationId, boolean cacheOnUpdate) {
-        if (nearCache == null) {
-            return;
-        }
-
-        if (cacheOnUpdate) {
-            Object valueToStore = nearCache.selectToSave(value, valueData);
-            nearCache.put(key, valueToStore);
-            return;
-        }
-
-        if (reservationId != NOT_RESERVED) {
-            if (valueData == null) {
-                // we are not caching nulls in near cache for jcache
-                nearCache.remove(key);
-            } else {
-                Object valueToStore = nearCache.selectToSave(value, valueData);
-                nearCache.tryPublishReserved(key, valueToStore, reservationId, false);
-            }
-        }
-    }
-
-    protected void invalidateNearCache(Data key) {
-        if (nearCache == null || key == null) {
-            return;
-        }
-
-        nearCache.remove(key);
     }
 
     protected void addListenerLocally(String regId, CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration) {
@@ -879,7 +648,8 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         }
     }
 
-    protected void waitCompletionLatch(Integer countDownLatchId, ICompletableFuture future) throws ExecutionException {
+    protected void waitCompletionLatch(Integer countDownLatchId, ICompletableFuture future) throws
+            ExecutionException {
         if (countDownLatchId != IGNORE_COMPLETION) {
             CountDownLatch countDownLatch = syncLocks.get(countDownLatchId);
             if (countDownLatch != null) {
@@ -948,222 +718,6 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
 
         @Override
         public void onListenerRegister() {
-        }
-    }
-
-    /**
-     * Needed to deal with client compatibility issues.
-     * Eventual consistency for near cache can be used with server versions >= 3.8.
-     * Other connected server versions must use {@link Pre38NearCacheEventHandler}
-     */
-    private final class ConnectedServerVersionAwareNearCacheEventHandler implements EventHandler<ClientMessage> {
-
-        private final RepairableNearCacheEventHandler repairingEventHandler = new RepairableNearCacheEventHandler();
-        private final Pre38NearCacheEventHandler pre38EventHandler = new Pre38NearCacheEventHandler();
-        private volatile boolean supportsRepairableNearCache;
-
-        @Override
-        public void beforeListenerRegister() {
-            pre38EventHandler.beforeListenerRegister();
-            repairingEventHandler.beforeListenerRegister();
-        }
-
-        @Override
-        public void onListenerRegister() {
-            supportsRepairableNearCache = supportsRepairableNearCache();
-
-            if (supportsRepairableNearCache) {
-                repairingEventHandler.onListenerRegister();
-            } else {
-                pre38EventHandler.onListenerRegister();
-            }
-        }
-
-        @Override
-        public void handle(ClientMessage clientMessage) {
-            if (supportsRepairableNearCache) {
-                repairingEventHandler.handle(clientMessage);
-            } else {
-                pre38EventHandler.handle(clientMessage);
-            }
-        }
-    }
-
-    /**
-     * This event handler can only be used with server versions >= 3.8 and supports near cache eventual consistency improvements.
-     * For repairing functionality please see {@link RepairingHandler}
-     */
-    private final class RepairableNearCacheEventHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler
-            implements EventHandler<ClientMessage> {
-
-        private volatile RepairingHandler repairingHandler;
-
-        @Override
-        public void beforeListenerRegister() {
-            nearCache.clear();
-            getRepairingTask().deregisterHandler(nameWithPrefix);
-        }
-
-        @Override
-        public void onListenerRegister() {
-            nearCache.clear();
-            repairingHandler = getRepairingTask().registerAndGetHandler(nameWithPrefix, nearCache);
-        }
-
-        @Override
-        public void handle(String name, Data key, String sourceUuid, UUID partitionUuid, long sequence) {
-            repairingHandler.handle(key, sourceUuid, partitionUuid, sequence);
-        }
-
-        @Override
-        public void handle(String name, Collection<Data> keys, Collection<String> sourceUuids,
-                           Collection<UUID> partitionUuids, Collection<Long> sequences) {
-            repairingHandler.handle(keys, sourceUuids, partitionUuids, sequences);
-        }
-
-        private RepairingTask getRepairingTask() {
-            ClientContext clientContext = getContext();
-            return clientContext.getRepairingTask(CacheService.SERVICE_NAME);
-        }
-    }
-
-    /**
-     * This event handler is here to be used with server versions < 3.8.
-     * <p>
-     * If server version is < 3.8 and client version is >= 3.8, this event handler must be used to
-     * listen near cache invalidations. Because new improvements for near cache eventual consistency cannot work
-     * with server versions < 3.8.
-     */
-    private final class Pre38NearCacheEventHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler
-            implements EventHandler<ClientMessage> {
-
-        private String clientUuid;
-
-        private Pre38NearCacheEventHandler() {
-            this.clientUuid = getContext().getClusterService().getLocalClient().getUuid();
-        }
-
-        @Override
-        public void handle(String name, Data key, String sourceUuid, UUID partitionUuid, long sequence) {
-            if (clientUuid.equals(sourceUuid)) {
-                return;
-            }
-            if (key != null) {
-                nearCache.remove(key);
-            } else {
-                nearCache.clear();
-            }
-        }
-
-        @Override
-        public void handle(String name, Collection<Data> keys, Collection<String> sourceUuids,
-                           Collection<UUID> partitionUuids, Collection<Long> sequences) {
-            if (sourceUuids != null && !sourceUuids.isEmpty()) {
-                Iterator<Data> keysIt = keys.iterator();
-                Iterator<String> sourceUuidsIt = sourceUuids.iterator();
-                while (keysIt.hasNext() && sourceUuidsIt.hasNext()) {
-                    Data key = keysIt.next();
-                    String sourceUuid = sourceUuidsIt.next();
-                    if (!clientUuid.equals(sourceUuid)) {
-                        nearCache.remove(key);
-                    }
-                }
-            } else {
-                for (Data key : keys) {
-                    nearCache.remove(key);
-                }
-            }
-        }
-
-        @Override
-        public void beforeListenerRegister() {
-        }
-
-        @Override
-        public void onListenerRegister() {
-            nearCache.clear();
-        }
-    }
-
-
-    private void registerInvalidationListener() {
-        if (nearCache == null || !nearCache.isInvalidatedOnChange()) {
-            return;
-        }
-
-        ListenerMessageCodec listenerCodec = createInvalidationListenerCodec();
-        ClientListenerService listenerService = clientContext.getListenerService();
-
-        EventHandler eventHandler = createInvalidationEventHandler();
-        nearCacheMembershipRegistrationId = listenerService.registerListener(listenerCodec, eventHandler);
-    }
-
-    private EventHandler createInvalidationEventHandler() {
-        return new ConnectedServerVersionAwareNearCacheEventHandler();
-    }
-
-    private ListenerMessageCodec createInvalidationListenerCodec() {
-        return new ListenerMessageCodec() {
-            @Override
-            public ClientMessage encodeAddRequest(boolean localOnly) {
-                if (supportsRepairableNearCache()) {
-                    // this is for servers >= 3.8
-                    return CacheAddNearCacheInvalidationListenerCodec.encodeRequest(nameWithPrefix, localOnly);
-                }
-                // this is for servers < 3.8
-                return CacheAddInvalidationListenerCodec.encodeRequest(nameWithPrefix, localOnly);
-            }
-
-            @Override
-            public String decodeAddResponse(ClientMessage clientMessage) {
-                if (supportsRepairableNearCache()) {
-                    // this is for servers >= 3.8
-                    return CacheAddNearCacheInvalidationListenerCodec.decodeResponse(clientMessage).response;
-                }
-                // this is for servers < 3.8
-                return CacheAddInvalidationListenerCodec.decodeResponse(clientMessage).response;
-            }
-
-            @Override
-            public ClientMessage encodeRemoveRequest(String realRegistrationId) {
-                return CacheRemoveEntryListenerCodec.encodeRequest(nameWithPrefix, realRegistrationId);
-            }
-
-            @Override
-            public boolean decodeRemoveResponse(ClientMessage clientMessage) {
-                return CacheRemoveEntryListenerCodec.decodeResponse(clientMessage).response;
-            }
-        };
-    }
-
-    private int getConnectedServerVersion() {
-        ClientContext clientContext = getContext();
-        ClientClusterService clusterService = clientContext.getClusterService();
-        Address ownerConnectionAddress = clusterService.getOwnerConnectionAddress();
-
-        HazelcastClientInstanceImpl client = getClient();
-        ClientConnectionManager connectionManager = client.getConnectionManager();
-        Connection connection = connectionManager.getConnection(ownerConnectionAddress);
-        if (connection == null) {
-            logger.warning(format("No owner connection is available, "
-                    + "near cached cache %s will be started in legacy mode", name));
-            return UNKNOWN_HAZELCAST_VERSION;
-        }
-
-        return ((ClientConnection) connection).getConnectedServerVersion();
-    }
-
-    private boolean supportsRepairableNearCache() {
-        return getConnectedServerVersion() >= minConsistentNearCacheSupportingServerVersion;
-    }
-
-    private void removeInvalidationListener() {
-        if (nearCache != null && nearCache.isInvalidatedOnChange()) {
-            String registrationId = nearCacheMembershipRegistrationId;
-            if (registrationId != null) {
-                clientContext.getRepairingTask(SERVICE_NAME).deregisterHandler(name);
-                clientContext.getListenerService().deregisterListener(registrationId);
-            }
         }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.impl;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.spi.serialization.SerializationService;
+
+/**
+ * Helper class which contains specific statistic calculations per context
+ */
+final class CacheStatsHandler {
+
+    private final ClientCacheStatisticsImpl statistics;
+    private final SerializationService serializationService;
+
+    CacheStatsHandler(SerializationService serializationService) {
+        this.serializationService = serializationService;
+        this.statistics = new ClientCacheStatisticsImpl(System.currentTimeMillis());
+    }
+
+    ClientCacheStatisticsImpl getStatistics() {
+        return statistics;
+    }
+
+    void onReplace(boolean isGet, long startNanos, Object response) {
+        if (isGet) {
+            statistics.addGetTimeNanos(System.nanoTime() - startNanos);
+            if (response != null) {
+                statistics.increaseCacheHits();
+                statistics.increaseCachePuts();
+                statistics.addPutTimeNanos(System.nanoTime() - startNanos);
+            } else {
+                statistics.increaseCacheMisses();
+            }
+        } else {
+            if (Boolean.TRUE.equals(response)) {
+                statistics.increaseCacheHits();
+                statistics.increaseCachePuts();
+                statistics.addPutTimeNanos(System.nanoTime() - startNanos);
+            } else {
+                statistics.increaseCacheMisses();
+            }
+        }
+    }
+
+    void onPutIfAbsent(long startNanos, boolean saved) {
+        if (saved) {
+            statistics.increaseCachePuts();
+            statistics.addPutTimeNanos(System.nanoTime() - startNanos);
+        }
+    }
+
+    ExecutionCallback<Boolean> newOnPutIfAbsentCallback(final long startNanos) {
+        return new ExecutionCallback<Boolean>() {
+            @Override
+            public void onResponse(Boolean responseData) {
+                Object response = toObject(responseData);
+                onPutIfAbsent(startNanos, (Boolean) response);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+            }
+        };
+    }
+
+    void onPut(boolean isGet, long startNanos, boolean cacheHit) {
+        statistics.increaseCachePuts();
+        statistics.addPutTimeNanos(System.nanoTime() - startNanos);
+        if (isGet) {
+            statistics.addGetTimeNanos(System.nanoTime() - startNanos);
+            if (cacheHit) {
+                statistics.increaseCacheHits();
+            } else {
+                statistics.increaseCacheMisses();
+            }
+        }
+    }
+
+    OneShotExecutionCallback newOnPutCallback(final boolean isGet, final long startNanos) {
+        return new OneShotExecutionCallback() {
+            @Override
+            protected void onResponseInternal(Object responseData) {
+                onPut(isGet, startNanos, responseData != null);
+            }
+
+            @Override
+            protected void onFailureInternal(Throwable t) {
+            }
+        };
+    }
+
+    void onRemove(boolean isGet, long startNanos, Object response) {
+        if (isGet) {
+            statistics.addGetTimeNanos(System.nanoTime() - startNanos);
+            if (response != null) {
+                statistics.increaseCacheHits();
+                statistics.increaseCacheRemovals();
+                statistics.addRemoveTimeNanos(System.nanoTime() - startNanos);
+            } else {
+                statistics.increaseCacheMisses();
+            }
+        } else {
+            if (Boolean.TRUE.equals(toObject(response))) {
+                statistics.increaseCacheRemovals();
+                statistics.addRemoveTimeNanos(System.nanoTime() - startNanos);
+            }
+        }
+    }
+
+    ExecutionCallback newOnRemoveCallback(final boolean isGet, final long startNanos) {
+        return new ExecutionCallback() {
+            public void onResponse(Object response) {
+                onRemove(isGet, startNanos, response);
+            }
+
+            public void onFailure(Throwable t) {
+
+            }
+        };
+    }
+
+    void onGet(long startNanos, boolean responseReceived) {
+        if (responseReceived) {
+            statistics.increaseCacheHits();
+        } else {
+            statistics.increaseCacheMisses();
+        }
+        statistics.addGetTimeNanos(System.nanoTime() - startNanos);
+    }
+
+    <T> ExecutionCallback<T> newOnGetCallback(final long startNanos) {
+        return new ExecutionCallback() {
+            @Override
+            public void onResponse(Object response) {
+                onGet(startNanos, response != null);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+
+            }
+        };
+    }
+
+    void onBatchRemove(long startNanos, int batchSize) {
+        // Actually we don't know how many of them are really removed or not.
+        // We just assume that if there is no exception, all of them are removed.
+        // Otherwise (if there is an exception), we don't update any cache stats about remove.
+        statistics.increaseCacheRemovals(batchSize);
+        statistics.addRemoveTimeNanos(System.nanoTime() - startNanos);
+    }
+
+    void onBatchGet(long startNanos, int batchSize) {
+        statistics.increaseCacheHits(batchSize);
+        statistics.addGetTimeNanos(System.nanoTime() - startNanos);
+    }
+
+    void onBatchPut(long startNanos, int batchSize) {
+        // we don't know how many of keys are actually loaded, so we assume that all of them are loaded
+        // and calculate statistics based on this assumption
+        statistics.increaseCachePuts(batchSize);
+        statistics.addPutTimeNanos(System.nanoTime() - startNanos);
+    }
+
+    void clear() {
+        statistics.clear();
+    }
+
+    private Object toObject(Object responseData) {
+        return serializationService.toObject(responseData);
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCachePartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCachePartitionIterator.java
@@ -16,11 +16,12 @@
 
 package com.hazelcast.client.cache.impl;
 
+import com.hazelcast.cache.impl.ICacheInternal;
 import com.hazelcast.client.spi.ClientContext;
 
 public class ClientCachePartitionIterator<K, V> extends ClientClusterWideIterator<K, V> {
 
-    public ClientCachePartitionIterator(ClientCacheProxy<K, V> cacheProxy, ClientContext context, int fetchSize,
+    public ClientCachePartitionIterator(ICacheInternal<K, V> cacheProxy, ClientContext context, int fetchSize,
                                         int partitionId, boolean prefetchValues) {
         super(cacheProxy, context, fetchSize, partitionId, prefetchValues);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxyFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxyFactory.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.ClientProxyFactory;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.NearCacheConfig;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -42,6 +43,11 @@ public class ClientCacheProxyFactory implements ClientProxyFactory {
         if (cacheConfig == null) {
             throw new CacheNotExistsException("Cache " + id + " is already destroyed or not created yet");
         }
+        NearCacheConfig nearCacheConfig = client.getClientConfig().getNearCacheConfig(cacheConfig.getName());
+        if (nearCacheConfig != null) {
+            return new NearCachedClientCacheProxy(cacheConfig);
+        }
+
         return new ClientCacheProxy(cacheConfig);
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheStatisticsImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheStatisticsImpl.java
@@ -30,11 +30,6 @@ public class ClientCacheStatisticsImpl extends CacheStatisticsImpl {
         super(creationTime);
     }
 
-    public ClientCacheStatisticsImpl(long creationTime, NearCacheStats nearCacheStats) {
-        super(creationTime);
-        this.nearCacheStats = nearCacheStats;
-    }
-
     @Override
     public long getOwnedEntryCount() {
         throw new UnsupportedOperationException("This statistic is not supported for client.");
@@ -74,5 +69,9 @@ public class ClientCacheStatisticsImpl extends CacheStatisticsImpl {
                 + ", removeTimeTakenNanos=" + removeTimeTakenNanos
                 + (nearCacheStats != null ? ", nearCacheStats=" + nearCacheStats : "")
                 + '}';
+    }
+
+    public void setNearCacheStats(NearCacheStats nearCacheStats) {
+        this.nearCacheStats = nearCacheStats;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.cache.impl;
 
 import com.hazelcast.cache.impl.AbstractClusterWideIterator;
+import com.hazelcast.cache.impl.ICacheInternal;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheIterateCodec;
@@ -43,14 +44,14 @@ import java.util.List;
  */
 public class ClientClusterWideIterator<K, V> extends AbstractClusterWideIterator<K, V> implements Iterator<Cache.Entry<K, V>> {
 
-    private ClientCacheProxy<K, V> cacheProxy;
+    private ICacheInternal<K, V> cacheProxy;
     private ClientContext context;
 
-    public ClientClusterWideIterator(ClientCacheProxy<K, V> cacheProxy, ClientContext context, boolean prefetchValues) {
+    public ClientClusterWideIterator(ICacheInternal<K, V> cacheProxy, ClientContext context, boolean prefetchValues) {
         this(cacheProxy, context, DEFAULT_FETCH_SIZE, prefetchValues);
     }
 
-    public ClientClusterWideIterator(ClientCacheProxy<K, V> cacheProxy, ClientContext context,
+    public ClientClusterWideIterator(ICacheInternal<K, V> cacheProxy, ClientContext context,
                                      int fetchSize, boolean prefetchValues) {
         super(cacheProxy, context.getPartitionService().getPartitionCount(), fetchSize, prefetchValues);
         this.cacheProxy = cacheProxy;
@@ -58,7 +59,7 @@ public class ClientClusterWideIterator<K, V> extends AbstractClusterWideIterator
         advance();
     }
 
-    public ClientClusterWideIterator(ClientCacheProxy<K, V> cacheProxy, ClientContext context, int fetchSize,
+    public ClientClusterWideIterator(ICacheInternal<K, V> cacheProxy, ClientContext context, int fetchSize,
                                      int partitionId, boolean prefetchValues) {
         super(cacheProxy, context.getPartitionService().getPartitionCount(), fetchSize, prefetchValues);
         this.cacheProxy = cacheProxy;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.cache.impl.AbstractHazelcastCacheManager;
 import com.hazelcast.cache.impl.ICacheInternal;
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.client.impl.ClientICacheManager;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.config.CacheConfig;
@@ -39,7 +40,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * {@link javax.cache.CacheManager} implementation for client side.
- *
+ * <p>
  * Provides client side CacheManager functionality.
  */
 public final class HazelcastClientCacheManager extends AbstractHazelcastCacheManager {
@@ -110,11 +111,11 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
     protected <K, V> ICacheInternal<K, V> createCacheProxy(CacheConfig<K, V> cacheConfig) {
         clientCacheProxyFactory.addCacheConfig(cacheConfig.getNameWithPrefix(), cacheConfig);
         try {
-            ClientCacheProxy<K, V> clientCacheProxy =
-                    (ClientCacheProxy<K, V>) client.getCacheManager()
-                            .getCacheByFullName(cacheConfig.getNameWithPrefix());
-            clientCacheProxy.setCacheManager(this);
-            return clientCacheProxy;
+            ClientICacheManager cacheManager = client.getCacheManager();
+            String nameWithPrefix = cacheConfig.getNameWithPrefix();
+            ICacheInternal cache = cacheManager.getCacheByFullName(nameWithPrefix);
+            cache.setCacheManager(this);
+            return cache;
         } catch (Throwable t) {
             clientCacheProxyFactory.removeCacheConfig(cacheConfig.getNameWithPrefix());
             throw ExceptionUtil.rethrow(t);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -1,0 +1,789 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.impl;
+
+import com.hazelcast.cache.CacheStatistics;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.ICacheInternal;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.client.connection.nio.ClientConnection;
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.CacheAddInvalidationListenerCodec;
+import com.hazelcast.client.impl.protocol.codec.CacheAddNearCacheInvalidationListenerCodec;
+import com.hazelcast.client.impl.protocol.codec.CacheRemoveEntryListenerCodec;
+import com.hazelcast.client.spi.ClientClusterService;
+import com.hazelcast.client.spi.ClientContext;
+import com.hazelcast.client.spi.ClientListenerService;
+import com.hazelcast.client.spi.EventHandler;
+import com.hazelcast.client.spi.impl.ClientInvocationFuture;
+import com.hazelcast.client.spi.impl.ListenerMessageCodec;
+import com.hazelcast.client.util.ClientDelegatingFuture;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NativeMemoryConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.internal.adapter.ICacheDataStructureAdapter;
+import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheManager;
+import com.hazelcast.internal.nearcache.impl.invalidation.RepairingHandler;
+import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
+
+import javax.cache.expiry.ExpiryPolicy;
+import javax.cache.integration.CompletionListener;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
+import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE;
+import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE;
+import static com.hazelcast.instance.BuildInfo.UNKNOWN_HAZELCAST_VERSION;
+import static com.hazelcast.instance.BuildInfo.calculateVersion;
+import static com.hazelcast.internal.nearcache.NearCache.CACHED_AS_NULL;
+import static com.hazelcast.internal.nearcache.NearCache.NOT_CACHED;
+import static com.hazelcast.internal.nearcache.NearCacheRecord.NOT_RESERVED;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.util.Preconditions.checkTrue;
+import static java.lang.String.format;
+
+/**
+ * An {@link ICacheInternal} implementation which handles near cache specific behaviour of methods.
+ *
+ * @param <K> the type of key.
+ * @param <V> the type of value.
+ */
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling",
+        "checkstyle:classfanoutcomplexity", "checkstyle:anoninnerlength"})
+public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy {
+
+    // Eventually consistent near cache can only be used with server versions >= 3.8.
+    private final int minConsistentNearCacheSupportingServerVersion = calculateVersion("3.8");
+
+    private boolean cacheOnUpdate;
+    private String nearCacheMembershipRegistrationId;
+    private NearCache<Data, Object> nearCache;
+    private NearCacheManager nearCacheManager;
+
+    public NearCachedClientCacheProxy(CacheConfig cacheConfig) {
+        super(cacheConfig);
+    }
+
+    public NearCache getNearCache() {
+        return nearCache;
+    }
+
+    public ClientContext getClientContext() {
+        return clientContext;
+    }
+
+    @Override
+    protected void onInitialize() {
+        super.onInitialize();
+
+        nearCacheManager = clientContext.getNearCacheManager();
+        ClientConfig clientConfig = clientContext.getClientConfig();
+
+        NearCacheConfig nearCacheConfig = checkNearCacheConfig(clientConfig.getNearCacheConfig(name),
+                clientConfig.getNativeMemoryConfig());
+        cacheOnUpdate = isCacheOnUpdate(nearCacheConfig, nameWithPrefix, logger);
+        ICacheDataStructureAdapter<K, V> adapter = new ICacheDataStructureAdapter<K, V>(this);
+        nearCache = nearCacheManager.getOrCreateNearCache(nameWithPrefix, nearCacheConfig, adapter);
+        CacheStatistics localCacheStatistics = super.getLocalCacheStatistics();
+        ((ClientCacheStatisticsImpl) localCacheStatistics).setNearCacheStats(nearCache.getNearCacheStats());
+
+        registerInvalidationListener();
+    }
+
+    @SuppressWarnings("deprecation")
+    static boolean isCacheOnUpdate(NearCacheConfig nearCacheConfig, String cacheName, ILogger logger) {
+        NearCacheConfig.LocalUpdatePolicy localUpdatePolicy = nearCacheConfig.getLocalUpdatePolicy();
+        if (localUpdatePolicy == CACHE) {
+            logger.warning(format("Deprecated local update policy is found for cache `%s`."
+                            + " The policy `%s` is subject to remove in further releases. Instead you can use `%s`",
+                    cacheName, CACHE, CACHE_ON_UPDATE));
+            return true;
+        }
+
+        return localUpdatePolicy == CACHE_ON_UPDATE;
+    }
+
+    private static NearCacheConfig checkNearCacheConfig(NearCacheConfig nearCacheConfig, NativeMemoryConfig nativeMemoryConfig) {
+        InMemoryFormat inMemoryFormat = nearCacheConfig.getInMemoryFormat();
+        if (inMemoryFormat != NATIVE) {
+            return nearCacheConfig;
+        }
+
+        checkTrue(nativeMemoryConfig.isEnabled(), "Enable native memory config to use NATIVE in-memory-format for Near Cache");
+        return nearCacheConfig;
+    }
+
+    @Override
+    protected Object getSyncInternal(Data keyData, ExpiryPolicy expiryPolicy) {
+        Object value = getCachedValue(keyData, true);
+        if (value != NOT_CACHED) {
+            return value;
+        }
+
+        long reservationId = nearCache.tryReserveForUpdate(keyData);
+        if (reservationId == NOT_RESERVED) {
+            value = super.getSyncInternal(keyData, expiryPolicy);
+        } else {
+            try {
+                value = super.getSyncInternal(keyData, expiryPolicy);
+                value = tryPublishReserved(keyData, value, reservationId);
+            } catch (Throwable throwable) {
+                invalidateNearCache(keyData);
+                throw rethrow(throwable);
+            }
+        }
+        return value;
+    }
+
+    @Override
+    public ClientDelegatingFuture getAsyncInternal(final Data keyData, ExpiryPolicy expiryPolicy, ExecutionCallback callback) {
+        long reservationId;
+        ClientDelegatingFuture future;
+        try {
+            reservationId = nearCache.tryReserveForUpdate(keyData);
+            future = super.getAsyncInternal(keyData, expiryPolicy, callback);
+        } catch (Throwable t) {
+            invalidateNearCache(keyData);
+            throw rethrow(t);
+        }
+
+        future.andThenInternal(new GetAsyncCallback(keyData, reservationId, callback), true);
+        return future;
+    }
+
+    private final class GetAsyncCallback implements ExecutionCallback<Data> {
+        private final Data keyData;
+        private final long reservationId;
+        private final ExecutionCallback callback;
+
+        public GetAsyncCallback(Data keyData, long reservationId, ExecutionCallback callback) {
+            this.keyData = keyData;
+            this.reservationId = reservationId;
+            this.callback = callback;
+        }
+
+        @Override
+        public void onResponse(Data valueData) {
+            try {
+                if (callback != null) {
+                    callback.onResponse(valueData);
+                }
+            } finally {
+                tryPublishReserved(keyData, valueData, reservationId, false);
+            }
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            try {
+                if (callback != null) {
+                    callback.onFailure(t);
+                }
+            } finally {
+                invalidateNearCache(keyData);
+            }
+        }
+    }
+
+    @Override
+    protected void onPutSyncInternal(Data keyData, Data valueData, Object value) {
+        try {
+            super.onPutSyncInternal(keyData, valueData, value);
+        } finally {
+            cacheOrInvalidate(keyData, valueData, value);
+        }
+    }
+
+    @Override
+    protected void onPutIfAbsentSyncInternal(Data keyData, Data valueData, Object value) {
+        try {
+            super.onPutIfAbsentSyncInternal(keyData, valueData, value);
+        } finally {
+            cacheOrInvalidate(keyData, valueData, value);
+        }
+    }
+
+    @Override
+    protected void onPutIfAbsentAsyncInternal(Data keyData, Data valueData, Object value,
+                                              ClientDelegatingFuture delegatingFuture, ExecutionCallback callback) {
+        CacheOrInvalidateCallback wrapped = new CacheOrInvalidateCallback(keyData, valueData, value, callback);
+        super.onPutIfAbsentAsyncInternal(keyData, valueData, value, delegatingFuture, wrapped);
+    }
+
+    @Override
+    protected ClientDelegatingFuture wrapPutAsyncFuture(Data keyData, Data valueData, Object value,
+                                                        ClientInvocationFuture invocationFuture,
+                                                        OneShotExecutionCallback callback) {
+        PutAsyncOneShotCallback nearCachePopulator = new PutAsyncOneShotCallback(keyData, valueData, value, callback);
+        return super.wrapPutAsyncFuture(keyData, valueData, value, invocationFuture, nearCachePopulator);
+    }
+
+    private final class PutAsyncOneShotCallback extends OneShotExecutionCallback<V> {
+        private final Data keyData;
+        private final Data newValueData;
+        private final Object newValue;
+        private final OneShotExecutionCallback statsCallback;
+
+        private PutAsyncOneShotCallback(Data keyData, Data newValueData, Object newValue, OneShotExecutionCallback callback) {
+            this.keyData = keyData;
+            this.newValueData = newValueData;
+            this.newValue = newValue;
+            this.statsCallback = callback;
+        }
+
+        @Override
+        protected void onResponseInternal(V response) {
+            try {
+                if (statsCallback != null) {
+                    statsCallback.onResponseInternal(response);
+                }
+            } finally {
+                cacheOrInvalidate(keyData, newValueData, newValue);
+            }
+        }
+
+        @Override
+        protected void onFailureInternal(Throwable t) {
+            try {
+                if (statsCallback != null) {
+                    statsCallback.onFailureInternal(t);
+                }
+            } finally {
+                invalidateNearCache(keyData);
+            }
+        }
+    }
+
+    @Override
+    protected void onRemoveAsyncInternal(Data keyData, ClientDelegatingFuture future, ExecutionCallback callback) {
+        try {
+            super.onRemoveAsyncInternal(keyData, future, callback);
+        } finally {
+            invalidateNearCache(keyData);
+        }
+    }
+
+    @Override
+    protected void onGetAndRemoveAsyncInternal(ClientDelegatingFuture future, ExecutionCallback callback, Data keyData) {
+        try {
+            super.onGetAndRemoveAsyncInternal(future, callback, keyData);
+        } finally {
+            invalidateNearCache(keyData);
+        }
+    }
+
+    @Override
+    protected void onReplaceInternalAsync(Data keyData, Data valueData, Object value,
+                                          ClientDelegatingFuture delegatingFuture, ExecutionCallback callback) {
+        CacheOrInvalidateCallback wrapped = new CacheOrInvalidateCallback(keyData, valueData, value, callback);
+        super.onReplaceInternalAsync(keyData, valueData, value, delegatingFuture, wrapped);
+    }
+
+    @Override
+    protected void onReplaceAndGetAsync(Data keyData, Data valueData, Object value,
+                                        ClientDelegatingFuture delegatingFuture, ExecutionCallback callback) {
+        CacheOrInvalidateCallback wrapped = new CacheOrInvalidateCallback(keyData, valueData, value, callback);
+        super.onReplaceAndGetAsync(keyData, valueData, value, delegatingFuture, wrapped);
+    }
+
+    private final class CacheOrInvalidateCallback implements ExecutionCallback<V> {
+        private final Data keyData;
+        private final Data valueData;
+        private final Object value;
+        private final ExecutionCallback<V> callback;
+
+        public CacheOrInvalidateCallback(Data keyData, Data valueData, Object value, ExecutionCallback<V> callback) {
+            this.callback = callback;
+            this.keyData = keyData;
+            this.valueData = valueData;
+            this.value = value;
+        }
+
+        @Override
+        public void onResponse(V response) {
+            try {
+                if (callback != null) {
+                    callback.onResponse(response);
+                }
+            } finally {
+                cacheOrInvalidate(keyData, valueData, value);
+            }
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            try {
+                if (callback != null) {
+                    callback.onFailure(t);
+                }
+            } finally {
+                invalidateNearCache(keyData);
+            }
+        }
+    }
+
+    @Override
+    protected Map getAllInternal(Collection dataKeys, ExpiryPolicy expiryPolicy, Map resultMap, long startNanos) {
+        populateResultFromNearCache(dataKeys, resultMap);
+        if (dataKeys.isEmpty()) {
+            return resultMap;
+        }
+
+        Map<Data, Long> reservations = createHashMap(dataKeys.size());
+        for (Object keyData : dataKeys) {
+            long reservationId = tryReserveForUpdate((Data) keyData);
+            if (reservationId != NOT_RESERVED) {
+                reservations.put((Data) keyData, reservationId);
+            }
+        }
+
+        try {
+            Map<K, V> all = (Map<K, V>) super.getAllInternal(dataKeys, expiryPolicy, resultMap, startNanos);
+
+            for (Map.Entry<K, V> entry : all.entrySet()) {
+                K key = entry.getKey();
+                V value = entry.getValue();
+
+                Data keyData = toData(key);
+                Long reservationId = reservations.get(keyData);
+                if (reservationId != null) {
+                    Object cachedValue = tryPublishReserved(keyData, value, reservationId);
+                    resultMap.put(key, toObject(cachedValue));
+                    reservations.remove(keyData);
+                }
+            }
+        } finally {
+            releaseRemainingReservedKeys(reservations);
+        }
+
+        return resultMap;
+    }
+
+    @Override
+    protected void putAllInternal(Map map, ExpiryPolicy expiryPolicy, List[] entriesPerPartition, long startNanos) {
+        try {
+            super.putAllInternal(map, expiryPolicy, entriesPerPartition, startNanos);
+            // cache or invalidate near cache
+            for (int partitionId = 0; partitionId < entriesPerPartition.length; partitionId++) {
+                List<Map.Entry<Data, Data>> entries = entriesPerPartition[partitionId];
+                for (Map.Entry<Data, Data> entry : entries) {
+                    cacheOrInvalidate(entry.getKey(), entry.getValue(), null);
+                }
+            }
+        } catch (Throwable t) {
+            for (int partitionId = 0; partitionId < entriesPerPartition.length; partitionId++) {
+                List<Map.Entry<Data, Data>> entries = entriesPerPartition[partitionId];
+                for (Map.Entry<Data, Data> entry : entries) {
+                    invalidateNearCache(entry.getKey());
+                }
+            }
+
+            throw rethrow(t);
+        }
+    }
+
+    @Override
+    protected boolean containsKeyInternal(Data keyData) {
+        Object cached = getCachedValue(keyData, false);
+        if (cached != NOT_CACHED) {
+            return true;
+        }
+        return super.containsKeyInternal(keyData);
+    }
+
+    @Override
+    protected void loadAllInternal(List dataKeys, boolean replaceExistingValues, CompletionListener completionListener) {
+        try {
+            super.loadAllInternal(dataKeys, replaceExistingValues, completionListener);
+        } finally {
+            for (Object dataKey : dataKeys) {
+                invalidateNearCache((Data) dataKey);
+            }
+        }
+    }
+
+    @Override
+    protected void removeAllKeysInternal(Collection dataKeys, long startNanos) {
+        try {
+            super.removeAllKeysInternal(dataKeys, startNanos);
+        } finally {
+            for (Object dataKey : dataKeys) {
+                invalidateNearCache((Data) dataKey);
+            }
+        }
+    }
+
+    @Override
+    public void onRemoveSyncInternal(Data keyData) {
+        try {
+            super.onRemoveSyncInternal(keyData);
+        } finally {
+            invalidateNearCache(keyData);
+        }
+    }
+
+    @Override
+    public void removeAll() {
+        try {
+            super.removeAll();
+        } finally {
+            nearCache.clear();
+        }
+    }
+
+    @Override
+    public void clear() {
+        try {
+            super.clear();
+        } finally {
+            nearCache.clear();
+        }
+    }
+
+    @Override
+    protected Object invokeInternal(Data keyData, Data epData, Object[] arguments) {
+        try {
+            return super.invokeInternal(keyData, epData, arguments);
+        } finally {
+            invalidateNearCache(keyData);
+        }
+    }
+
+    @Override
+    public void close() {
+        removeInvalidationListener();
+        nearCacheManager.clearNearCache(nearCache.getName());
+
+        super.close();
+    }
+
+    @Override
+    protected void onDestroy() {
+        removeInvalidationListener();
+        nearCacheManager.destroyNearCache(nearCache.getName());
+
+        super.onDestroy();
+    }
+
+    private void populateResultFromNearCache(Collection<Data> keys, Map<K, V> result) {
+        Iterator<Data> iterator = keys.iterator();
+        while (iterator.hasNext()) {
+            Data key = iterator.next();
+            Object cached = getCachedValue(key, true);
+            if (cached != NOT_CACHED) {
+                result.put((K) toObject(key), (V) cached);
+                iterator.remove();
+            }
+        }
+    }
+
+    private Object getCachedValue(Data keyData, boolean deserializeValue) {
+        Object cached = nearCache.get(keyData);
+        // caching null values is not supported for icache near cache
+        assert cached != CACHED_AS_NULL;
+
+        if (cached == null) {
+            return NOT_CACHED;
+        }
+        return deserializeValue ? toObject(cached) : cached;
+    }
+
+    private void cacheOrInvalidate(Data keyData, Data valueData, Object value) {
+        if (cacheOnUpdate) {
+            Object valueToStore = nearCache.selectToSave(valueData, value);
+            nearCache.put(keyData, valueToStore);
+        } else {
+            invalidateNearCache(keyData);
+        }
+    }
+
+    private void invalidateNearCache(Data key) {
+        assert key != null;
+
+        nearCache.remove(key);
+    }
+
+    private long tryReserveForUpdate(Data keyData) {
+        return nearCache.tryReserveForUpdate(keyData);
+    }
+
+    /**
+     * Publishes value got from remote or deletes reserved record when remote value is null
+     *
+     * @param key           key to update in near cache
+     * @param remoteValue   fetched value from server
+     * @param reservationId reservation id for this key
+     * @param deserialize   deserialize returned value
+     * @return last known value for the key
+     */
+    private Object tryPublishReserved(Data key, Object remoteValue, long reservationId, boolean deserialize) {
+        assert remoteValue != NOT_CACHED;
+
+        // caching null value is not supported for icache near cache
+        if (remoteValue == null) {
+            // needed to delete reserved record
+            invalidateNearCache(key);
+            return null;
+        }
+
+        Object cachedValue = nearCache.tryPublishReserved(key, remoteValue, reservationId, deserialize);
+        return cachedValue != null ? cachedValue : remoteValue;
+    }
+
+    private Object tryPublishReserved(Data key, Object remoteValue, long reservationId) {
+        return tryPublishReserved(key, remoteValue, reservationId, true);
+    }
+
+    private void releaseRemainingReservedKeys(Map<Data, Long> reservedKeys) {
+        for (Data key : reservedKeys.keySet()) {
+            nearCache.remove(key);
+        }
+    }
+
+    /**
+     * Needed to deal with client compatibility issues.
+     * Eventual consistency for near cache can be used with server versions >= 3.8.
+     * Other connected server versions must use {@link Pre38NearCacheEventHandler}
+     */
+    private final class ConnectedServerVersionAwareNearCacheEventHandler implements EventHandler<ClientMessage> {
+
+        private final RepairableNearCacheEventHandler repairingEventHandler = new RepairableNearCacheEventHandler();
+        private final Pre38NearCacheEventHandler pre38EventHandler = new Pre38NearCacheEventHandler();
+        private volatile boolean supportsRepairableNearCache;
+
+        @Override
+        public void beforeListenerRegister() {
+            pre38EventHandler.beforeListenerRegister();
+            repairingEventHandler.beforeListenerRegister();
+        }
+
+        @Override
+        public void onListenerRegister() {
+            supportsRepairableNearCache = supportsRepairableNearCache();
+
+            if (supportsRepairableNearCache) {
+                repairingEventHandler.onListenerRegister();
+            } else {
+                pre38EventHandler.onListenerRegister();
+            }
+        }
+
+        @Override
+        public void handle(ClientMessage clientMessage) {
+            if (supportsRepairableNearCache) {
+                repairingEventHandler.handle(clientMessage);
+            } else {
+                pre38EventHandler.handle(clientMessage);
+            }
+        }
+    }
+
+    /**
+     * This event handler can only be used with server versions >= 3.8 and supports near cache eventual consistency improvements.
+     * For repairing functionality please see {@link RepairingHandler}
+     */
+    private final class RepairableNearCacheEventHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler
+            implements EventHandler<ClientMessage> {
+
+        private volatile RepairingHandler repairingHandler;
+
+        @Override
+        public void beforeListenerRegister() {
+            nearCache.clear();
+            getRepairingTask().deregisterHandler(nameWithPrefix);
+        }
+
+        @Override
+        public void onListenerRegister() {
+            nearCache.clear();
+            repairingHandler = getRepairingTask().registerAndGetHandler(nameWithPrefix, nearCache);
+        }
+
+        @Override
+        public void handle(String name, Data key, String sourceUuid, UUID partitionUuid, long sequence) {
+            repairingHandler.handle(key, sourceUuid, partitionUuid, sequence);
+        }
+
+        @Override
+        public void handle(String name, Collection<Data> keys, Collection<String> sourceUuids,
+                           Collection<UUID> partitionUuids, Collection<Long> sequences) {
+            repairingHandler.handle(keys, sourceUuids, partitionUuids, sequences);
+        }
+
+        private RepairingTask getRepairingTask() {
+            return clientContext.getRepairingTask(CacheService.SERVICE_NAME);
+        }
+    }
+
+    /**
+     * This event handler is here to be used with server versions < 3.8.
+     * <p>
+     * If server version is < 3.8 and client version is >= 3.8, this event handler must be used to
+     * listen near cache invalidations. Because new improvements for near cache eventual consistency cannot work
+     * with server versions < 3.8.
+     */
+    private final class Pre38NearCacheEventHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler
+            implements EventHandler<ClientMessage> {
+
+        private String clientUuid;
+
+        private Pre38NearCacheEventHandler() {
+            this.clientUuid = clientContext.getClusterService().getLocalClient().getUuid();
+        }
+
+        @Override
+        public void handle(String name, Data key, String sourceUuid, UUID partitionUuid, long sequence) {
+            if (clientUuid.equals(sourceUuid)) {
+                return;
+            }
+            if (key != null) {
+                nearCache.remove(key);
+            } else {
+                nearCache.clear();
+            }
+        }
+
+        @Override
+        public void handle(String name, Collection<Data> keys, Collection<String> sourceUuids,
+                           Collection<UUID> partitionUuids, Collection<Long> sequences) {
+            if (sourceUuids != null && !sourceUuids.isEmpty()) {
+                Iterator<Data> keysIt = keys.iterator();
+                Iterator<String> sourceUuidsIt = sourceUuids.iterator();
+                while (keysIt.hasNext() && sourceUuidsIt.hasNext()) {
+                    Data key = keysIt.next();
+                    String sourceUuid = sourceUuidsIt.next();
+                    if (!clientUuid.equals(sourceUuid)) {
+                        nearCache.remove(key);
+                    }
+                }
+            } else {
+                for (Data key : keys) {
+                    nearCache.remove(key);
+                }
+            }
+        }
+
+        @Override
+        public void beforeListenerRegister() {
+        }
+
+        @Override
+        public void onListenerRegister() {
+            nearCache.clear();
+        }
+    }
+
+
+    private void registerInvalidationListener() {
+        if (!nearCache.isInvalidatedOnChange()) {
+            return;
+        }
+
+        ListenerMessageCodec listenerCodec = createInvalidationListenerCodec();
+        ClientListenerService listenerService = clientContext.getListenerService();
+
+        EventHandler eventHandler = createInvalidationEventHandler();
+        nearCacheMembershipRegistrationId = listenerService.registerListener(listenerCodec, eventHandler);
+    }
+
+    private EventHandler createInvalidationEventHandler() {
+        return new ConnectedServerVersionAwareNearCacheEventHandler();
+    }
+
+    private ListenerMessageCodec createInvalidationListenerCodec() {
+        return new ListenerMessageCodec() {
+            @Override
+            public ClientMessage encodeAddRequest(boolean localOnly) {
+                if (supportsRepairableNearCache()) {
+                    // this is for servers >= 3.8
+                    return CacheAddNearCacheInvalidationListenerCodec.encodeRequest(nameWithPrefix, localOnly);
+                }
+                // this is for servers < 3.8
+                return CacheAddInvalidationListenerCodec.encodeRequest(nameWithPrefix, localOnly);
+            }
+
+            @Override
+            public String decodeAddResponse(ClientMessage clientMessage) {
+                if (supportsRepairableNearCache()) {
+                    // this is for servers >= 3.8
+                    return CacheAddNearCacheInvalidationListenerCodec.decodeResponse(clientMessage).response;
+                }
+                // this is for servers < 3.8
+                return CacheAddInvalidationListenerCodec.decodeResponse(clientMessage).response;
+            }
+
+            @Override
+            public ClientMessage encodeRemoveRequest(String realRegistrationId) {
+                return CacheRemoveEntryListenerCodec.encodeRequest(nameWithPrefix, realRegistrationId);
+            }
+
+            @Override
+            public boolean decodeRemoveResponse(ClientMessage clientMessage) {
+                return CacheRemoveEntryListenerCodec.decodeResponse(clientMessage).response;
+            }
+        };
+    }
+
+    private int getConnectedServerVersion() {
+        ClientClusterService clusterService = clientContext.getClusterService();
+        Address ownerConnectionAddress = clusterService.getOwnerConnectionAddress();
+
+        HazelcastClientInstanceImpl client = getClient();
+        ClientConnectionManager connectionManager = client.getConnectionManager();
+        Connection connection = connectionManager.getConnection(ownerConnectionAddress);
+        if (connection == null) {
+            logger.warning(format("No owner connection is available, "
+                    + "near cached cache %s will be started in legacy mode", name));
+            return UNKNOWN_HAZELCAST_VERSION;
+        }
+
+        return ((ClientConnection) connection).getConnectedServerVersion();
+    }
+
+    private boolean supportsRepairableNearCache() {
+        return getConnectedServerVersion() >= minConsistentNearCacheSupportingServerVersion;
+    }
+
+    private void removeInvalidationListener() {
+        if (nearCache != null && nearCache.isInvalidatedOnChange()) {
+            String registrationId = nearCacheMembershipRegistrationId;
+            if (registrationId != null) {
+                clientContext.getRepairingTask(SERVICE_NAME).deregisterHandler(name);
+                clientContext.getListenerService().deregisterListener(registrationId);
+            }
+        }
+    }
+
+    long nowInNanosOrDefault() {
+        return statisticsEnabled ? System.nanoTime() : -1;
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientICacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientICacheManager.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.impl;
 
 import com.hazelcast.cache.HazelcastCacheManager;
-import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.ICacheInternal;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.spi.impl.ClientServiceNotFoundException;
 import com.hazelcast.core.HazelcastException;
@@ -42,12 +42,12 @@ public class ClientICacheManager implements ICacheManager {
     }
 
     @Override
-    public <K, V> ICache<K, V> getCache(String name) {
+    public <K, V> ICacheInternal<K, V> getCache(String name) {
         checkNotNull(name, "Retrieving a cache instance with a null name is not allowed!");
         return getCacheByFullName(HazelcastCacheManager.CACHE_MANAGER_PREFIX + name);
     }
 
-    public <K, V> ICache<K, V> getCacheByFullName(String fullName) {
+    public <K, V> ICacheInternal<K, V> getCacheByFullName(String fullName) {
         checkNotNull(fullName, "Retrieving a cache instance with a null name is not allowed!");
         try {
             return instance.getDistributedObject(ICacheService.SERVICE_NAME, fullName);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/AbstractClientCachePartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/AbstractClientCachePartitionIteratorTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.client.cache;
 
-import com.hazelcast.client.cache.impl.ClientCacheProxy;
+import com.hazelcast.cache.impl.ICacheInternal;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.EvictionConfig;
@@ -57,14 +57,14 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
 
     @Test
     public void test_HasNext_Returns_False_On_EmptyPartition() throws Exception {
-        ClientCacheProxy<Integer, Integer> cache = getCacheProxy();
+        ICacheInternal<Integer, Integer> cache = getCacheProxy();
         Iterator<Cache.Entry<Integer, Integer>> iterator = cache.iterator(10, 1, prefetchValues);
         assertFalse(iterator.hasNext());
     }
 
     @Test
     public void test_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
-        ClientCacheProxy<String, String> cache = getCacheProxy();
+        ICacheInternal<String, String> cache = getCacheProxy();
 
         String key = generateKeyForPartition(server, 1);
         String value = randomString();
@@ -76,7 +76,7 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
 
     @Test
     public void test_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
-        ClientCacheProxy<String, String> cache = getCacheProxy();
+        ICacheInternal<String, String> cache = getCacheProxy();
 
         String key = generateKeyForPartition(server, 1);
         String value = randomString();
@@ -89,7 +89,7 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
 
     @Test
     public void test_Next_Returns_Value_On_NonEmptyPartition_and_HasNext_Returns_False_when_Item_Consumed() throws Exception {
-        ClientCacheProxy<String, String> cache = getCacheProxy();
+        ICacheInternal<String, String> cache = getCacheProxy();
 
         String key = generateKeyForPartition(server, 1);
         String value = randomString();
@@ -104,7 +104,7 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
 
     @Test
     public void test_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
-        ClientCacheProxy<String, String> cache = getCacheProxy();
+        ICacheInternal<String, String> cache = getCacheProxy();
         String value = randomString();
         int count = 1000;
         for (int i = 0; i < count; i++) {
@@ -118,11 +118,11 @@ public abstract class AbstractClientCachePartitionIteratorTest extends Hazelcast
         }
     }
 
-    private <K, V> ClientCacheProxy<K, V> getCacheProxy() {
+    private <K, V> ICacheInternal<K, V> getCacheProxy() {
         String cacheName = randomString();
         CacheManager cacheManager = cachingProvider.getCacheManager();
         CacheConfig<K, V> config = new CacheConfig<K, V>();
         config.getEvictionConfig().setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT).setSize(10000000);
-        return (ClientCacheProxy<K, V>) cacheManager.createCache(cacheName, config);
+        return (ICacheInternal<K, V>) cacheManager.createCache(cacheName, config);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheProxyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheProxyTest.java
@@ -43,7 +43,7 @@ public class ClientCacheProxyTest extends HazelcastTestSupport {
     public void isCacheOnUpdate_prints_warning_message_for_deprecated_policy_CACHE() throws Exception {
         NearCacheConfig nearCacheConfig = new NearCacheConfig().setLocalUpdatePolicy(CACHE);
         TestLogger logger = new TestLogger();
-        new ClientCacheProxy(new CacheConfig()).isCacheOnUpdate(nearCacheConfig, "cacheName", logger);
+        new NearCachedClientCacheProxy(new CacheConfig()).isCacheOnUpdate(nearCacheConfig, "cacheName", logger);
 
         assertNotNull(logger.message);
     }
@@ -52,7 +52,7 @@ public class ClientCacheProxyTest extends HazelcastTestSupport {
     public void isCacheOnUpdate_not_prints_warning_message_for_policy_CACHE_ON_UPDATE() throws Exception {
         NearCacheConfig nearCacheConfig = new NearCacheConfig().setLocalUpdatePolicy(CACHE_ON_UPDATE);
         TestLogger logger = new TestLogger();
-        new ClientCacheProxy(new CacheConfig()).isCacheOnUpdate(nearCacheConfig, "cacheName", logger);
+        new NearCachedClientCacheProxy(new CacheConfig()).isCacheOnUpdate(nearCacheConfig, "cacheName", logger);
 
         assertNull(logger.message);
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheStaleReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheNearCacheStaleReadTest.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.client.cache.impl.nearcache;
 
-import com.hazelcast.client.cache.impl.ClientCacheProxy;
 import com.hazelcast.client.cache.impl.HazelcastClientCacheManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.cache.impl.NearCachedClientCacheProxy;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
@@ -181,7 +181,7 @@ public class ClientCacheNearCacheStaleReadTest extends HazelcastTestSupport {
      * Warning: this uses Hazelcast internals which might change from one version to the other.
      */
     private void flushClientNearCache(Cache cache) {
-        ((ClientCacheProxy) cache).getNearCache().clear();
+        ((NearCachedClientCacheProxy) cache).getNearCache().clear();
     }
 
     private void runTestInternal() throws Exception {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheRecordStateStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientCacheRecordStateStressTest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.client.cache.impl.nearcache;
 
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
-import com.hazelcast.client.cache.impl.ClientCacheProxy;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.cache.impl.NearCachedClientCacheProxy;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
@@ -191,7 +191,7 @@ public class ClientCacheRecordStateStressTest extends HazelcastTestSupport {
     }
 
     private void assertFinalRecordStateIsReadPermitted(Cache clientCache, HazelcastInstance member) {
-        ClientCacheProxy proxy = ((ClientCacheProxy) clientCache);
+        NearCachedClientCacheProxy proxy = ((NearCachedClientCacheProxy) clientCache);
         NearCache nearCache = proxy.getNearCache();
 
         DefaultNearCache unwrap = (DefaultNearCache) nearCache.unwrap(DefaultNearCache.class);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcherTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcherTest.java
@@ -17,8 +17,8 @@ package com.hazelcast.client.cache.impl.nearcache.invalidation;
 
 import com.hazelcast.cache.impl.CacheEventHandler;
 import com.hazelcast.cache.impl.CacheService;
-import com.hazelcast.client.cache.impl.ClientCacheProxy;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.cache.impl.NearCachedClientCacheProxy;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.spi.ClientContext;
@@ -96,7 +96,7 @@ public class ClientCacheMetaDataFetcherTest extends HazelcastTestSupport {
         CachingProvider clientCachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
         Cache<Integer, Integer> clientCache = clientCachingProvider.getCacheManager().createCache(cacheName, newCacheConfig());
 
-        ClientContext clientContext = ((ClientCacheProxy) clientCache).getClientContext();
+        ClientContext clientContext = ((NearCachedClientCacheProxy<Integer, Integer>) clientCache).getClientContext();
         return clientContext.getRepairingTask(SERVICE_NAME);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMemberAddRemoveTest.java
@@ -20,8 +20,8 @@ import com.hazelcast.cache.impl.CacheEventHandler;
 import com.hazelcast.cache.impl.CacheProxy;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
-import com.hazelcast.client.cache.impl.ClientCacheProxy;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.cache.impl.NearCachedClientCacheProxy;
 import com.hazelcast.client.cache.impl.nearcache.ClientNearCacheTestSupport;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
@@ -182,6 +182,10 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
                 for (int i = 0; i < KEY_COUNT; i++) {
                     Integer valueSeenFromMember = memberCache.get(i);
                     Integer valueSeenFromClient = clientCache.get(i);
+                    if(valueSeenFromMember !=null && valueSeenFromClient == null) {
+                        System.err.println("found");
+                        valueSeenFromClient = clientCache.get(i);
+                    }
 
                     String msg = createFailureMessage(i);
                     assertEquals(msg, valueSeenFromMember, valueSeenFromClient);
@@ -212,7 +216,7 @@ public class InvalidationMemberAddRemoveTest extends ClientNearCacheTestSupport 
             }
 
             private AbstractNearCacheRecordStore getAbstractNearCacheRecordStore() {
-                DefaultNearCache defaultNearCache = (DefaultNearCache) ((ClientCacheProxy) clientCache).getNearCache().unwrap(DefaultNearCache.class);
+                DefaultNearCache defaultNearCache = (DefaultNearCache) ((NearCachedClientCacheProxy) clientCache).getNearCache().unwrap(DefaultNearCache.class);
                 return (AbstractNearCacheRecordStore) defaultNearCache.getNearCacheRecordStore();
             }
         });

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractClusterWideIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractClusterWideIterator.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.cache.impl;
 
-import com.hazelcast.cache.ICache;
 import com.hazelcast.nio.serialization.Data;
 
 import javax.cache.Cache;
@@ -74,12 +73,11 @@ import java.util.NoSuchElementException;
  * @see com.hazelcast.cache.impl.ClusterWideIterator
  * @see CacheKeyIterationResult
  */
-public abstract class AbstractClusterWideIterator<K, V>
-        implements Iterator<Cache.Entry<K, V>> {
+public abstract class AbstractClusterWideIterator<K, V> implements Iterator<Cache.Entry<K, V>> {
 
     protected static final int DEFAULT_FETCH_SIZE = 100;
 
-    protected ICache<K, V> cache;
+    protected ICacheInternal<K, V> cache;
 
     protected List result;
     protected final int partitionCount;
@@ -100,7 +98,7 @@ public abstract class AbstractClusterWideIterator<K, V>
     protected int index;
     protected int currentIndex = -1;
 
-    public AbstractClusterWideIterator(ICache<K, V> cache, int partitionCount, int fetchSize, boolean prefetchValues) {
+    public AbstractClusterWideIterator(ICacheInternal<K, V> cache, int partitionCount, int fetchSize, boolean prefetchValues) {
         this.cache = cache;
         this.partitionCount = partitionCount;
         this.fetchSize = fetchSize;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -17,6 +17,7 @@
 package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.CacheStatistics;
+import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.impl.event.CachePartitionLostEventFilter;
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
 import com.hazelcast.cache.impl.event.InternalCachePartitionLostListenerAdapter;
@@ -106,8 +107,11 @@ abstract class AbstractInternalCacheProxy<K, V>
         return cacheManager;
     }
 
-    void setCacheManager(HazelcastServerCacheManager cacheManager) {
-        this.cacheManager = cacheManager;
+    @Override
+    public void setCacheManager(HazelcastCacheManager cacheManager) {
+        assert cacheManager instanceof HazelcastServerCacheManager;
+
+        this.cacheManager = (HazelcastServerCacheManager) cacheManager;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -335,6 +335,7 @@ public class CacheProxy<K, V>
         return new ClusterWideIterator<K, V>(this, fetchSize, false);
     }
 
+    @Override
     public Iterator<Entry<K, V>> iterator(int fetchSize, int partitionId, boolean prefetchValues) {
         ensureOpen();
         return new CachePartitionIterator<K, V>(this, fetchSize, partitionId, prefetchValues);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
@@ -36,7 +36,7 @@ public final class CacheProxyUtil {
 
     public static final int AWAIT_COMPLETION_TIMEOUT_SECONDS = 60;
 
-    private static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
+    public static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
     private static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
 
     private CacheProxyUtil() {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheInternal.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheInternal.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.cache.impl;
 
+import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.ICache;
 
 import javax.cache.configuration.CacheEntryListenerConfiguration;
+import java.util.Iterator;
 
 /**
  * Internal API for {@link com.hazelcast.cache.ICache} implementations.
@@ -28,8 +30,7 @@ import javax.cache.configuration.CacheEntryListenerConfiguration;
  * @see com.hazelcast.cache.ICache
  * @since 3.5
  */
-public interface ICacheInternal<K, V>
-        extends ICache<K, V> {
+public interface ICacheInternal<K, V> extends ICache<K, V> {
 
     /**
      * Opens cache if available (not destroyed).
@@ -41,9 +42,27 @@ public interface ICacheInternal<K, V>
 
     /**
      * Registers the provided listener configuration.
+     *
      * @param cacheEntryListenerConfiguration The cache configuration to be used for registering the entry listener
-     * @param addToConfig If true, the configuration is added to the existing listeners in the cache config.
+     * @param addToConfig                     If true, the configuration is added to the existing listeners in the cache config.
      */
     void registerCacheEntryListener(CacheEntryListenerConfiguration<K, V> cacheEntryListenerConfiguration, boolean addToConfig)
             throws IllegalArgumentException;
+
+    /**
+     * Cluster-wide iterator for {@link ICache}
+     *
+     * @param fetchSize      batch fetching size
+     * @param partitionId    partition id of the entries to iterate on
+     * @param prefetchValues prefetch values
+     * @return iterator for the entries of the partition
+     */
+    Iterator<Entry<K, V>> iterator(int fetchSize, int partitionId, boolean prefetchValues);
+
+    /**
+     * Sets relevant {@link HazelcastCacheManager} to client/server.
+     *
+     * @param cacheManager client or server {@link HazelcastCacheManager}
+     */
+    void setCacheManager(HazelcastCacheManager cacheManager);
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/CollectionUtil.java
@@ -57,7 +57,7 @@ public final class CollectionUtil {
 
     /**
      * Adds a value to a list of values in the map.
-     *
+     * <p>
      * Creates a new list if no list is found for the key.
      *
      * @param map   the given map of lists
@@ -109,12 +109,26 @@ public final class CollectionUtil {
      */
     public static <C> Collection<Data> objectToDataCollection(Collection<C> collection,
                                                               SerializationService serializationService) {
-        List<Data> dataKeys = new ArrayList<Data>(collection.size());
-        for (C item : collection) {
-            checkNotNull(item);
-            dataKeys.add(serializationService.toData(item));
+        List<Data> dataCollection = new ArrayList<Data>(collection.size());
+        objectToDataCollection(collection, dataCollection, serializationService, null);
+        return dataCollection;
+    }
+
+    /**
+     * Converts a collection of any type to a collection of {@link Data}.
+     *
+     * @param objectCollection     object items
+     * @param dataCollection       data items
+     * @param serializationService will be used for converting object to {@link Data}
+     * @param errorMessage         the errorMessage when an item is null
+     * @throws NullPointerException if collection is {@code null} or contains a {@code null} item
+     */
+    public static <C> void objectToDataCollection(Collection<C> objectCollection, Collection<Data> dataCollection,
+                                                  SerializationService serializationService, String errorMessage) {
+        for (C item : objectCollection) {
+            checkNotNull(item, errorMessage);
+            dataCollection.add(serializationService.toData(item));
         }
-        return dataKeys;
     }
 
     /**
@@ -151,7 +165,7 @@ public final class CollectionUtil {
 
     /**
      * Converts an int array to an Integer {@link List}.
-     *
+     * <p>
      * The returned collection can be modified after it is created; it isn't protected by an immutable wrapper.
      *
      * @param array the array


### PR DESCRIPTION
Introduced `NearCachedClientCacheProxy` as an extension of `ClientCacheProxy`. All near cache related logic is moved to this new proxy class. 