### PR TITLE
Fixed naming schema of unified Near Cache tests to *NearCacheBasicTest

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
@@ -14,7 +14,7 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.adapter.ICacheDataStructureAdapter;
-import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
@@ -33,13 +33,13 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import javax.cache.spi.CachingProvider;
-import java.util.Arrays;
 import java.util.Collection;
 
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static java.util.Arrays.asList;
 
 /**
  * Basic Near Cache tests for {@link ICache} on Hazelcast clients.
@@ -47,7 +47,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCach
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class BasicClientCacheNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+public class ClientCacheNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, String> {
 
     @Parameter
     public InMemoryFormat inMemoryFormat;
@@ -59,7 +59,7 @@ public class BasicClientCacheNearCacheTest extends AbstractBasicNearCacheTest<Da
 
     @Parameters(name = "format:{0} {1}")
     public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[][]{
+        return asList(new Object[][]{
                 {InMemoryFormat.BINARY, LocalUpdatePolicy.INVALIDATE},
                 {InMemoryFormat.BINARY, LocalUpdatePolicy.CACHE_ON_UPDATE},
                 {InMemoryFormat.OBJECT, LocalUpdatePolicy.INVALIDATE},

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
@@ -1,18 +1,18 @@
-package com.hazelcast.map.impl.nearcache;
+package com.hazelcast.client.map.impl.nearcache;
 
-import com.hazelcast.config.Config;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
-import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -23,28 +23,27 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
-import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static java.util.Arrays.asList;
 
 /**
- * Basic Near Cache tests for {@link IMap} on Hazelcast Lite members.
+ * Basic Near Cache tests for {@link IMap} on Hazelcast clients.
  */
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class BasicLiteMemberMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+public class ClientMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, String> {
 
     @Parameter
     public InMemoryFormat inMemoryFormat;
 
-    private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory(2);
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
     @Parameters(name = "format:{0}")
     public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[][]{
+        return asList(new Object[][]{
                 {InMemoryFormat.BINARY},
                 {InMemoryFormat.OBJECT},
         });
@@ -62,32 +61,30 @@ public class BasicLiteMemberMapNearCacheTest extends AbstractBasicNearCacheTest<
 
     @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
-        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(createConfig(nearCacheConfig, false));
-        HazelcastInstance liteMember = hazelcastFactory.newHazelcastInstance(createConfig(nearCacheConfig, true));
+        ClientConfig clientConfig = getClientConfig()
+                .addNearCacheConfig(nearCacheConfig);
+
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(getConfig());
+        HazelcastClientProxy client = (HazelcastClientProxy) hazelcastFactory.newHazelcastClient(clientConfig);
 
         IMap<K, V> memberMap = member.getMap(DEFAULT_NEAR_CACHE_NAME);
-        IMap<K, V> liteMemberMap = liteMember.getMap(DEFAULT_NEAR_CACHE_NAME);
+        IMap<K, V> clientMap = client.getMap(DEFAULT_NEAR_CACHE_NAME);
 
-        NearCacheManager nearCacheManager = getMapNearCacheManager(liteMember);
+        NearCacheManager nearCacheManager = client.client.getNearCacheManager();
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
 
         return new NearCacheTestContext<K, V, Data, String>(
-                getSerializationService(member),
-                liteMember,
+                client.getSerializationService(),
+                client,
                 member,
-                new IMapDataStructureAdapter<K, V>(liteMemberMap),
+                new IMapDataStructureAdapter<K, V>(clientMap),
                 new IMapDataStructureAdapter<K, V>(memberMap),
-                true,
+                false,
                 nearCache,
                 nearCacheManager);
     }
 
-    protected Config createConfig(NearCacheConfig nearCacheConfig, boolean liteMember) {
-        Config config = getConfig()
-                .setLiteMember(liteMember);
-
-        config.getMapConfig(DEFAULT_NEAR_CACHE_NAME).setNearCacheConfig(nearCacheConfig);
-
-        return config;
+    protected ClientConfig getClientConfig() {
+        return new ClientConfig();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -8,7 +8,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.internal.adapter.ReplicatedMapDataStructureAdapter;
-import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
@@ -25,15 +25,15 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category(QuickTest.class)
-public class BasicClientReplicatedMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, String> {
 
     @Parameter
     public InMemoryFormat inMemoryFormat;
@@ -42,7 +42,7 @@ public class BasicClientReplicatedMapNearCacheTest extends AbstractBasicNearCach
 
     @Parameters(name = "format:{0}")
     public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[][]{
+        return asList(new Object[][]{
                 {InMemoryFormat.BINARY},
                 {InMemoryFormat.OBJECT},
         });

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
  * @param <NK> key type of the tested Near Cache
  * @param <NV> value type of the tested Near Cache
  */
-public abstract class AbstractBasicNearCacheTest<NK, NV> extends HazelcastTestSupport {
+public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSupport {
 
     /**
      * The default count to be inserted into the Near Caches.

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -35,7 +35,7 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
      */
     public static NearCacheConfig createNearCacheConfig(InMemoryFormat inMemoryFormat) {
         NearCacheConfig nearCacheConfig = new NearCacheConfig()
-                .setName(AbstractBasicNearCacheTest.DEFAULT_NEAR_CACHE_NAME + "*")
+                .setName(AbstractNearCacheBasicTest.DEFAULT_NEAR_CACHE_NAME + "*")
                 .setInMemoryFormat(inMemoryFormat)
                 .setInvalidateOnChange(false);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
@@ -5,7 +5,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.adapter.IMapDataStructureAdapter;
-import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
@@ -22,11 +22,11 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static java.util.Arrays.asList;
 
 /**
  * Basic Near Cache tests for {@link IMap} on Hazelcast members.
@@ -34,7 +34,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCach
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({ParallelTest.class, QuickTest.class})
-public class BasicMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+public class MapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, String> {
 
     @Parameter
     public InMemoryFormat inMemoryFormat;
@@ -43,7 +43,7 @@ public class BasicMapNearCacheTest extends AbstractBasicNearCacheTest<Data, Stri
 
     @Parameters(name = "format:{0}")
     public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[][]{
+        return asList(new Object[][]{
                 {InMemoryFormat.BINARY},
                 {InMemoryFormat.OBJECT},
         });

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -5,7 +5,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.adapter.TransactionalMapDataStructureAdapter;
-import com.hazelcast.internal.nearcache.AbstractBasicNearCacheTest;
+import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
@@ -24,12 +24,12 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
 import java.util.Collection;
 
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheStats;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static java.util.Arrays.asList;
 
 /**
  * Basic Near Cache tests for {@link com.hazelcast.core.TransactionalMap} on Hazelcast members.
@@ -37,7 +37,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCach
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class BasicTxnMapNearCacheTest extends AbstractBasicNearCacheTest<Data, String> {
+public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, String> {
 
     @Parameter
     public InMemoryFormat inMemoryFormat;
@@ -46,7 +46,7 @@ public class BasicTxnMapNearCacheTest extends AbstractBasicNearCacheTest<Data, S
 
     @Parameters(name = "format:{0}")
     public static Collection<Object[]> parameters() {
-        return Arrays.asList(new Object[][]{
+        return asList(new Object[][]{
                 {InMemoryFormat.BINARY},
                 {InMemoryFormat.OBJECT},
         });


### PR DESCRIPTION
This aligned the naming schema with the other unified Near Cache tests like `AbstractNearCachePreloaderTest` and soon more (serialization count tests).