### PR TITLE
[BACKPORT] Backport remove deprecated unsafe helper usage

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
@@ -36,12 +36,12 @@ public final class UnsafeUtil {
     /**
      * If this constant is {@code true}, then {@link #UNSAFE} refers to a usable {@link sun.misc.Unsafe} instance.
      */
-    static final boolean UNSAFE_AVAILABLE;
+    public static final boolean UNSAFE_AVAILABLE;
 
     /**
      * The {@link sun.misc.Unsafe} instance which is available and ready to use.
      */
-    static final Unsafe UNSAFE;
+    public static final Unsafe UNSAFE;
 
     private static final ILogger LOGGER = Logger.getLogger(UnsafeUtil.class);
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/UnsafeHelper.java
@@ -146,8 +146,8 @@ public final class UnsafeHelper {
                 unsafe.putLong(buffer, normalize(arrayBaseOffset, Bits.LONG_SIZE_IN_BYTES), 4L);
                 unsafe.putDouble(buffer, normalize(arrayBaseOffset, Bits.DOUBLE_SIZE_IN_BYTES), 5d);
                 unsafe.copyMemory(new byte[buffer.length], arrayBaseOffset,
-                                  buffer, arrayBaseOffset,
-                                  buffer.length);
+                        buffer, arrayBaseOffset,
+                        buffer.length);
 
                 unsafeAvailable = true;
             }

--- a/hazelcast/src/test/java/com/hazelcast/util/JVMUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/JVMUtilTest.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+/**
+ * Invokes all {@link JVMUtil} method to ensure no exception is thrown.
+ */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class JVMUtilTest extends HazelcastTestSupport {
@@ -33,7 +36,11 @@ public class JVMUtilTest extends HazelcastTestSupport {
         assertUtilityConstructor(JVMUtil.class);
     }
 
-    // just invoke each JVMUtil static method to ensure no exception is thrown
+    @Test
+    public void testIs32bitJVM() {
+        JVMUtil.is32bitJVM();
+    }
+
     @Test
     public void testIsCompressedOops() {
         JVMUtil.isCompressedOops();
@@ -47,11 +54,6 @@ public class JVMUtilTest extends HazelcastTestSupport {
     @Test
     public void testIsObjectLayoutCompressedOopsOrNull() {
         JVMUtil.isObjectLayoutCompressedOopsOrNull();
-    }
-
-    @Test
-    public void testIs32bitJVM() {
-        JVMUtil.is32bitJVM();
     }
 
     // Prints the size of object reference as calculated by JVMUtil.


### PR DESCRIPTION
* removed last usage of deprecated UnsafeHelper
* small cleanup of JVMUtil

`UnsafeHelper` itself cannot be removed in the `master` branch yet, since it's used in dependencies of the Spring module (via the Hazelcast Hibernate module). I cannot remove those dependencies though, since the replacement `UnsafeUtil` needs to have public access, which is done in this PR.

I want to have this in HZ 3.8.1, so we can use the new `UnsafeUtil` as fast as possible in dependent projects like `hazelcast-hibernate3/4`, otherwise we will never get rid of the deprecated `UnsafeHelper`.

Backport of https://github.com/hazelcast/hazelcast/pull/10038