### PR TITLE
Offloading EP to non-partition threads for reads & writes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResource.java
@@ -33,6 +33,8 @@ public interface LockResource {
 
     boolean isTransactional();
 
+    boolean isLocal();
+
     boolean shouldBlockReads();
 
     long getThreadId();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStore.java
@@ -38,6 +38,18 @@ public interface LockStore {
     boolean lock(Data key, String caller, long threadId, long referenceId, long leaseTime);
 
     /**
+     * Lock a specific key on a local partition only
+     *
+     * @param key         the key to lock
+     * @param caller      the identifier for the caller
+     * @param threadId    the identifier for the thread on the caller
+     * @param referenceId the identifier for the invocation of the caller (e.g. operation call ID)
+     * @param leaseTime   the lease duration in milliseconds
+     * @return if the lock was successfully acquired
+     */
+    boolean localLock(Data key, String caller, long threadId, long referenceId, long leaseTime);
+
+    /**
      * Lock a specific key for use inside a transaction.
      *
      * @param key         the key to lock

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockStoreProxy.java
@@ -39,6 +39,12 @@ public final class LockStoreProxy implements LockStore {
     }
 
     @Override
+    public boolean localLock(Data key, String caller, long threadId, long referenceId, long leaseTime) {
+        LockStore lockStore = getLockStoreOrNull();
+        return lockStore != null && lockStore.localLock(key, caller, threadId, referenceId, leaseTime);
+    }
+
+    @Override
     public boolean txnLock(Data key, String caller, long threadId, long referenceId, long leaseTime, boolean blockReads) {
         LockStore lockStore = getLockStoreOrNull();
         return lockStore != null && lockStore.txnLock(key, caller, threadId, referenceId, leaseTime, blockReads);

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -1549,6 +1549,38 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * Returns the the object which is result of the process() method of EntryProcessor.
      * <p/>
      *
+     * The EntryProcessor may implement the Offloadable and ReadOnly interfaces.
+     *
+     * If the EntryProcessor implements the Offloadable interface the processing will be offloaded to the given
+     * ExecutorService allowing unblocking the partition-thread, which means that other partition-operations
+     * may proceed. The key will be locked for the time-span of the processing in order to not generate a write-conflict.
+     * In this case the threading looks as follows:
+     *  1.) partition-thread (fetch & lock)
+     *  2.) execution-thread (process)
+     *  3.) partition-thread (set & unlock, or just unlock if no changes)
+     *
+     * If the EntryProcessor implements the Offloadable and ReadOnly interfaces the processing will be offloaded to the
+     * given ExecutorService allowing unblocking the partition-thread. Since the EntryProcessor is not supposed to do
+     * any changes to the Entry the key will NOT be locked for the time-span of the processing. In this case the threading
+     * looks as follows:
+     *  1.) partition-thread (fetch & lock)
+     *  2.) execution-thread (process)
+     * In this case the EntryProcessor.getBackupProcessor() has to return null; otherwise an IllegalArgumentException
+     * exception is thrown.
+     *
+     * If the EntryProcessor implements only ReadOnly without implementing Offloadable the processing unit will not
+     * be offloaded, however, the EntryProcessor will not wait for the lock to be acquired, since the EP will not
+     * do any modifications.
+     *
+     * Using offloading is useful if the EntryProcessor encompasses heavy logic that may stall the partition-thread.
+     *
+     * Offloading will not be applied to backup partitions. It is possible to initialize the EntryBackupProcessor
+     * with some input provided by the EntryProcessor in the EntryProcessor.getBackupProcessor() method.
+     * The input allows providing context to the EntryBackupProcessor - for example the "delta"
+     * so that the EntryBackupProcessor does not have to calculate the "delta" but it may just apply it.
+     *
+     * @see Offloadable
+     * @see ReadOnly
      * @return result of entry process.
      * @throws NullPointerException if the specified key is null
      */
@@ -1569,6 +1601,38 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * Applies the user defined EntryProcessor to the entry mapped by the key with
      * specified ExecutionCallback to listen event status and returns immediately.
      *
+     * The EntryProcessor may implement the Offloadable and ReadOnly interfaces.
+     *
+     * If the EntryProcessor implements the Offloadable interface the processing will be offloaded to the given
+     * ExecutorService allowing unblocking the partition-thread, which means that other partition-operations
+     * may proceed. The key will be locked for the time-span of the processing in order to not generate a write-conflict.
+     * In this case the threading looks as follows:
+     *  1.) partition-thread (fetch & lock)
+     *  2.) execution-thread (process)
+     *  3.) partition-thread (set & unlock, or just unlock if no changes)
+     *
+     * If the EntryProcessor implements the Offloadable and ReadOnly interfaces the processing will be offloaded to the
+     * given ExecutorService allowing unblocking the partition-thread. Since the EntryProcessor is not supposed to do
+     * any changes to the Entry the key will NOT be locked for the time-span of the processing. In this case the threading
+     * looks as follows:
+     *  1.) partition-thread (fetch & lock)
+     *  2.) execution-thread (process)
+     * In this case the EntryProcessor.getBackupProcessor() has to return null; otherwise an IllegalArgumentException
+     * exception is thrown.
+     *
+     * If the EntryProcessor implements only ReadOnly without implementing Offloadable the processing unit will not
+     * be offloaded, however, the EntryProcessor will not wait for the lock to be acquired, since the EP will not
+     * do any modifications.
+     *
+     * Using offloading is useful if the EntryProcessor encompasses heavy logic that may stall the partition-thread.
+     *
+     * Offloading will not be applied to backup partitions. It is possible to initialize the EntryBackupProcessor
+     * with some input provided by the EntryProcessor in the EntryProcessor.getBackupProcessor() method.
+     * The input allows providing context to the EntryBackupProcessor - for example the "delta"
+     * so that the EntryBackupProcessor does not have to calculate the "delta" but it may just apply it.
+     *
+     * @see Offloadable
+     * @see ReadOnly
      * @param key            key to be processed.
      * @param entryProcessor processor to process the key.
      * @param callback       to listen whether operation is finished or not.
@@ -1582,6 +1646,38 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * EntryProcessor is not cancellable, so calling ICompletableFuture.cancel() method
      * won't cancel the operation of EntryProcessor.
      *
+     * The EntryProcessor may implement the Offloadable and ReadOnly interfaces.
+     *
+     * If the EntryProcessor implements the Offloadable interface the processing will be offloaded to the given
+     * ExecutorService allowing unblocking the partition-thread, which means that other partition-operations
+     * may proceed. The key will be locked for the time-span of the processing in order to not generate a write-conflict.
+     * In this case the threading looks as follows:
+     *  1.) partition-thread (fetch & lock)
+     *  2.) execution-thread (process)
+     *  3.) partition-thread (set & unlock, or just unlock if no changes)
+     *
+     * If the EntryProcessor implements the Offloadable and ReadOnly interfaces the processing will be offloaded to the
+     * given ExecutorService allowing unblocking the partition-thread. Since the EntryProcessor is not supposed to do
+     * any changes to the Entry the key will NOT be locked for the time-span of the processing. In this case the threading
+     * looks as follows:
+     *  1.) partition-thread (fetch & lock)
+     *  2.) execution-thread (process)
+     * In this case the EntryProcessor.getBackupProcessor() has to return null; otherwise an IllegalArgumentException
+     * exception is thrown.
+     *
+     * If the EntryProcessor implements only ReadOnly without implementing Offloadable the processing unit will not
+     * be offloaded, however, the EntryProcessor will not wait for the lock to be acquired, since the EP will not
+     * do any modifications.
+     *
+     * Using offloading is useful if the EntryProcessor encompasses heavy logic that may stall the partition-thread.
+     *
+     * Offloading will not be applied to backup partitions. It is possible to initialize the EntryBackupProcessor
+     * with some input provided by the EntryProcessor in the EntryProcessor.getBackupProcessor() method.
+     * The input allows providing context to the EntryBackupProcessor - for example the "delta"
+     * so that the EntryBackupProcessor does not have to calculate the "delta" but it may just apply it.
+     *
+     * @see Offloadable
+     * @see ReadOnly
      * @param key            key to be processed
      * @param entryProcessor processor to process the key
      * @return ICompletableFuture from which the result of the operation can be retrieved.

--- a/hazelcast/src/main/java/com/hazelcast/core/Offloadable.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Offloadable.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.core;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ExecutorConfig;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.spi.ExecutionService;
+
+/**
+ * Allows off-loading the processing unit implementing this interface to the specified or default Executor.
+ *
+ * Currently supported in:
+ * <ul>
+ *     <li>{@link IMap#executeOnKey(Object, EntryProcessor)}</li>
+ *     <li>{@link IMap#submitToKey(Object, EntryProcessor)} </li>
+ *     <li>{@link IMap#submitToKey(Object, EntryProcessor, ExecutionCallback)} </li>
+ * </ul>
+ */
+public interface Offloadable {
+
+    /**
+     * Constant meaning that there will be no off-loading if returned from the {@link #getExecutorName()} method.
+     */
+    String NO_OFFLOADING = "no-offloading";
+
+    /**
+     * Constant meaning that processing will be off-loaded to the default OFFLOADABLE_EXECUTOR executor.
+     * if returned from the {@link #getExecutorName()} method.
+     *
+     * @see ExecutionService#OFFLOADABLE_EXECUTOR
+     */
+    String OFFLOADABLE_EXECUTOR = ExecutionService.OFFLOADABLE_EXECUTOR;
+
+    /**
+     * Returns the name of the executor to which the processing unit will be off-loaded.
+     *
+     * The return value equal to {@value OFFLOADABLE_EXECUTOR} indicates that the processing should off-loaded to the
+     * default {@link ExecutionService#OFFLOADABLE_EXECUTOR}.
+     *
+     * The return value equal to {@value NO_OFFLOADING} indicates that the processing should not be off-loaded at all.
+     * The processing will be executed as if the processing-unit didn't implement the {@link Offloadable} interface.
+     *
+     * Other return values will lookup the executor with the returned value which can be configured in the Hazelcast
+     * configuration.
+     *
+     * @return the name of the executor to which the processing should be off-loaded.
+     * @see ExecutorConfig
+     * @see Config#addExecutorConfig(ExecutorConfig)
+     */
+    String getExecutorName();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/core/ReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ReadOnly.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.core;
+
+import com.hazelcast.map.EntryProcessor;
+
+/**
+ *
+ * Allows notifying Hazelcast that the processing unit implementing this interface will not do any modifications.
+ * This marker interface allows optimizing the processing to gain more performance.
+ *
+ * Currently supported in:
+ * <ul>
+ *     <li>{@link EntryProcessor} passed to {@link IMap#executeOnKey(Object, EntryProcessor)}</li>
+ *     <li>{@link EntryProcessor} passed to {@link IMap#submitToKey(Object, EntryProcessor)} </li>
+ *     <li>{@link EntryProcessor} passed to {@link IMap#submitToKey(Object, EntryProcessor, ExecutionCallback)} </li>
+ * </ul>
+ *
+ * @see Offloadable
+ *
+ */
+public interface ReadOnly {
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
@@ -56,6 +56,7 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
     private ManagedExecutorServiceMBean clientExecutorMBean;
     private ManagedExecutorServiceMBean queryExecutorMBean;
     private ManagedExecutorServiceMBean ioExecutorMBean;
+    private ManagedExecutorServiceMBean offloadableExecutorMBean;
     private PartitionServiceMBean partitionServiceMBean;
 
     protected InstanceMBean(HazelcastInstanceImpl hazelcastInstance, ManagementService managementService) {
@@ -91,6 +92,8 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
                 hazelcastInstance, executionService.getExecutor(ExecutionService.QUERY_EXECUTOR), service);
         ioExecutorMBean = new ManagedExecutorServiceMBean(
                 hazelcastInstance, executionService.getExecutor(ExecutionService.IO_EXECUTOR), service);
+        offloadableExecutorMBean = new ManagedExecutorServiceMBean(
+                hazelcastInstance, executionService.getExecutor(ExecutionService.OFFLOADABLE_EXECUTOR), service);
     }
 
     private void registerMBeans() {
@@ -107,6 +110,7 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
         register(clientExecutorMBean);
         register(queryExecutorMBean);
         register(ioExecutorMBean);
+        register(offloadableExecutorMBean);
     }
 
     private void createProperties(HazelcastInstanceImpl hazelcastInstance) {
@@ -143,6 +147,10 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
 
     public ManagedExecutorServiceMBean getIoExecutorMBean() {
         return ioExecutorMBean;
+    }
+
+    public ManagedExecutorServiceMBean getOffloadableExecutorMBean() {
+        return offloadableExecutorMBean;
     }
 
     public OperationServiceMBean getOperationServiceMBean() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
@@ -79,6 +79,7 @@ final class TimedMemberStateFactoryHelper {
         final ManagedExecutorService clientExecutor = executionService.getExecutor(ExecutionService.CLIENT_EXECUTOR);
         final ManagedExecutorService queryExecutor = executionService.getExecutor(ExecutionService.QUERY_EXECUTOR);
         final ManagedExecutorService ioExecutor = executionService.getExecutor(ExecutionService.IO_EXECUTOR);
+        final ManagedExecutorService offloadableExecutor = executionService.getExecutor(ExecutionService.OFFLOADABLE_EXECUTOR);
 
         final ManagedExecutorDTO systemExecutorDTO = new ManagedExecutorDTO(systemExecutor);
         final ManagedExecutorDTO asyncExecutorDTO = new ManagedExecutorDTO(asyncExecutor);
@@ -86,6 +87,7 @@ final class TimedMemberStateFactoryHelper {
         final ManagedExecutorDTO clientExecutorDTO = new ManagedExecutorDTO(clientExecutor);
         final ManagedExecutorDTO queryExecutorDTO = new ManagedExecutorDTO(queryExecutor);
         final ManagedExecutorDTO ioExecutorDTO = new ManagedExecutorDTO(ioExecutor);
+        final ManagedExecutorDTO offloadableExecutorDTO = new ManagedExecutorDTO(offloadableExecutor);
 
         beans.putManagedExecutor(ExecutionService.SYSTEM_EXECUTOR, systemExecutorDTO);
         beans.putManagedExecutor(ExecutionService.ASYNC_EXECUTOR, asyncExecutorDTO);
@@ -93,6 +95,7 @@ final class TimedMemberStateFactoryHelper {
         beans.putManagedExecutor(ExecutionService.CLIENT_EXECUTOR, clientExecutorDTO);
         beans.putManagedExecutor(ExecutionService.QUERY_EXECUTOR, queryExecutorDTO);
         beans.putManagedExecutor(ExecutionService.IO_EXECUTOR, ioExecutorDTO);
+        beans.putManagedExecutor(ExecutionService.OFFLOADABLE_EXECUTOR, offloadableExecutorDTO);
         memberState.setBeans(beans);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -40,6 +40,7 @@ import com.hazelcast.map.impl.operation.ContainsValueOperation;
 import com.hazelcast.map.impl.operation.ContainsValueOperationFactory;
 import com.hazelcast.map.impl.operation.DeleteOperation;
 import com.hazelcast.map.impl.operation.EntryBackupOperation;
+import com.hazelcast.map.impl.operation.EntryOffloadableSetUnlockOperation;
 import com.hazelcast.map.impl.operation.EntryOperation;
 import com.hazelcast.map.impl.operation.EvictAllBackupOperation;
 import com.hazelcast.map.impl.operation.EvictAllOperation;
@@ -283,8 +284,9 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int IS_KEYLOAD_FINISHED = 133;
     public static final int REMOVE_FROM_LOAD_ALL = 134;
     public static final int ENTRY_REMOVING_PROCESSOR = 135;
+    public static final int ENTRY_OFFLOADABLE_SET_UNLOCK = 136;
 
-    private static final int LEN = ENTRY_REMOVING_PROCESSOR + 1;
+    private static final int LEN = ENTRY_OFFLOADABLE_SET_UNLOCK + 1;
 
     @Override
     public int getFactoryId() {
@@ -953,6 +955,11 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[ENTRY_REMOVING_PROCESSOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return EntryRemovingProcessor.ENTRY_REMOVING_PROCESSOR;
+            }
+        };
+        constructors[ENTRY_OFFLOADABLE_SET_UNLOCK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new EntryOffloadableSetUnlockOperation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableLockMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableLockMismatchException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * Actor of the EntryOffloadableOperation -> EntryOffloadableSetUnlockOperation combined operations flow.
+ * If returned from the EntryOffloadableSetUnlockOperation, the preceding EntryOffloadableOperation will be retried.
+ */
+public class EntryOffloadableLockMismatchException extends HazelcastException {
+
+    public EntryOffloadableLockMismatchException() {
+    }
+
+    public EntryOffloadableLockMismatchException(final String message) {
+        super(message);
+    }
+
+    public EntryOffloadableLockMismatchException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public EntryOffloadableLockMismatchException(final Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableSetUnlockOperation.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.core.EntryView;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.DefaultObjectNamespace;
+import com.hazelcast.spi.EventService;
+import com.hazelcast.spi.Notifier;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.util.Clock;
+
+import java.io.IOException;
+
+import static com.hazelcast.core.EntryEventType.ADDED;
+import static com.hazelcast.core.EntryEventType.REMOVED;
+import static com.hazelcast.core.EntryEventType.UPDATED;
+import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
+import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
+
+/**
+ * Set & Unlock processing for the EntryOperation
+ *
+ * See the javadoc on {@link EntryOperation}
+ */
+public class EntryOffloadableSetUnlockOperation extends MutatingKeyBasedMapOperation implements BackupAwareOperation, Notifier {
+
+    protected String name;
+    protected Data value;
+    protected Data oldValue;
+    protected String caller;
+    protected long threadId;
+    protected long begin;
+    protected EntryEventType modificationType;
+    protected EntryBackupProcessor entryBackupProcessor;
+
+    public EntryOffloadableSetUnlockOperation() {
+    }
+
+    public EntryOffloadableSetUnlockOperation(String name, EntryEventType modificationType, Data key, Data oldValue,
+                                              Data value, String caller, long threadId, long begin,
+                                              EntryBackupProcessor entryBackupProcessor) {
+        super(name, key, value);
+        this.name = name;
+        this.value = value;
+        this.oldValue = oldValue;
+        this.caller = caller;
+        this.begin = begin;
+        this.threadId = threadId;
+        this.modificationType = modificationType;
+        this.entryBackupProcessor = entryBackupProcessor;
+    }
+
+    @Override
+    public void run() throws Exception {
+        verifyLock();
+        updateRecordStore();
+        unlockKey();
+    }
+
+    private void verifyLock() {
+        if (!recordStore.isLockedBy(dataKey, caller, threadId)) {
+            // we can't send a RetryableHazelcastException explicitly since it would retry this opertation and we want to retry
+            // the preceding EntryOperation that this operation is part of.
+            throw new EntryOffloadableLockMismatchException(
+                    String.format("The key is not locked by the caller=%s and threadId=%d", caller, threadId));
+        }
+    }
+
+    private void updateRecordStore() {
+        if (modificationType == null) {
+            return;
+        }
+        if (modificationType == REMOVED) {
+            recordStore.remove(dataKey);
+            getLocalMapStats().incrementRemoves(getLatencyFrom(begin));
+        } else if (modificationType == ADDED || modificationType == UPDATED) {
+            recordStore.set(dataKey, value, DEFAULT_TTL);
+            getLocalMapStats().incrementPuts(getLatencyFrom(begin));
+        } else {
+            throw new IllegalArgumentException("Unsupported event type " + modificationType);
+        }
+    }
+
+    private void unlockKey() {
+        boolean unlocked = recordStore.unlock(dataKey, caller, threadId, getCallId());
+        if (!unlocked) {
+            getLogger().severe(String.format("\"EntryOffloadableSetUnlockOperation finished but the unlock method "
+                    + "returned false  caller=%s and threadId=%d", caller, threadId));
+        }
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+        super.afterRun();
+        if (modificationType == null) {
+            return;
+        }
+
+        mapServiceContext.interceptAfterPut(name, value);
+        if (isPostProcessing(recordStore)) {
+            Record record = recordStore.getRecord(dataKey);
+            value = record == null ? null : toData(record.getValue());
+        }
+        invalidateNearCache(dataKey);
+        publishEntryEvent();
+        publishWanReplicationEvent();
+        evict(dataKey);
+    }
+
+    private void publishWanReplicationEvent() {
+        final MapContainer mapContainer = this.mapContainer;
+        if (mapContainer.getWanReplicationPublisher() == null && mapContainer.getWanMergePolicy() == null) {
+            return;
+        }
+        final Data key = getKey();
+
+        if (REMOVED.equals(modificationType)) {
+            mapEventPublisher.publishWanReplicationRemove(name, key, begin);
+
+        } else {
+            final Record record = recordStore.getRecord(key);
+            if (record != null) {
+                final EntryView entryView = createSimpleEntryView(key, value, record);
+                mapEventPublisher.publishWanReplicationUpdate(name, entryView);
+            }
+        }
+    }
+
+    private void publishEntryEvent() {
+        if (hasRegisteredListenerForThisMap()) {
+            nullifyOldValueIfNecessary();
+            mapEventPublisher.publishEvent(getCallerAddress(), name, modificationType, dataKey, oldValue, value);
+        }
+    }
+
+    private boolean hasRegisteredListenerForThisMap() {
+        final EventService eventService = getNodeEngine().getEventService();
+        return eventService.hasEventRegistration(SERVICE_NAME, name);
+    }
+
+    /**
+     * Nullify old value if in memory format is object and operation is not removal
+     * since old and new value in fired event {@link com.hazelcast.core.EntryEvent}
+     * may be same due to the object in memory format.
+     */
+    private void nullifyOldValueIfNecessary() {
+        final MapConfig mapConfig = mapContainer.getMapConfig();
+        final InMemoryFormat format = mapConfig.getInMemoryFormat();
+        if (format == InMemoryFormat.OBJECT && modificationType != REMOVED) {
+            oldValue = null;
+        }
+    }
+
+    private Data toData(Object obj) {
+        final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        return mapServiceContext.toData(obj);
+    }
+
+    private long getLatencyFrom(long begin) {
+        return Clock.currentTimeMillis() - begin;
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        // this has to be true, otherwise the calling side won't be notified about the exception thrown by this operation
+        return true;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        return entryBackupProcessor != null ? new EntryBackupOperation(name, dataKey, entryBackupProcessor) : null;
+    }
+
+    @Override
+    public boolean shouldBackup() {
+        return mapContainer.getTotalBackupCount() > 0 && entryBackupProcessor != null;
+    }
+
+    @Override
+    public int getAsyncBackupCount() {
+        return mapContainer.getAsyncBackupCount();
+    }
+
+    @Override
+    public int getSyncBackupCount() {
+        return mapContainer.getBackupCount();
+    }
+
+    @Override
+    public boolean shouldNotify() {
+        return true;
+    }
+
+    @Override
+    public WaitNotifyKey getNotifiedKey() {
+        return new LockWaitNotifyKey(new DefaultObjectNamespace(MapService.SERVICE_NAME, name), dataKey);
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.ENTRY_OFFLOADABLE_SET_UNLOCK;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeUTF(name);
+        out.writeUTF(modificationType != null ? modificationType.name() : "");
+        out.writeData(oldValue);
+        out.writeData(value);
+        out.writeUTF(caller);
+        out.writeLong(threadId);
+        out.writeLong(begin);
+        out.writeObject(entryBackupProcessor);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        name = in.readUTF();
+        String modificationTypeName = in.readUTF();
+        modificationType = modificationTypeName.equals("") ? null : EntryEventType.valueOf(modificationTypeName);
+        oldValue = in.readData();
+        value = in.readData();
+        caller = in.readUTF();
+        threadId = in.readLong();
+        begin = in.readLong();
+        entryBackupProcessor = in.readObject();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperation.java
@@ -16,51 +16,143 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.ManagedContext;
-import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.core.Offloadable;
+import com.hazelcast.core.ReadOnly;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
-import com.hazelcast.map.impl.LazyMapEntry;
-import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.BlockingOperation;
+import com.hazelcast.spi.DefaultObjectNamespace;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.WaitNotifyKey;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 import java.util.Map;
 
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.core.EntryEventType.ADDED;
 import static com.hazelcast.core.EntryEventType.REMOVED;
 import static com.hazelcast.core.EntryEventType.UPDATED;
+import static com.hazelcast.core.Offloadable.NO_OFFLOADING;
 import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
+import static com.hazelcast.spi.ExecutionService.OFFLOADABLE_EXECUTOR;
 
 /**
+ * Contains implementation of the off-loadable contract for EntryProcessor execution on a single key.
+ *
+ * ### Overview
+ *
+ * Implementation of the the Offloadable contract for the EntryProcessor execution on a single key.
+ *
+ * Allows off-loading the processing unit implementing this interface to the specified or default Executor.
+ * Currently supported in:
+ *
+ * IMap.executeOnKey(Object, EntryProcessor)
+ * IMap.submitToKey(Object, EntryProcessor)
+ * IMap.submitToKey(Object, EntryProcessor, ExecutionCallback)
+ *
+ * ### Offloadable (for reading & writing)
+ *
+ * If the EntryProcessor implements the Offloadable interface the processing will be offloaded to the given
+ * ExecutorService allowing unblocking the partition-thread. The key will be locked for the time-span of the processing
+ * in order to not generate a write-conflict.
+ *
+ * If the EntryProcessor implements Offloadable the invocation scenario looks as follows:
+ * - EntryOperation fetches the entry and locks the given key on partition-thread
+ * - Then the processing is offloaded to the given executor
+ * - When the processing finishes
+ * if there is a change to the entry, a EntryOffloadableSetUnlockOperation is spawned
+ * which sets the new value and unlocks the given key on partition-thread
+ * if there is no change to the entry, a UnlockOperation is spawned, which just unlocks the kiven key
+ * on partition thread
+ *
+ * There will not be a conflict on a write due to the pessimistic locking of the key.
+ * The threading looks as follows:
+ *
+ * 1. partition-thread (fetch & lock)
+ * 2. execution-thread (process)
+ * 3. partition-thread (set & unlock, or just unlock if no changes)
+ *
+ * ### Offloadable (for reading only)
+ *
+ * If the EntryProcessor implements the Offloadable and ReadOnly interfaces the processing will be offloaded to the
+ * givenExecutorService allowing unblocking the partition-thread. Since the EntryProcessor is not supposed to do any
+ * changes to the Entry the key will NOT be locked for the time-span of the processing.
+ *
+ * If the EntryProcessor implements Offloadable and ReadOnly the invocation scenario looks as follows:
+ * - EntryOperation fetches the entry and DOES NOT lock the given key on partition-thread
+ * - Then the processing is offloaded to the given executor
+ * - When the processing finishes
+ * if there is a change to the entry -> exception is thrown
+ * if there is no change to the entry -> the result is returned to the user from the executor-thread.
+ *
+ * In the read-only case the threading looks as follows:
+ *
+ * 1. partition-thread (fetch)
+ * 2. execution-thread (process)
+ *
+ * ### Primary partition - main actors
+ *
+ * - EntryOperation
+ * - EntryOffloadableSetUnlockOperation
+ *
+ * ### Backup partitions
+ *
+ * Offloading will not be applied to backup partitions. It is possible to initialize the EntryBackupProcessor
+ * with some input provided by the EntryProcessor in the EntryProcessor.getBackupProcessor() method.
+ * The input allows providing context to the EntryBackupProcessor - for example the "delta"
+ * so that the EntryBackupProcessor does not have to calculate the "delta" but it may just apply it.
+ *
+ * ### Locking
+ *
+ * The locking takes place only locally. If a partition locked by an off-loaded task gets migrated, the lock will not
+ * be migrated. In this situation the off-loaded task "relying" on the lock will fail on the unlock operation, since it
+ * will notice that there is no such a lock and therefore the processing for the key will get retried.
+ * The reason behind is that the off-loadable backup-processing does not use locking there cannot be any transfer of
+ * off-loadable locks from the primary replica to backup replicas.
+ *
  * GOTCHA : This operation LOADS missing keys from map-store, in contrast with PartitionWideEntryOperation.
  */
-public class EntryOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
+@SuppressWarnings("checkstyle:methodcount")
+public class EntryOperation extends MutatingKeyBasedMapOperation implements BackupAwareOperation, BlockingOperation {
 
-    protected Object oldValue;
     private EntryProcessor entryProcessor;
-    private EntryEventType eventType;
-    private Object response;
+
+    private transient boolean offloading;
+
+    // EntryOperation
+    private transient Object oldValue;
+    private transient EntryEventType eventType;
+    private transient Object response;
     private transient Object dataValue;
+
+    // EntryOffloadableOperation
+    private transient boolean readOnly;
+    private transient long begin;
+    private transient OperationServiceImpl ops;
 
     public EntryOperation() {
     }
@@ -74,6 +166,19 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
     public void innerBeforeRun() throws Exception {
         super.innerBeforeRun();
 
+        if (entryProcessor instanceof Offloadable) {
+            String executorName = ((Offloadable) entryProcessor).getExecutorName();
+            if (!executorName.equals(NO_OFFLOADING)) {
+                offloading = true;
+            }
+        }
+
+        if (offloading) {
+            this.ops = (OperationServiceImpl) getNodeEngine().getOperationService();
+            this.begin = getNow();
+            this.readOnly = entryProcessor instanceof ReadOnly;
+        }
+
         final SerializationService serializationService = getNodeEngine().getSerializationService();
         final ManagedContext managedContext = serializationService.getManagedContext();
         managedContext.initialize(entryProcessor);
@@ -81,6 +186,161 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
 
     @Override
     public void run() {
+        if (offloading) {
+            runOffloaded();
+        } else {
+            runVanilla();
+        }
+    }
+
+    public void runOffloaded() {
+        if (!(entryProcessor instanceof Offloadable)) {
+            throw new HazelcastException("EntryProcessor is expected to implement Offloadable for this operation");
+        }
+        if (readOnly && entryProcessor.getBackupProcessor() != null) {
+            throw new HazelcastException("EntryProcessor.getBackupProcessor() should return null if ReadOnly implemented");
+        }
+
+        boolean shouldCloneForOffloading = OBJECT.equals(mapContainer.getMapConfig().getInMemoryFormat());
+        Object value = recordStore.get(dataKey, false);
+        value = shouldCloneForOffloading ? toData(value) : value;
+
+        String executorName = ((Offloadable) entryProcessor).getExecutorName();
+        executorName = executorName.equals(Offloadable.OFFLOADABLE_EXECUTOR) ? OFFLOADABLE_EXECUTOR : executorName;
+
+        if (readOnly) {
+            runOffloadedReadOnlyEntryProcessor(value, executorName);
+        } else {
+            runOffloadedModifyingEntryProcessor(value, executorName);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void runOffloadedReadOnlyEntryProcessor(final Object previousValue, String executorName) {
+        ops.onStartAsyncOperation(this);
+        getNodeEngine().getExecutionService().execute(executorName, new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    final Map.Entry entry = createMapEntry(dataKey, previousValue);
+                    final Data result = process(entry);
+                    if (!noOp(entry, previousValue)) {
+                        throw new HazelcastException("It is not allowed to modify an entry in a ReadOnly EntryProcessor");
+                    }
+                    getOperationResponseHandler().sendResponse(EntryOperation.this, result);
+                } catch (Throwable t) {
+                    getOperationResponseHandler().sendResponse(EntryOperation.this, t);
+                } finally {
+                    ops.onCompletionAsyncOperation(EntryOperation.this);
+                }
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void runOffloadedModifyingEntryProcessor(final Object previousValue, String executorName) {
+        final OperationServiceImpl ops = (OperationServiceImpl) getNodeEngine().getOperationService();
+
+        final Data finalDataKey = dataKey;
+        final String finalCaller = getCallerUuid();
+        final long finalThreadId = threadId;
+        final long finalCallId = getCallId();
+        final long finalBegin = begin;
+
+        // The off-loading uses local locks, since the locking is used only on primary-replica.
+        // The locks are not supposed to be migrated on partition migration or partition promotion & downgrade.
+        recordStore.localLock(finalDataKey, finalCaller, finalThreadId, finalCallId, Long.MAX_VALUE);
+
+        ops.onStartAsyncOperation(this);
+        getNodeEngine().getExecutionService().execute(executorName, new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    final Map.Entry entry = createMapEntry(dataKey, previousValue);
+                    final Data result = process(entry);
+                    if (!noOp(entry, previousValue)) {
+                        Data newValue = toData(entry.getValue());
+
+                        EntryEventType modificationType;
+                        if (entry.getValue() == null) {
+                            modificationType = REMOVED;
+                        } else {
+                            modificationType = (previousValue == null) ? ADDED : UPDATED;
+                        }
+
+                        updateAndUnlock(toData(previousValue), newValue, modificationType, finalCaller, finalThreadId,
+                                result, finalBegin);
+                    } else {
+                        unlockOnly(result, finalCaller, finalThreadId, finalBegin);
+                    }
+                } catch (Throwable t) {
+                    unlockOnly(t, finalCaller, finalThreadId, finalBegin);
+                }
+            }
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void updateAndUnlock(Data previousValue, Data newValue, EntryEventType modificationType, String caller,
+                                 long threadId, final Object result, long now) {
+        EntryOffloadableSetUnlockOperation updateOperation = new EntryOffloadableSetUnlockOperation(name, modificationType,
+                dataKey, previousValue, newValue, caller, threadId, now, entryProcessor.getBackupProcessor());
+
+        updateOperation.setPartitionId(getPartitionId());
+        ops.invokeOnPartition(updateOperation).andThen(new ExecutionCallback<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                try {
+                    getOperationResponseHandler().sendResponse(EntryOperation.this, result);
+                } finally {
+                    ops.onCompletionAsyncOperation(EntryOperation.this);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                try {
+                    // EntryOffloadableLockMismatchException is a marker send from the EntryOffloadableSetUnlockOperation
+                    // meaning that the whole invocation of the EntryOffloadableOperation should be retried
+                    if (t instanceof EntryOffloadableLockMismatchException) {
+                        t = new RetryableHazelcastException(t.getMessage(), t);
+                    }
+                    getOperationResponseHandler().sendResponse(EntryOperation.this, t);
+                } finally {
+                    ops.onCompletionAsyncOperation(EntryOperation.this);
+                }
+            }
+        });
+    }
+
+    private void unlockOnly(final Object result, String caller, long threadId, long now) {
+        updateAndUnlock(null, null, null, caller, threadId, result, now);
+    }
+
+    @Override
+    public void onExecutionFailure(Throwable e) {
+        if (offloading) {
+            // This is required since if the returnsResponse() method returns false there won't be any response sent
+            // to the invoking party - this means that the operation won't be retried if the exception is instanceof
+            // HazelcastRetryableException
+            sendResponse(e);
+        } else {
+            super.onExecutionFailure(e);
+        }
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        if (offloading) {
+            // This has to be false, since the operation uses the deferred-response mechanism.
+            // This method returns false, but the response will be send later on using the response handler
+            return false;
+        } else {
+            return super.returnsResponse();
+        }
+    }
+
+    private void runVanilla() {
         final long now = getNow();
         boolean shouldClone = mapContainer.shouldCloneOnEntryProcessing();
         SerializationService serializationService = getNodeEngine().getSerializationService();
@@ -92,9 +352,15 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
         response = process(entry);
 
         // first call noOp, other if checks below depends on it.
-        if (noOp(entry)) {
+        if (noOp(entry, oldValue)) {
             return;
         }
+
+        // at this stage we see that the entry has been modified which is not allowed for readOnly processors
+        if (entryProcessor instanceof ReadOnly) {
+            throw new HazelcastException("ReadOnly processor is not allowed to make any changes to the processed Entry");
+        }
+
         if (entryRemoved(entry, now)) {
             return;
         }
@@ -103,19 +369,35 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
 
     @Override
     public void afterRun() throws Exception {
-        super.afterRun();
-        if (eventType == null) {
-            return;
+        if (!offloading) {
+            super.afterRun();
+            if (eventType == null) {
+                return;
+            }
+            mapServiceContext.interceptAfterPut(name, dataValue);
+            if (isPostProcessing(recordStore)) {
+                Record record = recordStore.getRecord(dataKey);
+                dataValue = record == null ? null : record.getValue();
+            }
+            invalidateNearCache(dataKey);
+            publishEntryEvent();
+            publishWanReplicationEvent();
+            evict(dataKey);
         }
-        mapServiceContext.interceptAfterPut(name, dataValue);
-        if (isPostProcessing(recordStore)) {
-            Record record = recordStore.getRecord(dataKey);
-            dataValue = record == null ? null : record.getValue();
+    }
+
+    @Override
+    public WaitNotifyKey getWaitKey() {
+        return new LockWaitNotifyKey(new DefaultObjectNamespace(MapService.SERVICE_NAME, name), dataKey);
+    }
+
+    @Override
+    public boolean shouldWait() {
+        // optimisation for ReadOnly processors -> they will not wait for the lock
+        if (entryProcessor instanceof ReadOnly) {
+            return false;
         }
-        invalidateNearCache(dataKey);
-        publishEntryEvent();
-        publishWanReplicationEvent();
-        evict(dataKey);
+        return !recordStore.canAcquireLock(dataKey, getCallerUuid(), getThreadId());
     }
 
     @Override
@@ -125,17 +407,26 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
 
     @Override
     public Object getResponse() {
+        if (offloading) {
+            return null;
+        }
         return response;
     }
 
     @Override
     public Operation getBackupOperation() {
+        if (offloading) {
+            return null;
+        }
         EntryBackupProcessor backupProcessor = entryProcessor.getBackupProcessor();
         return backupProcessor != null ? new EntryBackupOperation(name, dataKey, backupProcessor) : null;
     }
 
     @Override
     public boolean shouldBackup() {
+        if (offloading) {
+            return false;
+        }
         return mapContainer.getTotalBackupCount() > 0 && entryProcessor.getBackupProcessor() != null;
     }
 
@@ -156,20 +447,6 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
     private Data toData(Object obj) {
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         return mapServiceContext.toData(obj);
-    }
-
-    private long getNow() {
-        return Clock.currentTimeMillis();
-    }
-
-    /**
-     * noOp in two cases:
-     * - setValue not called on entry
-     * - or entry does not exist and no add operation is done.
-     */
-    private boolean noOp(Map.Entry entry) {
-        final LazyMapEntry mapEntrySimple = (LazyMapEntry) entry;
-        return !mapEntrySimple.isModified() || (oldValue == null && entry.getValue() == null);
     }
 
     private boolean entryRemoved(Map.Entry entry, long now) {
@@ -198,18 +475,6 @@ public class EntryOperation extends LockAwareOperation implements BackupAwareOpe
     private Data process(Map.Entry entry) {
         final Object result = entryProcessor.process(entry);
         return toData(result);
-    }
-
-    private Map.Entry createMapEntry(Data key, Object value) {
-        InternalSerializationService serializationService
-                = ((InternalSerializationService) getNodeEngine().getSerializationService());
-        return new LazyMapEntry(key, value, serializationService, mapContainer.getExtractors());
-    }
-
-    private LocalMapStatsImpl getLocalMapStats() {
-        final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-        final LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
-        return localMapStatsProvider.getLocalMapStatsImpl(name);
     }
 
     private boolean hasRegisteredListenerForThisMap() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
@@ -16,13 +16,20 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.map.impl.LazyMapEntry;
+import com.hazelcast.map.impl.LocalMapStatsProvider;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.util.Clock;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 
@@ -63,6 +70,32 @@ public abstract class MutatingKeyBasedMapOperation extends MapOperation
 
     public final Data getKey() {
         return dataKey;
+    }
+
+    /**
+     * noOp in two cases:
+     * - setValue not called on entry
+     * - or entry does not exist and no add operation is done.
+     */
+    protected boolean noOp(Map.Entry entry, Object oldValue) {
+        final LazyMapEntry mapEntrySimple = (LazyMapEntry) entry;
+        return !mapEntrySimple.isModified() || (oldValue == null && entry.getValue() == null);
+    }
+
+    protected Map.Entry createMapEntry(Data key, Object value) {
+        InternalSerializationService serializationService
+                = ((InternalSerializationService) getNodeEngine().getSerializationService());
+        return new LazyMapEntry(key, value, serializationService, mapContainer.getExtractors());
+    }
+
+    protected long getNow() {
+        return Clock.currentTimeMillis();
+    }
+
+    protected LocalMapStatsImpl getLocalMapStats() {
+        final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        final LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
+        return localMapStatsProvider.getLocalMapStatsImpl(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -929,7 +929,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V> {
     }
 
     private QueryCache<K, V> getQueryCacheInternal(String name, MapListener listener, Predicate<K, V> predicate,
-                                             Boolean includeValue, IMap<K, V> map) {
+                                                   Boolean includeValue, IMap<K, V> map) {
         QueryCacheContext queryCacheContext = mapServiceContext.getQueryCacheContext();
 
         QueryCacheRequest request = newQueryCacheRequest()

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -362,10 +362,23 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
+    public boolean localLock(Data key, String caller, long threadId, long referenceId, long ttl) {
+        checkIfLoaded();
+        return lockStore != null && lockStore.localLock(key, caller, threadId, referenceId, ttl);
+    }
+
+    @Override
     public boolean unlock(Data key, String caller, long threadId, long referenceId) {
         checkIfLoaded();
         return lockStore != null && lockStore.unlock(key, caller, threadId, referenceId);
     }
+
+    @Override
+    public boolean lock(Data key, String caller, long threadId, long referenceId, long ttl) {
+        checkIfLoaded();
+        return lockStore != null && lockStore.lock(key, caller, threadId, referenceId, ttl);
+    }
+
 
     @Override
     public boolean forceUnlock(Data dataKey) {
@@ -385,6 +398,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public boolean canAcquireLock(Data key, String caller, long threadId) {
         return lockStore == null || lockStore.canAcquireLock(key, caller, threadId);
+    }
+
+    @Override
+    public boolean isLockedBy(Data key, String caller, long threadId) {
+        return lockStore != null && lockStore.isLockedBy(key, caller, threadId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -223,6 +223,12 @@ public interface RecordStore<R extends Record> extends LocalRecordStoreStats {
 
     boolean extendLock(Data key, String caller, long threadId, long ttl);
 
+    boolean localLock(Data key, String caller, long threadId, long referenceId, long ttl);
+
+    boolean lock(Data key, String caller, long threadId, long referenceId, long ttl);
+
+    boolean isLockedBy(Data key, String caller, long threadId);
+
     boolean unlock(Data key, String caller, long threadId, long referenceId);
 
     boolean isLocked(Data key);

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -68,6 +68,11 @@ public interface ExecutionService {
     String IO_EXECUTOR = "hz:io";
 
     /**
+     * Name of the offloadable executor.
+     */
+    String OFFLOADABLE_EXECUTOR = "hz:offloadable";
+
+    /**
      * Name of the map-loader executor that loads the {@link com.hazelcast.core.MapLoader#loadAll(java.util.Collection)}.
      *
      * This is the executor you want to configure when you want to load more data from the database in parallel.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -67,6 +67,7 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
     private static final long AWAIT_TIME = 3;
     private static final int POOL_MULTIPLIER = 2;
     private static final int QUEUE_MULTIPLIER = 100000;
+    private static final int OFFLOADABLE_QUEUE_CAPACITY = 100000;
 
     private final NodeEngineImpl nodeEngine;
     private final ExecutorService cachedExecutorService;
@@ -143,6 +144,7 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
         // default executors
         register(SYSTEM_EXECUTOR, coreSize, Integer.MAX_VALUE, ExecutorType.CACHED);
         register(SCHEDULED_EXECUTOR, coreSize * POOL_MULTIPLIER, coreSize * QUEUE_MULTIPLIER, ExecutorType.CACHED);
+        register(OFFLOADABLE_EXECUTOR, coreSize, OFFLOADABLE_QUEUE_CAPACITY, ExecutorType.CACHED);
         this.globalTaskScheduler = getTaskScheduler(SCHEDULED_EXECUTOR);
 
         // register CompletableFuture task

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -103,9 +103,9 @@ public final class GroupProperty {
     public static final HazelcastProperty CLIENT_ENGINE_QUERY_THREAD_COUNT
             = new HazelcastProperty("hazelcast.clientengine.query.thread.count", -1);
     /**
-     *  Client connection is removed or owner node of a client is removed from cluster
-     *  ClientDisconnectedOperation runs and clean all resources of client(listeners are removed, locks/txn are released)
-     *  With this property, client has a window to connect back and prevent cleaning up its resources.
+     * Client connection is removed or owner node of a client is removed from cluster
+     * ClientDisconnectedOperation runs and clean all resources of client(listeners are removed, locks/txn are released)
+     * With this property, client has a window to connect back and prevent cleaning up its resources.
      */
     public static final HazelcastProperty CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.client.endpoint.remove.delay.seconds", 10);
@@ -186,11 +186,15 @@ public final class GroupProperty {
     public static final HazelcastProperty MAP_LOAD_CHUNK_SIZE
             = new HazelcastProperty("hazelcast.map.load.chunk.size", 1000);
 
-    /** The delay until the first run of the {@link com.hazelcast.internal.cluster.impl.SplitBrainHandler} */
+    /**
+     * The delay until the first run of the {@link com.hazelcast.internal.cluster.impl.SplitBrainHandler}
+     */
     public static final HazelcastProperty MERGE_FIRST_RUN_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.merge.first.run.delay.seconds", 300, SECONDS);
 
-    /** The interval between invocations of the {@link com.hazelcast.internal.cluster.impl.SplitBrainHandler} */
+    /**
+     * The interval between invocations of the {@link com.hazelcast.internal.cluster.impl.SplitBrainHandler}
+     */
     public static final HazelcastProperty MERGE_NEXT_RUN_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.merge.next.run.delay.seconds", 120, SECONDS);
 
@@ -277,13 +281,12 @@ public final class GroupProperty {
      * Possible values:
      * TERMINATE: Terminate Hazelcast immediately
      * GRACEFUL:  Initiate graceful shutdown. This can significantly slow-down JVM exit process, but it's tries to
-     *            retain data safety.
+     * retain data safety.
      *
      * Default: TERMINATE
      *
      * You should always shutdown Hazelcast explicitly via {@link HazelcastInstance#shutdown()}
      * It's not recommended to rely on shutdown hook, this is a last-effort measure.
-     *
      */
     public static final HazelcastProperty SHUTDOWNHOOK_POLICY
             = new HazelcastProperty("hazelcast.shutdownhook.policy", "TERMINATE");
@@ -305,7 +308,9 @@ public final class GroupProperty {
     public static final HazelcastProperty MAX_NO_HEARTBEAT_SECONDS
             = new HazelcastProperty("hazelcast.max.no.heartbeat.seconds", 300, SECONDS);
 
-    /** The interval at which master confirmations are sent from non-master nodes to the master node */
+    /**
+     * The interval at which master confirmations are sent from non-master nodes to the master node
+     */
     public static final HazelcastProperty MASTER_CONFIRMATION_INTERVAL_SECONDS
             = new HazelcastProperty("hazelcast.master.confirmation.interval.seconds", 30, SECONDS);
     /**
@@ -314,7 +319,9 @@ public final class GroupProperty {
     public static final HazelcastProperty MAX_NO_MASTER_CONFIRMATION_SECONDS
             = new HazelcastProperty("hazelcast.max.no.master.confirmation.seconds", 350, SECONDS);
 
-    /** The interval at which the master sends the member lists are sent to other non-master members */
+    /**
+     * The interval at which the master sends the member lists are sent to other non-master members
+     */
     public static final HazelcastProperty MEMBER_LIST_PUBLISH_INTERVAL_SECONDS
             = new HazelcastProperty("hazelcast.member.list.publish.interval.seconds", 300, SECONDS);
 
@@ -331,7 +338,9 @@ public final class GroupProperty {
     public static final HazelcastProperty ICMP_ENABLED
             = new HazelcastProperty("hazelcast.icmp.enabled", false);
 
-    /** Ping timeout in milliseconds. */
+    /**
+     * Ping timeout in milliseconds.
+     */
     public static final HazelcastProperty ICMP_TIMEOUT
             = new HazelcastProperty("hazelcast.icmp.timeout", 1000, MILLISECONDS);
     /**
@@ -601,7 +610,6 @@ public final class GroupProperty {
      */
     public static final HazelcastProperty AGGREGATION_ACCUMULATION_PARALLEL_EVALUATION
             = new HazelcastProperty("hazelcast.aggregation.accumulation.parallel.evaluation", true);
-
 
     /**
      * Result size limit for query operations on maps.

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Offloadable;
+import com.hazelcast.core.ReadOnly;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.bounce.BounceMemberRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class EntryProcessorOffloadableBouncingNodesTest extends HazelcastTestSupport {
+
+    public static final String MAP_NAME = "EntryProcessorOffloadableTest";
+    public static final int COUNT_ENTRIES = 1000;
+    private static final int CONCURRENCY = Runtime.getRuntime().availableProcessors();
+
+    @Rule
+    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getBouncingTestConfig()).build();
+
+    private void populateMap(IMap<Integer, SimpleValue> map) {
+        for (int i = 0; i < COUNT_ENTRIES; i++) {
+            map.put(i, new SimpleValue(i));
+        }
+    }
+
+    public Config getBouncingTestConfig() {
+        Config config = getConfig();
+        MapConfig mapConfig = new MapConfig(MAP_NAME);
+        mapConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        mapConfig.setAsyncBackupCount(1);
+        mapConfig.setBackupCount(0);
+        config.addMapConfig(mapConfig);
+        return config;
+    }
+
+    @Test
+    public void testOffloadableEntryProcessor() {
+        populateMap(getMap());
+        testForKey(0);
+    }
+
+    private void testForKey(int key) {
+        EntryProcessorRunnable[] tasks = new EntryProcessorRunnable[CONCURRENCY * 2];
+
+        // off-loadable writers
+        for (int i = 0; i < CONCURRENCY; i++) {
+            tasks[i] = new EntryProcessorRunnable(bounceMemberRule.getNextTestDriver(), new EntryIncOffloadable(), key);
+        }
+
+        // off-loadable readers
+        for (int i = CONCURRENCY; i < CONCURRENCY * 2; i++) {
+            tasks[i] = new EntryProcessorRunnable(bounceMemberRule.getNextTestDriver(), new EntryReadOnlyOffloadable(), key);
+        }
+
+        bounceMemberRule.testRepeatedly(tasks, MINUTES.toSeconds(3));
+    }
+
+    public static class EntryProcessorRunnable implements Runnable {
+        private final IMap map;
+        private final EntryProcessor ep;
+        private final int key;
+
+        public EntryProcessorRunnable(HazelcastInstance hz, EntryProcessor ep, int key) {
+            this.map = hz.getMap(MAP_NAME);
+            this.ep = ep;
+            this.key = key;
+        }
+
+        @Override
+        public void run() {
+            map.executeOnKey(key, ep);
+        }
+    }
+
+    private static class EntryIncOffloadable implements EntryProcessor<Integer, SimpleValue>, Offloadable,
+            EntryBackupProcessor<Integer, SimpleValue> {
+
+        @Override
+        public Object process(final Map.Entry<Integer, SimpleValue> entry) {
+            final SimpleValue value = entry.getValue();
+            int result = value.i;
+            value.i++;
+            entry.setValue(value);
+            sleepAtLeastMillis(10);
+            return result;
+        }
+
+        @Override
+        public EntryBackupProcessor<Integer, SimpleValue> getBackupProcessor() {
+            return this;
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<Integer, SimpleValue> entry) {
+            process(entry);
+        }
+    }
+
+    private static class EntryReadOnlyOffloadable implements EntryProcessor<Integer, SimpleValue>,
+            Offloadable, ReadOnly {
+
+        @Override
+        public Object process(final Map.Entry<Integer, SimpleValue> entry) {
+            return null;
+        }
+
+        @Override
+        public EntryBackupProcessor<Integer, SimpleValue> getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+    }
+
+    private IMap<Integer, SimpleValue> getMap() {
+        return bounceMemberRule.getSteadyMember().getMap(MAP_NAME);
+    }
+
+    private static class SimpleValue implements Serializable {
+        public int i;
+
+        SimpleValue() {
+        }
+
+        SimpleValue(final int i) {
+            this.i = i;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            SimpleValue that = (SimpleValue) o;
+
+            if (i != that.i) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "value: " + i;
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
@@ -1,0 +1,708 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Offloadable;
+import com.hazelcast.core.ReadOnly;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
+
+    public static final String MAP_NAME = "EntryProcessorOffloadableTest";
+
+    private HazelcastInstance[] instances;
+
+    @Parameterized.Parameter(0)
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameter(1)
+    public int syncBackupCount;
+
+    @Parameterized.Parameter(2)
+    public int asyncBackupCount;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Parameterized.Parameters(name = "{index}: {0} sync={1} async={2}")
+    public static Collection<Object[]> data() {
+        return asList(new Object[][]{
+                {BINARY, 0, 0}, {OBJECT, 0, 0},
+                {BINARY, 1, 0}, {OBJECT, 1, 0},
+                {BINARY, 0, 1}, {OBJECT, 0, 1}
+        });
+    }
+
+    private boolean isBackup() {
+        return syncBackupCount + asyncBackupCount > 0;
+    }
+
+    @Override
+    public Config getConfig() {
+        Config config = super.getConfig();
+        MapConfig mapConfig = new MapConfig(MAP_NAME);
+        mapConfig.setInMemoryFormat(inMemoryFormat);
+        mapConfig.setAsyncBackupCount(asyncBackupCount);
+        mapConfig.setBackupCount(syncBackupCount);
+        config.addMapConfig(mapConfig);
+        return config;
+    }
+
+    @Before
+    public void before() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        instances = factory.newInstances(getConfig());
+    }
+
+    @Test
+    public void testEntryProcessorWithKey_offloadable_setValue() {
+        String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+        SimpleValue expectedValue = new SimpleValue(2);
+
+        IMap<Object, Object> map = instances[1].getMap(MAP_NAME);
+        map.put(key, givenValue);
+        Object result = map.executeOnKey(key, new EntryIncOffloadable());
+
+        assertEquals(expectedValue, map.get(key));
+        assertBackupEventually(instances[1], MAP_NAME, key, isBackup() ? expectedValue : null);
+        assertEquals(givenValue.i, result);
+
+
+        instances[0].shutdown();
+        assertEquals(expectedValue, map.get(key));
+        assertEquals(givenValue.i, result);
+    }
+
+    private static class EntryIncOffloadable implements EntryProcessor<String, SimpleValue>, Offloadable, EntryBackupProcessor<String, SimpleValue> {
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            final SimpleValue value = entry.getValue();
+            int result = value.i;
+            value.i++;
+            entry.setValue(value);
+            return result;
+        }
+
+        @Override
+        public EntryBackupProcessor<String, SimpleValue> getBackupProcessor() {
+            return this;
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+    }
+
+    @Test
+    public void testEntryProcessorWithKey_offloadable_withoutSetValue() {
+        String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+        SimpleValue expectedValue = new SimpleValue(1);
+
+        IMap<Object, Object> map = instances[1].getMap(MAP_NAME);
+        map.put(key, givenValue);
+        Object result = map.executeOnKey(key, new EntryIncOffloadableNoSetValue());
+
+        assertEquals(expectedValue, map.get(key));
+        if (inMemoryFormat.equals(OBJECT)) {
+            assertBackupEventually(instances[1], MAP_NAME, key, isBackup() ? new SimpleValue(2) : null);
+        } else {
+            assertBackupEventually(instances[1], MAP_NAME, key, isBackup() ? expectedValue : null);
+        }
+        assertEquals(givenValue.i, result);
+
+        instances[0].shutdown();
+        assertEquals(expectedValue, map.get(key));
+    }
+
+    private static class EntryIncOffloadableNoSetValue implements EntryProcessor<String, SimpleValue>, Offloadable, EntryBackupProcessor<String, SimpleValue> {
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            final SimpleValue value = entry.getValue();
+            int result = value.i;
+            value.i++;
+            return result;
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return this;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+    }
+
+    @Test
+    public void testEntryProcessorWithKey_offloadableReadOnly_setValue() {
+        String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+
+        IMap<Object, Object> map = instances[1].getMap(MAP_NAME);
+        map.put(key, givenValue);
+
+        expectedException.expect(HazelcastException.class);
+
+        map.executeOnKey(key, new EntryIncOffloadableReadOnly());
+    }
+
+    private static class EntryIncOffloadableReadOnly implements EntryProcessor<String, SimpleValue>, Offloadable, ReadOnly,
+            EntryBackupProcessor<String, SimpleValue> {
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            final SimpleValue value = entry.getValue();
+            int result = value.i;
+            value.i++;
+            entry.setValue(value);
+            return result;
+        }
+
+        @Override
+        public EntryBackupProcessor<String, SimpleValue> getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+    }
+
+
+    @Test
+    public void testEntryProcessorWithKey_offloadableReadOnly_withoutSetValue() {
+        String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+        SimpleValue expectedValue = new SimpleValue(1);
+
+        IMap<Object, Object> map = instances[1].getMap(MAP_NAME);
+        map.put(key, givenValue);
+        Object result = map.executeOnKey(key, new EntryIncOffloadableReadOnlyNoSetValue());
+
+        assertEquals(expectedValue, map.get(key));
+        assertBackupEventually(instances[1], MAP_NAME, key, isBackup() ? expectedValue : null);
+        assertEquals(givenValue.i, result);
+
+        instances[0].shutdown();
+        assertEquals(expectedValue, map.get(key));
+    }
+
+    private static class EntryIncOffloadableReadOnlyNoSetValue implements EntryProcessor<String, SimpleValue>, Offloadable, ReadOnly,
+            EntryBackupProcessor<String, SimpleValue> {
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            final SimpleValue value = entry.getValue();
+            int result = value.i;
+            value.i++;
+            return result;
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+    }
+
+    @Test
+    public void testEntryProcessorWithKey_offloadableReadOnly_returnValue() {
+        String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+        SimpleValue expectedValue = new SimpleValue(1);
+
+        IMap<Object, Object> map = instances[1].getMap(MAP_NAME);
+        map.put(key, givenValue);
+        Object result = map.executeOnKey(key, new EntryIncOffloadableReadOnlyReturnValue());
+
+        assertEquals(expectedValue, map.get(key));
+        assertBackupEventually(instances[1], MAP_NAME, key, isBackup() ? expectedValue : null);
+        assertEquals(givenValue.i, result);
+
+        instances[0].shutdown();
+        assertEquals(expectedValue, map.get(key));
+    }
+
+    private static class EntryIncOffloadableReadOnlyReturnValue implements EntryProcessor<String, SimpleValue>, Offloadable, ReadOnly,
+            EntryBackupProcessor<String, SimpleValue> {
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            final SimpleValue value = entry.getValue();
+            return value.i;
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+    }
+
+
+    @Test
+    public void testEntryProcessorWithKey_offloadableReadOnly_noReturnValue() {
+        String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+        SimpleValue expectedValue = new SimpleValue(1);
+
+        IMap<Object, Object> map = instances[1].getMap(MAP_NAME);
+        map.put(key, givenValue);
+        Object result = map.executeOnKey(key, new EntryIncOffloadableReadOnlyNoReturnValue());
+        assertEquals(expectedValue, map.get(key));
+        assertBackupEventually(instances[1], MAP_NAME, key, isBackup() ? expectedValue : null);
+        assertEquals(null, result);
+
+        instances[0].shutdown();
+        assertEquals(expectedValue, map.get(key));
+    }
+
+    private static class EntryIncOffloadableReadOnlyNoReturnValue implements EntryProcessor<String, SimpleValue>, Offloadable, ReadOnly,
+            EntryBackupProcessor<String, SimpleValue> {
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            return null;
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+    }
+
+    @Test
+    public void testEntryProcessorWithKey_offloadableReadOnly_throwsException() {
+        String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+
+        IMap<Object, Object> map = instances[1].getMap(MAP_NAME);
+        map.put(key, givenValue);
+
+        expectedException.expect(RuntimeException.class);
+        map.executeOnKey(key, new EntryIncOffloadableReadOnlyException());
+        assertFalse(map.isLocked(key));
+    }
+
+    private static class EntryIncOffloadableReadOnlyException implements EntryProcessor<String, SimpleValue>, Offloadable, ReadOnly,
+            EntryBackupProcessor<String, SimpleValue> {
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            throw new RuntimeException("EP exception");
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+    }
+
+
+    @Test
+    public void testEntryProcessorWithKey_offloadableModifying_throwsException_keyNotLocked() {
+        String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+
+        IMap<Object, Object> map = instances[1].getMap(MAP_NAME);
+        map.put(key, givenValue);
+
+        expectedException.expect(RuntimeException.class);
+        map.executeOnKey(key, new EntryIncOffloadableException());
+
+        assertFalse(map.isLocked(key));
+    }
+
+    private static class EntryIncOffloadableException implements EntryProcessor<String, SimpleValue>, Offloadable,
+            EntryBackupProcessor<String, SimpleValue> {
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            throw new RuntimeException("EP exception");
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+    }
+
+    void assertBackupEventually(final HazelcastInstance instance, final String mapName, final Object key, Object expected) {
+        assertEqualsEventually(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return readFromMapBackup(instance, mapName, key);
+            }
+        }, expected);
+    }
+
+    @Test
+    public void testEntryProcessorWithKey_offloadable_otherModifyingWillWait() throws InterruptedException {
+        final String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+        SimpleValue expectedValue = new SimpleValue(4);
+
+        final IMap<Object, Object> map = instances[0].getMap(MAP_NAME);
+        map.put(key, givenValue);
+
+        final CountDownLatch epStarted = new CountDownLatch(1);
+        final CountDownLatch epStopped = new CountDownLatch(1);
+        new Thread() {
+            public void run() {
+                map.executeOnKey(key, new EntryLatchModifying(epStarted, epStopped));
+            }
+        }.start();
+
+        epStarted.await();
+        map.executeOnKey(key, new EntryLatchVerifying(epStarted, epStopped, 4));
+
+        // verified EPs not out-of-order, and not at the same time
+        assertEqualsEventually(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return map.get(key);
+            }
+        }, expectedValue);
+    }
+
+    private static class EntryLatchModifying implements EntryProcessor<String, SimpleValue>, Offloadable, EntryBackupProcessor<String, SimpleValue> {
+
+        private final CountDownLatch start;
+        private final CountDownLatch stop;
+
+        public EntryLatchModifying(CountDownLatch start, CountDownLatch stop) {
+            this.start = start;
+            this.stop = stop;
+        }
+
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            start.countDown();
+            try {
+                final SimpleValue value = entry.getValue();
+                value.i++;
+                entry.setValue(value);
+                return null;
+            } finally {
+                stop.countDown();
+            }
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+    }
+
+    private static class EntryLatchVerifying implements EntryProcessor<String, SimpleValue>, Offloadable, EntryBackupProcessor<String, SimpleValue> {
+
+        private final CountDownLatch otherStarted;
+        private final CountDownLatch otherStopped;
+        private final int valueToSet;
+
+        public EntryLatchVerifying(CountDownLatch otherStarted, CountDownLatch otherStopped, final int value) {
+            this.otherStarted = otherStarted;
+            this.otherStopped = otherStopped;
+            this.valueToSet = value;
+        }
+
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            if (otherStarted.getCount() != 0 || otherStopped.getCount() != 0) {
+                throw new RuntimeException("Wrong threading order");
+            }
+
+            final SimpleValue value = entry.getValue();
+            value.i = valueToSet;
+            entry.setValue(value);
+            return null;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+    }
+
+    @Test
+    public void testEntryProcessorWithKey_offloadable_otherReadingWillNotWait() throws InterruptedException {
+        final String key = generateKeyOwnedBy(instances[0]);
+        SimpleValue givenValue = new SimpleValue(1);
+        SimpleValue expectedValue = new SimpleValue(2);
+
+        final IMap<Object, Object> map = instances[0].getMap(MAP_NAME);
+        map.put(key, givenValue);
+
+        final CountDownLatch epStarted = new CountDownLatch(1);
+        final CountDownLatch epWaitToProceed = new CountDownLatch(1);
+        final CountDownLatch epStopped = new CountDownLatch(1);
+        new Thread() {
+            public void run() {
+                map.executeOnKey(key, new EntryLatchModifyingOtherReading(epStarted, epWaitToProceed, epStopped));
+            }
+        }.start();
+
+        epStarted.await();
+        map.executeOnKey(key, new EntryLatchReadOnlyVerifyingWhileOtherWriting(epStarted, epWaitToProceed, epStopped));
+        epStopped.await();
+
+        // verified EPs not out-of-order, and not at the same time
+        assertEqualsEventually(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return map.get(key);
+            }
+        }, expectedValue);
+    }
+
+    private static class EntryLatchModifyingOtherReading implements EntryProcessor<String, SimpleValue>, Offloadable, EntryBackupProcessor<String, SimpleValue> {
+
+        private final CountDownLatch start;
+        private final CountDownLatch stop;
+        private final CountDownLatch waitToProceed;
+
+        public EntryLatchModifyingOtherReading(CountDownLatch start, CountDownLatch waitToProceed, CountDownLatch stop) {
+            this.start = start;
+            this.stop = stop;
+            this.waitToProceed = waitToProceed;
+        }
+
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            start.countDown();
+            try {
+                waitToProceed.await();
+                final SimpleValue value = entry.getValue();
+                value.i++;
+                entry.setValue(value);
+                return null;
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } finally {
+                stop.countDown();
+            }
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+
+    }
+
+    private static class EntryLatchReadOnlyVerifyingWhileOtherWriting implements EntryProcessor<String, SimpleValue>,
+            EntryBackupProcessor<String, SimpleValue>, Offloadable, ReadOnly {
+
+        private final CountDownLatch otherStarted;
+        private final CountDownLatch otherWaitingToProceed;
+        private final CountDownLatch otherStopped;
+
+        public EntryLatchReadOnlyVerifyingWhileOtherWriting(CountDownLatch otherStarted, CountDownLatch otherWaitingToProceed,
+                                                            CountDownLatch otherStopped) {
+            this.otherStarted = otherStarted;
+            this.otherWaitingToProceed = otherWaitingToProceed;
+            this.otherStopped = otherStopped;
+        }
+
+        @Override
+        public Object process(final Map.Entry<String, SimpleValue> entry) {
+            if (otherStarted.getCount() != 0 || otherStopped.getCount() != 1) {
+                throw new RuntimeException("Wrong threading order");
+            }
+            otherWaitingToProceed.countDown();
+            return null;
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+
+        @Override
+        public void processBackup(Map.Entry<String, SimpleValue> entry) {
+            process(entry);
+        }
+
+        @Override
+        public String getExecutorName() {
+            return Offloadable.OFFLOADABLE_EXECUTOR;
+        }
+    }
+
+
+    private static class SimpleValue implements Serializable {
+
+        public int i;
+
+        SimpleValue() {
+        }
+
+        SimpleValue(final int i) {
+            this.i = i;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            SimpleValue that = (SimpleValue) o;
+
+            if (i != that.i) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "value: " + i;
+        }
+    }
+
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -1730,7 +1730,6 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         }
     }
 
-
     private IMap<Long, MyData> setupImapForEntryProcessorWithIndex() {
         Config config = getConfig();
         MapConfig testMapConfig = config.getMapConfig(MAP_NAME);
@@ -1841,4 +1840,5 @@ public class EntryProcessorTest extends HazelcastTestSupport {
             return null;
         }
     }
+
 }


### PR DESCRIPTION
Updated on 17.03.2017

### Overview

Implementation of the the Offloadable contract for the EntryProcessor execution on a single key.

Allows off-loading the processing unit implementing this interface to the specified or default Executor. Currently supported in:

  * IMap.executeOnKey(Object, EntryProcessor)
  * IMap.submitToKey(Object, EntryProcessoor)
  * IMap.submitToKey(Object, EntryProcessor, ExecutionCallback)

### Offloadable (for reading & writing)

If the EntryProcessor implements the Offloadable interface the processing will be offloaded to the given ExecutorService allowing unblocking the partition-thread. The key will be locked for the time-span of the processing in order to not generate a write-conflict.

 If the EntryProcessor implements Offloadable the invocation scenario looks as follows:
 - EntryOperation fetches the entry and locks the given key on partition-thread
 - Then the processing is offloaded to the given executor
 - When the processing finishes
    * if there is a change to the entry, a EntryOffloadableSetUnlockOperation is spawned
      which sets the new value and unlocks the given key on partition-thread
    * if there is no change to the entry, a EntryOffloadableSetUnlockOperation is spawned, which just unlocks the given key on partition thread

 There will not be a conflict on a write due to the pessimistic locking of the key.
 The threading looks as follows:

1. partition-thread (fetch & lock)
2. execution-thread (process)
3. partition-thread (set & unlock, or just unlock if no changes)

### Offloadable (for reading only)

If the EntryProcessor implements the Offloadable and ReadOnly interfaces the processing will be offloaded to the given ExecutorService allowing unblocking the partition-thread. Since the EntryProcessor is not supposed to do any changes to the Entry the key will NOT be locked for the time-span of the processing.

 If the EntryProcessor implements Offloadable and ReadOnly the invocation scenario looks as follows:
 - EntryOperation fetches the entry and DOES NOT lock the given key on partition-thread
 - Then the processing is offloaded to the given executor
 - When the processing finishes
    * if there is a change to the entry -> exception is thrown
    * if there is no change to the entry -> the result is returned to the user from the executor-thread.

In the read-only case the threading looks as follows:

1. partition-thread (fetch)
2. execution-thread (process)

### Primary partition - main actors

- EntryOperation (ordinary & offloaded cases)
- EntryOffloadableSetUnlockOperation

 ### Backup partitions

Offloading will not be applied to backup partitions. It is possible to initialize the EntryBackupProcessor with some input provided by the EntryProcessor in the EntryProcessor.getBackupProcessor() method.
The input allows providing context to the EntryBackupProcessor - for example the "delta" so that the EntryBackupProcessor does not have to calculate the "delta" but it may just apply it, so that it does not hog the partition-thread.

### Locking

The locking takes place only locally. If a partition locked by an off-loaded task gets migrated, the lock will not be migrated. In this situation the off-loaded task "relying" on the lock will fail on the unlock operation, since it will notice that there is no such a lock and therefore the processing for the key will get retried. The reason behind is that the off-loadable backup-processing does not use locking there cannot be any transfer of `off-loadable locks` from the primary replica to backup replicas and the other-way around.