### PR TITLE
Warm up partitions before starting tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
@@ -59,6 +59,7 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
     @Before
     public void setUp() {
         instances = createHazelcastInstanceFactory(NODE_COUNT).newInstances(new Config());
+        warmUpPartitions(instances);
     }
 
     @Test


### PR DESCRIPTION
When the partitions are not warmed up and the test starts, the partition assignment will start. In some cases the partition assignment lasts for a long time, causing invocations to fail on some members.

Fixes failing assertions (not timeouts) in https://github.com/hazelcast/hazelcast/issues/5103