### PR TITLE
Allow RANDOM eviction policy in XML configuration

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.9.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.9.xsd
@@ -385,6 +385,7 @@
             <xs:enumeration value="NONE"/>
             <xs:enumeration value="LRU"/>
             <xs:enumeration value="LFU"/>
+            <xs:enumeration value="RANDOM"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -78,6 +78,8 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
     static final String HAZELCAST_CLIENT_START_TAG =
             "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n";
 
+    static final String HAZELCAST_CLIENT_END_TAG = "</hazelcast-client>";
+
     private ClientConfig clientConfig;
 
     @Before
@@ -354,6 +356,33 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
     public void testHazelcastClientTagAppearsTwice() {
         String xml = HAZELCAST_CLIENT_START_TAG + "<hazelcast-client/></<hazelcast-client>";
         buildConfig(xml);
+    }
+
+    @Test
+    public void testNearCacheEvictionPolicy() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<near-cache name=\"lfu\">"
+                + "  <eviction eviction-policy=\"LFU\"/>"
+                + "</near-cache>"
+                + "<near-cache name=\"lru\">"
+                + "  <eviction eviction-policy=\"LRU\"/>"
+                + "</near-cache>"
+                + "<near-cache name=\"none\">"
+                + "  <eviction eviction-policy=\"NONE\"/>"
+                + "</near-cache>"
+                + "<near-cache name=\"random\">"
+                + "  <eviction eviction-policy=\"RANDOM\"/>"
+                + "</near-cache>"
+                + HAZELCAST_CLIENT_END_TAG;
+        ClientConfig clientConfig = buildConfig(xml);
+        assertEquals(EvictionPolicy.LFU, getNearCacheEvictionPolicy("lfu", clientConfig));
+        assertEquals(EvictionPolicy.LRU, getNearCacheEvictionPolicy("lru", clientConfig));
+        assertEquals(EvictionPolicy.NONE, getNearCacheEvictionPolicy("none", clientConfig));
+        assertEquals(EvictionPolicy.RANDOM, getNearCacheEvictionPolicy("random", clientConfig));
+    }
+
+    private EvictionPolicy getNearCacheEvictionPolicy(String mapName, ClientConfig clientConfig) {
+        return clientConfig.getNearCacheConfig(mapName).getEvictionConfig().getEvictionPolicy();
     }
 
     static ClientConfig buildConfig(String xml, Properties properties) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -1471,7 +1471,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="hazelcast-bean">
-                    <xs:all>
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
                         <xs:element name="spring-aware" type="xs:string" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
@@ -1481,9 +1481,9 @@
                         <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="proxy-factories" type="proxy-factories" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="load-balancer" type="load-balancer" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="near-cache" type="near-cache-client" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="near-cache" type="near-cache-client" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element name="query-caches" type="query-caches-client" minOccurs="0" maxOccurs="1"/>
-                    </xs:all>
+                    </xs:choice>
                     <xs:attribute name="executor-pool-size" type="xs:int" use="optional"/>
                     <xs:attribute name="credentials-ref" type="xs:string" use="optional"/>
                 </xs:extension>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -293,6 +293,19 @@ public class TestClientApplicationContext {
     }
 
     @Test
+    public void testClientNearCacheEvictionPolicies() {
+        ClientConfig config = client3.getClientConfig();
+        assertEquals(EvictionPolicy.LFU, getNearCacheEvictionPolicy("lfuNearCacheEviction", config));
+        assertEquals(EvictionPolicy.LRU, getNearCacheEvictionPolicy("lruNearCacheEviction", config));
+        assertEquals(EvictionPolicy.NONE, getNearCacheEvictionPolicy("noneNearCacheEviction", config));
+        assertEquals(EvictionPolicy.RANDOM, getNearCacheEvictionPolicy("randomNearCacheEviction", config));
+    }
+
+    private EvictionPolicy getNearCacheEvictionPolicy(String mapName, ClientConfig clientConfig) {
+        return clientConfig.getNearCacheConfig(mapName).getEvictionConfig().getEvictionPolicy();
+    }
+
+    @Test
     public void testFullQueryCacheConfig() throws Exception {
         ClientConfig config = client6.getClientConfig();
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -262,7 +262,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     @Test
     public void testMapConfig() {
         assertNotNull(config);
-        assertEquals(18, config.getMapConfigs().size());
+        assertEquals(26, config.getMapConfigs().size());
 
         MapConfig testMapConfig = config.getMapConfig("testMap");
         assertNotNull(testMapConfig);
@@ -993,6 +993,26 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(1111, hotRestartPersistenceConfig.getValidationTimeoutSeconds());
         assertEquals(2222, hotRestartPersistenceConfig.getDataLoadTimeoutSeconds());
         assertEquals(PARTIAL_RECOVERY_MOST_COMPLETE, hotRestartPersistenceConfig.getClusterDataRecoveryPolicy());
+    }
+
+    @Test
+    public void testMapEvictionPolicies() {
+        assertEquals(EvictionPolicy.LFU, config.getMapConfig("lfuEvictionMap").getEvictionPolicy());
+        assertEquals(EvictionPolicy.LRU, config.getMapConfig("lruEvictionMap").getEvictionPolicy());
+        assertEquals(EvictionPolicy.NONE, config.getMapConfig("noneEvictionMap").getEvictionPolicy());
+        assertEquals(EvictionPolicy.RANDOM, config.getMapConfig("randomEvictionMap").getEvictionPolicy());
+    }
+
+    @Test
+    public void testMemberNearCacheEvictionPolicies() {
+        assertEquals(EvictionPolicy.LFU, getNearCacheEvictionPolicy("lfuNearCacheEvictionMap", config));
+        assertEquals(EvictionPolicy.LRU, getNearCacheEvictionPolicy("lruNearCacheEvictionMap", config));
+        assertEquals(EvictionPolicy.NONE, getNearCacheEvictionPolicy("noneNearCacheEvictionMap", config));
+        assertEquals(EvictionPolicy.RANDOM, getNearCacheEvictionPolicy("randomNearCacheEvictionMap", config));
+    }
+
+    private EvictionPolicy getNearCacheEvictionPolicy(String mapName, Config config) {
+        return config.getMapConfig(mapName).getNearCacheConfig().getEvictionConfig().getEvictionPolicy();
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -264,6 +264,24 @@
                 </hz:entry-listeners>
             </hz:map>
 
+            <hz:map name="lfuEvictionMap" eviction-policy="LFU" />
+            <hz:map name="lruEvictionMap" eviction-policy="LRU" />
+            <hz:map name="noneEvictionMap" eviction-policy="NONE" />
+            <hz:map name="randomEvictionMap" eviction-policy="RANDOM" />
+
+            <hz:map name="lfuNearCacheEvictionMap">
+                <hz:near-cache eviction-policy="LFU" />
+            </hz:map>
+            <hz:map name="lruNearCacheEvictionMap">
+                <hz:near-cache eviction-policy="LRU" />
+            </hz:map>
+            <hz:map name="noneNearCacheEvictionMap">
+                <hz:near-cache eviction-policy="NONE" />
+            </hz:map>
+            <hz:map name="randomNearCacheEvictionMap">
+                <hz:near-cache eviction-policy="RANDOM" />
+            </hz:map>
+
             <hz:map name="testMap3"
                     backup-count="2"
                     max-size="0"

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -154,6 +154,14 @@
                        max-size="4000"
                        invalidate-on-change="true" local-update-policy="CACHE_ON_UPDATE"/>
 
+        <hz:near-cache name="lfuNearCacheEviction" eviction-policy="LFU" />
+        <hz:near-cache name="lruNearCacheEviction"
+                       eviction-policy="LRU" />
+        <hz:near-cache name="noneNearCacheEviction"
+                       eviction-policy="NONE" />
+        <hz:near-cache name="randomNearCacheEviction"
+                       eviction-policy="RANDOM" />
+
 
     </hz:client>
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -172,6 +172,7 @@
                         NONE (no eviction).
                         LRU (Least Recently Used).
                         LFU (Least Frequently Used).
+                        RANDOM (evict random entry).
                         NONE is the default.
                     </xs:documentation>
                 </xs:annotation>
@@ -2794,6 +2795,7 @@
             <xs:enumeration value="NONE"/>
             <xs:enumeration value="LRU"/>
             <xs:enumeration value="LFU"/>
+            <xs:enumeration value="RANDOM"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -521,6 +521,31 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testMapConfig_evictions() {
+        String xml = HAZELCAST_START_TAG
+                + "<map name=\"lruMap\">" +
+                "        <eviction-policy>LRU</eviction-policy>\n" +
+                "    </map>\n"
+                + "<map name=\"lfuMap\">" +
+                "        <eviction-policy>LFU</eviction-policy>\n" +
+                "    </map>\n"
+                + "<map name=\"noneMap\">" +
+                "        <eviction-policy>NONE</eviction-policy>\n" +
+                "    </map>\n"
+                + "<map name=\"randomMap\">" +
+                "        <eviction-policy>RANDOM</eviction-policy>\n" +
+                "    </map>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+
+        assertEquals(EvictionPolicy.LRU, config.getMapConfig("lruMap").getEvictionPolicy());
+        assertEquals(EvictionPolicy.LFU, config.getMapConfig("lfuMap").getEvictionPolicy());
+        assertEquals(EvictionPolicy.NONE, config.getMapConfig("noneMap").getEvictionPolicy());
+        assertEquals(EvictionPolicy.RANDOM, config.getMapConfig("randomMap").getEvictionPolicy());
+    }
+
+    @Test
     public void testMapConfig_optimizeQueries() {
         String xml1 = HAZELCAST_START_TAG
                 + "<map name=\"mymap1\">"
@@ -683,6 +708,42 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         NearCacheConfig ncConfig = mapConfig.getNearCacheConfig();
 
         assertEquals(InMemoryFormat.OBJECT, ncConfig.getInMemoryFormat());
+    }
+
+    @Test
+    public void testNearCacheEvictionPolicy() {
+        String xml = HAZELCAST_START_TAG
+                + "  <map name=\"lfuNearCache\">"
+                + "    <near-cache>"
+                + "      <eviction eviction-policy=\"LFU\"/>"
+                + "    </near-cache>"
+                + "  </map>"
+                + "  <map name=\"lruNearCache\">"
+                + "    <near-cache>"
+                + "      <eviction eviction-policy=\"LRU\"/>"
+                + "    </near-cache>"
+                + "  </map>"
+                + "  <map name=\"noneNearCache\">"
+                + "    <near-cache>"
+                + "      <eviction eviction-policy=\"NONE\"/>"
+                + "    </near-cache>"
+                + "  </map>"
+                + "  <map name=\"randomNearCache\">"
+                + "    <near-cache>"
+                + "      <eviction eviction-policy=\"RANDOM\"/>"
+                + "    </near-cache>"
+                + "  </map>"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        assertEquals(EvictionPolicy.LFU, getNearCacheEvictionPolicy("lfuNearCache", config));
+        assertEquals(EvictionPolicy.LRU, getNearCacheEvictionPolicy("lruNearCache", config));
+        assertEquals(EvictionPolicy.NONE, getNearCacheEvictionPolicy("noneNearCache", config));
+        assertEquals(EvictionPolicy.RANDOM, getNearCacheEvictionPolicy("randomNearCache", config));
+    }
+
+    private EvictionPolicy getNearCacheEvictionPolicy(String mapName, Config config) {
+        return config.getMapConfig(mapName).getNearCacheConfig().getEvictionConfig().getEvictionPolicy();
     }
 
     @Test


### PR DESCRIPTION
Also fixing [a regression](https://github.com/hazelcast/hazelcast/pull/9529) where only a single client near-cache could be configured in Spring XML.
Fixes #10053
This should be backported. 