### PR TITLE
Get or create "default" Hazelcast instance

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Hazelcast.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Hazelcast.java
@@ -69,11 +69,16 @@ public final class Hazelcast {
      * Hazelcast will look into two places for the configuration file:
      * <ol>
      *     <li>
-     *         System property: Hazelcast will first check if "hazelcast.config" system property is set to a file path.
-     *         Example: -Dhazelcast.config=C:/myhazelcast.xml.
+     *         System property: Hazelcast will first check if "hazelcast.config" system property is set to a file or a
+     *         {@code classpath:...} path.
+     *         Examples: -Dhazelcast.config=C:/myhazelcast.xml , -Dhazelcast.config=classpath:the-hazelcast-config.xml ,
+     *         -Dhazelcast.config=classpath:com/mydomain/hazelcast.xml
      *     </li>
      *     <li>
-     *         Classpath: If config file is not set as a system property, Hazelcast will check classpath for hazelcast.xml file.
+     *         "hazelcast.xml" file in current working directory
+     *     </li>
+     *     <li>
+     *         Classpath: Hazelcast will check classpath for hazelcast.xml file.
      *     </li>
      * </ol>
      * If Hazelcast doesn't find any config file, it will start with the default configuration (hazelcast-default.xml)
@@ -103,14 +108,59 @@ public final class Hazelcast {
     }
 
     /**
+     * Gets or creates a HazelcastInstance with the default XML configuration looked up in:
+     * <ol>
+     *     <li>
+     *         System property: Hazelcast will first check if "hazelcast.config" system property is set to a file or a
+     *         {@code classpath:...} path.
+     *         Examples: -Dhazelcast.config=C:/myhazelcast.xml , -Dhazelcast.config=classpath:the-hazelcast-config.xml ,
+     *         -Dhazelcast.config=classpath:com/mydomain/hazelcast.xml
+     *     </li>
+     *     <li>
+     *         "hazelcast.xml" file in current working directory
+     *     </li>
+     *     <li>
+     *         Classpath: Hazelcast will check classpath for hazelcast.xml file.
+     *     </li>
+     * </ol>
+     *
+     * If a configuration file is not located, an {@link IllegalArgumentException} will be thrown.
+     *
+     * If a Hazelcast instance with the same name as the configuration exists, then it is returned, otherwise it is created.
+     *
+     * @return the HazelcastInstance
+     * @throws IllegalArgumentException if the instance name of the config is null or empty or if no config file can be
+     * located.
+     */
+    public static HazelcastInstance getOrCreateHazelcastInstance() {
+        return HazelcastInstanceFactory.getOrCreateHazelcastInstance(null);
+    }
+
+    /**
      * Gets or creates the HazelcastInstance with a certain name.
      *
      * If a Hazelcast instance with the same name as the configuration exists, then it is returned, otherwise it is created.
      *
+     * If {@code config} is {@code null}, then an XML configuration file is looked up in the following order:
+     * <ol>
+     *     <li>
+     *         System property: Hazelcast will first check if "hazelcast.config" system property is set to a file or a
+     *         {@code classpath:...} path.
+     *         Examples: -Dhazelcast.config=C:/myhazelcast.xml , -Dhazelcast.config=classpath:the-hazelcast-config.xml ,
+     *         -Dhazelcast.config=classpath:com/mydomain/hazelcast.xml
+     *     </li>
+     *     <li>
+     *         "hazelcast.xml" file in current working directory
+     *     </li>
+     *     <li>
+     *         Classpath: Hazelcast will check classpath for hazelcast.xml file.
+     *     </li>
+     * </ol>
+     *
      * @param config the Config.
      * @return the HazelcastInstance
-     * @throws NullPointerException if config is null.
-     * @throws IllegalArgumentException if the instance name of the config is null or empty.
+     * @throws IllegalArgumentException if the instance name of the config is null or empty or if no config file can be
+     * located.
      */
     public static HazelcastInstance getOrCreateHazelcastInstance(Config config) {
         return HazelcastInstanceFactory.getOrCreateHazelcastInstance(config);

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -40,7 +40,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
 import static com.hazelcast.util.Preconditions.checkHasText;
-import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -83,7 +82,9 @@ public final class HazelcastInstanceFactory {
     }
 
     public static HazelcastInstance getOrCreateHazelcastInstance(Config config) {
-        checkNotNull(config, "config can't be null");
+        if (config == null) {
+            config = new XmlConfigBuilder().build();
+        }
 
         String name = config.getInstanceName();
         checkHasText(name, "instanceName must contain text");

--- a/hazelcast/src/test/java/com/hazelcast/core/HazelcastTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/HazelcastTest.java
@@ -37,6 +37,8 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class HazelcastTest extends HazelcastTestSupport {
 
+    public static final String HAZELCAST_CONFIG = "hazelcast.config";
+
     @Before
     @After
     public void cleanup() {
@@ -44,9 +46,27 @@ public class HazelcastTest extends HazelcastTestSupport {
         assertEquals(emptySet(), getAllHazelcastInstances());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void getOrCreateHazelcastInstance_nullConfig() {
         Hazelcast.getOrCreateHazelcastInstance(null);
+    }
+
+    @Test
+    public void getOrCreateDefaultHazelcastInstance() {
+        String hzConfigProperty = System.getProperty(HAZELCAST_CONFIG);
+        try {
+            System.setProperty(HAZELCAST_CONFIG, "classpath:test-hazelcast-jcache.xml");
+            HazelcastInstance hz1 = Hazelcast.getOrCreateHazelcastInstance();
+            HazelcastInstance hz2 = Hazelcast.getOrCreateHazelcastInstance();
+            assertEquals("Calling two times getOrCreateHazelcastInstance should return same instance", hz1,
+                    hz2);
+        } finally {
+            if (hzConfigProperty == null) {
+                System.clearProperty(HAZELCAST_CONFIG);
+            } else {
+                System.setProperty(HAZELCAST_CONFIG, hzConfigProperty);
+            }
+        }
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
* Introduces `Hazelcast.getOrCreateHazelcastInstance()` which, similarly to `HazelcastInstance.newHazelcastInstance`, looks up hazelcast.xml configuration in the same default locations and gets-or-creates an instance based on instance name (as in `getOrCreateHazelcastInstance(Config)`.
* Updates `getOrCreateHazelcastInstance(Config)` to accept a `null` argument.
* Updates javadoc with current `hazelcast.xml` lookup behaviour.

Reasoning: get-or-create methods' behaviour will match `newHazelcastInstance()`/`newHazelcastInstance(Config)`. Makes integration in other libraries more convenient, as the default configuration lookup logic is implemented within Hazelcast (instead of having to re-implement it in external code).

Fixes #10007 