### PR TITLE
Cleanup in common ClientExecutionService and ExecutionService usages

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientExecutionService.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.client.spi;
 
-import com.hazelcast.spi.ExecutionService;
+import com.hazelcast.spi.TaskScheduler;
 
 import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -30,7 +29,7 @@ import java.util.concurrent.ExecutorService;
  * Any schedule submit or execute operation runs on internal executors.
  * When user code needs to run getUserExecutor() should be utilized
  */
-public interface ClientExecutionService extends ExecutionService, Executor {
+public interface ClientExecutionService extends TaskScheduler {
 
     /**
      * @return executorService that alien (user code) runs on

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -17,15 +17,11 @@
 package com.hazelcast.client.spi.impl;
 
 import com.hazelcast.client.spi.ClientExecutionService;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.spi.TaskScheduler;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
-import com.hazelcast.util.executor.ExecutorType;
 import com.hazelcast.util.executor.LoggingScheduledExecutor;
-import com.hazelcast.util.executor.ManagedExecutorService;
 import com.hazelcast.util.executor.PoolExecutorThreadFactory;
 
 import java.util.concurrent.Callable;
@@ -83,43 +79,13 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     }
 
     @Override
-    public ManagedExecutorService register(String name, int poolSize, int queueCapacity, ExecutorType type) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ManagedExecutorService getExecutor(String name) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void shutdownExecutor(String name) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void execute(String name, Runnable command) {
-        execute(command);
-    }
-
-    @Override
-    public Future<?> submit(String name, Runnable task) {
-        return internalExecutor.submit(task);
-    }
-
-    @Override
-    public <T> Future<T> submit(String name, Callable<T> task) {
-        return internalExecutor.submit(task);
-    }
-
-    @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
         return internalExecutor.schedule(command, delay, unit);
     }
 
     @Override
-    public ScheduledFuture<?> schedule(String name, Runnable command, long delay, TimeUnit unit) {
-        return schedule(command, delay, unit);
+    public <V> ScheduledFuture<Future<V>> schedule(Callable<V> command, long delay, TimeUnit unit) {
+        return (ScheduledFuture<Future<V>>) internalExecutor.schedule(command, delay, unit);
     }
 
     @Override
@@ -128,34 +94,13 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService 
     }
 
     @Override
-    public ScheduledFuture<?> scheduleWithRepetition(String name, Runnable command, long initialDelay, long period,
-                                                     TimeUnit unit) {
-        return scheduleWithRepetition(command, initialDelay, period, unit);
-    }
-
-    @Override
-    public TaskScheduler getGlobalTaskScheduler() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public TaskScheduler getTaskScheduler(String name) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <V> ICompletableFuture<V> asCompletableFuture(Future<V> future) {
-        throw new UnsupportedOperationException();
+    public void execute(Runnable command) {
+        internalExecutor.execute(command);
     }
 
     @Override
     public ExecutorService getUserExecutor() {
         return userExecutor;
-    }
-
-    @Override
-    public void execute(Runnable command) {
-        internalExecutor.execute(command);
     }
 
     public void shutdown() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImplTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImplTest.java
@@ -23,21 +23,17 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.executor.ExecutorType;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -74,16 +70,6 @@ public class ClientExecutionServiceImplTest {
     }
 
     @Test
-    public void testSubmitInternal() throws Exception {
-        TestRunnable runnable = new TestRunnable();
-
-        Future<?> future = executionService.submit(null, runnable);
-        future.get();
-
-        assertTrue(runnable.isExecuted());
-    }
-
-    @Test
     public void testExecute() {
         TestRunnable runnable = new TestRunnable();
 
@@ -93,87 +79,10 @@ public class ClientExecutionServiceImplTest {
     }
 
     @Test
-    public void testSubmit_withRunnable() throws Exception {
-        TestRunnable runnable = new TestRunnable();
-
-        Future<?> future = executionService.submit(null, runnable);
-        future.get();
-
-        assertTrue(runnable.isExecuted());
-    }
-
-    @Test
-    public void testSubmit_withCallable() throws Exception {
-        TestCallable callable = new TestCallable();
-
-        Future<Integer> future = executionService.submit(null, callable);
-        int result = future.get();
-
-        assertTrue(callable.isExecuted());
-        assertEquals(42, result);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testRegister() {
-        executionService.register("myExecutor", 3, 5, ExecutorType.CACHED);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetExecutor() {
-        executionService.getExecutor("myExecutor");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testShutdownExecutor() {
-        executionService.shutdownExecutor("myExecutor");
-    }
-
-    @Test
-    public void testExecute_withName() {
-        TestRunnable runnable = new TestRunnable();
-
-        executionService.execute("myExecution", runnable);
-
-        runnable.await();
-    }
-
-    @Test
-    public void testSubmit_withRunnable_withName() throws Exception {
-        TestRunnable runnable = new TestRunnable();
-
-        Future<?> future = executionService.submit("mySubmit", runnable);
-        future.get();
-
-        assertTrue(runnable.isExecuted());
-    }
-
-    @Test
-    public void testSubmit_withCallable_withName() throws Exception {
-        TestCallable callable = new TestCallable();
-
-        Future<Integer> future = executionService.submit("mySubmit", callable);
-        int result = future.get();
-
-        assertTrue(callable.isExecuted());
-        assertEquals(42, result);
-    }
-
-    @Test
     public void testSchedule() throws Exception {
         TestRunnable runnable = new TestRunnable();
 
         ScheduledFuture<?> future = executionService.schedule(runnable, 0, SECONDS);
-        Object result = future.get();
-
-        assertTrue(runnable.isExecuted());
-        assertNull(result);
-    }
-
-    @Test
-    public void testSchedule_withName() throws Exception {
-        TestRunnable runnable = new TestRunnable();
-
-        ScheduledFuture<?> future = executionService.schedule("mySchedule", runnable, 0, SECONDS);
         Object result = future.get();
 
         assertTrue(runnable.isExecuted());
@@ -191,33 +100,6 @@ public class ClientExecutionServiceImplTest {
         assertTrue(result);
     }
 
-    @Test
-    public void testScheduleWithRepetition_withName() throws Exception {
-        TestRunnable runnable = new TestRunnable(5);
-
-        ScheduledFuture<?> future = executionService.scheduleWithRepetition("mySchedule", runnable, 0, 100, MILLISECONDS);
-        runnable.await();
-
-        boolean result = future.cancel(true);
-        assertTrue(result);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetGlobalTaskScheduler() {
-        executionService.getGlobalTaskScheduler();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetTaskScheduler() {
-        executionService.getTaskScheduler("myScheduler");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAsCompletableFuture() {
-        executionService.asCompletableFuture(null);
-    }
-
-    @Test
     public void testGetAsyncExecutor() {
         assertNotNull(executionService.getUserExecutor());
     }
@@ -249,21 +131,6 @@ public class ClientExecutionServiceImplTest {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
-        }
-    }
-
-    private class TestCallable implements Callable<Integer> {
-
-        private CountDownLatch isExecuted = new CountDownLatch(1);
-
-        @Override
-        public Integer call() throws Exception {
-            isExecuted.countDown();
-            return 42;
-        }
-
-        private boolean isExecuted() {
-            return isExecuted.getCount() == 0;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/ExpirationManager.java
@@ -134,7 +134,8 @@ public final class ExpirationManager {
         }
 
         ClearExpiredRecordsTask task = new ClearExpiredRecordsTask();
-        expirationTask = executionService.scheduleWithRepetition(task, taskPeriodSeconds, taskPeriodSeconds, SECONDS);
+        expirationTask = executionService.getGlobalTaskScheduler().
+                scheduleWithRepetition(task, taskPeriodSeconds, taskPeriodSeconds, SECONDS);
     }
 
     public synchronized void stop() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -63,7 +63,7 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
 
     public MapNearCacheManager(MapServiceContext mapServiceContext) {
         super(mapServiceContext.getNodeEngine().getSerializationService(),
-                mapServiceContext.getNodeEngine().getExecutionService(), null);
+                mapServiceContext.getNodeEngine().getExecutionService().getGlobalTaskScheduler(), null);
         this.nodeEngine = mapServiceContext.getNodeEngine();
         this.partitionService = new MemberMinimalPartitionService(nodeEngine.getPartitionService());
         this.mapServiceContext = mapServiceContext;
@@ -115,7 +115,8 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
 
         MetaDataFetcher metaDataFetcher = new MemberMapMetaDataFetcher(clusterService, operationService, logger);
         String localUuid = nodeEngine.getLocalMember().getUuid();
-        return new RepairingTask(metaDataFetcher, executionService, partitionService, properties, localUuid, logger);
+        return new RepairingTask(metaDataFetcher, executionService.getGlobalTaskScheduler(),
+                partitionService, properties, localUuid, logger);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
@@ -403,7 +403,7 @@ public class JobSupervisor {
     private void asyncCancelRemoteOperations(final Set<Address> addresses) {
         final NodeEngine nodeEngine = mapReduceService.getNodeEngine();
         TaskScheduler taskScheduler = nodeEngine.getExecutionService().getGlobalTaskScheduler();
-        taskScheduler.submit(new Runnable() {
+        taskScheduler.execute(new Runnable() {
 
             @Override
             public void run() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/TaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/TaskScheduler.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -38,7 +39,7 @@ import java.util.concurrent.TimeUnit;
  * {@link java.util.concurrent.ScheduledExecutorService#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)}
  *
  */
-public interface TaskScheduler extends ExecutorService {
+public interface TaskScheduler extends Executor {
 
     /**
      * Creates and executes a one-shot action that becomes enabled

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskScheduler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskScheduler.java
@@ -18,16 +18,12 @@ package com.hazelcast.spi.impl.executionservice.impl;
 
 import com.hazelcast.spi.TaskScheduler;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -44,21 +40,6 @@ public final class DelegatingTaskScheduler implements TaskScheduler {
     @Override
     public void execute(Runnable command) {
         executor.execute(command);
-    }
-
-    @Override
-    public <T> Future<T> submit(Callable<T> task) {
-        return executor.submit(task);
-    }
-
-    @Override
-    public <T> Future<T> submit(Runnable task, T result) {
-        return executor.submit(task, result);
-    }
-
-    @Override
-    public Future<?> submit(Runnable task) {
-        return executor.submit(task);
     }
 
     @Override
@@ -80,55 +61,6 @@ public final class DelegatingTaskScheduler implements TaskScheduler {
         checkNotNull(command);
         Runnable decoratedTask = new DelegateAndSkipOnConcurrentExecutionDecorator(command, executor);
         return scheduledExecutorService.scheduleAtFixedRate(decoratedTask, initialDelay, period, unit);
-    }
-
-    @Override
-    public void shutdown() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<Runnable> shutdownNow() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean isShutdown() {
-        return false;
-    }
-
-    @Override
-    public boolean isTerminated() {
-        return false;
-    }
-
-    @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
-            throws InterruptedException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
-            throws InterruptedException, ExecutionException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        throw new UnsupportedOperationException();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/CommonNearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/CommonNearCacheTestSupport.java
@@ -18,27 +18,20 @@ package com.hazelcast.internal.nearcache;
 
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.internal.nearcache.impl.store.NearCacheDataRecordStore;
 import com.hazelcast.internal.nearcache.impl.store.NearCacheObjectRecordStore;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.TaskScheduler;
+import com.hazelcast.spi.impl.executionservice.impl.DelegatingTaskScheduler;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.util.executor.ExecutorType;
-import com.hazelcast.util.executor.ManagedExecutorService;
 import org.junit.After;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 public abstract class CommonNearCacheTestSupport extends HazelcastTestSupport {
 
@@ -81,83 +74,9 @@ public abstract class CommonNearCacheTestSupport extends HazelcastTestSupport {
         return recordStore;
     }
 
-    protected ExecutionService createExecutionService() {
+    protected TaskScheduler createTaskScheduler() {
         ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
         scheduledExecutorServices.add(scheduledExecutorService);
-        return new TestExecutionService(scheduledExecutorService);
-    }
-
-    private static class TestExecutionService implements ExecutionService {
-
-        private final ScheduledExecutorService executorService;
-
-        private TestExecutionService(ScheduledExecutorService executorService) {
-            this.executorService = executorService;
-        }
-
-        @Override
-        public ManagedExecutorService register(String name, int poolSize, int queueCapacity, ExecutorType type) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public ManagedExecutorService getExecutor(String name) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void shutdownExecutor(String name) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void execute(String name, Runnable command) {
-            executorService.execute(command);
-        }
-
-        @Override
-        public Future<?> submit(String name, Runnable task) {
-            return executorService.submit(task);
-        }
-
-        @Override
-        public <T> Future<T> submit(String name, Callable<T> task) {
-            return executorService.submit(task);
-        }
-
-        @Override
-        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-            return executorService.schedule(command, delay, unit);
-        }
-
-        @Override
-        public ScheduledFuture<?> schedule(String name, Runnable command, long delay, TimeUnit unit) {
-            return executorService.schedule(command, delay, unit);
-        }
-
-        @Override
-        public ScheduledFuture<?> scheduleWithRepetition(Runnable command, long initialDelay, long period, TimeUnit unit) {
-            return executorService.scheduleAtFixedRate(command, initialDelay, period, unit);
-        }
-
-        @Override
-        public ScheduledFuture<?> scheduleWithRepetition(String name, Runnable command, long initialDelay, long period, TimeUnit unit) {
-            return executorService.scheduleAtFixedRate(command, initialDelay, period, unit);
-        }
-
-        @Override
-        public TaskScheduler getGlobalTaskScheduler() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public TaskScheduler getTaskScheduler(String name) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public <V> ICompletableFuture<V> asCompletableFuture(Future<V> future) {
-            throw new UnsupportedOperationException();
-        }
+        return new DelegatingTaskScheduler(scheduledExecutorService, scheduledExecutorService);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTest.java
@@ -30,7 +30,7 @@ public class NearCacheManagerTest extends NearCacheManagerTestSupport {
 
     @Override
     protected NearCacheManager createNearCacheManager() {
-        return new DefaultNearCacheManager(ss, executionService, null);
+        return new DefaultNearCacheManager(ss, executionService.getGlobalTaskScheduler(), null);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
@@ -33,7 +33,7 @@ public class NearCacheTest extends NearCacheTestSupport {
     protected NearCache<Integer, String> createNearCache(String name, NearCacheConfig nearCacheConfig,
                                                          ManagedNearCacheRecordStore nearCacheRecordStore) {
         return new DefaultNearCache<Integer, String>(name, nearCacheConfig,
-                nearCacheRecordStore, ss, executionService, null);
+                nearCacheRecordStore, ss, executionService.getGlobalTaskScheduler(), null);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/RepairingTaskTest.java
@@ -86,6 +86,7 @@ public class RepairingTaskTest extends HazelcastTestSupport {
         String uuid = UuidUtil.newUnsecureUUID().toString();
         ILogger logger = Logger.getLogger(RepairingTask.class);
         HazelcastProperties hazelcastProperties = new HazelcastProperties(config);
-        return new RepairingTask(metaDataFetcher, executionService, minimalPartitionService, hazelcastProperties, uuid, logger);
+        return new RepairingTask(metaDataFetcher, executionService.getGlobalTaskScheduler(),
+                minimalPartitionService, hazelcastProperties, uuid, logger);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/scheduler/SecondsBasedEntryTaskSchedulerTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
 public class SecondsBasedEntryTaskSchedulerTest {
 
     @Mock
-    private TaskScheduler executorService = mock(TaskScheduler.class);
+    private TaskScheduler taskScheduler = mock(TaskScheduler.class);
 
     @Mock
     @SuppressWarnings("unchecked")
@@ -61,13 +61,13 @@ public class SecondsBasedEntryTaskSchedulerTest {
     @Before
     @SuppressWarnings("unchecked")
     public void mockScheduleMethod() {
-        when(executorService.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+        when(taskScheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
                 .thenReturn(mock(ScheduledFuture.class));
     }
 
     @Test
     public void test_scheduleEntry_postpone() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, POSTPONE);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertNotNull(scheduler.get(1));
@@ -76,7 +76,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_rescheduleEntry_postpone() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, POSTPONE);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertTrue(scheduler.schedule(10000, 1, 1));
@@ -86,7 +86,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test(timeout = 10000)
     public void test_doNotRescheduleEntryWithinSameSecond_postpone() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, POSTPONE);
         final int delayMillis = 0;
         final int key = 1;
 
@@ -117,7 +117,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelEntry_postpone() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, POSTPONE);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertEquals(1, scheduler.size());
@@ -127,7 +127,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_scheduleEntry_foreach() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, FOR_EACH);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertNotNull(scheduler.get(1));
@@ -136,7 +136,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_scheduleEntryMultipleTimes_foreach() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, FOR_EACH);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertTrue(scheduler.schedule(100, 1, 1));
@@ -146,7 +146,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelIfExists_postpone() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, POSTPONE);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, POSTPONE);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertEquals(1, scheduler.cancelIfExists(1, 1));
@@ -154,7 +154,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelIfExists_foreach() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, FOR_EACH);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertEquals(1, scheduler.cancelIfExists(1, 1));
@@ -162,7 +162,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelIfExistsWithInvalidValue_foreach() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, FOR_EACH);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertEquals(0, scheduler.cancelIfExists(1, 0));
@@ -170,7 +170,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelIfExistsMultiple_foreach() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, FOR_EACH);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertTrue(scheduler.schedule(100, 1, 2));
@@ -179,7 +179,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_cancelAll() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, FOR_EACH);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertTrue(scheduler.schedule(100, 1, 2));
@@ -191,10 +191,10 @@ public class SecondsBasedEntryTaskSchedulerTest {
     @SuppressWarnings("unchecked")
     public void test_executeScheduledEntry() {
         ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-        when(executorService.schedule(runnableCaptor.capture(), anyLong(), any(TimeUnit.class)))
+        when(taskScheduler.schedule(runnableCaptor.capture(), anyLong(), any(TimeUnit.class)))
                 .thenReturn(mock(ScheduledFuture.class));
 
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, FOR_EACH);
 
         assertTrue(scheduler.schedule(100, 1, 1));
         assertEquals(1, scheduler.size());
@@ -207,7 +207,7 @@ public class SecondsBasedEntryTaskSchedulerTest {
 
     @Test
     public void test_toString() {
-        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(executorService, entryProcessor, FOR_EACH);
+        scheduler = new SecondsBasedEntryTaskScheduler<Integer, Integer>(taskScheduler, entryProcessor, FOR_EACH);
 
         assertNotNull(scheduler.toString());
     }


### PR DESCRIPTION
TaskScheduler is used in common places instead of ExecutionService interface.

This way, ClientExectionService does not have to extend ExecutionService.