### PR TITLE
Include internal callbacks to backpressure

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -42,6 +42,7 @@ import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.ClientTransactionManagerService;
 import com.hazelcast.client.spi.ProxyManager;
 import com.hazelcast.client.spi.impl.AwsAddressProvider;
+import com.hazelcast.client.spi.impl.CallIdSequence;
 import com.hazelcast.client.spi.impl.ClientClusterServiceImpl;
 import com.hazelcast.client.spi.impl.ClientExecutionServiceImpl;
 import com.hazelcast.client.spi.impl.ClientInvocation;
@@ -156,6 +157,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
+import static com.hazelcast.client.spi.properties.ClientProperty.MAX_CONCURRENT_INVOCATIONS;
 import static java.lang.System.currentTimeMillis;
 
 public class HazelcastClientInstanceImpl implements HazelcastInstance, SerializationServiceSupport {
@@ -191,6 +193,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     private final ClientLockReferenceIdGenerator lockReferenceIdGenerator;
     private final ClientExceptionFactory clientExceptionFactory;
+    private final CallIdSequence callIdSequence;
 
     public HazelcastClientInstanceImpl(ClientConfig config,
                                        ClientConnectionManagerFactory clientConnectionManagerFactory,
@@ -225,6 +228,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         connectionManager = clientConnectionManagerFactory.createConnectionManager(config, this, discoveryService);
         Collection<AddressProvider> addressProviders = createAddressProviders(externalAddressProvider);
         clusterService = new ClientClusterServiceImpl(this, addressProviders);
+
+        int maxAllowedConcurrentInvocations = properties.getInteger(MAX_CONCURRENT_INVOCATIONS);
+        callIdSequence = new CallIdSequence.CallIdSequenceFailFast(maxAllowedConcurrentInvocations);
+
         invocationService = initInvocationService();
         listenerService = initListenerService();
         userContext = new ConcurrentHashMap<String, Object>();
@@ -703,6 +710,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public ClientExtension getClientExtension() {
         return clientExtension;
+    }
+
+    public CallIdSequence getCallIdSequence() {
+        return callIdSequence;
     }
 
     public Credentials getCredentials() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -78,7 +78,8 @@ public class ClientInvocation implements Runnable {
         this.connection = connection;
         this.retryTimeoutPointInMillis = System.currentTimeMillis() + invocationService.getInvocationTimeoutMillis();
         this.logger = invocationService.invocationLogger;
-        this.clientInvocationFuture = new ClientInvocationFuture(this, executionService, clientMessage, logger);
+        this.clientInvocationFuture = new ClientInvocationFuture(this, executionService,
+                clientMessage, logger, client.getCallIdSequence());
     }
 
     public ClientInvocation(HazelcastClientInstanceImpl client, ClientMessage clientMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -201,7 +201,7 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
     }
 
     @Override
-    public final void andThen(ExecutionCallback<V> callback) {
+    public void andThen(ExecutionCallback<V> callback) {
         andThen(callback, defaultExecutor);
     }
 
@@ -359,10 +359,15 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
                 return false;
             }
             if (compareAndSetState(oldState, value)) {
+                onComplete();
                 unblockAll(oldState, defaultExecutor);
                 return true;
             }
         }
+    }
+
+    protected void onComplete() {
+
     }
 
     // it can be that this future is already completed, e.g. when an invocation already


### PR DESCRIPTION
CallIdSequence will be completed to accept next invocation only when
the callbacks running on internal executors are completed.

A second change made to achieve back pressure safely. If response
is already available when andThen is called with an internal callback.
Then internal callback runs on calling thread instead of executor.
Since it is already not permitted to do any blocking call in internal
threads, this will achieve a natural backpressure.

fixes #9665
fixes #8568