### PR TITLE
Made UnsafeUtil constants public

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/UnsafeUtil.java
@@ -36,12 +36,12 @@ public final class UnsafeUtil {
     /**
      * If this constant is {@code true}, then {@link #UNSAFE} refers to a usable {@link sun.misc.Unsafe} instance.
      */
-    static final boolean UNSAFE_AVAILABLE;
+    public static final boolean UNSAFE_AVAILABLE;
 
     /**
      * The {@link sun.misc.Unsafe} instance which is available and ready to use.
      */
-    static final Unsafe UNSAFE;
+    public static final Unsafe UNSAFE;
 
     private static final ILogger LOGGER = Logger.getLogger(UnsafeUtil.class);
 


### PR DESCRIPTION
Made `UnsafeUtil` constants public, so they can be used instead of the
deprecated `UnsafeHelper`. This is important for dependent projects like
Hazelcast Hibernate, which still use the outdated class. We also have
to fix this, since Hazelcast itself has a cyclic dependency on those
external modules.