### PR TITLE
[DO NOT MERGE] Add sslEnabled to TimedMemberState

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -23,6 +23,7 @@ import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.GroupConfig;
+import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.Member;
 import com.hazelcast.executor.impl.DistributedExecutorService;
@@ -116,7 +117,7 @@ public class TimedMemberStateFactory {
         createMemberState(timedMemberState, memberState, services);
         timedMemberState.setMaster(instance.node.isMaster());
         timedMemberState.setMemberList(new ArrayList<String>());
-        if (timedMemberState.getMaster()) {
+        if (timedMemberState.isMaster()) {
             Set<Member> memberSet = instance.getCluster().getMembers();
             for (Member member : memberSet) {
                 MemberImpl memberImpl = (MemberImpl) member;
@@ -127,6 +128,8 @@ public class TimedMemberStateFactory {
         timedMemberState.setMemberState(memberState);
         GroupConfig groupConfig = instance.getConfig().getGroupConfig();
         timedMemberState.setClusterName(groupConfig.getName());
+        SSLConfig sslConfig = instance.getConfig().getNetworkConfig().getSSLConfig();
+        timedMemberState.setSslEnabled(sslConfig != null && sslConfig.isEnabled());
 
         return timedMemberState;
     }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
@@ -40,8 +40,9 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
     MemberStateImpl memberState;
     Set<String> instanceNames;
     List<String> memberList;
-    Boolean master;
+    boolean master;
     String clusterName;
+    boolean sslEnabled;
 
     public List<String> getMemberList() {
         return memberList;
@@ -51,11 +52,11 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         this.memberList = memberList;
     }
 
-    public Boolean getMaster() {
+    public boolean isMaster() {
         return master;
     }
 
-    public void setMaster(Boolean master) {
+    public void setMaster(boolean master) {
         this.master = master;
     }
 
@@ -91,6 +92,14 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         this.memberState = memberState;
     }
 
+    public boolean isSslEnabled() {
+        return sslEnabled;
+    }
+
+    public void setSslEnabled(boolean sslEnabled) {
+        this.sslEnabled = sslEnabled;
+    }
+
     @Override
     public TimedMemberState clone() throws CloneNotSupportedException {
         TimedMemberState state = (TimedMemberState) super.clone();
@@ -100,6 +109,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         state.setMemberList(memberList);
         state.setMaster(master);
         state.setClusterName(clusterName);
+        state.setSslEnabled(sslEnabled);
         return state;
     }
 
@@ -122,6 +132,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
             root.add("memberList", members);
         }
         root.add("memberState", memberState.toJson());
+        root.add("sslEnabled", sslEnabled);
         return root;
     }
 
@@ -143,6 +154,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         final JsonObject jsonMemberState = getObject(json, "memberState");
         memberState = new MemberStateImpl();
         memberState.fromJson(jsonMemberState);
+        sslEnabled = getBoolean(json, "sslEnabled", false);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateTest.java
@@ -36,13 +36,14 @@ import java.util.Set;
 import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class TimedMemberStateTest extends HazelcastTestSupport {
 
     private TimedMemberState timedMemberState;
-    HazelcastInstance hz;
+    private HazelcastInstance hz;
 
     @Before
     public void setUp() {
@@ -56,6 +57,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         timedMemberState.setClusterName("ClusterName");
         timedMemberState.setTime(1827731);
         timedMemberState.setInstanceNames(instanceNames);
+        timedMemberState.setSslEnabled(true);
     }
 
     @Test
@@ -69,6 +71,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         assertEquals(1, cloned.getInstanceNames().size());
         assertContains(cloned.getInstanceNames(), "topicStats");
         assertNotNull(cloned.getMemberState());
+        assertTrue(cloned.isSslEnabled());
         assertNotNull(cloned.toString());
     }
 
@@ -85,6 +88,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         assertEquals(1, deserialized.getInstanceNames().size());
         assertContains(deserialized.getInstanceNames(), "topicStats");
         assertNotNull(deserialized.getMemberState());
+        assertTrue(deserialized.isSslEnabled());
         assertNotNull(deserialized.toString());
     }
 


### PR DESCRIPTION
We need this so that Management Center knows if the cluster is SSL enabled, and if so, uses an `https` prefix when accessing cluster's REST API.