### PR TITLE
Use a factory method to get a member config

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -969,7 +969,7 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     @Test
     public void receives_one_clearEvent_after_mapClear_call_from_member() {
         // 1. Start new member and populate map.
-        HazelcastInstance member = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance member = hazelcastFactory.newHazelcastInstance(newConfig());
         IMap memberMap = member.getMap("test");
         populateMap(memberMap, 1000);
 


### PR DESCRIPTION
This `newConfig()` method is overridden in EE test
 where EE-specific configuration is applied