### PR TITLE
Fix scheduled task not getting rescheduled after dead member

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -256,6 +256,10 @@ public class ScheduledExecutorContainer {
     void promoteStash() {
         for (ScheduledTaskDescriptor descriptor : tasks.values()) {
             try {
+                if (logger.isFinestEnabled()) {
+                    logger.finest("[Partition: " + partitionId + "] " + "Attempt to promote stashed " + descriptor);
+                }
+
                 if (descriptor.shouldSchedule()) {
                     doSchedule(descriptor);
                 }
@@ -285,9 +289,11 @@ public class ScheduledExecutorContainer {
                     // Best effort to cancel & interrupt the task.
                     // In the case of Runnable the DelegateAndSkipOnConcurrentExecutionDecorator is not exposing access
                     // to the Executor's Future, hence, we have no access on the runner thread to interrupt. In this case
-                    // the line below is only cancelling future scheduling attempts.
+                    // the line below is only cancelling future runs.
                     try {
                         descriptor.cancel(true);
+                        descriptor.setScheduledFuture(null);
+                        descriptor.setTaskOwner(false);
                     } catch (Exception ex) {
                         throw rethrow(ex);
                     }

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionLostEvent;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.RootCauseMatcher;
@@ -41,9 +42,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -1020,4 +1019,5 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
         expected.expectCause(new RootCauseMatcher(IllegalStateException.class, "Erroneous task"));
         future.get();
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -256,6 +256,18 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
 
     }
 
+    static class EchoTask implements Runnable, Serializable {
+
+        public EchoTask() {
+        }
+
+        @Override
+        public void run() {
+            System.out.println("Echo ...cho ...oo ..o");
+        }
+
+    }
+
     static class ErroneousCallableTask
             implements Callable<Double>, Serializable, HazelcastInstanceAware {
 


### PR DESCRIPTION
This patch is fixing the following logic defect.
When a migration starts, upon replication of a given task, the Future associated
with the task is cancelled. If a migration fails (rollback) or for any other reason
the partition gets promoted once again on the same member, the task is trying to reschedule itself.
However, the algorithm responsible for rescheduling it, it first checks if the task is completed or
running, by checking the result and the future variables respectively. If either of them is found non-null
then the task will not be re-scheduled. To fix, when the task is cancelled, we nullify the Future associated
and reset the isTaskOwner flag, both will set again when and if the task gets another chance to run.

Fix #10060