### PR TITLE
[BACKPORT] ThreadLocalRandomProvide does not rely on non-arg constructor of Random

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandomProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ThreadLocalRandomProvider.java
@@ -24,6 +24,8 @@ import java.util.Random;
  */
 public final class ThreadLocalRandomProvider {
 
+    private static final Random SEED_GENERATOR = new Random();
+
     private static final ThreadLocal<Random> THREAD_LOCAL_RANDOM = new ThreadLocal<Random>();
     private static final ThreadLocal<SecureRandom> THREAD_LOCAL_SECURE_RANDOM = new ThreadLocal<SecureRandom>();
 
@@ -38,7 +40,8 @@ public final class ThreadLocalRandomProvider {
     public static Random get() {
         Random random = THREAD_LOCAL_RANDOM.get();
         if (random == null) {
-            random = new Random();
+            long seed = SEED_GENERATOR.nextLong();
+            random = new Random(seed);
             THREAD_LOCAL_RANDOM.set(random);
         }
         return random;


### PR DESCRIPTION
backport of https://github.com/hazelcast/hazelcast/pull/10078

some JDK implementations do not have thread-safe  seed generation -> 2 concurrent calls
could create Random instances initialized with the same seed. As a result UUIDUtil could
generate the same UUID.

(cherry picked from commit a5fc577)