### PR TITLE
[BACKPORT] Fix racy scheduled executor, syncState when task is cancelled. (#10034)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -201,7 +201,17 @@ public class ScheduledExecutorContainer {
 
         descriptor.setState(newState);
         descriptor.setStats(stats);
-        descriptor.setTaskResult(resolution);
+
+        if (descriptor.getTaskResult() != null) {
+            // Task result previously populated - ie. through cancel
+            // Ignore all subsequent results
+            if (logger.isFineEnabled()) {
+                logger.fine(String.format("[Scheduler: " + name + "][Partition: " + partitionId + "] syncState result skipped. "
+                                        + "Current: %s New: %s", descriptor.getTaskResult(), resolution));
+            }
+        } else {
+            descriptor.setTaskResult(resolution);
+        }
     }
 
     public boolean shouldParkGetResult(String taskName)

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/operations/SyncStateOperation.java
@@ -41,7 +41,7 @@ public class SyncStateOperation
 
     protected ScheduledTaskResult result;
 
-    protected boolean shouldRun;
+    private boolean shouldRun;
 
     public SyncStateOperation() {
     }

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceSlowTest.java
@@ -30,6 +30,8 @@ import java.util.concurrent.ExecutionException;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({SlowTest.class, ParallelTest.class})
@@ -49,7 +51,7 @@ public class ScheduledExecutorServiceSlowTest
 
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture<Double> future = executorService.schedule(
-                new ScheduledExecutorServiceBasicTest.ICountdownLatchCallableTask("runsCountLatchName", 15000), delay, SECONDS);
+                new ICountdownLatchCallableTask("runsCountLatchName", 15000), delay, SECONDS);
 
         double result = future.get();
 
@@ -74,7 +76,7 @@ public class ScheduledExecutorServiceSlowTest
         latch.trySetCount(1);
 
         IScheduledFuture future = executorService.scheduleOnKeyOwnerAtFixedRate(
-                new ScheduledExecutorServiceBasicTest.StatefulRunnableTask("latch", "runC", "loadC"),
+                new StatefulRunnableTask("latch", "runC", "loadC"),
                 key, 10, 10, SECONDS);
 
         // Wait for task to get scheduled and start
@@ -106,7 +108,7 @@ public class ScheduledExecutorServiceSlowTest
 
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture future = executorService.scheduleOnKeyOwnerAtFixedRate(
-                new ScheduledExecutorServiceBasicTest.ICountdownLatchRunnableTask("latch"), key, 0, 10, SECONDS);
+                new ICountdownLatchRunnableTask("latch"), key, 0, 10, SECONDS);
 
         Thread.sleep(12000);
 
@@ -130,7 +132,7 @@ public class ScheduledExecutorServiceSlowTest
 
         IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
         IScheduledFuture future = executorService.scheduleAtFixedRate(
-                new ScheduledExecutorServiceBasicTest.ICountdownLatchRunnableTask("latch"), 0, 10, SECONDS);
+                new ICountdownLatchRunnableTask("latch"), 0, 10, SECONDS);
 
 
         latch.await(120, SECONDS);
@@ -292,4 +294,77 @@ public class ScheduledExecutorServiceSlowTest
 
         assertEquals(expectedTotal, actualTotal, 0);
     }
+
+    @Test
+    public void cancelUninterruptedTask_waitUntilRunCompleted_checkStatusIsCancelled()
+            throws ExecutionException, InterruptedException {
+
+        HazelcastInstance[] instances = createClusterWithCount(1);
+
+        String runFinishedLatchName = "runFinishedLatch";
+        ICountDownLatch latch = instances[0].getCountDownLatch(runFinishedLatchName);
+        latch.trySetCount(1);
+
+        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
+        IScheduledFuture future = executorService.scheduleAtFixedRate(
+                new HotLoopBusyTask(runFinishedLatchName), 0, 1, SECONDS);
+
+        assertFalse(future.isCancelled());
+        assertFalse(future.isDone());
+
+        future.cancel(false);
+
+        assertTrue(future.isCancelled());
+        assertTrue(future.isDone());
+
+        // Even though we cancelled the task is current task is still running.
+        // Wait till the task is actually done
+        latch.await(60, SECONDS);
+
+        // Make sure SyncState goes through
+        sleepSeconds(10);
+
+        // Check once more that the task status is consistent
+        assertTrue(future.isCancelled());
+        assertTrue(future.isDone());
+    }
+
+    @Test
+    public void cancelUninterruptedTask_waitUntilRunCompleted_killMember_checkStatusIsCancelled()
+            throws ExecutionException, InterruptedException {
+
+        HazelcastInstance[] instances = createClusterWithCount(2);
+
+        String key = generateKeyOwnedBy(instances[1]);
+
+        String runFinishedLatchName = "runFinishedLatch";
+        ICountDownLatch latch = instances[0].getCountDownLatch(runFinishedLatchName);
+        latch.trySetCount(1);
+
+        IScheduledExecutorService executorService = getScheduledExecutor(instances, "s");
+        IScheduledFuture future = executorService.scheduleOnKeyOwnerAtFixedRate(
+                new HotLoopBusyTask(runFinishedLatchName), key, 0, 1, SECONDS);
+
+        assertFalse(future.isCancelled());
+        assertFalse(future.isDone());
+
+        future.cancel(false);
+
+        assertTrue(future.isCancelled());
+        assertTrue(future.isDone());
+
+        // Even though we cancelled the task is current task is still running.
+        // Wait till the task is actually done
+        latch.await(60, SECONDS);
+
+        // Make sure SyncState goes through
+        sleepSeconds(10);
+
+        instances[1].getLifecycleService().terminate();
+
+        // Check once more that the task status is consistent
+        assertTrue(future.isCancelled());
+        assertTrue(future.isDone());
+    }
+
 }


### PR DESCRIPTION
Cancelling an in-flight task (not handling interrupts properly), results in a cancel task state, which is racy with the syncState when the task finally completes execution. This is only documenting itself when replication happens, where the result of the task is used as decision mechanism to re-schedule it or not on the new partition owner.

The patch is gating the result assignment to check whether it was set before.
If so, the new result is ignored.

Fix #9984
(cherry picked from commit 4c7b5b71f984f4d27ab8ebc1fbead42ddb971d40)