### PR TITLE
[BACKPORT] Inject HazelcastInstance in backup entry processor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/AbstractEntryProcessor.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.map;
 
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.nio.serialization.impl.BinaryInterface;
 
 import java.util.Map;
@@ -65,10 +67,21 @@ public abstract class AbstractEntryProcessor<K, V> implements EntryProcessor<K, 
         return entryBackupProcessor;
     }
 
-    private class EntryBackupProcessorImpl implements EntryBackupProcessor<K, V> {
+    private class EntryBackupProcessorImpl implements EntryBackupProcessor<K, V>, HazelcastInstanceAware {
+        // generated for EntryBackupProcessorImpl which doesn't implement HazelcastInstanceAware
+        static final long serialVersionUID = -5081502753526394129L;
+
         @Override
         public void processBackup(Map.Entry<K, V> entry) {
             process(entry);
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            final AbstractEntryProcessor<K, V> outer = AbstractEntryProcessor.this;
+            if (outer instanceof HazelcastInstanceAware) {
+                ((HazelcastInstanceAware) outer).setHazelcastInstance(hazelcastInstance);
+            }
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/BackupEntryProcessorInstanceAwareTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BackupEntryProcessorInstanceAwareTest.java
@@ -1,0 +1,81 @@
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class BackupEntryProcessorInstanceAwareTest extends HazelcastTestSupport {
+    public static final String MAP_NAME = "EntryProcessorTest";
+
+    @Override
+    public Config getConfig() {
+        final MapConfig mapConfig = new MapConfig(MAP_NAME)
+                .setReadBackupData(true)
+                .setInMemoryFormat(BINARY);
+        return super.getConfig().addMapConfig(mapConfig);
+    }
+
+    @Test
+    public void test() throws ExecutionException, InterruptedException {
+        final Config cfg = getConfig();
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        final HazelcastInstance i1 = factory.newHazelcastInstance(cfg);
+        final HazelcastInstance i2 = factory.newHazelcastInstance(cfg);
+        final IMap<String, Integer> m1 = i1.getMap(MAP_NAME);
+        final IMap<String, Integer> m2 = i2.getMap(MAP_NAME);
+
+        m1.put("a", 1);
+        m1.put("b", 2);
+        m1.executeOnEntries(new PartitionAwareTestEntryProcessor());
+
+        for (final String key : m1.keySet()) {
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run() throws Exception {
+                    final Integer k = m1.get(key);
+                    final Integer v = m2.get(key);
+                    assertEquals(k, v);
+                }
+            });
+        }
+        i1.shutdown();
+    }
+
+    private static class PartitionAwareTestEntryProcessor extends AbstractEntryProcessor<String, Integer>
+            implements HazelcastInstanceAware {
+
+        private transient HazelcastInstance hz;
+
+        @Override
+        public Object process(Map.Entry<String, Integer> entry) {
+            if (hz != null) {
+                entry.setValue(entry.getValue() + 1);
+            }
+            return null;
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.hz = hazelcastInstance;
+        }
+    }
+}


### PR DESCRIPTION
If the supplied entry procesor extended AbstractEntryProcessor and implemented HazelcastInstanceAware, the backup processor would never get the hazelcast instance injected and the process method could fail with NPE. The fix checks if the entry processor implements HazelcastInstanceAware and supplies a different backup processor in that case.

Fixes : hazelcast#10083

(cherry picked from commit d222005)