### PR TITLE
Use the java.version property for checking Java version

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassloadingMutexProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassloadingMutexProvider.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.internal.usercodedeployment.impl;
 
+import com.hazelcast.internal.util.JavaVersion;
 import com.hazelcast.util.ContextMutexFactory;
 
 import java.io.Closeable;
+
+import static com.hazelcast.internal.util.JavaVersion.JAVA_1_7;
 
 /**
  * Java 7+ onwards allows parallel classloading. Therefore we can define use a lock with per-class granularity.
@@ -30,7 +33,6 @@ import java.io.Closeable;
  */
 public class ClassloadingMutexProvider {
 
-    private static final String JAVA_VERSION_WHERE_PARALLEL_CLASSLOADING_IS_NOT_POSSIBLE = "1.6";
     private static final boolean USE_PARALLEL_LOADING = isParallelClassLoadingPossible();
 
     private final ContextMutexFactory mutexFactory = new ContextMutexFactory();
@@ -45,7 +47,6 @@ public class ClassloadingMutexProvider {
     }
 
     private static boolean isParallelClassLoadingPossible() {
-        String implVersion = Runtime.class.getPackage().getImplementationVersion();
-        return !implVersion.startsWith(JAVA_VERSION_WHERE_PARALLEL_CLASSLOADING_IS_NOT_POSSIBLE);
+        return JavaVersion.isAtLeast(JAVA_1_7);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+/**
+ * Utility for checking runtime Java version.
+ *
+ */
+public enum JavaVersion {
+    UNKNOWN,
+    JAVA_1_6,
+    JAVA_1_7,
+    JAVA_1_8,
+    JAVA_1_9;
+
+    private static final JavaVersion CURRENT_VERSION = detectCurrentVersion();
+
+    /**
+     * Check if the current runtime version is at least the given version.
+     *
+     * @param version version to be compared against the current runtime version
+     * @return Return true if current runtime version of Java is the same or greater than given version.
+     *         When the passed version is {@link #UNKNOWN} then it always returns true.
+     */
+    public static boolean isAtLeast(JavaVersion version) {
+        return isAtLeast(CURRENT_VERSION, version);
+    }
+
+    private static JavaVersion detectCurrentVersion() {
+        String version = System.getProperty("java.version");
+        return parseVersion(version);
+    }
+
+    static JavaVersion parseVersion(String version) {
+        if (version == null) {
+            // this should not happen but it's better to stay on the safe side
+            return UNKNOWN;
+        }
+        if (version.startsWith("1.")) {
+            String withoutMajor = version.substring(2, version.length());
+            if (withoutMajor.startsWith("6")) {
+                return JAVA_1_6;
+            } else if (withoutMajor.startsWith("7")) {
+                return JAVA_1_7;
+            } else if (withoutMajor.startsWith("8")) {
+                return JAVA_1_8;
+            }
+            return UNKNOWN;
+        } else if (version.startsWith("9")) {
+            // from version 9 the string does not start with "1."
+            return JAVA_1_9;
+        }
+        return UNKNOWN;
+    }
+
+    static boolean isAtLeast(JavaVersion currentVersion, JavaVersion minVersion) {
+        return currentVersion.ordinal() >= minVersion.ordinal();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
@@ -1,0 +1,79 @@
+package com.hazelcast.internal.util;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+
+import static com.hazelcast.internal.util.JavaVersion.JAVA_1_6;
+import static com.hazelcast.internal.util.JavaVersion.JAVA_1_7;
+import static com.hazelcast.internal.util.JavaVersion.JAVA_1_8;
+import static com.hazelcast.internal.util.JavaVersion.JAVA_1_9;
+import static com.hazelcast.internal.util.JavaVersion.UNKNOWN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class JavaVersionTest extends HazelcastTestSupport {
+
+    @Test
+    public void parseVersion() throws Exception {
+        assertEquals(UNKNOWN, JavaVersion.parseVersion("foo"));
+        assertEquals(JAVA_1_6, JavaVersion.parseVersion("1.6"));
+        assertEquals(JAVA_1_7, JavaVersion.parseVersion("1.7"));
+        assertEquals(JAVA_1_8, JavaVersion.parseVersion("1.8"));
+        assertEquals(JAVA_1_9, JavaVersion.parseVersion("9-ea"));
+        assertEquals(JAVA_1_9, JavaVersion.parseVersion("9"));
+    }
+
+    @Test
+    public void testIsAtLeast_unknown() {
+        assertTrue(JavaVersion.isAtLeast(UNKNOWN, UNKNOWN));
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_7));
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_8));
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_9));
+    }
+
+    @Test
+    public void testIsAtLeast_1_6() {
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_6, UNKNOWN));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_6));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_7));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_8));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_9));
+    }
+
+    @Test
+    public void testIsAtLeast_1_7() {
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_7, UNKNOWN));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_6));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_7));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_8));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_9));
+    }
+
+    @Test
+    public void testIsAtLeast_1_8() {
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_8, UNKNOWN));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_8, JAVA_1_6));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_8, JAVA_1_7));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_8, JAVA_1_8));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_1_9));
+    }
+
+    @Test
+    public void testIsAtLeast_1_9() {
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, UNKNOWN));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, JAVA_1_6));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, JAVA_1_7));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, JAVA_1_8));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, JAVA_1_9));
+    }
+}


### PR DESCRIPTION
The previous appoach with Runtime.class.getPackage().getImplementationVersion()
is not reliable as some version of IBM J9 JVM returns null.