### PR TITLE
Cleanup of client cache related proxy classes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -76,15 +76,15 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
         }
     };
 
-    protected AbstractClientCacheProxy(CacheConfig<K, V> cacheConfig) {
+    AbstractClientCacheProxy(CacheConfig<K, V> cacheConfig) {
         super(cacheConfig);
     }
 
-    protected Object getSyncInternal(Data keyData, ExpiryPolicy expiryPolicy) {
+    protected V getSyncInternal(Data keyData, ExpiryPolicy expiryPolicy) {
         long startNanos = nowInNanosOrDefault();
         try {
-            ClientDelegatingFuture future = getInternal(keyData, expiryPolicy, false);
-            Object value = future.get();
+            ClientDelegatingFuture<V> future = getInternal(keyData, expiryPolicy, false);
+            V value = future.get();
             if (statisticsEnabled) {
                 statsHandler.onGet(startNanos, value != null);
             }
@@ -156,7 +156,7 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public ICompletableFuture<V> getAndPutAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        return (ICompletableFuture<V>) putAsyncInternal(key, value, expiryPolicy, true, false, newStatsCallbackOrNull(true));
+        return putAsyncInternal(key, value, expiryPolicy, true, false, newStatsCallbackOrNull(true));
     }
 
     @Override
@@ -171,7 +171,7 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public ICompletableFuture<V> getAndRemoveAsync(K key) {
-        return getAndRemoveAsyncInternal(key, false);
+        return getAndRemoveAsyncInternal(key);
     }
 
     @Override
@@ -208,7 +208,7 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
     public V get(K key, ExpiryPolicy expiryPolicy) {
         ensureOpen();
         validateNotNull(key);
-        return (V) toObject(getSyncInternal(toData(key), expiryPolicy));
+        return toObject(getSyncInternal(toData(key), expiryPolicy));
     }
 
     @Override
@@ -253,12 +253,12 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public void put(K key, V value, ExpiryPolicy expiryPolicy) {
-        putSyncInternal(key, value, expiryPolicy, false, true);
+        putSyncInternal(key, value, expiryPolicy, false);
     }
 
     @Override
     public V getAndPut(K key, V value, ExpiryPolicy expiryPolicy) {
-        return (V) putSyncInternal(key, value, expiryPolicy, true, true);
+        return putSyncInternal(key, value, expiryPolicy, true);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
@@ -57,7 +57,7 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
  */
 abstract class AbstractClientCacheProxyBase<K, V> extends ClientProxy implements ICacheInternal<K, V> {
 
-    static final int TIMEOUT = 10;
+    private static final int TIMEOUT = 10;
 
     @SuppressWarnings("unchecked")
     private static final ClientMessageDecoder LOAD_ALL_DECODER = new ClientMessageDecoder() {
@@ -84,8 +84,9 @@ abstract class AbstractClientCacheProxyBase<K, V> extends ClientProxy implements
 
     protected ClientContext clientContext;
     protected ILogger logger;
-    protected CacheStatsHandler statsHandler;
+
     boolean statisticsEnabled;
+    CacheStatsHandler statsHandler;
     SerializationService serializationService;
 
     private final ConcurrentMap<Future, CompletionListener> loadAllCalls = new ConcurrentHashMap<Future, CompletionListener>();
@@ -213,12 +214,11 @@ abstract class AbstractClientCacheProxyBase<K, V> extends ClientProxy implements
     }
 
     @Override
-    protected ClientMessage invoke(ClientMessage clientMessage) {
+    protected <T> T invoke(ClientMessage clientMessage) {
         try {
             Future<ClientMessage> future = new ClientInvocation(
                     (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance(), clientMessage).invoke();
-            return future.get();
-
+            return (T) future.get();
         } catch (Exception e) {
             throw rethrow(e);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
@@ -104,10 +104,10 @@ final class CacheStatsHandler {
         }
     }
 
-    OneShotExecutionCallback newOnPutCallback(final boolean isGet, final long startNanos) {
-        return new OneShotExecutionCallback() {
+    <T> OneShotExecutionCallback<T> newOnPutCallback(final boolean isGet, final long startNanos) {
+        return new OneShotExecutionCallback<T>() {
             @Override
-            protected void onResponseInternal(Object responseData) {
+            protected void onResponseInternal(T responseData) {
                 onPut(isGet, startNanos, responseData != null);
             }
 
@@ -135,9 +135,9 @@ final class CacheStatsHandler {
         }
     }
 
-    ExecutionCallback newOnRemoveCallback(final boolean isGet, final long startNanos) {
-        return new ExecutionCallback() {
-            public void onResponse(Object response) {
+    <T> ExecutionCallback<T> newOnRemoveCallback(final boolean isGet, final long startNanos) {
+        return new ExecutionCallback<T>() {
+            public void onResponse(T response) {
                 onRemove(isGet, startNanos, response);
             }
 
@@ -158,7 +158,7 @@ final class CacheStatsHandler {
     <T> ExecutionCallback<T> newOnGetCallback(final long startNanos) {
         return new ExecutionCallback<T>() {
             @Override
-            public void onResponse(Object response) {
+            public void onResponse(T response) {
                 onGet(startNanos, response != null);
             }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientClusterWideIterator.java
@@ -72,21 +72,21 @@ public class ClientClusterWideIterator<K, V> extends AbstractClusterWideIterator
     protected List fetch() {
         HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) context.getHazelcastInstance();
         if (prefetchValues) {
-            ClientMessage request = CacheIterateEntriesCodec
-                    .encodeRequest(cacheProxy.getPrefixedName(), partitionIndex, lastTableIndex, fetchSize);
+            ClientMessage request = CacheIterateEntriesCodec.encodeRequest(cacheProxy.getPrefixedName(), partitionIndex,
+                    lastTableIndex, fetchSize);
             try {
                 ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionIndex);
                 ClientInvocationFuture future = clientInvocation.invoke();
-                CacheIterateEntriesCodec.ResponseParameters responseParameters = CacheIterateEntriesCodec.
-                        decodeResponse(future.get());
+                CacheIterateEntriesCodec.ResponseParameters responseParameters = CacheIterateEntriesCodec.decodeResponse(
+                        future.get());
                 setLastTableIndex(responseParameters.entries, responseParameters.tableIndex);
                 return responseParameters.entries;
             } catch (Exception e) {
                 throw rethrow(e);
             }
         } else {
-            ClientMessage request = CacheIterateCodec
-                    .encodeRequest(cacheProxy.getPrefixedName(), partitionIndex, lastTableIndex, fetchSize);
+            ClientMessage request = CacheIterateCodec.encodeRequest(cacheProxy.getPrefixedName(), partitionIndex, lastTableIndex,
+                    fetchSize);
             try {
                 ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionIndex);
                 ClientInvocationFuture future = clientInvocation.invoke();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCachingProvider.java
@@ -146,8 +146,7 @@ public final class HazelcastClientCachingProvider extends AbstractHazelcastCachi
             throw new URISyntaxException(uri.toString(), "Unsupported protocol in configuration location URL");
         }
         try {
-            ClientConfig config = getConfig(configURL, classLoader, instanceName);
-            return config;
+            return getConfig(configURL, classLoader, instanceName);
         } catch (Exception e) {
             throw rethrow(e);
         }


### PR DESCRIPTION
* mostly fixed missing generics
* removed parameters with constant value (`name` is always `value`)
* made some methods and fields more private

Depends on https://github.com/hazelcast/hazelcast/issues/10127