### PR TITLE
Fixes [any] operator handling in built-in aggregators for null/empty collections/arrays

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AbstractAggregator.java
+++ b/hazelcast/src/main/java/com/hazelcast/aggregation/impl/AbstractAggregator.java
@@ -58,9 +58,12 @@ public abstract class AbstractAggregator<I, E, R> extends Aggregator<I, R> {
         E extractedValue = extract(entry);
         if (extractedValue instanceof MultiResult) {
             @SuppressWarnings("unchecked")
-            List<E> results = ((MultiResult<E>) extractedValue).getResults();
-            for (E o : results) {
-                accumulateExtracted(o);
+            MultiResult<E> multiResult = (MultiResult<E>) extractedValue;
+            List<E> results = multiResult.getResults();
+            for (int i = 0; i < results.size(); i++) {
+                if (!multiResult.isTargetNullOrEmpty(i)) {
+                    accumulateExtracted(results.get(i));
+                }
             }
         } else {
             accumulateExtracted(extractedValue);

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
@@ -46,7 +46,7 @@ public class DefaultPortableReader extends ValueReader implements PortableReader
 
     static {
         MultiResult<Object> result = new MultiResult<Object>();
-        result.addNullEmptyTarget();
+        result.addNullOrEmptyTarget();
         NULL_EMPTY_TARGET_MULTIRESULT = new ImmutableMultiResult<Object>(result);
     }
 
@@ -634,7 +634,7 @@ public class DefaultPortableReader extends ValueReader implements PortableReader
                 T read = readSinglePosition(position);
                 result.add(read);
             } else {
-                result.addNullEmptyTarget();
+                result.addNullOrEmptyTarget();
             }
         }
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultPortableReader.java
@@ -28,6 +28,7 @@ import com.hazelcast.query.extractor.ValueCallback;
 import com.hazelcast.query.extractor.ValueCollector;
 import com.hazelcast.query.extractor.ValueReader;
 import com.hazelcast.query.extractor.ValueReadingException;
+import com.hazelcast.query.impl.getters.ImmutableMultiResult;
 import com.hazelcast.query.impl.getters.MultiResult;
 
 import java.io.IOException;
@@ -40,6 +41,14 @@ import static com.hazelcast.internal.serialization.impl.PortableUtils.getPortabl
  * Can't be accessed concurrently
  */
 public class DefaultPortableReader extends ValueReader implements PortableReader {
+
+    private static final MultiResult NULL_EMPTY_TARGET_MULTIRESULT;
+
+    static {
+        MultiResult<Object> result = new MultiResult<Object>();
+        result.addNullEmptyTarget();
+        NULL_EMPTY_TARGET_MULTIRESULT = new ImmutableMultiResult<Object>(result);
+    }
 
     protected final ClassDefinition cd;
     protected final PortableSerializer serializer;
@@ -597,11 +606,17 @@ public class DefaultPortableReader extends ValueReader implements PortableReader
             if (position.isMultiPosition()) {
                 return readMultiPosition(position.asMultiPosition());
             } else if (position.isNull()) {
+                if (position.isAny()) {
+                    return NULL_EMPTY_TARGET_MULTIRESULT;
+                }
                 return null;
             } else if (position.isEmpty()) {
                 if (position.isLeaf() && position.getType() != null) {
                     return readSinglePosition(position);
                 } else {
+                    if (position.isAny()) {
+                        return NULL_EMPTY_TARGET_MULTIRESULT;
+                    }
                     return null;
                 }
             } else {
@@ -615,11 +630,12 @@ public class DefaultPortableReader extends ValueReader implements PortableReader
     private <T> MultiResult<T> readMultiPosition(List<PortablePosition> positions) throws IOException {
         MultiResult<T> result = new MultiResult<T>();
         for (PortablePosition position : positions) {
-            T read = null;
             if (!position.isNullOrEmpty()) {
-                read = readSinglePosition(position);
+                T read = readSinglePosition(position);
+                result.add(read);
+            } else {
+                result.addNullEmptyTarget();
             }
-            result.add(read);
         }
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePositionNavigator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/PortablePositionNavigator.java
@@ -514,6 +514,7 @@ final class PortablePositionNavigator {
             int currentIndex = 0;
             while (index > currentIndex) {
                 int indexElementLen = in.readInt();
+                indexElementLen = indexElementLen < 0 ? 0 : indexElementLen;
                 in.position(in.position() + indexElementLen);
                 currentIndex++;
             }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
@@ -101,11 +101,15 @@ public abstract class AbstractMultiValueGetter extends Getter {
         return inputType.getComponentType();
     }
 
-    private void collectResult(MultiResult collector, Object parentObject) throws IllegalAccessException,
-            InvocationTargetException {
+    private void collectResult(MultiResult collector, Object parentObject, boolean targetNullOrEmpty)
+            throws IllegalAccessException, InvocationTargetException {
         // re-add nulls from parent extraction without extracting further down the path
         if (parentObject == null) {
-            collector.add(null);
+            if (targetNullOrEmpty) {
+                collector.addNullEmptyTarget();
+            } else {
+                collector.add(null);
+            }
         } else {
             Object currentObject = extractFrom(parentObject);
             if (shouldReduce()) {
@@ -119,8 +123,9 @@ public abstract class AbstractMultiValueGetter extends Getter {
     private Object extractFromMultiResult(MultiResult parentMultiResult) throws IllegalAccessException,
             InvocationTargetException {
         MultiResult collector = new MultiResult();
-        for (Object parentResult : parentMultiResult.getResults()) {
-            collectResult(collector, parentResult);
+        int size = parentMultiResult.getResults().size();
+        for (int i = 0; i < size; i++) {
+            collectResult(collector, parentMultiResult.getResults().get(i), parentMultiResult.isTargetNullOrEmpty(i));
         }
 
         return collector;
@@ -160,7 +165,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
     private void reduceArrayInto(MultiResult collector, Object[] currentObject) {
         Object[] array = currentObject;
         if (array.length == 0) {
-            collector.add(null);
+            collector.addNullEmptyTarget();
         } else {
             for (int i = 0; i < array.length; i++) {
                 collector.add(array[i]);
@@ -171,7 +176,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
     private void reducePrimitiveArrayInto(MultiResult collector, Object primitiveArray) {
         int length = Array.getLength(primitiveArray);
         if (length == 0) {
-            collector.add(null);
+            collector.addNullEmptyTarget();
         } else {
             for (int i = 0; i < length; i++) {
                 collector.add(Array.get(primitiveArray, i));
@@ -182,7 +187,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
     protected void reduceCollectionInto(MultiResult collector, Collection currentObject) {
         Collection collection = currentObject;
         if (collection.isEmpty()) {
-            collector.add(null);
+            collector.addNullEmptyTarget();
         } else {
             for (Object o : collection) {
                 collector.add(o);
@@ -198,8 +203,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
         }
 
         if (currentObject == null) {
-            // collect null since it's a valid result
-            collector.add(null);
+            collector.addNullEmptyTarget();
         } else if (currentObject instanceof Collection) {
             reduceCollectionInto(collector, (Collection) currentObject);
         } else if (currentObject instanceof Object[]) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
@@ -101,15 +101,11 @@ public abstract class AbstractMultiValueGetter extends Getter {
         return inputType.getComponentType();
     }
 
-    private void collectResult(MultiResult collector, Object parentObject, boolean targetNullOrEmpty)
+    private void collectResult(MultiResult collector, Object parentObject)
             throws IllegalAccessException, InvocationTargetException {
         // re-add nulls from parent extraction without extracting further down the path
         if (parentObject == null) {
-            if (targetNullOrEmpty) {
-                collector.addNullEmptyTarget();
-            } else {
-                collector.add(null);
-            }
+            collector.add(null);
         } else {
             Object currentObject = extractFrom(parentObject);
             if (shouldReduce()) {
@@ -123,9 +119,10 @@ public abstract class AbstractMultiValueGetter extends Getter {
     private Object extractFromMultiResult(MultiResult parentMultiResult) throws IllegalAccessException,
             InvocationTargetException {
         MultiResult collector = new MultiResult();
+        collector.setNullOrEmptyTarget(parentMultiResult.isNullEmptyTarget());
         int size = parentMultiResult.getResults().size();
         for (int i = 0; i < size; i++) {
-            collectResult(collector, parentMultiResult.getResults().get(i), parentMultiResult.isTargetNullOrEmpty(i));
+            collectResult(collector, parentMultiResult.getResults().get(i));
         }
 
         return collector;
@@ -165,7 +162,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
     private void reduceArrayInto(MultiResult collector, Object[] currentObject) {
         Object[] array = currentObject;
         if (array.length == 0) {
-            collector.addNullEmptyTarget();
+            collector.addNullOrEmptyTarget();
         } else {
             for (int i = 0; i < array.length; i++) {
                 collector.add(array[i]);
@@ -176,7 +173,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
     private void reducePrimitiveArrayInto(MultiResult collector, Object primitiveArray) {
         int length = Array.getLength(primitiveArray);
         if (length == 0) {
-            collector.addNullEmptyTarget();
+            collector.addNullOrEmptyTarget();
         } else {
             for (int i = 0; i < length; i++) {
                 collector.add(Array.get(primitiveArray, i));
@@ -187,7 +184,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
     protected void reduceCollectionInto(MultiResult collector, Collection currentObject) {
         Collection collection = currentObject;
         if (collection.isEmpty()) {
-            collector.addNullEmptyTarget();
+            collector.addNullOrEmptyTarget();
         } else {
             for (Object o : collection) {
                 collector.add(o);
@@ -203,7 +200,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
         }
 
         if (currentObject == null) {
-            collector.addNullEmptyTarget();
+            collector.addNullOrEmptyTarget();
         } else if (currentObject instanceof Collection) {
             reduceCollectionInto(collector, (Collection) currentObject);
         } else if (currentObject instanceof Object[]) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
@@ -26,6 +26,8 @@ import static com.hazelcast.query.impl.getters.AbstractMultiValueGetter.validate
 
 public final class GetterFactory {
 
+    private static final String ANY_POSTFIX = "[any]";
+
     private GetterFactory() {
     }
 
@@ -47,6 +49,9 @@ public final class GetterFactory {
                 returnType = getCollectionType(collection);
             }
             if (returnType == null) {
+                if (modifierSuffix.equals(ANY_POSTFIX)) {
+                    return NullMultiValueGetter.NULL_MULTIVALUE_GETTER;
+                }
                 return NullGetter.NULL_GETTER;
             }
         } else if (isExtractingFromArray(fieldType, modifierSuffix)) {
@@ -92,6 +97,9 @@ public final class GetterFactory {
                 returnType = getCollectionType(collection);
             }
             if (returnType == null) {
+                if (modifierSuffix.equals(ANY_POSTFIX)) {
+                    return NullMultiValueGetter.NULL_MULTIVALUE_GETTER;
+                }
                 return NullGetter.NULL_GETTER;
             }
         } else if (isExtractingFromArray(methodReturnType, modifierSuffix)) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 
 import static com.hazelcast.query.impl.getters.AbstractMultiValueGetter.validateModifier;
+import static com.hazelcast.query.impl.getters.NullGetter.NULL_GETTER;
+import static com.hazelcast.query.impl.getters.NullMultiValueGetter.NULL_MULTIVALUE_GETTER;
 
 public final class GetterFactory {
 
@@ -39,7 +41,7 @@ public final class GetterFactory {
             validateModifier(modifierSuffix);
             Object currentObject = getCurrentObject(object, parentGetter);
             if (currentObject == null) {
-                return NullGetter.NULL_GETTER;
+                return NULL_GETTER;
             }
             if (currentObject instanceof MultiResult) {
                 MultiResult multiResult = (MultiResult) currentObject;
@@ -50,15 +52,15 @@ public final class GetterFactory {
             }
             if (returnType == null) {
                 if (modifierSuffix.equals(ANY_POSTFIX)) {
-                    return NullMultiValueGetter.NULL_MULTIVALUE_GETTER;
+                    return NULL_MULTIVALUE_GETTER;
                 }
-                return NullGetter.NULL_GETTER;
+                return NULL_GETTER;
             }
         } else if (isExtractingFromArray(fieldType, modifierSuffix)) {
             validateModifier(modifierSuffix);
             Object currentObject = getCurrentObject(object, parentGetter);
             if (currentObject == null) {
-                return NullGetter.NULL_GETTER;
+                return NULL_GETTER;
             }
         }
         return new FieldGetter(parentGetter, field, modifierSuffix, returnType);
@@ -87,7 +89,7 @@ public final class GetterFactory {
             validateModifier(modifierSuffix);
             Object currentObject = getCurrentObject(object, parentGetter);
             if (currentObject == null) {
-                return NullGetter.NULL_GETTER;
+                return NULL_GETTER;
             }
             if (currentObject instanceof MultiResult) {
                 MultiResult multiResult = (MultiResult) currentObject;
@@ -98,15 +100,15 @@ public final class GetterFactory {
             }
             if (returnType == null) {
                 if (modifierSuffix.equals(ANY_POSTFIX)) {
-                    return NullMultiValueGetter.NULL_MULTIVALUE_GETTER;
+                    return NULL_MULTIVALUE_GETTER;
                 }
-                return NullGetter.NULL_GETTER;
+                return NULL_GETTER;
             }
         } else if (isExtractingFromArray(methodReturnType, modifierSuffix)) {
             validateModifier(modifierSuffix);
             Object currentObject = getCurrentObject(object, parentGetter);
             if (currentObject == null) {
-                return NullGetter.NULL_GETTER;
+                return NULL_GETTER;
             }
         }
         return new MethodGetter(parentGetter, method, modifierSuffix, returnType);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ImmutableMultiResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ImmutableMultiResult.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+import java.util.List;
+
+/**
+ * Immutable version of the MultiResult
+ *
+ * @param <T> type of the underlying result store in the MultiResult
+ */
+public class ImmutableMultiResult<T> extends MultiResult<T> {
+
+    private final MultiResult<T> multiResult;
+
+    public ImmutableMultiResult(MultiResult<T> multiResult) {
+        this.multiResult = multiResult;
+    }
+
+    /**
+     * @param result result to be added to this MultiResult
+     */
+    public void add(T result) {
+        throw new UnsupportedOperationException("Can't modify an immutable MultiResult");
+    }
+
+
+    public void addNullEmptyTarget() {
+        throw new UnsupportedOperationException("Can't modify an immutable MultiResult");
+    }
+
+    /**
+     * @return a mutable underlying list of collected results
+     */
+    public List<T> getResults() {
+        return multiResult.getResults();
+    }
+
+    /**
+     * @return true if the MultiResult is empty; false otherwise
+     */
+    public boolean isEmpty() {
+        return multiResult.isEmpty();
+    }
+
+    public boolean isTargetNullOrEmpty(int index) {
+        return multiResult.isTargetNullOrEmpty(index);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ImmutableMultiResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ImmutableMultiResult.java
@@ -23,7 +23,7 @@ import java.util.List;
  *
  * @param <T> type of the underlying result store in the MultiResult
  */
-public class ImmutableMultiResult<T> extends MultiResult<T> {
+public final class ImmutableMultiResult<T> extends MultiResult<T> {
 
     private final MultiResult<T> multiResult;
 
@@ -39,7 +39,7 @@ public class ImmutableMultiResult<T> extends MultiResult<T> {
     }
 
 
-    public void addNullEmptyTarget() {
+    public void addNullOrEmptyTarget() {
         throw new UnsupportedOperationException("Can't modify an immutable MultiResult");
     }
 
@@ -57,8 +57,12 @@ public class ImmutableMultiResult<T> extends MultiResult<T> {
         return multiResult.isEmpty();
     }
 
-    public boolean isTargetNullOrEmpty(int index) {
-        return multiResult.isTargetNullOrEmpty(index);
+    public boolean isNullEmptyTarget() {
+        return multiResult.isNullEmptyTarget();
+    }
+
+    public void setNullOrEmptyTarget(boolean nullOrEmptyTarget) {
+        throw new UnsupportedOperationException("Can't modify an immutable MultiResult");
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullMultiValueGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullMultiValueGetter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+/**
+ * NullMultiValue getter describes neutral behaviour for a {@link Getter}.
+ * Always returns a MultiResult that indicates that the MultiValue object (Collection/Array) was null.
+ */
+public final class NullMultiValueGetter extends Getter {
+
+    /**
+     * Shared singleton instance of this class.
+     */
+    public static final NullMultiValueGetter NULL_MULTIVALUE_GETTER = new NullMultiValueGetter();
+
+    private static final MultiResult NULL_MULTIVALUE_RESULT;
+
+    static {
+        MultiResult<Object> result = new MultiResult<Object>();
+        result.addNullEmptyTarget();
+        NULL_MULTIVALUE_RESULT = new ImmutableMultiResult<Object>(result);
+    }
+
+    private NullMultiValueGetter() {
+        super(null);
+    }
+
+    @Override
+    Object getValue(Object obj) throws Exception {
+        return NULL_MULTIVALUE_RESULT;
+    }
+
+    @Override
+    Class getReturnType() {
+        return null;
+    }
+
+    @Override
+    boolean isCacheable() {
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullMultiValueGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/NullMultiValueGetter.java
@@ -31,7 +31,7 @@ public final class NullMultiValueGetter extends Getter {
 
     static {
         MultiResult<Object> result = new MultiResult<Object>();
-        result.addNullEmptyTarget();
+        result.addNullOrEmptyTarget();
         NULL_MULTIVALUE_RESULT = new ImmutableMultiResult<Object>(result);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 
 import static com.hazelcast.query.QueryConstants.THIS_ATTRIBUTE_NAME;
 import static com.hazelcast.query.impl.getters.NullGetter.NULL_GETTER;
+import static com.hazelcast.query.impl.getters.NullMultiValueGetter.NULL_MULTIVALUE_GETTER;
 import static com.hazelcast.query.impl.getters.SuffixModifierUtils.getModifierSuffix;
 import static com.hazelcast.query.impl.getters.SuffixModifierUtils.removeModifierSuffix;
 
@@ -125,7 +126,7 @@ public final class ReflectionHelper {
                             final Method method = clazz.getMethod(methodName);
                             method.setAccessible(true);
                             localGetter = GetterFactory.newMethodGetter(obj, parent, method, modifier);
-                            if (localGetter == NULL_GETTER) {
+                            if (localGetter == NULL_GETTER || localGetter == NULL_MULTIVALUE_GETTER) {
                                 return localGetter;
                             }
                             clazz = method.getReturnType();
@@ -138,7 +139,7 @@ public final class ReflectionHelper {
                         try {
                             final Field field = clazz.getField(baseName);
                             localGetter = GetterFactory.newFieldGetter(obj, parent, field, modifier);
-                            if (localGetter == NULL_GETTER) {
+                            if (localGetter == NULL_GETTER || localGetter == NULL_MULTIVALUE_GETTER) {
                                 return localGetter;
                             }
                             clazz = field.getType();
@@ -153,8 +154,8 @@ public final class ReflectionHelper {
                                 final Field field = c.getDeclaredField(baseName);
                                 field.setAccessible(true);
                                 localGetter = GetterFactory.newFieldGetter(obj, parent, field, modifier);
-                                if (localGetter == NULL_GETTER) {
-                                    return NULL_GETTER;
+                                if (localGetter == NULL_GETTER || localGetter == NULL_MULTIVALUE_GETTER) {
+                                    return localGetter;
                                 }
                                 clazz = field.getType();
                                 break;

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsPortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsPortableTest.java
@@ -22,6 +22,10 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -31,9 +35,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.Serializable;
+import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -42,11 +45,10 @@ import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class AggregatorsTest extends HazelcastTestSupport {
+public class AggregatorsPortableTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructors() {
@@ -54,54 +56,48 @@ public class AggregatorsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void aggregate_emptyNullSkipped_nullInValues() {
+    public void aggregate_emptyNullSkipped_nullInValues_nullFirst() {
         // GIVEN
         IMap<Integer, Car> map = getMapWithNodeCount(1, false, InMemoryFormat.OBJECT);
-        Car cornerCaseCar = getCornerCaseCar(null, 1L);
+        Car cornerCaseCar = getCornerCaseCar(null, "1");
         map.put(0, cornerCaseCar);
 
         // WHEN
-        List<Long> accumulatedArray = map.aggregate(new TestAggregator("wheelsA[any].tiresA[any]"));
-        List<Long> accumulatedCollection = map.aggregate(new TestAggregator("wheelsC[any].tiresC[any]"));
+        List<String> accumulated = map.aggregate(new TestAggregator("wheels[any]"));
 
         // THEN
-        assertEquals(accumulatedArray, accumulatedCollection);
-        assertThat(accumulatedArray, containsInAnyOrder(1L, null));
-        assertThat(accumulatedArray, hasSize(2));
+        assertThat(accumulated, containsInAnyOrder(null, "1"));
+        assertThat(accumulated, hasSize(2));
+    }
+
+    @Test
+    public void aggregate_emptyNullSkipped_nullInValues() {
+        // GIVEN
+        IMap<Integer, Car> map = getMapWithNodeCount(1, false, InMemoryFormat.OBJECT);
+        Car cornerCaseCar = getCornerCaseCar("1", null, "2", null);
+        map.put(0, cornerCaseCar);
+
+        // WHEN
+        List<String> accumulated = map.aggregate(new TestAggregator("wheels[any]"));
+
+        // THEN
+        assertThat(accumulated, containsInAnyOrder("1", null, "2", null));
+        assertThat(accumulated, hasSize(4));
     }
 
     @Test
     public void aggregate_emptyNullSkipped_noNullInValues() {
         // GIVEN
         IMap<Integer, Car> map = getMapWithNodeCount(1, false, InMemoryFormat.OBJECT);
-        Car cornerCaseCar = getCornerCaseCar(2L, 1L);
+        Car cornerCaseCar = getCornerCaseCar("2", "1");
         map.put(0, cornerCaseCar);
 
         // WHEN
-        List<Long> accumulatedArray = map.aggregate(new TestAggregator("wheelsA[any].tiresA[any]"));
-        List<Long> accumulatedCollection = map.aggregate(new TestAggregator("wheelsC[any].tiresC[any]"));
+        List<String> accumulated = map.aggregate(new TestAggregator("wheels[any]"));
 
         // THEN
-        assertEquals(accumulatedArray, accumulatedCollection);
-        assertThat(accumulatedArray, containsInAnyOrder(1L, 2L));
-        assertThat(accumulatedArray, hasSize(2));
-    }
-
-    @Test
-    public void aggregate_emptyNullSkipped_moreThanOneNullInValues() {
-        // GIVEN
-        IMap<Integer, Car> map = getMapWithNodeCount(1, false, InMemoryFormat.OBJECT);
-        Car cornerCaseCar = getCornerCaseCar(2L, null, 1L, null);
-        map.put(0, cornerCaseCar);
-
-        // WHEN
-        List<Long> accumulatedArray = map.aggregate(new TestAggregator("wheelsA[any].tiresA[any]"));
-        List<Long> accumulatedCollection = map.aggregate(new TestAggregator("wheelsC[any].tiresC[any]"));
-
-        // THEN
-        assertEquals(accumulatedArray, accumulatedCollection);
-        assertThat(accumulatedArray, containsInAnyOrder(1L, 2L, null, null));
-        assertThat(accumulatedArray, hasSize(4));
+        assertThat(accumulated, containsInAnyOrder("1", "2"));
+        assertThat(accumulated, hasSize(2));
     }
 
     @Test
@@ -112,47 +108,43 @@ public class AggregatorsTest extends HazelcastTestSupport {
         map.put(0, cornerCaseCar);
 
         // WHEN
-        List<Long> accumulatedArray = map.aggregate(new TestAggregator("wheelsA[any].tiresA[any]"));
-        List<Long> accumulatedCollection = map.aggregate(new TestAggregator("wheelsC[any].tiresC[any]"));
+        List<String> accumulated = map.aggregate(new TestAggregator("wheels[any]"));
 
         // THEN
-        assertEquals(accumulatedArray, accumulatedCollection);
-        assertThat(accumulatedCollection, hasSize(0));
+        assertThat(accumulated, hasSize(0));
     }
 
-    private Car getCornerCaseCar(Long... values) {
-        Wheel nullWheel = new Wheel();
+    @Test
+    public void aggregate_emptyFirstArray() {
+        // GIVEN
+        IMap<Integer, Car> map = getMapWithNodeCount(1, false, InMemoryFormat.OBJECT);
+        Car cornerCaseCar = new Car();
+        cornerCaseCar.wheels = new String[]{};
+        map.put(0, cornerCaseCar);
 
-        Wheel emptyWheel = new Wheel();
-        emptyWheel.tiresA = new Long[0];
-        emptyWheel.tiresC = new ArrayList<Long>();
+        // WHEN
+        List<String> accumulated = map.aggregate(new TestAggregator("wheels[any]"));
 
-        Wheel wheel = new Wheel();
-        wheel.tiresA = values;
-        wheel.tiresC = new ArrayList<Long>();
-        for (Long value : values) {
-            wheel.tiresC.add(value);
-        }
 
+        // THEN
+        assertThat(accumulated, hasSize(0));
+    }
+
+    private Car getCornerCaseCar(String... values) {
         Car car = new Car();
-        car.wheelsA = new Wheel[]{wheel, emptyWheel, nullWheel};
-        car.wheelsC = new ArrayList<Wheel>();
-        car.wheelsC.add(emptyWheel);
-        car.wheelsC.add(wheel);
-        car.wheelsC.add(nullWheel);
-
+        car.wheels = values;
         return car;
     }
 
-    private static class TestAggregator extends AbstractAggregator<Map.Entry<Integer, Car>, Long, List<Long>> {
-        private List<Long> accumulated = new ArrayList<Long>();
+    private static class TestAggregator extends AbstractAggregator<Map.Entry<Integer, Car>, String, List<String>> {
+        private List<String> accumulated = new ArrayList<String>();
 
         public TestAggregator(String attribute) {
             super(attribute);
         }
 
         @Override
-        protected void accumulateExtracted(Long value) {
+        protected void accumulateExtracted(String value) {
             accumulated.add(value);
         }
 
@@ -162,7 +154,7 @@ public class AggregatorsTest extends HazelcastTestSupport {
         }
 
         @Override
-        public List<Long> aggregate() {
+        public List<String> aggregate() {
             return accumulated;
         }
     }
@@ -181,18 +173,47 @@ public class AggregatorsTest extends HazelcastTestSupport {
                 .setProperty(AGGREGATION_ACCUMULATION_PARALLEL_EVALUATION.getName(), String.valueOf(parallelAccumulation))
                 .addMapConfig(mapConfig);
 
+        config.getSerializationConfig().addPortableFactory(CarFactory.ID, new CarFactory());
+
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(nodeCount);
         HazelcastInstance instance = factory.newInstances(config)[0];
         return instance.getMap("aggr");
     }
 
-    static class Car implements Serializable {
-        Collection<Wheel> wheelsC;
-        Wheel[] wheelsA;
+    static class Car implements Portable {
+        String[] wheels;
+
+        @Override
+        public int getFactoryId() {
+            return CarFactory.ID;
+        }
+
+        @Override
+        public int getClassId() {
+            return 1;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeUTFArray("wheels", wheels);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            wheels = reader.readUTFArray("wheels");
+        }
     }
 
-    static class Wheel implements Serializable {
-        Collection<Long> tiresC;
-        Long[] tiresA;
+    static class CarFactory implements PortableFactory {
+        static final int ID = 1;
+
+        @Override
+        public Portable create(int classId) {
+            if (classId == 1) {
+                return new Car();
+            } else {
+                return null;
+            }
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
@@ -35,15 +35,19 @@ import org.junit.runners.Parameterized;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
 
 import static com.hazelcast.spi.properties.GroupProperty.AGGREGATION_ACCUMULATION_PARALLEL_EVALUATION;
 import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
@@ -54,18 +58,30 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
     @Parameterized.Parameter(0)
     public InMemoryFormat inMemoryFormat;
 
-    @Parameterized.Parameters(name = "{0}")
+    @Parameterized.Parameter(1)
+    public boolean parallelAccumulation;
+
+    @Parameterized.Parameter(2)
+    public String postfix;
+
+    @Parameterized.Parameters(name = "{0} parallelAccumulation={1}, postfix={2}")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][]{
-                {InMemoryFormat.BINARY},
-                {InMemoryFormat.OBJECT},
+                {InMemoryFormat.BINARY, false, ""},
+                {InMemoryFormat.OBJECT, false, ""},
+                {InMemoryFormat.BINARY, true, ""},
+                {InMemoryFormat.OBJECT, true, ""},
+
+                {InMemoryFormat.BINARY, false, "[any]"},
+                {InMemoryFormat.OBJECT, false, "[any]"},
+                {InMemoryFormat.BINARY, true, "[any]"},
+                {InMemoryFormat.OBJECT, true, "[any]"},
         });
     }
 
     @Test
-    public void testAggregators_withParallelAccumulation() {
-        IMap<Integer, Person> map = getMapWithNodeCount(3, true);
-        String postfix = "";
+    public void testAggregators() {
+        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation);
         populateMapWithPersons(map, postfix);
 
         assertMinAggregators(map, postfix);
@@ -74,67 +90,6 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
         assertAverageAggregators(map, postfix);
         assertCountAggregators(map, postfix);
         assertDistinctAggregators(map, postfix);
-    }
-
-    @Test
-    public void testAggregators_withCallerRunsAccumulation() {
-        IMap<Integer, Person> map = getMapWithNodeCount(2, false);
-        String postfix = "";
-        populateMapWithPersons(map, postfix);
-
-        assertMinAggregators(map, postfix);
-        assertMaxAggregators(map, postfix);
-        assertSumAggregators(map, postfix);
-        assertAverageAggregators(map, postfix);
-        assertCountAggregators(map, postfix);
-        assertDistinctAggregators(map, postfix);
-    }
-
-    @Test
-    public void testAggregators_withParallelAccumulation_withAny() {
-        IMap<Integer, Person> map = getMapWithNodeCount(3, true);
-        String postfix = "[any]";
-        populateMapWithPersons(map, postfix);
-
-        assertMinAggregators(map, postfix);
-        assertMaxAggregators(map, postfix);
-        assertSumAggregators(map, postfix);
-        assertAverageAggregators(map, postfix);
-        assertCountAggregators(map, postfix);
-        assertDistinctAggregators(map, postfix);
-    }
-
-    @Test
-    public void testAggregators_withCallerRunsAccumulation_withAny() {
-        IMap<Integer, Person> map = getMapWithNodeCount(2, false);
-        String postfix = "[any]";
-        populateMapWithPersons(map, postfix);
-
-        assertMinAggregators(map, postfix);
-        assertMaxAggregators(map, postfix);
-        assertSumAggregators(map, postfix);
-        assertAverageAggregators(map, postfix);
-        assertCountAggregators(map, postfix);
-        assertDistinctAggregators(map, postfix);
-    }
-
-    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation) {
-        if (nodeCount < 1) {
-            throw new IllegalArgumentException("node count < 1");
-        }
-
-        MapConfig mapConfig = new MapConfig()
-                .setName("aggr")
-                .setInMemoryFormat(inMemoryFormat);
-
-        Config config = getConfig()
-                .setProperty(PARTITION_COUNT.getName(), String.valueOf(nodeCount))
-                .setProperty(AGGREGATION_ACCUMULATION_PARALLEL_EVALUATION.getName(), String.valueOf(parallelAccumulation))
-                .addMapConfig(mapConfig);
-
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(nodeCount);
-        HazelcastInstance instance = factory.newInstances(config)[0];
-        return instance.getMap("aggr");
     }
 
     public static void assertMinAggregators(IMap<Integer, Person> map, String p) {
@@ -214,7 +169,7 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     public static void assertDistinctAggregators(IMap<Integer, Person> map, String p) {
         // projections do not support [any] but we have one element only so here we go.
-        String projection = p.equals("[any]") ? "[0]" : "";
+        String projection = p.contains("[any]") ? "[0]" : "";
         assertCollectionEquals(map.project(Projections.<Map.Entry<Integer, Person>, Double>singleAttribute("doubleValue" + projection)),
                 map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>distinct("doubleValue" + p)));
         assertCollectionEquals(map.project(Projections.<Map.Entry<Integer, Person>, Long>singleAttribute("longValue" + projection)),
@@ -229,6 +184,147 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
                 map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Comparable>distinct("comparableValue" + p)));
     }
 
+    @Test
+    public void testAggregators_nullCornerCases() {
+        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation);
+        map.put(0, postfix.contains("[any]") ? PersonAny.nulls() : new Person());
+
+        if (postfix.contains("[any]")) {
+            assertMinAggregatorsAnyCornerCase(map, postfix);
+            assertMaxAggregatorsAnyCornerCase(map, postfix);
+            assertSumAggregatorsAnyCornerCase(map, postfix);
+            assertAverageAggregatorsAnyCornerCase(map, postfix);
+            assertCountAggregatorsAnyCornerCase(map, postfix, 0);
+            assertDistinctAggregatorsAnyCornerCase(map, postfix, emptySet());
+        } else {
+            assertMinAggregatorsAnyCornerCase(map, postfix);
+            assertMaxAggregatorsAnyCornerCase(map, postfix);
+            // sum and avg do not accept null values, thus skipped
+            assertCountAggregatorsAnyCornerCase(map, postfix, 1);
+            HashSet expected = new HashSet();
+            expected.add(null);
+            assertDistinctAggregatorsAnyCornerCase(map, postfix, expected);
+        }
+    }
+
+    @Test
+    public void testAggregators_emptyCornerCases() {
+        IMap<Integer, Person> map = getMapWithNodeCount(3, parallelAccumulation);
+
+        if (postfix.contains("[any]")) {
+            map.put(0, PersonAny.empty());
+            assertMinAggregatorsAnyCornerCase(map, postfix);
+            assertMaxAggregatorsAnyCornerCase(map, postfix);
+            assertSumAggregatorsAnyCornerCase(map, postfix);
+            assertAverageAggregatorsAnyCornerCase(map, postfix);
+            assertCountAggregatorsAnyCornerCase(map, postfix, 0);
+            assertDistinctAggregatorsAnyCornerCase(map, postfix, emptySet());
+        }
+    }
+
+    private void assertMinAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleMin("doubleValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longMin("longValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerMin("intValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalMin("bigDecimalValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerMin("bigIntegerValue" + p)));
+
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>comparableMin("doubleValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Long>comparableMin("longValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Integer>comparableMin("intValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigDecimal>comparableMin("bigDecimalValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigInteger>comparableMin("bigIntegerValue" + p)));
+
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, String>comparableMin("comparableValue" + p)));
+    }
+
+    public static void assertMaxAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleMax("doubleValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longMax("longValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerMax("intValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalMax("bigDecimalValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerMax("bigIntegerValue" + p)));
+
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>comparableMax("doubleValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Long>comparableMax("longValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Integer>comparableMax("intValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigDecimal>comparableMax("bigDecimalValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigInteger>comparableMax("bigIntegerValue" + p)));
+
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, String>comparableMax("comparableValue" + p)));
+    }
+
+    public static void assertSumAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleSum("doubleValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longSum("longValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerSum("intValue" + p)));
+        assertEquals(BigDecimal.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalSum("bigDecimalValue" + p)));
+        assertEquals(BigInteger.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerSum("bigIntegerValue" + p)));
+
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("doubleValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("longValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("intValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("bigIntegerValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("bigDecimalValue" + p)));
+
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum("doubleValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum("longValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum("intValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum("bigDecimalValue" + p)));
+    }
+
+    public static void assertAverageAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleAvg("doubleValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longAvg("longValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerAvg("intValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalAvg("bigDecimalValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerAvg("bigIntegerValue" + p)));
+
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("doubleValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("longValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("intValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("bigDecimalValue" + p)));
+        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("bigIntegerValue" + p)));
+    }
+
+    public static void assertCountAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, long value) {
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("doubleValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("longValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("intValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("bigDecimalValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("bigIntegerValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("comparableValue" + p)));
+    }
+
+    public static void assertDistinctAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, Set result) {
+        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>distinct("doubleValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Long>distinct("longValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Integer>distinct("intValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigDecimal>distinct("bigDecimalValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigInteger>distinct("bigIntegerValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Comparable>distinct("comparableValue" + p)));
+    }
+
+    protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation) {
+        if (nodeCount < 1) {
+            throw new IllegalArgumentException("node count < 1");
+        }
+
+        MapConfig mapConfig = new MapConfig()
+                .setName("aggr")
+                .setInMemoryFormat(inMemoryFormat);
+
+        Config config = getConfig()
+                .setProperty(PARTITION_COUNT.getName(), String.valueOf(nodeCount))
+                .setProperty(AGGREGATION_ACCUMULATION_PARALLEL_EVALUATION.getName(), String.valueOf(parallelAccumulation))
+                .addMapConfig(mapConfig);
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(nodeCount);
+        HazelcastInstance instance = factory.newInstances(config)[0];
+        return instance.getMap("aggr");
+    }
+
     private static void assertCollectionEquals(Collection a, Collection b) {
         TreeSet aSorted = new TreeSet(a);
         TreeSet bSorted = new TreeSet(b);
@@ -237,15 +333,15 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     public static void populateMapWithPersons(IMap<Integer, Person> map, String postfix) {
         for (int i = 1; i < 1000; i++) {
-            map.put(i, postfix.equals("[any]") ? new PersonAny(i) : new Person(i));
+            map.put(i, postfix.contains("[any]") ? new PersonAny(i) : new Person(i));
         }
     }
 
     public static class Person implements Serializable {
 
-        public int intValue;
-        public double doubleValue;
-        public long longValue;
+        public Integer intValue;
+        public Double doubleValue;
+        public Long longValue;
         public BigDecimal bigDecimalValue;
         public BigInteger bigIntegerValue;
         public String comparableValue;
@@ -255,8 +351,8 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
         public Person(int numberValue) {
             this.intValue = numberValue;
-            this.doubleValue = numberValue;
-            this.longValue = numberValue;
+            this.doubleValue = Double.valueOf(numberValue);
+            this.longValue = Long.valueOf(numberValue);
             this.bigDecimalValue = BigDecimal.valueOf(numberValue);
             this.bigIntegerValue = BigInteger.valueOf(numberValue);
             this.comparableValue = String.valueOf(numberValue);
@@ -282,6 +378,22 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
             this.bigDecimalValue = asList(BigDecimal.valueOf(numberValue));
             this.bigIntegerValue = asList(BigInteger.valueOf(numberValue));
             this.comparableValue = asList(String.valueOf(numberValue));
+        }
+
+        public static PersonAny empty() {
+            PersonAny person = new PersonAny();
+            person.intValue = new int[]{};
+            person.doubleValue = new double[]{};
+            person.longValue = new long[]{};
+            person.bigDecimalValue = new ArrayList<BigDecimal>();
+            person.bigIntegerValue = new ArrayList<BigInteger>();
+            person.comparableValue = new ArrayList<String>();
+            return person;
+        }
+
+        public static PersonAny nulls() {
+            PersonAny person = new PersonAny();
+            return person;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsTest.java
@@ -65,7 +65,8 @@ public class AggregatorsTest extends HazelcastTestSupport {
         List<Long> accumulatedCollection = map.aggregate(new TestAggregator("wheelsC[any].tiresC[any]"));
 
         // THEN
-        assertEquals(accumulatedArray, accumulatedCollection);
+        assertThat(accumulatedCollection, containsInAnyOrder(accumulatedArray.toArray()));
+        assertThat(accumulatedArray, containsInAnyOrder(accumulatedCollection.toArray()));
         assertThat(accumulatedArray, containsInAnyOrder(1L, null));
         assertThat(accumulatedArray, hasSize(2));
     }
@@ -82,7 +83,8 @@ public class AggregatorsTest extends HazelcastTestSupport {
         List<Long> accumulatedCollection = map.aggregate(new TestAggregator("wheelsC[any].tiresC[any]"));
 
         // THEN
-        assertEquals(accumulatedArray, accumulatedCollection);
+        assertThat(accumulatedCollection, containsInAnyOrder(accumulatedArray.toArray()));
+        assertThat(accumulatedArray, containsInAnyOrder(accumulatedCollection.toArray()));
         assertThat(accumulatedArray, containsInAnyOrder(1L, 2L));
         assertThat(accumulatedArray, hasSize(2));
     }
@@ -99,7 +101,8 @@ public class AggregatorsTest extends HazelcastTestSupport {
         List<Long> accumulatedCollection = map.aggregate(new TestAggregator("wheelsC[any].tiresC[any]"));
 
         // THEN
-        assertEquals(accumulatedArray, accumulatedCollection);
+        assertThat(accumulatedCollection, containsInAnyOrder(accumulatedArray.toArray()));
+        assertThat(accumulatedArray, containsInAnyOrder(accumulatedCollection.toArray()));
         assertThat(accumulatedArray, containsInAnyOrder(1L, 2L, null, null));
         assertThat(accumulatedArray, hasSize(4));
     }
@@ -116,7 +119,8 @@ public class AggregatorsTest extends HazelcastTestSupport {
         List<Long> accumulatedCollection = map.aggregate(new TestAggregator("wheelsC[any].tiresC[any]"));
 
         // THEN
-        assertEquals(accumulatedArray, accumulatedCollection);
+        assertThat(accumulatedCollection, containsInAnyOrder(accumulatedArray.toArray()));
+        assertThat(accumulatedArray, containsInAnyOrder(accumulatedCollection.toArray()));
         assertThat(accumulatedCollection, hasSize(0));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
@@ -168,7 +168,7 @@ public class DefaultPortableReaderSpecTest extends HazelcastTestSupport {
         if (result instanceof MultiResult) {
             MultiResult multiResult = (MultiResult) result;
             if(multiResult.getResults().size() == 1
-                    && multiResult.getResults().get(0) == null && multiResult.isTargetNullOrEmpty(0)) {
+                    && multiResult.getResults().get(0) == null && multiResult.isNullEmptyTarget()) {
                 // explode null in case of a single multi-result target result
                 result = null;
             } else {
@@ -801,23 +801,23 @@ public class DefaultPortableReaderSpecTest extends HazelcastTestSupport {
         result.add(scenario(input, expectedUtfArray, UTFArray, "portables[any].portables[any].string_", p));
 
         result.addAll(asList(
-                scenario(input, list(null, p1.byte_, p10.byte_, null, p20.byte_), Generic,
+                scenario(input, list(null, p1.byte_, p10.byte_, p20.byte_), Generic,
                         "portables[any].portables[any].byte_", p),
-                scenario(input, list(null, p1.short_, p10.short_, null, p20.short_), Generic,
+                scenario(input, list(null, p1.short_, p10.short_, p20.short_), Generic,
                         "portables[any].portables[any].short_", p),
-                scenario(input, list(null, p1.int_, p10.int_, null, p20.int_), Generic,
+                scenario(input, list(null, p1.int_, p10.int_, p20.int_), Generic,
                         "portables[any].portables[any].int_", p),
-                scenario(input, list(null, p1.long_, p10.long_, null, p20.long_), Generic,
+                scenario(input, list(null, p1.long_, p10.long_, p20.long_), Generic,
                         "portables[any].portables[any].long_", p),
-                scenario(input, list(null, p1.char_, p10.char_, null, p20.char_), Generic,
+                scenario(input, list(null, p1.char_, p10.char_, p20.char_), Generic,
                         "portables[any].portables[any].char_", p),
-                scenario(input, list(null, p1.float_, p10.float_, null, p20.float_), Generic,
+                scenario(input, list(null, p1.float_, p10.float_, p20.float_), Generic,
                         "portables[any].portables[any].float_", p),
-                scenario(input, list(null, p1.double_, p10.double_, null, p20.double_), Generic,
+                scenario(input, list(null, p1.double_, p10.double_, p20.double_), Generic,
                         "portables[any].portables[any].double_", p),
-                scenario(input, list(null, p1.boolean_, p10.boolean_, null, p20.boolean_), Generic,
+                scenario(input, list(null, p1.boolean_, p10.boolean_, p20.boolean_), Generic,
                         "portables[any].portables[any].boolean_", p),
-                scenario(input, list(null, p1.string_, p10.string_, null, p20.string_), Generic,
+                scenario(input, list(null, p1.string_, p10.string_, p20.string_), Generic,
                         "portables[any].portables[any].string_", p)
         ));
 
@@ -915,23 +915,23 @@ public class DefaultPortableReaderSpecTest extends HazelcastTestSupport {
         result.add(scenario(input, expectedUtfArray, UTFArray, "portables[any].portables[any].strings[any]", p));
 
         result.addAll(asList(
-                scenario(input, list(null, null, p10.bytes, null, null, p20.bytes, null), Generic,
+                scenario(input, list(null, p10.bytes, p20.bytes), Generic,
                         "portables[any].portables[any].bytes[any]", p),
-                scenario(input, list(null, null, p10.shorts, null, null, p20.shorts, null), Generic,
+                scenario(input, list(null, p10.shorts, p20.shorts), Generic,
                         "portables[any].portables[any].shorts[any]", p),
-                scenario(input, list(null, null, p10.ints, null, null, p20.ints, null), Generic,
+                scenario(input, list(null, p10.ints, p20.ints), Generic,
                         "portables[any].portables[any].ints[any]", p),
-                scenario(input, list(null, null, p10.longs, null, null, p20.longs, null), Generic,
+                scenario(input, list(null, p10.longs, p20.longs), Generic,
                         "portables[any].portables[any].longs[any]", p),
-                scenario(input, list(null, null, p10.chars, null, null, p20.chars, null), Generic,
+                scenario(input, list(null, p10.chars, p20.chars), Generic,
                         "portables[any].portables[any].chars[any]", p),
-                scenario(input, list(null, null, p10.floats, null, null, p20.floats, null), Generic,
+                scenario(input, list(null, p10.floats, p20.floats), Generic,
                         "portables[any].portables[any].floats[any]", p),
-                scenario(input, list(null, null, p10.doubles, null, null, p20.doubles, null), Generic,
+                scenario(input, list(null, p10.doubles, p20.doubles), Generic,
                         "portables[any].portables[any].doubles[any]", p),
-                scenario(input, list(null, null, p10.booleans, null, null, p20.booleans, null), Generic,
+                scenario(input, list(null, p10.booleans, p20.booleans), Generic,
                         "portables[any].portables[any].booleans[any]", p),
-                scenario(input, list(null, null, p10.strings, null, null, p20.strings, null), Generic,
+                scenario(input, list(null, p10.strings, p20.strings), Generic,
                         "portables[any].portables[any].strings[any]", p)
         ));
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderSpecTest.java
@@ -166,10 +166,20 @@ public class DefaultPortableReaderSpecTest extends HazelcastTestSupport {
         // assert the condition
         Object result = Invoker.invoke(reader(inputObject), readMethodNameToInvoke, pathToRead);
         if (result instanceof MultiResult) {
-            // in case of multi result while invoking generic "read" method deal with the multi results
-            result = ((MultiResult) result).getResults().toArray();
+            MultiResult multiResult = (MultiResult) result;
+            if(multiResult.getResults().size() == 1
+                    && multiResult.getResults().get(0) == null && multiResult.isTargetNullOrEmpty(0)) {
+                // explode null in case of a single multi-result target result
+                result = null;
+            } else {
+                // in case of multi result while invoking generic "read" method deal with the multi results
+                result = ((MultiResult) result).getResults().toArray();
+            }
+            assertThat(result, equalTo(resultToMatch));
+        } else {
+            assertThat(result, equalTo(resultToMatch));
         }
-        assertThat(result, equalTo(resultToMatch));
+
     }
 
     private void printlnScenarioDescription(Object resultToMatch) {
@@ -1230,14 +1240,6 @@ public class DefaultPortableReaderSpecTest extends HazelcastTestSupport {
 
     private static Object[] scenario(Portable input, Object result, Method method, String path, String parent) {
         return new Object[]{input, result, method, path, parent};
-    }
-
-    private static Collection<Object[]> test(Object[]... scenarios) {
-        List<Object[]> result = new ArrayList<Object[]>();
-        for (Object[] scenario : scenarios) {
-            result.add(scenario);
-        }
-        return result;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ComplexTestDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/specification/ComplexTestDataStructure.java
@@ -340,7 +340,9 @@ public class ComplexTestDataStructure {
         if (limb.fingers_array != null) {
             portable.fingers_portable = new Portable[limb.fingers_array.length];
             for (int i = 0; i < limb.fingers_array.length; i++) {
-                portable.fingers_portable[i] = limb.fingers_array[i].getPortable();
+                if(limb.fingers_array[i] != null) {
+                    portable.fingers_portable[i] = limb.fingers_array[i].getPortable();
+                }
             }
         }
         portable.tattoos_portable = limb.tattoos_array;
@@ -375,7 +377,9 @@ public class ComplexTestDataStructure {
         if (person.limbs_array != null) {
             portable.limbs_portable = new Portable[person.limbs_array.length];
             for (int i = 0; i < person.limbs_array.length; i++) {
-                portable.limbs_portable[i] = person.limbs_array[i].getPortable();
+                if(person.limbs_array[i] != null) {
+                    portable.limbs_portable[i] = person.limbs_array[i].getPortable();
+                }
             }
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryTest.java
@@ -110,7 +110,7 @@ public class GetterFactoryTest {
         OuterObject object = OuterObject.emptyInner("name");
         Getter getter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
 
-        assertSame(NullGetter.NULL_GETTER, getter);
+        assertSame(NullMultiValueGetter.NULL_MULTIVALUE_GETTER, getter);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class GetterFactoryTest {
         OuterObject object = OuterObject.emptyInner("name");
         Getter getter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
 
-        assertSame(NullGetter.NULL_GETTER, getter);
+        assertSame(NullMultiValueGetter.NULL_MULTIVALUE_GETTER, getter);
     }
 
     @Test
@@ -128,7 +128,7 @@ public class GetterFactoryTest {
         OuterObject object = OuterObject.nullInner("name");
         Getter getter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
 
-        assertSame(NullGetter.NULL_GETTER, getter);
+        assertSame(NullMultiValueGetter.NULL_MULTIVALUE_GETTER, getter);
     }
 
     @Test
@@ -137,7 +137,7 @@ public class GetterFactoryTest {
         OuterObject object = OuterObject.nullInner("name");
         Getter getter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
 
-        assertSame(NullGetter.NULL_GETTER, getter);
+        assertSame(NullMultiValueGetter.NULL_MULTIVALUE_GETTER, getter);
     }
 
     @Test
@@ -252,7 +252,7 @@ public class GetterFactoryTest {
         Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
         Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesCollectionField, "[any]");
 
-        assertSame(NullGetter.NULL_GETTER, innerObjectNameGetter);
+        assertSame(NullMultiValueGetter.NULL_MULTIVALUE_GETTER, innerObjectNameGetter);
     }
 
     @Test
@@ -263,7 +263,7 @@ public class GetterFactoryTest {
         Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
         Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesCollectionMethod, "[any]");
 
-        assertSame(NullGetter.NULL_GETTER, innerObjectNameGetter);
+        assertSame(NullMultiValueGetter.NULL_MULTIVALUE_GETTER, innerObjectNameGetter);
     }
 
     @Test
@@ -274,7 +274,7 @@ public class GetterFactoryTest {
         Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
         Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesCollectionField, "[any]");
 
-        assertSame(NullGetter.NULL_GETTER, innerObjectNameGetter);
+        assertSame(NullMultiValueGetter.NULL_MULTIVALUE_GETTER, innerObjectNameGetter);
     }
 
     @Test
@@ -285,7 +285,7 @@ public class GetterFactoryTest {
         Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
         Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesCollectionMethod, "[any]");
 
-        assertSame(NullGetter.NULL_GETTER, innerObjectNameGetter);
+        assertSame(NullMultiValueGetter.NULL_MULTIVALUE_GETTER, innerObjectNameGetter);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullMultiValueGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullMultiValueGetterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertInstanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class NullMultiValueGetterTest {
+
+    @Test
+    public void test_getReturnType() throws Exception {
+        Class returnType = NullMultiValueGetter.NULL_MULTIVALUE_GETTER.getReturnType();
+
+        assertNull(returnType);
+    }
+
+    @Test
+    public void test_isCacheable() throws Exception {
+        boolean cacheable = NullMultiValueGetter.NULL_MULTIVALUE_GETTER.isCacheable();
+
+        assertFalse(cacheable);
+    }
+
+    @Test
+    public void test_getValue() throws Exception {
+        Object value = NullMultiValueGetter.NULL_MULTIVALUE_GETTER.getValue("anything");
+
+        assertInstanceOf(MultiResult.class, value);
+        assertTrue(((MultiResult) value).isTargetNullOrEmpty(0));
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullMultiValueGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/NullMultiValueGetterTest.java
@@ -51,7 +51,7 @@ public class NullMultiValueGetterTest {
         Object value = NullMultiValueGetter.NULL_MULTIVALUE_GETTER.getValue("anything");
 
         assertInstanceOf(MultiResult.class, value);
-        assertTrue(((MultiResult) value).isTargetNullOrEmpty(0));
+        assertTrue(((MultiResult) value).isNullEmptyTarget());
     }
 
 }


### PR DESCRIPTION
Fixes #10126

Allows differentiating whether a null in the MultiResult is a null value because the value of the field was null or whether the null means that the targetObject was null.

For query evaluation the difference is not important - and we need to return null in both cases there. (see [any] corner cases in the reference manual)
For aggregations it makes a difference and we need this context knowledge there.

MultiResult is a structure returned if an extraction contains an `[any]` operator, since a single read of a `person.hands[any].length` expression may return more than one result.

Here's more info about `[any]`: http://docs.hazelcast.org/docs/3.8/manual/html-single/index.html#querying-in-collections-and-arrays