### PR TITLE
New group property, hazelcast.socket.allow.any.public.address

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/BindMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/BindMessage.java
@@ -27,14 +27,16 @@ public class BindMessage implements IdentifiedDataSerializable {
 
     private Address localAddress;
     private Address targetAddress;
+    private Address translatedAddress;
     private boolean reply;
 
     public BindMessage() {
     }
 
-    public BindMessage(Address localAddress, Address targetAddress, boolean reply) {
+    public BindMessage(Address localAddress, Address targetAddress, Address translatedAddress, boolean reply) {
         this.localAddress = localAddress;
         this.targetAddress = targetAddress;
+        this.translatedAddress = translatedAddress;
         this.reply = reply;
     }
 
@@ -44,6 +46,10 @@ public class BindMessage implements IdentifiedDataSerializable {
 
     public Address getTargetAddress() {
         return targetAddress;
+    }
+
+    public Address getTranslatedAddress() {
+        return translatedAddress;
     }
 
     public boolean shouldReply() {
@@ -70,6 +76,11 @@ public class BindMessage implements IdentifiedDataSerializable {
             targetAddress.readData(in);
         }
         reply = in.readBoolean();
+        boolean hasTranslatedAddress = in.readBoolean();
+        if (hasTranslatedAddress) {
+            translatedAddress = new Address();
+            translatedAddress.readData(in);
+        }
     }
 
     @Override
@@ -81,6 +92,11 @@ public class BindMessage implements IdentifiedDataSerializable {
             targetAddress.writeData(out);
         }
         out.writeBoolean(reply);
+        boolean hasTranslatedAddress =  translatedAddress != null;
+        out.writeBoolean(hasTranslatedAddress);
+        if (hasTranslatedAddress) {
+            translatedAddress.writeData(out);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -79,6 +79,8 @@ public interface IOService {
 
     boolean isSocketBindAny();
 
+    boolean isSocketAllowAnyPublicAddress();
+
     int getSocketReceiveBufferSize();
 
     int getSocketSendBufferSize();

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -199,6 +199,11 @@ public class NodeIOService implements IOService {
     }
 
     @Override
+    public boolean isSocketAllowAnyPublicAddress() {
+        return node.getProperties().getBoolean(GroupProperty.SOCKET_ALLOW_ANY_PUBLIC_ADDRESS);
+    }
+
+    @Override
     public int getSocketReceiveBufferSize() {
         return node.getProperties().getInteger(GroupProperty.SOCKET_RECEIVE_BUFFER_SIZE);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -226,6 +226,14 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.socket.send.buffer.size", 32);
 
     /**
+     * Allows connections to a member when members public address is different than the target address of
+     * incoming connection. Useful especially in containerized environments where public address of a container
+     * and binded (private) address of a member differs.
+     */
+    public static final HazelcastProperty SOCKET_ALLOW_ANY_PUBLIC_ADDRESS
+            = new HazelcastProperty("hazelcast.socket.allow.any.public.address", false);
+
+    /**
      * If the bytebuffers used in the socket should be a direct bytebuffer (true) or a regular bytebuffer (false).
      */
     public static final HazelcastProperty SOCKET_BUFFER_DIRECT

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -180,6 +180,11 @@ public class MockIOService implements IOService {
     }
 
     @Override
+    public boolean isSocketAllowAnyPublicAddress() {
+        return true;
+    }
+
+    @Override
     public int getSocketReceiveBufferSize() {
         return 32;
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_BindTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_BindTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp;
+
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class TcpIpConnectionManager_BindTest extends HazelcastTestSupport {
+
+
+    @Before
+    public void setup() {
+        Hazelcast.shutdownAll();
+    }
+
+    @After
+    public void after() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void test() {
+        Config config = new Config();
+        config.setProperty(GroupProperty.SOCKET_ALLOW_ANY_PUBLIC_ADDRESS.getName(), "true");
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).addMember("localhost");
+
+        Config config2 = new Config();
+        config2.setProperty(GroupProperty.SOCKET_ALLOW_ANY_PUBLIC_ADDRESS.getName(), "true");
+        config2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config2.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).addMember("127.0.0.1:5702");
+
+        Hazelcast.newHazelcastInstance(config2);
+        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assert instance.getCluster().getMembers().size() == 2;
+            }
+        });
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectMemberBaseTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_ConnectMemberBaseTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionType;
 import com.hazelcast.test.AssertTask;
@@ -120,6 +121,25 @@ public abstract class TcpIpConnectionManager_ConnectMemberBaseTest extends TcpIp
         startAllConnectionManagers();
 
         TcpIpConnection connAB = connect(connManagerA, addressB);
+        assertTrue(connAB.isAlive());
+        assertEquals(ConnectionType.MEMBER, connAB.getType());
+        assertEquals(1, connManagerA.getActiveConnectionCount());
+
+        TcpIpConnection connBA = (TcpIpConnection) connManagerB.getConnection(addressA);
+        assertTrue(connBA.isAlive());
+        assertEquals(ConnectionType.MEMBER, connBA.getType());
+        assertEquals(1, connManagerB.getActiveConnectionCount());
+
+        assertEquals(connManagerA.getIoService().getThisAddress(), connBA.getEndPoint());
+        assertEquals(connManagerB.getIoService().getThisAddress(), connAB.getEndPoint());
+    }
+
+    @Test
+    public void connect_withTranslatedAddress() throws UnknownHostException {
+        startAllConnectionManagers();
+
+        Address testAddress = new Address("localhost", 5702);
+        TcpIpConnection connAB = connect(connManagerA, testAddress);
         assertTrue(connAB.isAlive());
         assertEquals(ConnectionType.MEMBER, connAB.getType());
         assertEquals(1, connManagerA.getActiveConnectionCount());


### PR DESCRIPTION
I've added a new property `hazelcast.socket.allow.any.public.address`  to provide a solution to the infamous error message "Wrong bind request! ... This node is not requested endpoint".

This property will be useful especially in containerized environments. (Docker in specific). 
When Hazelcast starts in a container it can bind itself to a local address but other containers can connect to that container only through its public IP address which causes the aforementioned error.

One solution is to set public IP address in `NetworkConfig`  but this approach is not scalable/applicable where IP addresses changes dynamically (imagine you're creating new containers using Swarm, Kubernetes etc).

So I've introduced this new property which skips the local address control and also members send it's public/private addresses in the `BindMessage` for connection mapping.

Below are the issues for the need;

https://github.com/hazelcast/hazelcast/issues/9219
https://github.com/hazelcast/hazelcast/issues/4537 