### PR TITLE
Fixed dependency to javax.cache in ClientICacheManager

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -113,7 +113,7 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
         try {
             ClientICacheManager cacheManager = client.getCacheManager();
             String nameWithPrefix = cacheConfig.getNameWithPrefix();
-            ICacheInternal cache = cacheManager.getCacheByFullName(nameWithPrefix);
+            ICacheInternal<K, V> cache = (ICacheInternal<K, V>) cacheManager.getCacheByFullName(nameWithPrefix);
             cache.setCacheManager(this);
             return cache;
         } catch (Throwable t) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientICacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientICacheManager.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.impl;
 
 import com.hazelcast.cache.HazelcastCacheManager;
-import com.hazelcast.cache.impl.ICacheInternal;
+import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.client.spi.impl.ClientServiceNotFoundException;
 import com.hazelcast.core.HazelcastException;
@@ -42,12 +42,12 @@ public class ClientICacheManager implements ICacheManager {
     }
 
     @Override
-    public <K, V> ICacheInternal<K, V> getCache(String name) {
+    public <K, V> ICache<K, V> getCache(String name) {
         checkNotNull(name, "Retrieving a cache instance with a null name is not allowed!");
         return getCacheByFullName(HazelcastCacheManager.CACHE_MANAGER_PREFIX + name);
     }
 
-    public <K, V> ICacheInternal<K, V> getCacheByFullName(String fullName) {
+    public <K, V> ICache<K, V> getCacheByFullName(String fullName) {
         checkNotNull(fullName, "Retrieving a cache instance with a null name is not allowed!");
         try {
             return instance.getDistributedObject(ICacheService.SERVICE_NAME, fullName);

--- a/hazelcast-client/src/test/java/classloading/JavaXCacheDependencyClientTest.java
+++ b/hazelcast-client/src/test/java/classloading/JavaXCacheDependencyClientTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classloading;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class JavaXCacheDependencyClientTest extends AbstractJavaXCacheDependencyTest {
+
+    private static HazelcastInstance hazelcast;
+
+    @BeforeClass
+    public static void setUp() {
+        hazelcast = Hazelcast.newHazelcastInstance();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        hazelcast.getLifecycleService().terminate();
+    }
+
+    protected String getConfigClass() {
+        return "com.hazelcast.client.config.ClientConfig";
+    }
+
+    protected String getHazelcastClass() {
+        return "com.hazelcast.client.HazelcastClient";
+    }
+
+    protected String getNewInstanceMethod() {
+        return "newHazelcastClient";
+    }
+}

--- a/hazelcast/src/test/java/classloading/AbstractJavaXCacheDependencyTest.java
+++ b/hazelcast/src/test/java/classloading/AbstractJavaXCacheDependencyTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classloading;
+
+import com.hazelcast.util.FilteringClassLoader;
+import com.hazelcast.util.RootCauseMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Creates a member or client {@link com.hazelcast.core.Hazelcast} instance with an explicit exclusion of {@code javax.cache}.
+ *
+ * If the method {@link #createHazelcastInstance()} or {@link #createHazelcastInstance_getCacheManager()} fails with a
+ * {@link ClassNotFoundException} with the cause "javax.cache.* - Package excluded explicitly!" we accidentally introduced
+ * a runtime dependency on {@link javax.cache} with a default configuration.
+ *
+ * The method {@link #createHazelcastInstance_getCache()} is expected to fail, since it actually tries to invoke
+ * {@link com.hazelcast.core.ICacheManager#getCache(String)}.
+ */
+public abstract class AbstractJavaXCacheDependencyTest {
+
+    private static final String EXPECTED_CAUSE = "javax.cache.Cache - Package excluded explicitly!";
+
+    private static final ClassLoader CLASS_LOADER;
+
+    static {
+        List<String> excludes = singletonList("javax.cache");
+        CLASS_LOADER = new FilteringClassLoader(excludes, "com.hazelcast");
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void createHazelcastInstance() throws Exception {
+        createHazelcastInstance(false, false);
+    }
+
+    @Test
+    public void createHazelcastInstance_getCacheManager() throws Exception {
+        createHazelcastInstance(true, false);
+    }
+
+    @Test
+    public void createHazelcastInstance_getCache() throws Exception {
+        createHazelcastInstance(true, true);
+    }
+
+    protected abstract String getConfigClass();
+
+    protected abstract String getHazelcastClass();
+
+    protected abstract String getNewInstanceMethod();
+
+    private void createHazelcastInstance(boolean testGetCacheManager, boolean testGetCache) throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader tccl = thread.getContextClassLoader();
+        thread.setContextClassLoader(CLASS_LOADER);
+        try {
+            Class<?> configClazz = CLASS_LOADER.loadClass(getConfigClass());
+            Class<?> hazelcastClazz = CLASS_LOADER.loadClass(getHazelcastClass());
+            Class<?> hazelcastInstanceClazz = CLASS_LOADER.loadClass("com.hazelcast.core.HazelcastInstance");
+            Class<?> cacheManagerClazz = CLASS_LOADER.loadClass("com.hazelcast.core.ICacheManager");
+            try {
+                Object config = configClazz.newInstance();
+
+                Method setClassLoader = configClazz.getDeclaredMethod("setClassLoader", ClassLoader.class);
+                setClassLoader.invoke(config, CLASS_LOADER);
+
+                Method newHazelcastInstance = hazelcastClazz.getDeclaredMethod(getNewInstanceMethod(), configClazz);
+                Object hazelcastInstance = newHazelcastInstance.invoke(hazelcastClazz, config);
+
+                if (testGetCacheManager) {
+                    Method getCacheManager = hazelcastInstanceClazz.getDeclaredMethod("getCacheManager");
+                    getCacheManager.invoke(hazelcastInstance);
+                }
+                if (testGetCache) {
+                    expectedException.expect(new RootCauseMatcher(ClassNotFoundException.class, EXPECTED_CAUSE));
+                    cacheManagerClazz.getDeclaredMethod("getCache", String.class);
+                }
+            } finally {
+                Method shutdownAll = hazelcastClazz.getDeclaredMethod("shutdownAll");
+                shutdownAll.invoke(hazelcastClazz);
+            }
+        } finally {
+            thread.setContextClassLoader(tccl);
+        }
+    }
+}

--- a/hazelcast/src/test/java/classloading/JavaXCacheDependencyTest.java
+++ b/hazelcast/src/test/java/classloading/JavaXCacheDependencyTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classloading;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class JavaXCacheDependencyTest extends AbstractJavaXCacheDependencyTest {
+
+    protected String getConfigClass() {
+        return "com.hazelcast.config.Config";
+    }
+
+    protected String getHazelcastClass() {
+        return "com.hazelcast.core.Hazelcast";
+    }
+
+    protected String getNewInstanceMethod() {
+        return "newHazelcastInstance";
+    }
+}


### PR DESCRIPTION
* fixed an unwanted dependency on java.cache in `ClientICacheManager`
* added tests which exclude `javax.cache` via the `FilteringClassloader`

Without this fix I get the following error when starting a client with just an IMap and Near Cache configuration:
```
BuildInfo{version='3.9-SNAPSHOT', build='20170322', buildNumber=20170322, revision=ccd594b, enterprise=false, serializationVersion=1}
java.lang.NoClassDefFoundError: javax/cache/Cache
    at java.lang.ClassLoader.defineClass1(Native Method)
    at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
    at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    at com.hazelcast.client.impl.HazelcastClientInstanceImpl.<init>(HazelcastClientInstanceImpl.java:241)
    at com.hazelcast.client.HazelcastClient$1.createHazelcastInstanceClient(HazelcastClient.java:55)
    at com.hazelcast.client.HazelcastClientManager.newHazelcastClient(HazelcastClientManager.java:74)
    at com.hazelcast.client.HazelcastClient.newHazelcastClient(HazelcastClient.java:72)
```

This reverts a tiny part of https://github.com/hazelcast/hazelcast/pull/10035