### PR TITLE
Introduce NO_MIGRATION cluster state

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -232,9 +232,9 @@ public interface Cluster {
      * @throws TransactionException  if there's already an ongoing transaction
      *                               or this transaction fails
      *                               or this transaction timeouts
-     * @see {@link GroupProperty#CLUSTER_SHUTDOWN_TIMEOUT_SECONDS}
-     * @see {@link #changeClusterState(ClusterState)}
-     * @see {@link ClusterState#PASSIVE}
+     * @see GroupProperty#CLUSTER_SHUTDOWN_TIMEOUT_SECONDS
+     * @see #changeClusterState(ClusterState)
+     * @see ClusterState#PASSIVE
      * @since 3.6
      */
     void shutdown();
@@ -256,9 +256,9 @@ public interface Cluster {
      * @throws TransactionException  if there's already an ongoing transaction
      *                               or this transaction fails
      *                               or this transaction timeouts
-     * @see {@link GroupProperty#CLUSTER_SHUTDOWN_TIMEOUT_SECONDS}
-     * @see {@link #changeClusterState(ClusterState)}
-     * @see {@link ClusterState#PASSIVE}
+     * @see GroupProperty#CLUSTER_SHUTDOWN_TIMEOUT_SECONDS
+     * @see #changeClusterState(ClusterState)
+     * @see ClusterState#PASSIVE
      * @since 3.6
      */
     void shutdown(TransactionOptions transactionOptions);

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeState.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeState.java
@@ -39,8 +39,8 @@ public enum NodeState {
 
     /**
      * Initial state of the Node. An {@code ACTIVE} node is allowed to execute/process
-     * all kinds of operations. A node is in {@code ACTIVE} state while cluster state is
-     * {@link ClusterState#ACTIVE} or {@link ClusterState#FROZEN}.
+     * all kinds of operations. A node is in {@code ACTIVE} state while cluster state is one of
+     * {@link ClusterState#ACTIVE}, {@link ClusterState#NO_MIGRATION} or {@link ClusterState#FROZEN}.
      */
     ACTIVE,
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -41,7 +41,9 @@ import java.util.List;
 import java.util.Set;
 
 import static com.hazelcast.util.StringUtil.bytesToString;
+import static com.hazelcast.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.util.StringUtil.stringToBytes;
+import static com.hazelcast.util.StringUtil.upperCaseInternal;
 
 public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostCommand> {
     private static final byte[] QUEUE_SIMPLE_VALUE_CONTENT_TYPE = stringToBytes("text/plain");
@@ -116,16 +118,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             if (!(groupConfig.getName().equals(groupName) && groupConfig.getPassword().equals(groupPass))) {
                 res = response(ResponseType.FORBIDDEN);
             } else {
-                ClusterState state = clusterService.getClusterState();
-                if (stateParam.equals("frozen")) {
-                    state = ClusterState.FROZEN;
-                }
-                if (stateParam.equals("active")) {
-                    state = ClusterState.ACTIVE;
-                }
-                if (stateParam.equals("passive")) {
-                    state = ClusterState.PASSIVE;
-                }
+                ClusterState state = ClusterState.valueOf(upperCaseInternal(stateParam));
                 if (!state.equals(clusterService.getClusterState())) {
                     clusterService.changeClusterState(state);
                     res = response(ResponseType.SUCCESS, "state", state.toString().toLowerCase());
@@ -148,7 +141,8 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             if (!checkCredentials(command)) {
                 res = response(ResponseType.FORBIDDEN);
             } else {
-                res = response(ResponseType.SUCCESS, "state", clusterService.getClusterState().toString().toLowerCase());
+                ClusterState clusterState = clusterService.getClusterState();
+                res = response(ResponseType.SUCCESS, "state", lowerCaseInternal(clusterState.toString()));
             }
         } catch (Throwable throwable) {
             logger.warning("Error occurred while getting cluster state", throwable);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -293,13 +293,13 @@ public class ClusterJoinManager {
             return true;
         }
 
-        if (state == ClusterState.ACTIVE) {
+        if (state.isJoinAllowed()) {
             return false;
         }
 
-        if (clusterService.isMemberRemovedWhileClusterIsNotActive(target)) {
+        if (clusterService.isMemberRemovedInNotJoinableState(target)) {
             MemberImpl memberRemovedWhileClusterIsNotActive =
-                    clusterService.getMembershipManager().getMemberRemovedWhileClusterIsNotActive(uuid);
+                    clusterService.getMembershipManager().getMemberRemovedInNotJoinableState(uuid);
 
             if (memberRemovedWhileClusterIsNotActive != null
                     && !target.equals(memberRemovedWhileClusterIsNotActive.getAddress())) {
@@ -314,7 +314,7 @@ public class ClusterJoinManager {
             return false;
         }
 
-        if (clusterService.isMemberRemovedWhileClusterIsNotActive(uuid)) {
+        if (clusterService.isMemberRemovedInNotJoinableState(uuid)) {
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -495,7 +495,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
             return;
         }
 
-        if (getClusterState() == ClusterState.ACTIVE) {
+        if (getClusterState().isMigrationAllowed()) {
             return;
         }
 
@@ -505,11 +505,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
         Address address = member.getAddress();
         MemberImpl memberRemovedWhileClusterIsNotActive
-                = membershipManager.getMemberRemovedWhileClusterIsNotActive(member.getUuid());
+                = membershipManager.getMemberRemovedInNotJoinableState(member.getUuid());
         if (memberRemovedWhileClusterIsNotActive != null) {
             Address oldAddress = memberRemovedWhileClusterIsNotActive.getAddress();
             if (!oldAddress.equals(address)) {
-                assert !isMemberRemovedWhileClusterIsNotActive(address);
+                assert !isMemberRemovedInNotJoinableState(address);
 
                 logger.warning(member + " is returning with a new address. Old one was: " + oldAddress
                         + ". Will update partition table with the new address.");
@@ -639,16 +639,16 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         return nodeEngine;
     }
 
-    public boolean isMemberRemovedWhileClusterIsNotActive(Address target) {
-        return membershipManager.isMemberRemovedWhileClusterIsNotActive(target);
+    public boolean isMemberRemovedInNotJoinableState(Address target) {
+        return membershipManager.isMemberRemovedInNotJoinableState(target);
     }
 
-    boolean isMemberRemovedWhileClusterIsNotActive(String uuid) {
-        return membershipManager.isMemberRemovedWhileClusterIsNotActive(uuid);
+    boolean isMemberRemovedInNotJoinableState(String uuid) {
+        return membershipManager.isMemberRemovedInNotJoinableState(uuid);
     }
 
-    public Collection<Member> getCurrentMembersAndMembersRemovedWhileClusterIsNotActive() {
-        return membershipManager.getCurrentMembersAndMembersRemovedWhileClusterIsNotActive();
+    public Collection<Member> getCurrentMembersAndMembersRemovedInNotJoinableState() {
+        return membershipManager.getCurrentMembersAndMembersRemovedInNotJoinableState();
     }
 
     public void notifyForRemovedMember(MemberImpl member) {
@@ -660,8 +660,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         }
     }
 
-    public void shrinkMembersRemovedWhileClusterIsNotActiveState(Collection<String> memberUuidsToRemove) {
-        membershipManager.shrinkMembersRemovedWhileClusterIsNotActiveState(memberUuidsToRemove);
+    public void shrinkMembersRemovedInNotJoinableState(Collection<String> memberUuidsToRemove) {
+        membershipManager.shrinkMembersRemovedInNotJoinableState(memberUuidsToRemove);
     }
 
     private void sendMemberAttributeEvent(MemberImpl member, MemberAttributeOperationType operationType, String key,
@@ -1000,8 +1000,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                 options, partitionStateVersion, false);
     }
 
-    void addMembersRemovedInNotActiveState(Collection<MemberImpl> members) {
-        membershipManager.addMembersRemovedInNotActiveState(members);
+    void addMembersRemovedInNotJoinableState(Collection<MemberImpl> members) {
+        membershipManager.addMembersRemovedInNotJoinableState(members);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainHandler.java
@@ -66,8 +66,7 @@ final class SplitBrainHandler implements Runnable {
         }
 
         final ClusterState clusterState = clusterService.getClusterState();
-        return clusterState == ClusterState.ACTIVE;
-
+        return clusterState.isJoinAllowed();
     }
 
     private void searchForOtherClusters() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
@@ -144,7 +144,7 @@ public class SplitBrainMergeValidationOp extends AbstractJoinOperation {
         }
 
         final ClusterState clusterState = clusterService.getClusterState();
-        if (clusterState != ClusterState.ACTIVE) {
+        if (!clusterState.isJoinAllowed()) {
             logger.info("Ignoring join check from " + getCallerAddress() + ", because cluster is in "
                     + clusterState + " state ...");
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -215,7 +215,7 @@ public class PartitionReplicaManager {
      * partition and schedule a new sync request that is to be run in the case of timeout
      */
     private boolean fireSyncReplicaRequest(ReplicaSyncInfo syncInfo, Address target) {
-        if (node.clusterService.isMemberRemovedWhileClusterIsNotActive(target)) {
+        if (node.clusterService.isMemberRemovedInNotJoinableState(target)) {
             return false;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -117,7 +117,7 @@ public class PartitionStateManager {
      * Arranges the partitions if:
      * <ul>
      * <li>this instance {@link NodeExtension#isStartCompleted()}</li>
-     * <li>the cluster is {@link ClusterState#ACTIVE}</li>
+     * <li>the cluster state allows migrations. See {@link ClusterState#isMigrationAllowed()}</li>
      * </ul>
      * This will also set the manager state to initialized (if not already) and invoke the
      * {@link PartitionListener#replicaChanged(PartitionReplicaChangeEvent)} for all changed replicas which
@@ -149,7 +149,7 @@ public class PartitionStateManager {
         // if it's started and not locked the state yet.
         stateVersion.incrementAndGet();
         ClusterState clusterState = node.getClusterService().getClusterState();
-        if (clusterState != ClusterState.ACTIVE) {
+        if (!clusterState.isMigrationAllowed()) {
             // cluster state is either changed or locked, decrement version back and fail.
             stateVersion.decrementAndGet();
             logger.warning("Partitions can't be assigned since cluster-state= " + clusterState);
@@ -165,7 +165,10 @@ public class PartitionStateManager {
         return true;
     }
 
-    /** Returns {@code true} if the node has started and the cluster is {@link ClusterState#ACTIVE} */
+    /**
+     * Returns {@code true} if the node has started and
+     * the cluster state allows migrations (see {@link ClusterState#isMigrationAllowed()}).
+     * */
     private boolean isPartitionAssignmentAllowed() {
         if (!node.getNodeExtension().isStartCompleted()) {
             logger.warning("Partitions can't be assigned since startup is not completed yet.");
@@ -173,7 +176,7 @@ public class PartitionStateManager {
         }
 
         ClusterState clusterState = node.getClusterService().getClusterState();
-        if (clusterState != ClusterState.ACTIVE) {
+        if (!clusterState.isMigrationAllowed()) {
             logger.warning("Partitions can't be assigned since cluster-state= " + clusterState);
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -117,8 +117,8 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
     private void verifyClusterState() {
         final NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         ClusterState clusterState = nodeEngine.getClusterService().getClusterState();
-        if (clusterState != ClusterState.ACTIVE) {
-            throw new IllegalStateException("Cluster state is not active! " + clusterState);
+        if (!clusterState.isMigrationAllowed()) {
+            throw new IllegalStateException("Cluster state does not allow migrations! " + clusterState);
         }
         final Node node = nodeEngine.getNode();
         if (!node.getNodeExtension().isStartCompleted()) {

--- a/hazelcast/src/main/resources/cluster.sh
+++ b/hazelcast/src/main/resources/cluster.sh
@@ -87,7 +87,7 @@ if [ "$OPERATION" = "get-state" ]; then
  	response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
  	if [ "$STATUS" = "fail" ];then
-        echo "An error occured while listing !";
+        echo "An error occurred while listing !";
     	exit 0
     fi
 	if [ "$STATUS" = "forbidden" ];then
@@ -106,12 +106,12 @@ fi
 if [ "$OPERATION" = "change-state" ]; then
 
     if [ -z "$STATE" ]; then
-        echo "No new state is defined, Please define new state with --state 'active', 'frozen', 'passive' "
+        echo "No new state is defined, Please define new state with --state 'active', 'no_migration, ''frozen', 'passive' "
         exit 0
     fi
 
-    if [ "$STATE" != "frozen" ] && [ "$STATE" != "active" ] && [ "$STATE" != "passive" ]; then
-        echo "Not a valid cluster state, valid states  are 'active' || 'frozen' || 'passive'"
+    if [ "$STATE" != "frozen" ] && [ "$STATE" != "active" ] && [ "$STATE" != "no_migration" ] && [ "$STATE" != "passive" ]; then
+        echo "Not a valid cluster state, valid states  are 'active' || 'frozen' || 'passive' || 'no_migration'"
         exit 0
     fi
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ChangeClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ChangeClusterStateTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.internal.cluster.impl.BasicClusterStateTest.assertClusterState;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ChangeClusterStateTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameters(name = "from:{0} to:{1}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {
+                {ClusterState.ACTIVE, ClusterState.FROZEN},
+                {ClusterState.ACTIVE, ClusterState.NO_MIGRATION},
+                {ClusterState.ACTIVE, ClusterState.PASSIVE},
+                {ClusterState.NO_MIGRATION, ClusterState.ACTIVE},
+                {ClusterState.NO_MIGRATION, ClusterState.FROZEN},
+                {ClusterState.NO_MIGRATION, ClusterState.PASSIVE},
+                {ClusterState.FROZEN, ClusterState.ACTIVE},
+                {ClusterState.FROZEN, ClusterState.NO_MIGRATION},
+                {ClusterState.FROZEN, ClusterState.PASSIVE},
+                {ClusterState.PASSIVE, ClusterState.ACTIVE},
+                {ClusterState.PASSIVE, ClusterState.NO_MIGRATION},
+                {ClusterState.PASSIVE, ClusterState.FROZEN}
+        });
+    }
+
+    @Parameterized.Parameter(0)
+    public ClusterState from;
+
+    @Parameterized.Parameter(1)
+    public ClusterState to;
+
+    @Test
+    public void changeClusterState() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+        HazelcastInstance[] instances = factory.newInstances();
+
+        HazelcastInstance hz = instances[instances.length - 1];
+        hz.getCluster().changeClusterState(from);
+        assertClusterState(from, instances);
+
+        hz.getCluster().changeClusterState(to);
+        assertClusterState(to, instances);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -323,7 +323,7 @@ public class ClusterStateManagerTest {
         clusterStateManager.commitClusterState(newState, initiator, TXN);
 
         assertEquals(newState.getNewState(), clusterStateManager.getState());
-        verify(membershipManager, times(1)).removeMembersDeadWhileClusterIsNotActive();
+        verify(membershipManager, times(1)).removeMembersDeadInNotJoinableState();
     }
 
     private Address newAddress() throws UnknownHostException {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ServiceConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.partition.InternalPartition;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.MigrationAwareService;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PartitionMigrationEvent;
+import com.hazelcast.spi.PartitionReplicationEvent;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.instance.TestUtil.terminateInstance;
+import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class NoMigrationClusterStateTest extends HazelcastTestSupport {
+
+    private final NoReplicationService service = new NoReplicationService();
+
+    @Test
+    public void rebalancing_shouldNotHappen_whenMemberLeaves() {
+        Config config = newConfigWithMigrationAwareService();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = factory.newInstances(config, 3);
+        warmUpPartitions(instances);
+        waitAllForSafeState(instances);
+
+        changeClusterStateEventually(instances[1], ClusterState.NO_MIGRATION);
+        terminateInstance(instances[0]);
+
+        final HazelcastInstance hz = factory.newHazelcastInstance(config);
+
+        assertTrueAllTheTime(new AssertTask() {
+            final Node node = getNode(hz);
+            final InternalPartitionService partitionService = node.getPartitionService();
+
+            @Override
+            public void run() throws Exception {
+                List<Integer> memberPartitions = partitionService.getMemberPartitions(node.getThisAddress());
+                assertThat(memberPartitions, empty());
+                service.assertNoReplication();
+            }
+        }, 10);
+    }
+
+    @Test
+    public void promotions_shouldHappen_whenMemberLeaves() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = factory.newInstances(new Config(), 3);
+        warmUpPartitions(instances);
+        waitAllForSafeState(instances);
+
+        changeClusterStateEventually(instances[1], ClusterState.NO_MIGRATION);
+        terminateInstance(instances[0]);
+
+        assertClusterSizeEventually(2, instances[1]);
+        assertAllPartitionsAreAssigned(instances[1], 1);
+
+        assertClusterSizeEventually(2, instances[2]);
+        assertAllPartitionsAreAssigned(instances[2], 1);
+    }
+
+    private static void assertAllPartitionsAreAssigned(HazelcastInstance instance, final int replicaCount) {
+        final ClusterServiceImpl clusterService = getNode(instance).getClusterService();
+        final InternalPartitionService partitionService = getNode(instance).getPartitionService();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                InternalPartition[] partitions = partitionService.getInternalPartitions();
+                for (InternalPartition partition : partitions) {
+                    for (int i = 0; i < replicaCount; i++) {
+                        Address owner = partition.getReplicaAddress(i);
+                        assertNotNull(i + "th replica owner is null: " + partition, owner);
+                        assertNotNull("No member for: " + owner, clusterService.getMember(owner));
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void backupReplication_shouldNotHappen_whenMemberLeaves() {
+        Config config = newConfigWithMigrationAwareService();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = factory.newInstances(config, 3);
+        warmUpPartitions(instances);
+        waitAllForSafeState(instances);
+
+        changeClusterStateEventually(instances[1], ClusterState.NO_MIGRATION);
+        terminateInstance(instances[0]);
+
+        assertClusterSizeEventually(2, instances[1]);
+        assertClusterSizeEventually(2, instances[2]);
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                service.assertNoReplication();
+            }
+        }, 10);
+    }
+
+    @Test
+    public void rebalancing_shouldHappen_whenStateBecomesActive() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = factory.newInstances(new Config(), 3);
+        warmUpPartitions(instances);
+        waitAllForSafeState(instances);
+
+        changeClusterStateEventually(instances[1], ClusterState.NO_MIGRATION);
+        terminateInstance(instances[0]);
+
+        assertClusterSizeEventually(2, instances[1]);
+        assertClusterSizeEventually(2, instances[2]);
+
+        changeClusterStateEventually(instances[1], ClusterState.ACTIVE);
+        assertAllPartitionsAreAssigned(instances[1], 2);
+        assertAllPartitionsAreAssigned(instances[2], 2);
+    }
+
+    @Test
+    public void rebalancing_shouldNotHappen_whenStateBecomesFrozen() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance[] instances = factory.newInstances(newConfigWithMigrationAwareService(), 3);
+        warmUpPartitions(instances);
+        waitAllForSafeState(instances);
+
+        changeClusterStateEventually(instances[1], ClusterState.NO_MIGRATION);
+        terminateInstance(instances[0]);
+
+        assertClusterSizeEventually(2, instances[1]);
+        assertClusterSizeEventually(2, instances[2]);
+
+        changeClusterStateEventually(instances[1], ClusterState.FROZEN);
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                service.assertNoReplication();
+            }
+        }, 10);
+    }
+
+    private Config newConfigWithMigrationAwareService() {
+        Config config = new Config();
+        config.getServicesConfig().addServiceConfig(new ServiceConfig()
+                .setEnabled(true)
+                .setName("no-replication-service")
+                .setImplementation(service));
+        return config;
+    }
+
+    private static class NoReplicationService implements MigrationAwareService {
+
+        private final AtomicReference<AssertionError> replicationRequested = new AtomicReference<AssertionError>();
+
+        @Override
+        public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
+            AssertionError error = new AssertionError("Replication requested: " + event);
+            replicationRequested.compareAndSet(null, error);
+            throw error;
+        }
+
+        @Override
+        public void beforeMigration(PartitionMigrationEvent event) {
+        }
+
+        @Override
+        public void commitMigration(PartitionMigrationEvent event) {
+        }
+
+        @Override
+        public void rollbackMigration(PartitionMigrationEvent event) {
+        }
+
+        void assertNoReplication() {
+            AssertionError error = replicationRequested.get();
+            if (error != null) {
+                throw error;
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -216,6 +216,11 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         promotion_shouldFail_whenClusterState_NotAllowMigration(ClusterState.FROZEN);
     }
 
+    @Test
+    public void promotion_shouldFail_whenClusterStateNoMigration() {
+        promotion_shouldFail_whenClusterState_NotAllowMigration(ClusterState.NO_MIGRATION);
+    }
+
     private void promotion_shouldFail_whenClusterState_NotAllowMigration(ClusterState state) {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.partition.impl;
 
+import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.partition.InternalPartition;
@@ -65,6 +66,7 @@ public class PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest exten
     public void setUp() {
         ILogger logger = getLogger(PartitionReplicaStateChecker_triggerAndWaitForReplicaSyncTest.class);
         ClusterServiceImpl clusterService = mock(ClusterServiceImpl.class);
+        when(clusterService.getClusterState()).thenReturn(ClusterState.ACTIVE);
 
         node = mock(Node.class);
         when(node.getLogger(any(Class.class))).thenReturn(logger);


### PR DESCRIPTION
`NO_MIGRATION` state stands between `ACTIVE` and `FROZEN` cluster states.
Like `ACTIVE` state, it allows new members to join but also doesn't allow
repartitioning/rebalancing and creating new backups similar to `FROZEN`.
Only promotions for missing primaries are performed which are already local,
no data movement is involved.

Once state becomes `ACTIVE`, repartitioning is triggered and missing backups
are replicated.

See [Gigantic Cache Migration Enhancements](https://hazelcast.atlassian.net/wiki/display/PM/Gigantic+Cache+Migration+Enhancements) requirement 3.

>Add manual control to use the new member added to the cluster so that the user can choose when to incur the degradation:
> 1. Once the cluster is started, Man Center can declare a NO_MIGRATION mode.
> 2. When a node is lost existing backup partitions get promoted. Avoid creating new backup partitions to prevent data migration in this mode.
> 3. If primary and backups are missing create new primary, empty partitions and also backup partitions as this does not cause any data copying.
> 4. When a node is added it has no partitions until Ops turns ACTIVE mode back on.
> 5. When this is done, partitions are added to the new node, backups are created and migrations performed. 

See [Gigantic Cache Migration Enhancements Design](https://hazelcast.atlassian.net/wiki/display/EN/Gigantic+Cache+Migration+Enhancements+Design) for more details.