### PR TITLE
Add capability to promote a lite member to a normal member

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientClusterProxy.java
@@ -110,4 +110,9 @@ public class ClientClusterProxy implements Cluster {
     public void changeClusterVersion(Version version, TransactionOptions options) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void promoteLocalLiteMember() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Cluster.java
@@ -84,6 +84,18 @@ public interface Cluster {
     Member getLocalMember();
 
     /**
+     * Promotes local lite member to data member.
+     * When this method returns both {@link #getLocalMember()} and {@link #getMembers()}
+     * reflects the promotion.
+     *
+     * @throws IllegalStateException if member is not a lite member
+     * @throws IllegalStateException if mastership claim in progress
+     * @throws IllegalArgumentException if local member cannot be identified as a member of the cluster
+     * @since 3.9
+     */
+    void promoteLocalLiteMember();
+
+    /**
      * Returns the cluster-wide time in milliseconds.
      * <p/>
      * Cluster tries to keep a cluster-wide time which might be different than the member's own system time.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -45,6 +45,7 @@ import com.hazelcast.internal.cluster.impl.operations.ShutdownNodeOp;
 import com.hazelcast.internal.cluster.impl.operations.SplitBrainMergeValidationOp;
 import com.hazelcast.internal.cluster.impl.operations.TriggerExplicitSuspicionOp;
 import com.hazelcast.internal.cluster.impl.operations.TriggerMemberListPublishOp;
+import com.hazelcast.internal.cluster.impl.operations.PromoteLiteMemberOp;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.ArrayDataSerializableFactory;
@@ -102,8 +103,9 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public static final int TRIGGER_EXPLICIT_SUSPICION = 39;
     public static final int MEMBERS_VIEW_METADATA = 40;
     public static final int HEARTBEAT_COMPLAINT = 41;
+    public static final int PROMOTE_LITE_MEMBER = 42;
 
-    public static final int LEN = HEARTBEAT_COMPLAINT + 1;
+    static final int LEN = PROMOTE_LITE_MEMBER + 1;
 
     @Override
     public int getFactoryId() {
@@ -331,7 +333,11 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
                 return new HeartbeatComplaintOp();
             }
         };
-
+        constructors[PROMOTE_LITE_MEMBER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PromoteLiteMemberOp();
+            }
+        };
         return new ArrayDataSerializableFactory(constructors);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -167,12 +167,12 @@ public class ClusterHeartbeatManager {
             MembershipManager membershipManager = clusterService.getMembershipManager();
             MemberImpl member = membershipManager.getMember(senderAddress, senderMembersViewMetadata.getMemberUuid());
             if (member != null) {
-                if (node.getThisUuid().equals(receiverUuid)) {
+                if (clusterService.getThisUuid().equals(receiverUuid)) {
                     onHeartbeat(member, timestamp);
                     return;
                 }
 
-                logger.warning("Local uuid mismatch on received heartbeat. local uuid: " + node.getThisUuid()
+                logger.warning("Local uuid mismatch on received heartbeat. local uuid: " + clusterService.getThisUuid()
                         + " received uuid: " + receiverUuid + " with " + senderMembersViewMetadata);
             }
 
@@ -601,7 +601,7 @@ public class ClusterHeartbeatManager {
         try {
             MembersViewMetadata membersViewMetadata = clusterService.getMembershipManager().createLocalMembersViewMetadata();
             Operation op = new HeartbeatOp(membersViewMetadata, target.getUuid(), clusterClock.getClusterTime());
-            op.setCallerUuid(node.getThisUuid());
+            op.setCallerUuid(clusterService.getThisUuid());
             node.nodeEngine.getOperationService().send(op, target.getAddress());
         } catch (Exception e) {
             if (logger.isFineEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.instance.LifecycleServiceImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.properties.GroupProperty;
@@ -113,6 +114,10 @@ class ClusterMergeTask implements Runnable {
         // reset all services to their initial state
         Collection<ManagedService> managedServices = node.nodeEngine.getServices(ManagedService.class);
         for (ManagedService service : managedServices) {
+            if (service instanceof ClusterService) {
+                // ClusterService is already reset in resetState()
+                continue;
+            }
             service.reset();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -35,6 +35,7 @@ import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.ExplicitSuspicionOp;
 import com.hazelcast.internal.cluster.impl.operations.MemberRemoveOperation;
+import com.hazelcast.internal.cluster.impl.operations.PromoteLiteMemberOp;
 import com.hazelcast.internal.cluster.impl.operations.ShutdownNodeOp;
 import com.hazelcast.internal.cluster.impl.operations.TriggerExplicitSuspicionOp;
 import com.hazelcast.internal.cluster.impl.operations.TriggerMemberListPublishOp;
@@ -49,6 +50,7 @@ import com.hazelcast.spi.EventPublishingService;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.ExecutionService;
+import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MemberAttributeServiceEvent;
 import com.hazelcast.spi.MembershipAwareService;
@@ -63,6 +65,7 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
+import com.hazelcast.util.UuidUtil;
 import com.hazelcast.util.executor.ExecutorType;
 import com.hazelcast.version.Version;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -70,11 +73,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.NON_LOCAL_MEMBER_SELECTOR;
@@ -97,7 +100,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     private static final long CLUSTER_SHUTDOWN_SLEEP_DURATION_IN_MILLIS = 1000;
     private static final boolean ASSERTION_ENABLED = ClusterServiceImpl.class.desiredAssertionStatus();
 
-    private final Lock lock = new ReentrantLock();
+    private final ReentrantLock lock = new ReentrantLock();
 
     private final Node node;
 
@@ -121,12 +124,15 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     private final boolean useLegacyMemberListFormat;
 
+    private volatile MemberImpl localMember;
+
     private volatile Address masterAddress;
 
     private volatile String clusterId;
 
-    public ClusterServiceImpl(Node node) {
+    public ClusterServiceImpl(Node node, MemberImpl localMember) {
         this.node = node;
+        this.localMember = localMember;
         nodeEngine = node.nodeEngine;
 
         logger = node.getLogger(ClusterService.class.getName());
@@ -171,7 +177,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     }
 
     public void sendLocalMembershipEvent() {
-        membershipManager.sendMembershipEvents(Collections.<MemberImpl>emptySet(), Collections.singleton(node.getLocalMember()));
+        membershipManager.sendMembershipEvents(Collections.<MemberImpl>emptySet(), Collections.singleton(getLocalMember()));
     }
 
     public void handleExplicitSuspicion(MembersViewMetadata expectedMembersViewMetadata, Address suspectedAddress) {
@@ -325,6 +331,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     // called under cluster service lock
     // mastership is accepted when all members before the candidate is suspected
     private boolean shouldAcceptMastership(MemberMap memberMap, MemberImpl candidate) {
+        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         for (MemberImpl member : memberMap.headMemberSet(candidate, false)) {
             if (!membershipManager.isMemberSuspected(member.getAddress())) {
                 logger.fine("Should not accept mastership claim of " + candidate + ", because " + member
@@ -345,14 +352,26 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     public void reset() {
         lock.lock();
         try {
-            membershipManager.reset();
-            clusterHeartbeatManager.reset();
-            clusterStateManager.reset();
-            clusterJoinManager.reset();
+            resetLocalMemberUuid();
             resetClusterId();
+            clearInternalState();
         } finally {
             lock.unlock();
         }
+    }
+
+    private void resetLocalMemberUuid() {
+        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
+        assert !isJoined() : "Cannot reset local member uuid when joined.";
+
+        Address address = getThisAddress();
+        String newUuid = UuidUtil.createMemberUuid(address);
+        logger.warning("Resetting local member uuid. Previous: " + localMember.getUuid() + ", new: " + newUuid);
+        boolean liteMember = localMember.isLiteMember();
+        Map<String, Object> memberAttributes = localMember.getAttributes();
+        localMember = new MemberImpl(address, localMember.getVersion(), true, newUuid, memberAttributes,
+                liteMember, node.hazelcastInstance);
+        node.loggingService.setThisMember(localMember);
     }
 
     public void resetJoinState() {
@@ -446,7 +465,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
         Member localMember = getLocalMember();
         assert membersView.containsMember(localMember.getAddress(), localMember.getUuid())
-                : "Not applying member update because member list doesn't contain us! -> " + membersView;
+                : "Not applying member update because member list doesn't contain us! -> " + membersView
+                    + ", local member: " + localMember;
     }
 
     private boolean checkValidMaster(Address callerAddress) {
@@ -454,6 +474,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     }
 
     void repairPartitionTableIfReturningMember(MemberImpl member) {
+        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         if (!isMaster()) {
             return;
         }
@@ -688,7 +709,19 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     @Override
     public void shutdown(boolean terminate) {
-        reset();
+        clearInternalState();
+    }
+
+    private void clearInternalState() {
+        lock.lock();
+        try {
+            membershipManager.reset();
+            clusterHeartbeatManager.reset();
+            clusterStateManager.reset();
+            clusterJoinManager.reset();
+        } finally {
+            lock.unlock();
+        }
     }
 
     public boolean setMasterAddressToJoin(final Address master) {
@@ -714,6 +747,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     // should be called under lock
     void setMasterAddress(Address master) {
+        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         if (master != null) {
             if (logger.isFineEnabled()) {
                 logger.fine("Setting master address to " + master);
@@ -739,11 +773,16 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     @Override
     public MemberImpl getLocalMember() {
-        return node.getLocalMember();
+        return localMember;
+    }
+
+    public String getThisUuid() {
+        return localMember.getUuid();
     }
 
     // should be called under lock
     void setJoined(boolean val) {
+        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         joined.set(val);
     }
 
@@ -787,12 +826,14 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
     // called under cluster service lock
     void setClusterId(String newClusterId) {
+        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         assert clusterId == null : "Cluster id should be null: " + clusterId;
         clusterId = newClusterId;
     }
 
     // called under cluster service lock
     private void resetClusterId() {
+        assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         clusterId = null;
     }
 
@@ -1017,6 +1058,60 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     public MembershipManagerCompat getMembershipManagerCompat() {
         assert getClusterVersion().isLessThan(Versions.V3_9);
         return membershipManagerCompat;
+    }
+
+    @Override
+    public void promoteLocalLiteMember() {
+        if (getClusterVersion().isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException("Lite member promotion is not available!");
+        }
+
+        MemberImpl member = getLocalMember();
+        if (!member.isLiteMember()) {
+            throw new IllegalStateException(member + " is not a lite member!");
+        }
+
+        MemberImpl master = getMasterMember();
+        PromoteLiteMemberOp op = new PromoteLiteMemberOp();
+        op.setCallerUuid(member.getUuid());
+
+        InternalCompletableFuture<MembersView> future =
+                nodeEngine.getOperationService().invokeOnTarget(SERVICE_NAME, op, master.getAddress());
+        MembersView view = future.join();
+
+        lock.lock();
+        try {
+            if (!member.getAddress().equals(master.getAddress())) {
+                updateMembers(view, master.getAddress(), master.getUuid());
+            }
+
+            MemberImpl localMemberInMemberList = membershipManager.getMember(member.getAddress());
+            if (localMemberInMemberList.isLiteMember()) {
+                throw new IllegalStateException("Cannot promote to data member! Previous master was: " + master.getAddress()
+                    + ", Current master is: " + getMasterAddress());
+            }
+
+            localMember = new MemberImpl(member.getAddress(), member.getVersion(), true, member.getUuid(),
+                    member.getAttributes(), false, node.hazelcastInstance);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private MemberImpl getMasterMember() {
+        MemberImpl master;
+        lock.lock();
+        try {
+            Address masterAddress = getMasterAddress();
+            if (masterAddress == null) {
+                throw new IllegalStateException("Master is not known yet!");
+            }
+
+            master = getMember(masterAddress);
+        } finally {
+            lock.unlock();
+        }
+        return master;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -149,7 +149,7 @@ public class MulticastJoiner extends AbstractJoiner {
     }
 
     void onReceivedJoinRequest(JoinRequest joinRequest) {
-        if (joinRequest.getUuid().compareTo(node.getThisUuid()) < 0) {
+        if (joinRequest.getUuid().compareTo(clusterService.getThisUuid()) < 0) {
             maxTryCount.incrementAndGet();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
@@ -96,10 +96,8 @@ public class MembersUpdateOp extends VersionedClusterOperation {
 
     final void checkLocalMemberUuid() {
         ClusterServiceImpl clusterService = getService();
-        NodeEngineImpl nodeEngine = clusterService.getNodeEngine();
-        Node node = nodeEngine.getNode();
-        if (!node.getThisUuid().equals(targetUuid)) {
-            String msg = "targetUuid: " + targetUuid + " is different than this node's uuid: " + node.getThisUuid();
+        if (!clusterService.getThisUuid().equals(targetUuid)) {
+            String msg = "targetUuid: " + targetUuid + " is different than this node's uuid: " + clusterService.getThisUuid();
             throw new IllegalStateException(msg);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PromoteLiteMemberOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/PromoteLiteMemberOp.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl.operations;
+
+import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.cluster.impl.MembersView;
+import com.hazelcast.internal.cluster.impl.MembershipManager;
+import com.hazelcast.nio.Address;
+
+/**
+ * Promotes caller lite member to a normal member. Should be executed on only master node.
+ *
+ * @since 3.9
+ */
+public class PromoteLiteMemberOp extends AbstractClusterOperation {
+
+    private transient MembersView response;
+
+    public PromoteLiteMemberOp() {
+    }
+
+    @Override
+    public void run() throws Exception {
+        ClusterServiceImpl service = getService();
+        Address callerAddress = getCallerAddress();
+        String callerUuid = getCallerUuid();
+
+        MembershipManager membershipManager = service.getMembershipManager();
+        response = membershipManager.promoteToNormalMember(callerAddress, callerUuid);
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return true;
+    }
+
+    @Override
+    public Object getResponse() {
+        return response;
+    }
+
+    @Override
+    public int getId() {
+        return ClusterDataSerializerHook.PROMOTE_LITE_MEMBER;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -338,9 +338,9 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         logger.fine("Adding " + member);
         lock.lock();
         try {
-            if (!member.localMember()) {
+//            if (!member.localMember()) {
                 partitionStateManager.updateMemberGroupsSize();
-            }
+//            }
             lastMaster = node.getClusterService().getMasterAddress();
 
             if (node.isMaster()) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -19,7 +19,6 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.Member;
 import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
@@ -185,8 +184,7 @@ public class NodeEngineImpl implements NodeEngine {
     }
 
     private Diagnostics newDiagnostics() {
-        Member localMember = node.getLocalMember();
-        Address address = localMember.getAddress();
+        Address address = node.getThisAddress();
         String addressString = address.getHost().replace(":", "_") + "_" + address.getPort();
         String name = "diagnostics-" + addressString + "-" + currentTimeMillis();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -828,11 +828,11 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         return factory.getAllHazelcastInstances();
     }
 
-    private static void assertMaster(Address masterAddress, HazelcastInstance instance) {
+    static void assertMaster(Address masterAddress, HazelcastInstance instance) {
         assertEquals(masterAddress, getNode(instance).getMasterAddress());
     }
 
-    private void suspectMember(HazelcastInstance suspectingInstance, HazelcastInstance suspectedInstance) {
+    static void suspectMember(HazelcastInstance suspectingInstance, HazelcastInstance suspectedInstance) {
         ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(suspectingInstance);
         Member suspectedMember = suspectedInstance.getCluster().getLocalMember();
         clusterService.suspectMember(suspectedMember.getAddress(), suspectedMember.getUuid(), "test", false);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Cluster;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.internal.cluster.impl.operations.PromoteLiteMemberOp;
+import com.hazelcast.internal.partition.InternalPartition;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.impl.operationservice.impl.Invocation;
+import com.hazelcast.spi.impl.operationservice.impl.InvocationRegistry;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.UuidUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.EXPLICIT_SUSPICION;
+import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMBER_INFO_UPDATE;
+import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.PROMOTE_LITE_MEMBER;
+import static com.hazelcast.internal.cluster.impl.MembershipFailureTest.assertMaster;
+import static com.hazelcast.internal.cluster.impl.MembershipFailureTest.suspectMember;
+import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.dropOperationsBetween;
+import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.dropOperationsFrom;
+import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.resetPacketFiltersFrom;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PromoteLiteMemberTest extends HazelcastTestSupport {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void liteMaster_promoted() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config().setLiteMember(true));
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz3 = factory.newHazelcastInstance(new Config());
+
+        hz1.getCluster().promoteLocalLiteMember();
+        assertFalse(getMember(hz1).isLiteMember());
+        assertAllNormalMembers(hz1.getCluster());
+
+        assertAllNormalMembersEventually(hz2.getCluster());
+        assertAllNormalMembersEventually(hz3.getCluster());
+    }
+
+    @Test
+    public void liteMember_promoted() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config().setLiteMember(true));
+        HazelcastInstance hz3 = factory.newHazelcastInstance(new Config());
+
+        hz2.getCluster().promoteLocalLiteMember();
+        assertFalse(getMember(hz2).isLiteMember());
+        assertAllNormalMembers(hz1.getCluster());
+
+        assertAllNormalMembersEventually(hz2.getCluster());
+        assertAllNormalMembersEventually(hz3.getCluster());
+    }
+
+    @Test
+    public void normalMember_promotion_shouldFail_onLocal() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+
+        exception.expect(IllegalStateException.class);
+        hz1.getCluster().promoteLocalLiteMember();
+    }
+
+    @Test
+    public void normalMember_promotion_shouldFail_onNonMaster() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz3 = factory.newHazelcastInstance(new Config());
+
+        PromoteLiteMemberOp op = new PromoteLiteMemberOp();
+        op.setCallerUuid(getMember(hz2).getUuid());
+
+        InternalCompletableFuture<MembersView> future =
+                getOperationService(hz2).invokeOnTarget(ClusterServiceImpl.SERVICE_NAME, op, getAddress(hz3));
+        exception.expect(IllegalStateException.class);
+        future.join();
+    }
+
+    @Test
+    public void normalMember_promotion_shouldBeNoop_onMaster() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+
+        PromoteLiteMemberOp op = new PromoteLiteMemberOp();
+        op.setCallerUuid(getMember(hz2).getUuid());
+
+        InternalCompletableFuture<MembersView> future =
+                getOperationService(hz2).invokeOnTarget(ClusterServiceImpl.SERVICE_NAME, op, getAddress(hz1));
+        future.join();
+    }
+
+    @Test
+    public void notExistingMember_promotion_shouldFail() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+
+        PromoteLiteMemberOp op = new PromoteLiteMemberOp();
+        op.setCallerUuid(UuidUtil.newUnsecureUuidString());
+
+        InternalCompletableFuture<MembersView> future =
+                getOperationService(hz2).invokeOnTarget(ClusterServiceImpl.SERVICE_NAME, op, getAddress(hz1));
+        exception.expect(IllegalArgumentException.class);
+        future.join();
+    }
+
+    @Test
+    public void standaloneLiteMember_promoted() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz = factory.newHazelcastInstance(new Config().setLiteMember(true));
+        
+        hz.getCluster().promoteLocalLiteMember();
+        assertFalse(getMember(hz).isLiteMember());
+        assertAllNormalMembers(hz.getCluster());
+
+        warmUpPartitions(hz);
+        assertPartitionsAssigned(hz);
+    }
+
+    @Test
+    public void promotedMasterLiteMember_shouldHave_partitionsAssigned() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config().setLiteMember(true));
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz3 = factory.newHazelcastInstance(new Config());
+
+        warmUpPartitions(hz1, hz2, hz3);
+        assertNoPartitionsAssigned(hz1);
+
+        hz1.getCluster().promoteLocalLiteMember();
+
+        assertPartitionsAssignedEventually(hz1);
+    }
+
+    @Test
+    public void promotedLiteMember_shouldHave_partitionsAssigned() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config().setLiteMember(true));
+        HazelcastInstance hz3 = factory.newHazelcastInstance(new Config());
+
+        warmUpPartitions(hz1, hz2, hz3);
+        assertNoPartitionsAssigned(hz2);
+
+        hz2.getCluster().promoteLocalLiteMember();
+
+        assertPartitionsAssignedEventually(hz2);
+    }
+
+    @Test
+    public void promotion_shouldFail_whenMastershipClaimInProgress_duringPromotion() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config().setLiteMember(true));
+
+        // artificially set mastership claim flag
+        ClusterServiceImpl clusterService = getNode(hz1).getClusterService();
+        clusterService.getClusterJoinManager().setMastershipClaimInProgress();
+
+        Cluster cluster = hz2.getCluster();
+        exception.expect(IllegalStateException.class);
+        cluster.promoteLocalLiteMember();
+    }
+
+    @Test
+    public void promotion_shouldFail_whenMasterLeaves_duringPromotion() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+        HazelcastInstance hz3 = factory.newHazelcastInstance(new Config().setLiteMember(true));
+
+        assertClusterSizeEventually(3, hz2);
+
+        dropOperationsBetween(hz3, hz1, PROMOTE_LITE_MEMBER);
+        final Cluster cluster = hz3.getCluster();
+        Future<Exception> future = spawn(new Callable<Exception>() {
+            @Override
+            public Exception call() throws Exception {
+                try {
+                    cluster.promoteLocalLiteMember();
+                } catch (Exception e) {
+                    return e;
+                }
+                return null;
+            }
+        });
+        assertPromotionInvocationStarted(hz3);
+
+        hz1.getLifecycleService().terminate();
+        assertClusterSizeEventually(2, hz2);
+        assertClusterSizeEventually(2, hz3);
+
+        Exception exception = future.get();
+        // MemberLeftException is wrapped by HazelcastException
+        assertInstanceOf(MemberLeftException.class, exception.getCause());
+    }
+
+    @Test
+    public void promotion_shouldFail_whenMasterIsSuspected_duringPromotion() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
+        final HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
+        final HazelcastInstance hz3 = factory.newHazelcastInstance(new Config().setLiteMember(true));
+
+        assertClusterSizeEventually(3, hz2);
+
+        dropOperationsBetween(hz3, hz1, PROMOTE_LITE_MEMBER, EXPLICIT_SUSPICION);
+        dropOperationsFrom(hz2, MEMBER_INFO_UPDATE, EXPLICIT_SUSPICION);
+
+        final Cluster cluster = hz3.getCluster();
+        Future future = spawn(new Runnable() {
+            @Override
+            public void run() {
+                cluster.promoteLocalLiteMember();
+            }
+        });
+
+        assertPromotionInvocationStarted(hz3);
+
+        suspectMember(hz3, hz1);
+        suspectMember(hz2, hz1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertMaster(getAddress(hz2), hz3);
+            }
+        });
+
+        resetPacketFiltersFrom(hz3);
+        try {
+            future.get();
+            fail("Promotion should fail!");
+        } catch (ExecutionException e) {
+            assertInstanceOf(IllegalStateException.class, e.getCause());
+        }
+    }
+
+    private void assertPromotionInvocationStarted(HazelcastInstance instance) {
+        final OperationServiceImpl operationService =
+                (OperationServiceImpl) getNode(instance).getNodeEngine().getOperationService();
+        final InvocationRegistry invocationRegistry = operationService.getInvocationRegistry();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                for (Map.Entry<Long, Invocation> entry : invocationRegistry.entrySet()) {
+                    if (entry.getValue().op instanceof PromoteLiteMemberOp) {
+                        return;
+                    }
+                }
+                fail("Cannot find PromoteLiteMemberOp invocation!");
+            }
+        });
+    }
+
+    private static void assertPartitionsAssignedEventually(final HazelcastInstance instance) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertPartitionsAssigned(instance);
+            }
+        });
+    }
+
+    private static void assertPartitionsAssigned(HazelcastInstance instance) {
+        Address address = getAddress(instance);
+        InternalPartition[] partitions = getPartitionService(instance).getInternalPartitions();
+
+        int k = 0;
+        for (InternalPartition partition : partitions) {
+            if (address.equals(partition.getOwnerOrNull())) {
+                k++;
+            }
+        }
+        assertThat(k, greaterThan(0));
+    }
+
+    private static void assertNoPartitionsAssigned(HazelcastInstance instance) {
+        Address address = getAddress(instance);
+        InternalPartition[] partitions = getPartitionService(instance).getInternalPartitions();
+        for (InternalPartition partition : partitions) {
+            for (int i = 0; i < InternalPartition.MAX_REPLICA_COUNT; i++) {
+                assertNotEquals(address, partition.getReplicaAddress(i));
+            }
+        }
+    }
+
+    private static void assertAllNormalMembers(Cluster cluster) {
+        for (Member member : cluster.getMembers()) {
+            assertFalse("Member is lite: " + member, member.isLiteMember());
+        }
+    }
+
+    private static void assertAllNormalMembersEventually(final Cluster cluster) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertAllNormalMembers(cluster);
+            }
+        });
+    }
+
+    private static Member getMember(HazelcastInstance hz) {
+        return hz.getCluster().getLocalMember();
+    }
+}


### PR DESCRIPTION
Added a new method `Cluster.promoteLocalLiteMember()` which promotes
local member to a normal data member if it's a lite member. After promotion,
partition rebalancing is triggered if cluster state allows. Eventually
promoted member will own some portion of partitions.

See [Gigantic Cache Migration Enhancements](https://hazelcast.atlassian.net/wiki/display/PM/Gigantic+Cache+Migration+Enhancements) requirement 6.

See [Gigantic Cache Migration Enhancements Design](https://hazelcast.atlassian.net/wiki/display/EN/Gigantic+Cache+Migration+Enhancements+Design) for more details.

Depends on https://github.com/hazelcast/hazelcast/pull/10137