### PR TITLE
Fix getter construction when collection is null/empty or first element is null

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collection;
 
 import static java.util.Arrays.asList;
@@ -37,33 +38,33 @@ import static org.junit.Assert.assertSame;
 public class GetterFactoryTest {
 
     private Field outerNameField;
-    private Field innersField;
+    private Field innersCollectionField;
     private Field innersArrayField;
     private Field innerNameField;
-    private Field innerAttributesField;
+    private Field innerAttributesCollectionField;
     private Field innerAttributesArrayField;
 
     private Method outerNameMethod;
-    private Method innersMethod;
+    private Method innersCollectionMethod;
     private Method innersArrayMethod;
     private Method innerNameMethod;
-    private Method innerAttributesMethod;
+    private Method innerAttributesCollectionMethod;
     private Method innerAttributesArrayMethod;
 
     @Before
     public void setUp() throws NoSuchFieldException, NoSuchMethodException {
         outerNameField = OuterObject.class.getDeclaredField("name");
-        innersField = OuterObject.class.getDeclaredField("inners");
+        innersCollectionField = OuterObject.class.getDeclaredField("innersCollection");
         innersArrayField = OuterObject.class.getDeclaredField("innersArray");
         innerNameField = InnerObject.class.getDeclaredField("name");
-        innerAttributesField = InnerObject.class.getDeclaredField("attributes");
+        innerAttributesCollectionField = InnerObject.class.getDeclaredField("attributesCollection");
         innerAttributesArrayField = InnerObject.class.getDeclaredField("attributesArray");
 
         outerNameMethod = OuterObject.class.getDeclaredMethod("getName");
-        innersMethod = OuterObject.class.getDeclaredMethod("getInners");
+        innersCollectionMethod = OuterObject.class.getDeclaredMethod("getInnersCollection");
         innersArrayMethod = OuterObject.class.getDeclaredMethod("getInnersArray");
         innerNameMethod = InnerObject.class.getDeclaredMethod("getName");
-        innerAttributesMethod = InnerObject.class.getDeclaredMethod("getAttributes");
+        innerAttributesCollectionMethod = InnerObject.class.getDeclaredMethod("getAttributesCollection");
         innerAttributesArrayMethod = InnerObject.class.getDeclaredMethod("getAttributesArray");
     }
 
@@ -106,8 +107,8 @@ public class GetterFactoryTest {
     @Test
     public void newFieldGetter_whenExtractingFromEmpty_Collection_AndReducerSuffixInNotEmpty_thenReturnNullGetter()
             throws Exception {
-        OuterObject object = new OuterObject("name");
-        Getter getter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
+        OuterObject object = OuterObject.emptyInner("name");
+        Getter getter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
 
         assertSame(NullGetter.NULL_GETTER, getter);
     }
@@ -115,8 +116,26 @@ public class GetterFactoryTest {
     @Test
     public void newMethodGetter_whenExtractingFromEmpty_Collection_AndReducerSuffixInNotEmpty_thenReturnNullGetter()
             throws Exception {
-        OuterObject object = new OuterObject("name");
-        Getter getter = GetterFactory.newMethodGetter(object, null, innersMethod, "[any]");
+        OuterObject object = OuterObject.emptyInner("name");
+        Getter getter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
+
+        assertSame(NullGetter.NULL_GETTER, getter);
+    }
+
+    @Test
+    public void newFieldGetter_whenExtractingFromNull_Collection_AndReducerSuffixInNotEmpty_thenReturnNullGetter()
+            throws Exception {
+        OuterObject object = OuterObject.nullInner("name");
+        Getter getter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
+
+        assertSame(NullGetter.NULL_GETTER, getter);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNull_Collection_AndReducerSuffixInNotEmpty_thenReturnNullGetter()
+            throws Exception {
+        OuterObject object = OuterObject.nullInner("name");
+        Getter getter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
 
         assertSame(NullGetter.NULL_GETTER, getter);
     }
@@ -125,7 +144,7 @@ public class GetterFactoryTest {
     public void newFieldGetter_whenExtractingFromNonEmpty_Collection_AndReducerSuffixInNotEmpty_thenInferTypeFromCollectionItem()
             throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner"));
-        Getter getter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
+        Getter getter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
 
         Class returnType = getter.getReturnType();
         assertEquals(InnerObject.class, returnType);
@@ -135,7 +154,7 @@ public class GetterFactoryTest {
     public void newMethodGetter_whenExtractingFromNonEmpty_Collection_AndReducerSuffixInNotEmpty_thenInferTypeFromCollectionItem()
             throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner"));
-        Getter getter = GetterFactory.newMethodGetter(object, null, innersMethod, "[any]");
+        Getter getter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
 
         Class returnType = getter.getReturnType();
         assertEquals(InnerObject.class, returnType);
@@ -144,7 +163,7 @@ public class GetterFactoryTest {
     @Test
     public void newFieldGetter_whenExtractingFromEmpty_Array_AndReducerSuffixInNotEmpty_thenReturnNullGetter()
             throws Exception {
-        OuterObject object = new OuterObject("name");
+        OuterObject object = OuterObject.emptyInner("name");
         Getter getter = GetterFactory.newFieldGetter(object, null, innersArrayField, "[any]");
 
         Class returnType = getter.getReturnType();
@@ -154,7 +173,27 @@ public class GetterFactoryTest {
     @Test
     public void newMethodGetter_whenExtractingFromEmpty_Array_AndReducerSuffixInNotEmpty_thenReturnNullGetter()
             throws Exception {
-        OuterObject object = new OuterObject("name");
+        OuterObject object = OuterObject.emptyInner("name");
+        Getter getter = GetterFactory.newMethodGetter(object, null, innersArrayMethod, "[any]");
+
+        Class returnType = getter.getReturnType();
+        assertEquals(InnerObject.class, returnType);
+    }
+
+    @Test
+    public void newFieldGetter_whenExtractingFromNull_Array_AndReducerSuffixInNotEmpty_thenReturnNullGetter()
+            throws Exception {
+        OuterObject object = OuterObject.nullInner("name");
+        Getter getter = GetterFactory.newFieldGetter(object, null, innersArrayField, "[any]");
+
+        Class returnType = getter.getReturnType();
+        assertEquals(InnerObject.class, returnType);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNull_Array_AndReducerSuffixInNotEmpty_thenReturnNullGetter()
+            throws Exception {
+        OuterObject object = OuterObject.nullInner("name");
         Getter getter = GetterFactory.newMethodGetter(object, null, innersArrayMethod, "[any]");
 
         Class returnType = getter.getReturnType();
@@ -186,7 +225,7 @@ public class GetterFactoryTest {
             throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner"));
 
-        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
         Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerNameField, null);
 
         Class returnType = innerObjectNameGetter.getReturnType();
@@ -198,7 +237,7 @@ public class GetterFactoryTest {
             throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner"));
 
-        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersMethod, "[any]");
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
         Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerNameMethod, null);
 
         Class returnType = innerObjectNameGetter.getReturnType();
@@ -208,10 +247,10 @@ public class GetterFactoryTest {
     @Test
     public void newFieldGetter_whenExtractingFromEmpty_Collection_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
             throws Exception {
-        OuterObject object = new OuterObject("name", new InnerObject("inner"));
+        OuterObject object = new OuterObject("name", InnerObject.emptyInner("inner"));
 
-        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
-        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesField, "[any]");
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesCollectionField, "[any]");
 
         assertSame(NullGetter.NULL_GETTER, innerObjectNameGetter);
     }
@@ -219,10 +258,32 @@ public class GetterFactoryTest {
     @Test
     public void newMethodGetter_whenExtractingFromEmpty_Collection_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
             throws Exception {
-        OuterObject object = new OuterObject("name", new InnerObject("inner"));
+        OuterObject object = new OuterObject("name", InnerObject.emptyInner("inner"));
 
-        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersMethod, "[any]");
-        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesMethod, "[any]");
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesCollectionMethod, "[any]");
+
+        assertSame(NullGetter.NULL_GETTER, innerObjectNameGetter);
+    }
+
+    @Test
+    public void newFieldGetter_whenExtractingFromNull_Collection_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", InnerObject.nullInner("inner"));
+
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesCollectionField, "[any]");
+
+        assertSame(NullGetter.NULL_GETTER, innerObjectNameGetter);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNull_Collection_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", InnerObject.nullInner("inner"));
+
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesCollectionMethod, "[any]");
 
         assertSame(NullGetter.NULL_GETTER, innerObjectNameGetter);
     }
@@ -232,8 +293,8 @@ public class GetterFactoryTest {
             throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner", 0, 1, 2, 3));
 
-        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersField, "[any]");
-        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesField, "[any]");
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesCollectionField, "[any]");
 
         Class returnType = innerObjectNameGetter.getReturnType();
         assertEquals(Integer.class, returnType);
@@ -244,8 +305,80 @@ public class GetterFactoryTest {
             throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner", 0, 1, 2, 3));
 
-        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersMethod, "[any]");
-        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesMethod, "[any]");
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesCollectionMethod, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newFieldGetter_whenExtractingFromNonEmpty_Collection_nullFirst_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", null, new InnerObject("inner", 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesCollectionField, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNonEmpty_Collection_nullFirst_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", null, new InnerObject("inner", 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesCollectionMethod, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newFieldGetter_whenExtractingFromNonEmpty_Collection_FieldAndParentIsNonEmptyMultiResult_nullValueFirst_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", new InnerObject("inner", null, 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesCollectionField, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNonEmpty_Collection_FieldAndParentIsNonEmptyMultiResult_nullValueFirst_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", new InnerObject("inner", null, 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesCollectionMethod, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newFieldGetter_whenExtractingFromNonEmpty_Collection_bothNullFirst_FieldAndParentIsNonEmptyMultiResult_nullValueFirst_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", null, new InnerObject("inner", null, 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersCollectionField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesCollectionField, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNonEmpty_Collection_bothNullFirst_FieldAndParentIsNonEmptyMultiResult_nullValueFirst_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", null, new InnerObject("inner", null, 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersCollectionMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesCollectionMethod, "[any]");
 
         Class returnType = innerObjectNameGetter.getReturnType();
         assertEquals(Integer.class, returnType);
@@ -254,7 +387,7 @@ public class GetterFactoryTest {
     @Test
     public void newFieldGetter_whenExtractingFromEmpty_Array_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
             throws Exception {
-        OuterObject object = new OuterObject("name", new InnerObject("inner"));
+        OuterObject object = new OuterObject("name", InnerObject.emptyInner("inner"));
 
         Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersArrayField, "[any]");
         Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesArrayField, "[any]");
@@ -266,7 +399,31 @@ public class GetterFactoryTest {
     @Test
     public void newMethodGetter_whenExtractingFromEmpty_Array_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
             throws Exception {
-        OuterObject object = new OuterObject("name", new InnerObject("inner"));
+        OuterObject object = new OuterObject("name", InnerObject.emptyInner("inner"));
+
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersArrayMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesArrayMethod, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newFieldGetter_whenExtractingFromNull_Array_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", InnerObject.nullInner("inner"));
+
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersArrayField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesArrayField, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNull_Array_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", InnerObject.nullInner("inner"));
 
         Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersArrayMethod, "[any]");
         Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesArrayMethod, "[any]");
@@ -300,6 +457,78 @@ public class GetterFactoryTest {
     }
 
     @Test
+    public void newFieldGetter_whenExtractingFromNonEmpty_Array_nullFirst_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", null, new InnerObject("inner", 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersArrayField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesArrayField, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNonEmpty_Array_nullFirst_FieldAndParentIsNonEmptyMultiResult_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", null, new InnerObject("inner", 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersArrayMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesArrayMethod, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newFieldGetter_whenExtractingFromNonEmpty_Array_FieldAndParentIsNonEmptyMultiResult_nullFirstValue_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", new InnerObject("inner", null, 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersArrayField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesArrayField, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNonEmpty_Array_FieldAndParentIsNonEmptyMultiResult_nullFirstValue_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", new InnerObject("inner", null, 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersArrayMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesArrayMethod, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newFieldGetter_whenExtractingFromNonEmpty_Array_bothNullFirst_FieldAndParentIsNonEmptyMultiResult_nullFirstValue_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", null, new InnerObject("inner", null, 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newFieldGetter(object, null, innersArrayField, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newFieldGetter(object, parentGetter, innerAttributesArrayField, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
+    public void newMethodGetter_whenExtractingFromNonEmpty_Array_bothNullFirst_FieldAndParentIsNonEmptyMultiResult_nullFirstValue_thenInferReturnType()
+            throws Exception {
+        OuterObject object = new OuterObject("name", null, new InnerObject("inner", null, 0, 1, 2, 3));
+
+        Getter parentGetter = GetterFactory.newMethodGetter(object, null, innersArrayMethod, "[any]");
+        Getter innerObjectNameGetter = GetterFactory.newMethodGetter(object, parentGetter, innerAttributesArrayMethod, "[any]");
+
+        Class returnType = innerObjectNameGetter.getReturnType();
+        assertEquals(Integer.class, returnType);
+    }
+
+    @Test
     public void newThisGetter() throws Exception {
         OuterObject object = new OuterObject("name", new InnerObject("inner", 0, 1, 2, 3));
         Getter innerObjectThisGetter = GetterFactory.newThisGetter(null, object);
@@ -310,21 +539,35 @@ public class GetterFactoryTest {
 
     public static class OuterObject {
         final String name;
-        final Collection<InnerObject> inners;
+        final Collection<InnerObject> innersCollection;
         final InnerObject[] innersArray;
 
-        OuterObject(String name, InnerObject... inners) {
+        OuterObject(String name, InnerObject... innersCollection) {
             this.name = name;
-            this.inners = asList(inners);
-            this.innersArray = inners;
+            this.innersCollection = asList(innersCollection);
+            this.innersArray = innersCollection;
+        }
+
+        OuterObject(String name, InnerObject[] attributesArray, Collection<InnerObject> attributesCollection) {
+            this.name = name;
+            this.innersCollection = attributesCollection;
+            this.innersArray = attributesArray;
+        }
+
+        public static OuterObject nullInner(String name) {
+            return new OuterObject(name, null, null);
+        }
+
+        public static OuterObject emptyInner(String name) {
+            return new OuterObject(name, new InnerObject[0], new ArrayList<InnerObject>());
         }
 
         public String getName() {
             return name;
         }
 
-        public Collection<InnerObject> getInners() {
-            return inners;
+        public Collection<InnerObject> getInnersCollection() {
+            return innersCollection;
         }
 
         public InnerObject[] getInnersArray() {
@@ -334,21 +577,35 @@ public class GetterFactoryTest {
 
     public static class InnerObject {
         final String name;
-        final Collection<Integer> attributes;
+        final Collection<Integer> attributesCollection;
         final Integer[] attributesArray;
 
-        InnerObject(String name, Integer... attributes) {
+        InnerObject(String name, Integer[] attributesArray, Collection<Integer> attributesCollection) {
             this.name = name;
-            this.attributes = asList(attributes);
-            this.attributesArray = attributes;
+            this.attributesCollection = attributesCollection;
+            this.attributesArray = attributesArray;
+        }
+
+        InnerObject(String name, Integer... attributesCollection) {
+            this.name = name;
+            this.attributesCollection = asList(attributesCollection);
+            this.attributesArray = attributesCollection;
+        }
+
+        public static InnerObject nullInner(String name) {
+            return new InnerObject(name, null, null);
+        }
+
+        public static InnerObject emptyInner(String name) {
+            return new InnerObject(name, new Integer[0], new ArrayList<Integer>());
         }
 
         public String getName() {
             return name;
         }
 
-        public Collection<Integer> getAttributes() {
-            return attributes;
+        public Collection<Integer> getAttributesCollection() {
+            return attributesCollection;
         }
 
         public Integer[] getAttributesArray() {


### PR DESCRIPTION
Without this fix: if a collection contained a null as the first element and then some non-null values, the GetterFactory would have returned a NullGetter if the collection was addressed with the `[any]` operator.

This applies to both: a field in the middle of an expression or at the end of an expression.
If the null element was in the middle of an expression it would have been even worse, since the expression wouldn't have been evaluated till the end, and a NullGetter would have been returned.

