### PR TITLE
copy-paste mistake in javadoc

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -738,7 +738,7 @@ public class CacheSimpleConfig {
             public enum ExpiryPolicyType {
 
                 /**
-                 * Expiry policy type for the "javax.cache.expiry.AccessedExpiryPolicy"
+                 * Expiry policy type for the "javax.cache.expiry.CreatedExpiryPolicy"
                  */
                 CREATED,
                 /**


### PR DESCRIPTION
No code changes, just a small correction in the descrition for the CREATED ExpiryPolicyType 