### PR TITLE
Experimental settings for io backoff and response backoff

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/SelectorMode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/SelectorMode.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.networking.nonblocking;
 
-import com.hazelcast.util.StringUtil;
+import static java.lang.String.format;
 
 /**
  * Controls the mode in which IO and acceptor thread selectors will be operating
@@ -26,20 +26,27 @@ public enum SelectorMode {
     SELECT_NOW,
     SELECT_WITH_FIX;
 
+    public static final String SELECT_STRING = "select";
+    public static final String SELECT_WITH_FIX_STRING = "selectwithfix";
+    public static final String SELECT_NOW_STRING = "selectnow";
+
     public static SelectorMode getConfiguredValue() {
-        return fromString(System.getProperty("hazelcast.io.selectorMode"));
+        return fromString(getConfiguredString());
+    }
+
+    public static String getConfiguredString() {
+        return System.getProperty("hazelcast.io.selectorMode", SELECT_STRING).trim().toLowerCase();
     }
 
     public static SelectorMode fromString(String value) {
-        String valueToCheck = StringUtil.isNullOrEmptyAfterTrim(value) ? null : value.trim().toLowerCase();
-        if (valueToCheck == null) {
+        if (value.equals(SELECT_STRING)) {
             return SELECT;
-        } else if (valueToCheck.equals("selectnow")) {
-            return SELECT_NOW;
-        } else if (valueToCheck.equals("selectwithfix")) {
+        } else if (value.equals(SELECT_WITH_FIX_STRING)) {
             return SELECT_WITH_FIX;
+        } else if (value.equals(SELECT_NOW_STRING) || value.startsWith(SELECT_NOW_STRING + ",")) {
+            return SELECT_NOW;
         } else {
-            return SELECT;
+            throw new IllegalArgumentException(format("Unrecognized selectorMode [%s]", value));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/AsyncInboundResponseHandler.java
@@ -39,6 +39,7 @@ import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkTrue;
+import static com.hazelcast.util.concurrent.BackoffIdleStrategy.createBackoffIdleStrategy;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -105,10 +106,12 @@ public class AsyncInboundResponseHandler implements PacketHandler, MetricsProvid
         String idleStrategyString = properties.getString(property);
         if ("block".equals(idleStrategyString)) {
             return null;
-        } else if ("backoff".equals(idleStrategyString)) {
-            return new BackoffIdleStrategy(IDLE_MAX_SPINS, IDLE_MAX_YIELDS, IDLE_MIN_PARK_NS, IDLE_MAX_PARK_NS);
         } else if ("busyspin".equals(idleStrategyString)) {
             return new BusySpinIdleStrategy();
+        } else if ("backoff".equals(idleStrategyString)) {
+            return new BackoffIdleStrategy(IDLE_MAX_SPINS, IDLE_MAX_YIELDS, IDLE_MIN_PARK_NS, IDLE_MAX_PARK_NS);
+        } else if (idleStrategyString.startsWith("backoff,")) {
+            return createBackoffIdleStrategy(idleStrategyString);
         } else {
             throw new IllegalStateException("Unrecognized " + property.getName() + " value=" + idleStrategyString);
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/NonBlockingIOThreadAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/NonBlockingIOThreadAbstractTest.java
@@ -84,7 +84,7 @@ public abstract class NonBlockingIOThreadAbstractTest extends HazelcastTestSuppo
     }
 
     private void startThread() {
-        thread = new NonBlockingIOThread(null, "foo", logger, oomeHandler, selectorMode(), selector);
+        thread = new NonBlockingIOThread(null, "foo", logger, oomeHandler, selectorMode(), selector, null);
         beforeStartThread();
         thread.start();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectorModeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectorModeTest.java
@@ -55,13 +55,12 @@ public class SelectorModeTest {
     }
 
     @Test
-    public void fromString_whenSelect() throws Exception {
-        assertEquals(SelectorMode.SELECT, SelectorMode.fromString("select"));
+    public void fromString_whenSelectNowWithConfig() throws Exception {
+        assertEquals(SelectorMode.SELECT_NOW, SelectorMode.fromString("selectnow,1,2,3,4"));
     }
 
     @Test
-    public void fromString_whenNull() throws Exception {
-        assertEquals(SelectorMode.SELECT, SelectorMode.fromString(null));
+    public void fromString_whenSelect() throws Exception {
+        assertEquals(SelectorMode.SELECT, SelectorMode.fromString("select"));
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/concurrent/BackoffIdleStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/concurrent/BackoffIdleStrategyTest.java
@@ -30,6 +30,20 @@ import static org.junit.Assert.assertEquals;
 public class BackoffIdleStrategyTest {
 
     @Test
+    public void test_createBackoffIdleStrategy() {
+        BackoffIdleStrategy idleStrategy = BackoffIdleStrategy.createBackoffIdleStrategy("foo,1,2,10,15");
+        assertEquals(1, idleStrategy.yieldThreshold);
+        assertEquals(3, idleStrategy.parkThreshold);
+        assertEquals(10, idleStrategy.minParkPeriodNs);
+        assertEquals(15, idleStrategy.maxParkPeriodNs);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_createBackoffIdleStrategy_invalidConfig() {
+        BackoffIdleStrategy.createBackoffIdleStrategy("foo,1");
+    }
+
+    @Test
     public void when_proposedShiftLessThanAllowed_then_shiftProposed() {
         final BackoffIdleStrategy strat = new BackoffIdleStrategy(0, 0, 1, 4);
 


### PR DESCRIPTION
In case of the io system using the selectnow, a configurable
backoff policy is available instead of always spinning.

The same goes for response queue for member and client.

It can be configured using
```
somesystemproperty=selectnow,20,50,1,100
somesystemproperty==backoff,20,50,11,100
```
20=spins
50=yields
1 is min park nanos
100 is max park nanos

These experimental settings aren't set by default, so the user
explicitly needs to set either selectnow or configure the
response queue to get any behavior different than the default
behavior.

Under certain conditions doing a backoff instead of blocking
can lead to an interesting performance gain. These settings have
been added to do further experiments and case specific tuning.