### PR TITLE
Fixed missing callbacks in JCache Client replace() methods

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -176,22 +176,22 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public ICompletableFuture<Boolean> replaceAsync(K key, V value) {
-        return replaceInternal(key, null, value, null, false, false, true);
+        return replaceAsyncInternal(key, null, value, null, false, false, true);
     }
 
     @Override
     public ICompletableFuture<Boolean> replaceAsync(K key, V value, ExpiryPolicy expiryPolicy) {
-        return replaceInternal(key, null, value, expiryPolicy, false, false, true);
+        return replaceAsyncInternal(key, null, value, expiryPolicy, false, false, true);
     }
 
     @Override
     public ICompletableFuture<Boolean> replaceAsync(K key, V oldValue, V newValue) {
-        return replaceInternal(key, oldValue, newValue, null, true, false, true);
+        return replaceAsyncInternal(key, oldValue, newValue, null, true, false, true);
     }
 
     @Override
     public ICompletableFuture<Boolean> replaceAsync(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy) {
-        return replaceInternal(key, oldValue, newValue, expiryPolicy, true, false, true);
+        return replaceAsyncInternal(key, oldValue, newValue, expiryPolicy, true, false, true);
     }
 
     @Override
@@ -390,32 +390,12 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
 
     @Override
     public boolean replace(K key, V oldValue, V newValue, ExpiryPolicy expiryPolicy) {
-        final long startNanos = nowInNanosOrDefault();
-        final Future<Boolean> future = replaceInternal(key, oldValue, newValue, expiryPolicy, true, true, false);
-        try {
-            boolean replaced = future.get();
-            if (statisticsEnabled) {
-                statsHandler.onReplace(false, startNanos, replaced);
-            }
-            return replaced;
-        } catch (Throwable e) {
-            throw rethrowAllowedTypeFirst(e, CacheException.class);
-        }
+        return replaceSyncInternal(key, oldValue, newValue, expiryPolicy, true);
     }
 
     @Override
     public boolean replace(K key, V value, ExpiryPolicy expiryPolicy) {
-        final long startNanos = nowInNanosOrDefault();
-        final Future<Boolean> future = replaceInternal(key, null, value, expiryPolicy, false, true, false);
-        try {
-            boolean replaced = future.get();
-            if (statisticsEnabled) {
-                statsHandler.onReplace(false, startNanos, replaced);
-            }
-            return replaced;
-        } catch (Throwable e) {
-            throw rethrowAllowedTypeFirst(e, CacheException.class);
-        }
+        return replaceSyncInternal(key, null, value, expiryPolicy, false);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/CacheStatsHandler.java
@@ -57,6 +57,19 @@ final class CacheStatsHandler {
         }
     }
 
+    <T> ExecutionCallback<T> newOnReplaceCallback(final long startNanos) {
+        return new ExecutionCallback<T>() {
+            @Override
+            public void onResponse(T response) {
+                onReplace(true, startNanos, toObject(response));
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+            }
+        };
+    }
+
     void onPutIfAbsent(long startNanos, boolean saved) {
         if (saved) {
             statistics.increaseCachePuts();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheLiteMemberTest.java
@@ -94,11 +94,6 @@ public class ClientMapNearCacheLiteMemberTest {
     }
 
     @Test
-    public void testReplace() {
-        NearCacheLiteMemberTest.testReplace(client, lite, mapName);
-    }
-
-    @Test
     public void testEvict() {
         NearCacheLiteMemberTest.testEvict(client, lite, mapName);
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -345,50 +345,6 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
-    public void testAfterReplaceIfSameNearCacheIsInvalidated() {
-        int mapSize = 1000;
-        String mapName = randomMapName();
-        hazelcastFactory.newHazelcastInstance(newConfig());
-        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationOnChangeEnabledNearCacheConfig(mapName));
-
-        final IMap<Integer, Integer> clientMap = client.getMap(mapName);
-        populateMap(clientMap, mapSize);
-        populateNearCache(clientMap, mapSize);
-
-        for (int i = 0; i < mapSize; i++) {
-            clientMap.replace(i, i, i + mapSize);
-        }
-
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertThatOwnedEntryCountEquals(clientMap, 0);
-            }
-        });
-    }
-
-    @Test
-    public void testAfterReplaceNearCacheIsInvalidated() {
-        int mapSize = 1000;
-        String mapName = randomMapName();
-        hazelcastFactory.newHazelcastInstance(newConfig());
-        HazelcastInstance client = getClient(hazelcastFactory, newInvalidationOnChangeEnabledNearCacheConfig(mapName));
-
-        final IMap<Integer, Integer> clientMap = client.getMap(mapName);
-        populateMap(clientMap, mapSize);
-        populateNearCache(clientMap, mapSize);
-
-        for (int i = 0; i < mapSize; i++) {
-            clientMap.replace(i, i + mapSize);
-        }
-
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertThatOwnedEntryCountEquals(clientMap, 0);
-            }
-        });
-    }
-
-    @Test
     public void testAfterSetNearCacheIsInvalidated() {
         int mapSize = 1000;
         String mapName = randomMapName();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -119,4 +119,28 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
     @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
     public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
     }
+
+    @Test(expected = UnsupportedOperationException.class)
+    @Override
+    public void whenReplaceIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+        super.whenReplaceIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    @Override
+    public void whenReplaceIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
+        super.whenReplaceIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    @Override
+    public void whenReplaceWithOldValueIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+        super.whenReplaceWithOldValueIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    @Override
+    public void whenReplaceWithOldValueIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
+        super.whenReplaceWithOldValueIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter();
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheLiteMemberTest.java
@@ -117,11 +117,6 @@ public class NearCacheLiteMemberTest {
     }
 
     @Test
-    public void testReplace() {
-        testReplace(instance, lite, mapName);
-    }
-
-    @Test
     public void testEvict() {
         testEvict(instance, lite, mapName);
     }
@@ -288,18 +283,6 @@ public class NearCacheLiteMemberTest {
         Map<Object, Object> localMap = new HashMap<Object, Object>();
         localMap.put(1, 2);
         map.putAll(localMap);
-
-        assertNullNearCacheEntryEventually(lite, mapName, 1);
-    }
-
-    public static void testReplace(HazelcastInstance instance, HazelcastInstance lite, String mapName) {
-        IMap<Object, Object> map = instance.getMap(mapName);
-        map.put(1, 1);
-
-        IMap<Object, Object> liteMap = lite.getMap(mapName);
-        liteMap.get(1);
-
-        map.replace(1, 2);
 
         assertNullNearCacheEntryEventually(lite, mapName, 1);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
@@ -600,25 +600,6 @@ public class NearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
-    public void testAfterReplaceNearCacheIsInvalidated() {
-        int mapSize = 1000;
-        String mapName = randomMapName();
-
-        Config config = createNearCachedMapConfig(mapName);
-        HazelcastInstance instance = createHazelcastInstance(config);
-
-        IMap<Integer, Integer> map = instance.getMap(mapName);
-        populateMap(map, mapSize);
-        populateNearCache(map, mapSize);
-
-        for (int i = 0; i < mapSize; i++) {
-            map.replace(i, i, mapSize - 1 - i);
-        }
-
-        assertEquals(0, getNearCacheStats(map).getOwnedEntryCount());
-    }
-
-    @Test
     public void testAfterSubmitToKeyWithCallbackNearCacheIsInvalidated() throws Exception {
         int mapSize = 1000;
         String mapName = randomMapName();


### PR DESCRIPTION
* added unified Near Cache tests for `DataStructureAdapter.replace()`
* added missing callbacks in `AbstractClientInternalCacheProxy`

Part of https://github.com/hazelcast/hazelcast/issues/10127