### PR TITLE
Removed unused constructors of EntryOffloadableLockMismatchException

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableLockMismatchException.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOffloadableLockMismatchException.java
@@ -24,19 +24,7 @@ import com.hazelcast.core.HazelcastException;
  */
 public class EntryOffloadableLockMismatchException extends HazelcastException {
 
-    public EntryOffloadableLockMismatchException() {
-    }
-
-    public EntryOffloadableLockMismatchException(final String message) {
+    public EntryOffloadableLockMismatchException(String message) {
         super(message);
     }
-
-    public EntryOffloadableLockMismatchException(final String message, final Throwable cause) {
-        super(message, cause);
-    }
-
-    public EntryOffloadableLockMismatchException(final Throwable cause) {
-        super(cause);
-    }
-
 }


### PR DESCRIPTION
The class has just 25% code coverage due to the unused constructors -> dead code