### PR TITLE
Cache.getAsync on a near-cached client cache should increase stats.cacheGets by one

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -145,8 +145,8 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy {
     protected ClientDelegatingFuture getAsyncInternal(Data dataKey, ExpiryPolicy expiryPolicy, ExecutionCallback callback) {
         try {
             long reservationId = nearCache.tryReserveForUpdate(dataKey);
-            ClientDelegatingFuture future = super.getAsyncInternal(dataKey, expiryPolicy, callback);
-            future.andThenInternal(new GetAsyncCallback(dataKey, reservationId, callback), true);
+            GetAsyncCallback getAsyncCallback = new GetAsyncCallback(dataKey, reservationId, callback);
+            ClientDelegatingFuture future = super.getAsyncInternal(dataKey, expiryPolicy, getAsyncCallback);
             return future;
         } catch (Throwable t) {
             invalidateNearCache(dataKey);


### PR DESCRIPTION
The stats maintenance callback should be registered for execution once.
Adds tests for asserting `ICache` stats when async methods are used. Parametrizes client-side cache statistics test to execute on plain and near-cached client-side cache proxy.