### PR TITLE
Add WAN publisher support for discovery SPI

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -2086,6 +2086,8 @@
                     <xs:sequence>
                         <xs:element name="queue-full-behavior" type="wan-queue-full-behavior" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="queue-capacity" type="xs:integer" default="10000" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
                     </xs:sequence>
                     <xs:attributeGroup ref="class-or-bean-name"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -649,19 +649,26 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("127.0.0.1:5700", members.get(0));
         assertEquals("127.0.0.1:5701", members.get(1));
         assertEquals("127.0.0.1:5700", tcp.getRequiredMember());
-        AwsConfig aws = networkConfig.getJoin().getAwsConfig();
+        assertAwsConfig(networkConfig.getJoin().getAwsConfig());
+
+        assertTrue("reuse-address", networkConfig.isReuseAddress());
+
+        assertDiscoveryConfig(networkConfig.getJoin().getDiscoveryConfig());
+    }
+
+    private void assertAwsConfig(AwsConfig aws) {
         assertFalse(aws.isEnabled());
         assertEquals("sample-access-key", aws.getAccessKey());
         assertEquals("sample-secret-key", aws.getSecretKey());
         assertEquals("sample-region", aws.getRegion());
+        assertEquals("sample-header", aws.getHostHeader());
         assertEquals("sample-group", aws.getSecurityGroupName());
         assertEquals("sample-tag-key", aws.getTagKey());
         assertEquals("sample-tag-value", aws.getTagValue());
         assertEquals("sample-role", aws.getIamRole());
+    }
 
-        assertTrue("reuse-address", networkConfig.isReuseAddress());
-
-        DiscoveryConfig discoveryConfig = networkConfig.getJoin().getDiscoveryConfig();
+    private void assertDiscoveryConfig(DiscoveryConfig discoveryConfig) {
         assertTrue(discoveryConfig.getDiscoveryServiceProvider() instanceof DummyDiscoveryServiceProvider);
         assertTrue(discoveryConfig.getNodeFilter() instanceof DummyNodeFilter);
         List<DiscoveryStrategyConfig> discoveryStrategyConfigs
@@ -762,6 +769,10 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, customPublisher.getQueueFullBehavior());
         Map<String, Comparable> customPublisherProps = customPublisher.getProperties();
         assertEquals("prop.publisher", customPublisherProps.get("custom.prop.publisher"));
+        assertEquals("5", customPublisherProps.get("discovery.period"));
+        assertEquals("2", customPublisherProps.get("maxEndpoints"));
+        assertAwsConfig(customPublisher.getAwsConfig());
+        assertDiscoveryConfig(customPublisher.getDiscoveryConfig());
 
         WanConsumerConfig consumerConfig = wcfg.getWanConsumerConfig();
         assertEquals("com.hazelcast.wan.custom.WanConsumer", consumerConfig.getClassName());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -66,8 +66,35 @@
                 </hz:wan-publisher>
                 <hz:wan-publisher group-name="istanbul" class-name="com.hazelcast.wan.custom.CustomPublisher">
                     <hz:queue-full-behavior>THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE</hz:queue-full-behavior>
+                    <hz:aws enabled="false"
+                            access-key="sample-access-key"
+                            secret-key="sample-secret-key"
+                            region="sample-region"
+                            host-header="sample-header"
+                            security-group-name="sample-group"
+                            tag-key="sample-tag-key"
+                            tag-value="sample-tag-value"
+                            iam-role="sample-role"/>
+                    <hz:discovery-strategies>
+                        <hz:node-filter implementation="dummyNodeFilter"/>
+                        <hz:discovery-strategy discovery-strategy-factory="dummyDiscoveryStrategyFactory">
+                            <hz:properties>
+                                <hz:property name="key-string">foo</hz:property>
+                                <hz:property name="key-int">123</hz:property>
+                                <hz:property name="key-boolean">true</hz:property>
+                            </hz:properties>
+                        </hz:discovery-strategy>
+                        <hz:discovery-strategy class-name="com.hazelcast.spring.DummyDiscoveryStrategy">
+                            <hz:properties>
+                                <hz:property name="key-string">foo2</hz:property>
+                            </hz:properties>
+                        </hz:discovery-strategy>
+                        <hz:discovery-service-provider implementation="dummyDiscoveryServiceProvider"/>
+                    </hz:discovery-strategies>
                     <hz:properties>
                         <hz:property name="custom.prop.publisher">prop.publisher</hz:property>
+                        <hz:property name="discovery.period">5</hz:property>
+                        <hz:property name="maxEndpoints">2</hz:property>
                     </hz:properties>
                 </hz:wan-publisher>
                 <hz:wan-consumer class-name="com.hazelcast.wan.custom.WanConsumer">
@@ -97,9 +124,15 @@
                         <hz:interface>127.0.0.1:5700</hz:interface>
                         <hz:interface>127.0.0.1:5701</hz:interface>
                     </hz:tcp-ip>
-                    <hz:aws enabled="false" access-key="sample-access-key" secret-key="sample-secret-key"
-                            region="sample-region" security-group-name="sample-group"
-                            tag-key="sample-tag-key" tag-value="sample-tag-value" iam-role="sample-role"/>
+                    <hz:aws enabled="false"
+                            access-key="sample-access-key"
+                            secret-key="sample-secret-key"
+                            region="sample-region"
+                            host-header="sample-header"
+                            security-group-name="sample-group"
+                            tag-key="sample-tag-key"
+                            tag-value="sample-tag-value"
+                            iam-role="sample-role"/>
                     <hz:discovery-strategies>
                         <hz:node-filter implementation="dummyNodeFilter"/>
                         <hz:discovery-strategy discovery-strategy-factory="dummyDiscoveryStrategyFactory">

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -450,11 +450,13 @@ public class ConfigXmlGenerator {
             gen.open("wan-replication", "name", wan.getName());
             for (WanPublisherConfig p : wan.getWanPublisherConfigs()) {
                 gen.open("wan-publisher", "group-name", p.getGroupName())
-                        .node("class-name", p.getClassName())
-                        .node("queue-full-behavior", p.getQueueFullBehavior())
-                        .node("queue-capacity", p.getQueueCapacity())
-                        .appendProperties(p.getProperties())
-                        .close();
+                   .node("class-name", p.getClassName())
+                   .node("queue-full-behavior", p.getQueueFullBehavior())
+                   .node("queue-capacity", p.getQueueCapacity())
+                   .appendProperties(p.getProperties());
+                awsConfigXmlGenerator(gen, p.getAwsConfig());
+                discoveryStrategyConfigXmlGenerator(gen, p.getDiscoveryConfig());
+                gen.close();
             }
 
             final WanConsumerConfig consumerConfig = wan.getWanConsumerConfig();
@@ -491,8 +493,8 @@ public class ConfigXmlGenerator {
         gen.open("join");
         multicastConfigXmlGenerator(gen, join);
         tcpConfigXmlGenerator(gen, join);
-        awsConfigXmlGenerator(gen, join);
-        discoveryStrategyConfigXmlGenerator(gen, join);
+        awsConfigXmlGenerator(gen, join.getAwsConfig());
+        discoveryStrategyConfigXmlGenerator(gen, join.getDiscoveryConfig());
         gen.close();
 
         interfacesConfigXmlGenerator(gen, netCfg);
@@ -799,8 +801,10 @@ public class ConfigXmlGenerator {
                 .close();
     }
 
-    private static void awsConfigXmlGenerator(XmlGenerator gen, JoinConfig join) {
-        final AwsConfig c = join.getAwsConfig();
+    private static void awsConfigXmlGenerator(XmlGenerator gen, AwsConfig c) {
+        if (c == null) {
+            return;
+        }
         gen.open("aws", "enabled", c.isEnabled())
                 .node("access-key", c.getAccessKey())
                 .node("secret-key", c.getSecretKey())
@@ -813,8 +817,7 @@ public class ConfigXmlGenerator {
                 .close();
     }
 
-    private static void discoveryStrategyConfigXmlGenerator(XmlGenerator gen, JoinConfig join) {
-        final DiscoveryConfig c = join.getDiscoveryConfig();
+    private static void discoveryStrategyConfigXmlGenerator(XmlGenerator gen, DiscoveryConfig c) {
         if (c == null) {
             return;
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -119,4 +119,14 @@ public class DiscoveryConfig {
     public void addDiscoveryStrategyConfig(DiscoveryStrategyConfig discoveryStrategyConfig) {
         discoveryStrategyConfigs.add(discoveryStrategyConfig);
     }
+
+    @Override
+    public String toString() {
+        return "DiscoveryConfig{"
+                + "discoveryStrategyConfigs=" + discoveryStrategyConfigs
+                + ", discoveryServiceProvider=" + discoveryServiceProvider
+                + ", nodeFilter=" + nodeFilter
+                + ", nodeFilterClass='" + nodeFilterClass + '\''
+                + '}';
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -73,4 +73,13 @@ public class DiscoveryStrategyConfig {
     public Map<String, Comparable> getProperties() {
         return Collections.unmodifiableMap(properties);
     }
+
+    @Override
+    public String toString() {
+        return "DiscoveryStrategyConfig{"
+                + "properties=" + properties
+                + ", className='" + className + '\''
+                + ", discoveryStrategyFactory=" + discoveryStrategyFactory
+                + '}';
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
@@ -25,7 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Config to be used by WanReplicationConsumer instances (EE only).
+ * Config to be used by WanReplicationConsumer instances (EE only). This allows creating a custom WAN consumer which is
+ * usually used in combination with a custom WAN publisher.
  */
 public class WanConsumerConfig implements IdentifiedDataSerializable {
 
@@ -33,28 +34,61 @@ public class WanConsumerConfig implements IdentifiedDataSerializable {
     private String className;
     private Object implementation;
 
+    /**
+     * Return the properties for this WAN consumer.
+     *
+     * @return the WAN consumer properties
+     */
     public Map<String, Comparable> getProperties() {
         return properties;
     }
 
+    /**
+     * Set the properties for the WAN consumer. These properties are accessible when initalizing the WAN consumer.
+     *
+     * @param properties the properties for the WAN consumer
+     * @return this config
+     */
     public WanConsumerConfig setProperties(Map<String, Comparable> properties) {
         this.properties = properties;
         return this;
     }
 
+    /**
+     * Get the fully qualified class name of the class implementing WanReplicationConsumer.
+     *
+     * @return fully qualified class name
+     */
     public String getClassName() {
         return className;
     }
 
+    /**
+     * Set the name of the class implementing WanReplicationConsumer.
+     *
+     * @param className fully qualified class name
+     * @return this config
+     */
     public WanConsumerConfig setClassName(String className) {
         this.className = className;
         return this;
     }
 
+    /**
+     * Get the implementation implementing WanReplicationConsumer.
+     *
+     * @return the implementation for this WAN consumer
+     */
     public Object getImplementation() {
         return implementation;
     }
 
+    /**
+     * Set the implementation for this WAN consumer. The object must implement WanReplicationConsumer.
+     *
+     * @param implementation the object implementing WanReplicationConsumer
+     * @return this config
+     */
     public WanConsumerConfig setImplementation(Object implementation) {
         this.implementation = implementation;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -24,8 +24,14 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.util.Preconditions.isNotNull;
+
 /**
- * Configuration object for WAN publishers.
+ * Configuration object for WAN publishers. A single publisher defines how WAN events are sent to a specific endpoint.
+ * The endpoint can be a different cluster defined by static IP's or discovered using a cloud discovery mechanism.
+ *
+ * @see DiscoveryConfig
+ * @see AwsConfig
  */
 public class WanPublisherConfig implements IdentifiedDataSerializable {
 
@@ -38,11 +44,26 @@ public class WanPublisherConfig implements IdentifiedDataSerializable {
     private Map<String, Comparable> properties = new HashMap<String, Comparable>();
     private String className;
     private Object implementation;
+    private AwsConfig awsConfig = new AwsConfig();
+    private DiscoveryConfig discoveryConfig = new DiscoveryConfig();
 
+    /**
+     * Return the group name of this publisher. The group name is used for identifying the publisher in a
+     * {@link WanReplicationConfig} and for authentication on the target endpoint.
+     *
+     * @return the publisher group name
+     */
     public String getGroupName() {
         return groupName;
     }
 
+    /**
+     * Set the group name of this publisher. The group name is used for identifying the publisher in a
+     * {@link WanReplicationConfig} and for authentication on the target endpoint.
+     *
+     * @param groupName the publisher group name
+     * @return this config
+     */
     public WanPublisherConfig setGroupName(String groupName) {
         this.groupName = groupName;
         return this;
@@ -126,15 +147,53 @@ public class WanPublisherConfig implements IdentifiedDataSerializable {
         return this;
     }
 
+    /**
+     * @return the awsConfig join configuration
+     */
+    public AwsConfig getAwsConfig() {
+        return awsConfig;
+    }
+
+    /**
+     * @param awsConfig the AwsConfig join configuration to set
+     * @throws IllegalArgumentException if awsConfig is null
+     */
+    public WanPublisherConfig setAwsConfig(final AwsConfig awsConfig) {
+        this.awsConfig = isNotNull(awsConfig, "awsConfig");
+        return this;
+    }
+
+    /**
+     * Returns the currently defined {@link DiscoveryConfig}
+     *
+     * @return current DiscoveryProvidersConfig instance
+     */
+    public DiscoveryConfig getDiscoveryConfig() {
+        return discoveryConfig;
+    }
+
+    /**
+     * Sets a custom defined {@link DiscoveryConfig}
+     *
+     * @param discoveryConfig configuration to set
+     * @throws java.lang.IllegalArgumentException if discoveryProvidersConfig is null
+     */
+    public WanPublisherConfig setDiscoveryConfig(DiscoveryConfig discoveryConfig) {
+        this.discoveryConfig = isNotNull(discoveryConfig, "discoveryProvidersConfig");
+        return this;
+    }
+
     @Override
     public String toString() {
         return "WanPublisherConfig{"
-                + "properties=" + properties
-                + ", className='" + className + '\''
-                + ", implementation=" + implementation
-                + ", groupName='" + groupName + '\''
+                + "groupName='" + groupName + '\''
                 + ", queueCapacity=" + queueCapacity
                 + ", queueFullBehavior=" + queueFullBehavior
+                + ", properties=" + properties
+                + ", className='" + className + '\''
+                + ", implementation=" + implementation
+                + ", awsConfig=" + awsConfig
+                + ", discoveryConfig=" + discoveryConfig
                 + '}';
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -25,7 +25,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Configuration for wan replication.
+ * Configuration for WAN replication. This configuration is referenced from a map or cache to determine the receivers for the
+ * WAN events. Each receiver is defined with a {@link WanPublisherConfig}
+ *
+ * @see MapConfig#setWanReplicationRef
+ * @see CacheConfig#setWanReplicationRef
  */
 public class WanReplicationConfig implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -569,6 +569,10 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             publisherConfig.setQueueCapacity(queueCapacity);
         } else if ("properties".equals(targetChildName)) {
             fillProperties(targetChild, publisherConfig.getProperties());
+        } else if ("aws".equals(targetChildName)) {
+            handleAWS(publisherConfig.getAwsConfig(), targetChild);
+        } else if ("discovery-strategies".equals(targetChildName)) {
+            handleDiscoveryStrategies(publisherConfig.getDiscoveryConfig(), targetChild);
         }
     }
 
@@ -755,9 +759,9 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             } else if ("tcp-ip".equals(name)) {
                 handleTcpIp(child);
             } else if ("aws".equals(name)) {
-                handleAWS(child);
+                handleAWS(config.getNetworkConfig().getJoin().getAwsConfig(), child);
             } else if ("discovery-strategies".equals(name)) {
-                handleDiscoveryStrategies(child);
+                handleDiscoveryStrategies(config.getNetworkConfig().getJoin().getDiscoveryConfig(), child);
             }
         }
 
@@ -765,9 +769,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         joinConfig.verify();
     }
 
-    private void handleDiscoveryStrategies(Node node) {
-        JoinConfig join = config.getNetworkConfig().getJoin();
-        DiscoveryConfig discoveryConfig = join.getDiscoveryConfig();
+    private void handleDiscoveryStrategies(DiscoveryConfig discoveryConfig, Node node) {
         for (Node child : childElements(node)) {
             String name = cleanNodeName(child);
             if ("discovery-strategy".equals(name)) {
@@ -818,10 +820,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         discoveryConfig.addDiscoveryStrategyConfig(new DiscoveryStrategyConfig(clazz, properties));
     }
 
-    private void handleAWS(Node node) {
-        JoinConfig join = config.getNetworkConfig().getJoin();
+    private void handleAWS(AwsConfig awsConfig, Node node) {
         NamedNodeMap atts = node.getAttributes();
-        AwsConfig awsConfig = join.getAwsConfig();
         for (int a = 0; a < atts.getLength(); a++) {
             Node att = atts.item(a);
             String value = getTextContent(att).trim();

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -210,7 +210,8 @@ public class Node {
             clusterService = new ClusterServiceImpl(this, localMember);
             textCommandService = new TextCommandServiceImpl(this);
             multicastService = createMulticastService(addressPicker.getBindAddress(), this, config, logger);
-            discoveryService = createDiscoveryService(config, localMember);
+            discoveryService = createDiscoveryService(
+                    this.config.getNetworkConfig().getJoin().getDiscoveryConfig().getAsReadOnly(), localMember);
             joiner = nodeContext.createJoiner(this);
         } catch (Throwable e) {
             try {
@@ -244,10 +245,7 @@ public class Node {
         return hazelcastThreadGroup;
     }
 
-    private DiscoveryService createDiscoveryService(Config config, Member localMember) {
-        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
-        DiscoveryConfig discoveryConfig = joinConfig.getDiscoveryConfig().getAsReadOnly();
-
+    public DiscoveryService createDiscoveryService(DiscoveryConfig discoveryConfig, Member localMember) {
         DiscoveryServiceProvider factory = discoveryConfig.getDiscoveryServiceProvider();
         if (factory == null) {
             factory = new DefaultDiscoveryServiceProvider();

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AddWanConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AddWanConfigOperation.java
@@ -25,7 +25,7 @@ import com.hazelcast.wan.WanReplicationService;
 import java.io.IOException;
 
 /**
- * Operation to update map configuration from Management Center.
+ * Operation to add a new {@link WanReplicationConfig} at runtime.
  */
 public class AddWanConfigOperation extends AbstractManagementOperation {
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
@@ -19,6 +19,7 @@ package com.hazelcast.nio;
 import com.hazelcast.internal.usercodedeployment.impl.ClassSource;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.ConcurrentReferenceHashMap;
+import com.hazelcast.util.ExceptionUtil;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Constructor;
@@ -65,6 +66,29 @@ public final class ClassLoaderUtil {
     }
 
     private ClassLoaderUtil() {
+    }
+
+    /**
+     * Returns the {@code instance} if not null, otherwise constructs a new instance of the class using
+     * {@link #newInstance(Class, ClassLoader, String)}.
+     *
+     * @param instance    the instance of the class, can be null
+     * @param classLoader the classloader used for class instantiation
+     * @param className   the name of the class being constructed
+     * @return either the provided {@code instance} or a newly constructed instance of {@code className}
+     */
+    public static <T> T getOrCreate(T instance, ClassLoader classLoader, String className) {
+        if (instance != null) {
+            return instance;
+        } else if (className != null) {
+            try {
+                return ClassLoaderUtil.newInstance(classLoader, className);
+            } catch (Exception e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+        } else {
+            return null;
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/hazelcast/src/main/java/com/hazelcast/spi/StatisticsAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/StatisticsAwareService.java
@@ -22,13 +22,17 @@ import com.hazelcast.spi.annotation.Beta;
 import java.util.Map;
 
 /**
- *
+ * A service implementating this interface provides local instance statistics.
  * This interface is in BETA stage and is subject to change in upcoming releases.
  *
+ * @param <T> type of returned
  */
 @Beta
-public interface StatisticsAwareService {
-
-    <T extends LocalInstanceStats> Map<String, T> getStats();
-
+public interface StatisticsAwareService<T extends LocalInstanceStats> {
+    /**
+     * Return the service statistics for the local instance.
+     *
+     * @return the statistics, grouped by distributed object name
+     */
+    Map<String, T> getStats();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/PredefinedDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/PredefinedDiscoveryService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.discovery.impl;
+
+import com.hazelcast.spi.discovery.DiscoveryNode;
+import com.hazelcast.spi.discovery.DiscoveryStrategy;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+
+import java.util.Map;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Discovery service with a predefined and supplied discovery strategy. All methods delegate to the provided strategy.
+ */
+public class PredefinedDiscoveryService implements DiscoveryService {
+    private final DiscoveryStrategy strategy;
+
+    public PredefinedDiscoveryService(DiscoveryStrategy strategy) {
+        this.strategy = checkNotNull(strategy, "Discovery strategy should be not-null");
+    }
+
+    @Override
+    public void start() {
+        strategy.start();
+    }
+
+    @Override
+    public Iterable<DiscoveryNode> discoverNodes() {
+        return strategy.discoverNodes();
+    }
+
+    @Override
+    public Map<String, Object> discoverLocalMetadata() {
+        return strategy.discoverLocalMetadata();
+    }
+
+    @Override
+    public void destroy() {
+        strategy.destroy();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -28,8 +28,7 @@ import com.hazelcast.spi.StatisticsAwareService;
  * to replicate values to other clusters over the wide area network, so it has to deal with long
  * delays, slow uploads and higher latencies.
  */
-public interface WanReplicationService
-        extends CoreService, StatisticsAwareService {
+public interface WanReplicationService extends CoreService, StatisticsAwareService {
 
     /**
      * Service name.
@@ -102,7 +101,8 @@ public interface WanReplicationService
     void clearQueues(String wanReplicationName, String targetGroupName);
 
     /**
-     * Adds a new {@link WanReplicationConfig} to all members.
+     * Adds a new {@link WanReplicationConfig} to this member and creates the {@link WanReplicationPublisher}s specified
+     * in the config.
      */
     void addWanReplicationConfig(WanReplicationConfig wanConfig);
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -2018,12 +2018,16 @@
             <xs:element name="class-name" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
-                        Name of the class implementation for the WAN replication.
+                        Fully qualified class name of WAN Replication implementation implementing WanReplicationEndpoint.
+                        Hazelcast Enterprise comes with com.hazelcast.enterprise.wan.replication.WanBatchReplication:
+                        Waits until a batch size is reached or a delay time is passed.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="queue-capacity" type="xs:integer" default="10000" minOccurs="0" maxOccurs="1"/>
             <xs:element name="queue-full-behavior" type="wan-queue-full-behavior" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="group-name" type="xs:string" use="required">

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -111,8 +111,8 @@ https://hazelcast.org/documentation/.
     
     The <wan-replication> element has the following sub-elements:
     * <wan-publisher>:
-	Fully qualified class name of WAN Replication implementation. Hazelcast Enterprise comes with;
-    	- com.hazelcast.enterprise.wan.replication.WanBatchReplication:
+	Fully qualified class name of WAN Replication implementation implementing WanReplicationEndpoint.
+	Hazelcast Enterprise comes with com.hazelcast.enterprise.wan.replication.WanBatchReplication:
 		Waits until a batch size is reached or a delay time is passed.
 		Please see the `batch.size and batch.max.delay.millis configuration descriptions below.
     * <wan-consumer>:
@@ -151,6 +151,51 @@ https://hazelcast.org/documentation/.
 	- THROW_EXCEPTION: 
 		The WAN queue size is checked before each supported mutating operation. If one of the queues of the target 
 		cluster is full, WANReplicationQueueFullException is thrown and the operation is not allowed.
+    * <aws>:
+		Set its "enabled" attribute to true for discovery within Amazon EC2. It has the following sub-elements:
+		- <access-key>:
+			Access key of your account on EC2.
+		- <secret-key>:
+			Secret key of your account on EC2.
+		- <iam-role>:
+			IAM role that binds with your instance.
+		- <region>:
+			The region where your Hazelcast members run. Default value is us-east-1.
+                        It needs to be specified if the region is other than the default one.
+		- <host-header>:
+			The URL that is the entry point for a web service. It is optional.
+		- <security-group-name>:
+			Name of the security group you specified at the EC2 management console.
+                        It is used to narrow the Hazelcast members to be within this group. It is optional.
+		- <tag-key>:
+			To narrow the members in the cloud down to only Hazelcast members, you can set
+                        this to the one you specified in the EC2 console. It is optional.
+		- <tag-value>:
+			To narrow the members in the cloud down to only Hazelcast members, you can set
+                        this to the one you specified in the EC2 console. It is optional.
+	* <discovery-strategies>:
+		Set its "enabled" attribute to true for discovery in various cloud infrastructures.
+		You can define multiple discovery strategies using the <discovery-strategy> sub-element and its properties.
+		Please refer to
+		http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members
+		to see the properties you can use.
+		The following is an example for EC2 cloud.
+		<discovery-strategies>
+		    <discovery-strategy enabled="true" class="com.hazelcast.aws.AwsDiscoveryStrategy">
+                <properties>
+                    <property name="access-key">test-access-key</property>
+                    <property name="secret-key">test-secret-key</property>
+                    <property name="region">test-region</property>
+                    <property name="iam-role">test-iam-role</property>
+                    <property name="host-header">ec2.test-host-header</property>
+                    <property name="security-group-name">test-security-group-name</property>
+                    <property name="tag-key">test-tag-key</property>
+                    <property name="tag-value">test-tag-value</property>
+                    <property name="connection-timeout-seconds">10</property>
+                    <property name="hz-port">5702</property>
+                </properties>
+            </discovery-strategy>
+		</discovery-strategies>
 -->        
     <wan-replication name="my-wan-cluster-batch">
         <wan-publisher group-name="nyc">
@@ -166,6 +211,25 @@ https://hazelcast.org/documentation/.
                 <property name="snapshot.enabled">false</property>
                 <property name="group.password">nyc-pass</property>
             </properties>
+            <!--<aws enabled="false">-->
+                <!--<access-key>my-access-key</access-key>-->
+                <!--<secret-key>my-secret-key</secret-key>-->
+                <!--<iam-role>dummy</iam-role>-->
+                <!--<region>us-west-1</region>-->
+                <!--<host-header>ec2.amazonaws.com</host-header>-->
+                <!--<security-group-name>hazelcast-sg</security-group-name>-->
+                <!--<tag-key>type</tag-key>-->
+                <!--<tag-value>hz-nodes</tag-value>-->
+            <!--</aws>-->
+            <!--<discovery-strategies>-->
+                <!--<discovery-strategy class="com.hazelcast.jclouds.JCloudsDiscoveryStrategy" enabled="true">-->
+                    <!--<properties>-->
+                        <!--<property name="provider">google-compute-engine</property>-->
+                        <!--<property name="identity">GCE_IDENTITY</property>-->
+                        <!--<property name="credential">GCE_CREDENTIAL</property>-->
+                    <!--</properties>-->
+                <!--</discovery-strategy>-->
+            <!--</discovery-strategies>-->
         </wan-publisher>
     </wan-replication>
 <!--
@@ -210,7 +274,7 @@ https://hazelcast.org/documentation/.
 	shut it down. It is optional and its default value is false.
     * <join>:
 	This configuration lets you choose a discovery mechanism that Hazelcast will use to form a cluster. 
-	Hazelcast can find members by multicast, TCP/IP lists and in the clouds supported by jclouds API. 
+	Hazelcast can find members by multicast, TCP/IP lists and by various discovery mechanisms provided by different cloud APIs.
 	The following are the elements of <join>:
 	- <multicast>:
 		Set its "enabled" attribute to true for discovery by multicast. It has another attribute
@@ -273,12 +337,12 @@ https://hazelcast.org/documentation/.
 			To narrow the members in the cloud down to only Hazelcast members, you can set
                         this to the one you specified in the EC2 console. It is optional.
 	- <discovery-strategies>:
-		Set its "enabled" attribute to true for discovery in a jclouds backed cloud. You also need to set the
+		Set its "enabled" attribute to true for discovery in various cloud infrastructures. You also need to set the
 		value of "hazelcast.discovery.enabled" property to true. See the description of the <properties> element
 		to learn how to do this.
 		You can define multiple discovery strategies using the <discovery-strategy> sub-element and its 
 		properties. Please refer to 
-		http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-members-with-jclouds
+		http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members
 		to see the properties you can use.
 		The following is an example for EC2 cloud.
 		<discovery-strategies>
@@ -346,24 +410,34 @@ https://hazelcast.org/documentation/.
             <ports>34500</ports>
         </outbound-ports>
         <reuse-address>false</reuse-address>
-        <join>
-            <multicast enabled="true">
-                <multicast-group>224.2.2.3</multicast-group>
-                <multicast-port>54327</multicast-port>
-            </multicast>
-            <tcp-ip enabled="false">
-                <interface>127.0.0.1</interface>
-            </tcp-ip>
-            <discovery-strategies>
-		<discovery-strategy class="com.hazelcast.jclouds.JCloudsDiscoveryStrategy" enabled="true">
-			<properties>
-				<property name="provider">google-compute-engine</property>
-				<property name="identity">GCE_IDENTITY</property>
-				<property name="credential">GCE_CREDENTIAL</property>
-			</properties>
-		</discovery-strategy>
-            </discovery-strategies>
-        </join>
+       <join>
+           <multicast enabled="true">
+               <multicast-group>224.2.2.3</multicast-group>
+               <multicast-port>54327</multicast-port>
+           </multicast>
+           <tcp-ip enabled="false">
+               <interface>127.0.0.1</interface>
+           </tcp-ip>
+           <aws enabled="false">
+               <access-key>my-access-key</access-key>
+               <secret-key>my-secret-key</secret-key>
+               <iam-role>dummy</iam-role>
+               <region>us-west-1</region>
+               <host-header>ec2.amazonaws.com</host-header>
+               <security-group-name>hazelcast-sg</security-group-name>
+               <tag-key>type</tag-key>
+               <tag-value>hz-nodes</tag-value>
+           </aws>
+           <discovery-strategies>
+               <discovery-strategy class="com.hazelcast.jclouds.JCloudsDiscoveryStrategy" enabled="true">
+                   <properties>
+                       <property name="provider">google-compute-engine</property>
+                       <property name="identity">GCE_IDENTITY</property>
+                       <property name="credential">GCE_CREDENTIAL</property>
+                   </properties>
+               </discovery-strategy>
+           </discovery-strategies>
+       </join>
         <interfaces enabled="true">
             <interface>10.10.1.*</interface>
         </interfaces>

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -142,38 +142,81 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     @Test
     public void readAwsConfig() {
         String xml = HAZELCAST_START_TAG
-                + "   <group>\n"
-                + "        <name>dev</name>\n"
-                + "        <password>dev-pass</password>\n"
-                + "    </group>\n"
-                + "    <network>\n"
-                + "        <port auto-increment=\"true\">5701</port>\n"
-                + "        <join>\n"
-                + "            <multicast enabled=\"false\">\n"
-                + "                <multicast-group>224.2.2.3</multicast-group>\n"
-                + "                <multicast-port>54327</multicast-port>\n"
-                + "            </multicast>\n"
-                + "            <tcp-ip enabled=\"false\">\n"
-                + "                <interface>127.0.0.1</interface>\n"
-                + "            </tcp-ip>\n"
-                + "            <aws enabled=\"true\" connection-timeout-seconds=\"10\" >\n"
-                + "                <access-key>access</access-key>\n"
-                + "                <secret-key>secret</secret-key>\n"
-                + "            </aws>\n"
-                + "        </join>\n"
-                + "        <interfaces enabled=\"false\">\n"
-                + "            <interface>10.10.1.*</interface>\n"
-                + "        </interfaces>\n"
-                + "    </network>\n"
+                + "   <group>\n" +
+                "        <name>dev</name>\n" +
+                "        <password>dev-pass</password>\n" +
+                "    </group>\n" +
+                "    <network>\n" +
+                "        <port auto-increment=\"true\">5701</port>\n" +
+                "        <join>\n" +
+                "            <multicast enabled=\"false\">\n" +
+                "                <multicast-group>224.2.2.3</multicast-group>\n" +
+                "                <multicast-port>54327</multicast-port>\n" +
+                "            </multicast>\n" +
+                "            <tcp-ip enabled=\"false\">\n" +
+                "                <interface>127.0.0.1</interface>\n" +
+                "            </tcp-ip>\n" +
+                "            <aws enabled=\"true\" connection-timeout-seconds=\"10\" >\n" +
+                "                <access-key>sample-access-key</access-key>\n" +
+                "                <secret-key>sample-secret-key</secret-key>\n" +
+                "                <iam-role>sample-role</iam-role>\n" +
+                "                <region>sample-region</region>\n" +
+                "                <host-header>sample-header</host-header>\n" +
+                "                <security-group-name>sample-group</security-group-name>\n" +
+                "                <tag-key>sample-tag-key</tag-key>\n" +
+                "                <tag-value>sample-tag-value</tag-value>\n" +
+                "            </aws>\n" +
+                "        </join>\n" +
+                "        <interfaces enabled=\"false\">\n" +
+                "            <interface>10.10.1.*</interface>\n" +
+                "        </interfaces>\n" +
+                "    </network>"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        AwsConfig awsConfig = config.getNetworkConfig().getJoin().getAwsConfig();
+        final AwsConfig aws = config.getNetworkConfig().getJoin().getAwsConfig();
+        assertTrue(aws.isEnabled());
+        assertAwsConfig(aws);
+    }
 
-        assertTrue(awsConfig.isEnabled());
-        assertEquals(10, config.getNetworkConfig().getJoin().getAwsConfig().getConnectionTimeoutSeconds());
-        assertEquals("access", awsConfig.getAccessKey());
-        assertEquals("secret", awsConfig.getSecretKey());
+    @Test
+    public void readDiscoveryConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "   <group>\n" +
+                "        <name>dev</name>\n" +
+                "        <password>dev-pass</password>\n" +
+                "    </group>\n" +
+                "    <network>\n" +
+                "        <port auto-increment=\"true\">5701</port>\n" +
+                "        <join>\n" +
+                "            <multicast enabled=\"false\">\n" +
+                "                <multicast-group>224.2.2.3</multicast-group>\n" +
+                "                <multicast-port>54327</multicast-port>\n" +
+                "            </multicast>\n" +
+                "            <tcp-ip enabled=\"false\">\n" +
+                "                <interface>127.0.0.1</interface>\n" +
+                "            </tcp-ip>\n" +
+                "            <discovery-strategies>\n" +
+                "                <node-filter class=\"DummyFilterClass\" />\n" +
+                "                <discovery-strategy class=\"DummyDiscoveryStrategy1\" enabled=\"true\">\n" +
+                "                    <properties>\n" +
+                "                        <property name=\"key-string\">foo</property>\n" +
+                "                        <property name=\"key-int\">123</property>\n" +
+                "                        <property name=\"key-boolean\">true</property>\n" +
+                "                    </properties>\n" +
+                "                </discovery-strategy>\n" +
+                "            </discovery-strategies>\n" +
+                "        </join>\n" +
+                "        <interfaces enabled=\"false\">\n" +
+                "            <interface>10.10.1.*</interface>\n" +
+                "        </interfaces>\n" +
+                "    </network>"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        final DiscoveryConfig discoveryConfig = config.getNetworkConfig().getJoin().getDiscoveryConfig();
+        assertTrue(discoveryConfig.isEnabled());
+        assertDiscoveryConfig(discoveryConfig);
     }
 
     @Test
@@ -998,26 +1041,48 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     @Test
     public void testWanConfig() {
         String xml = HAZELCAST_START_TAG
-                + "<wan-replication name=\"my-wan-cluster\">\n"
-                + "    <wan-publisher group-name=\"istanbul\">\n"
-                + "       <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>\n"
-                + "       <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>\n"
-                + "       <queue-capacity>21</queue-capacity>\n"
-                + "       <properties>\n"
-                + "           <property name=\"custom.prop.publisher\">prop.publisher</property>\n"
-                + "       </properties>\n"
-                + "    </wan-publisher>\n"
-                + "    <wan-publisher group-name=\"ankara\">\n"
-                + "       <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>\n"
-                + "       <queue-full-behavior>THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE</queue-full-behavior>\n"
-                + "    </wan-publisher>\n"
-                + "    <wan-consumer>\n"
-                + "       <class-name>com.hazelcast.wan.custom.WanConsumer</class-name>\n"
-                + "       <properties>\n"
-                + "           <property name=\"custom.prop.consumer\">prop.consumer</property>\n"
-                + "       </properties>\n"
-                + "    </wan-consumer>\n"
-                + "</wan-replication>\n"
+                + "   <wan-replication name=\"my-wan-cluster\">\n" +
+                "      <wan-publisher group-name=\"istanbul\">\n" +
+                "         <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>\n" +
+                "         <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>\n" +
+                "         <queue-capacity>21</queue-capacity>\n" +
+                "         <aws enabled=\"false\" connection-timeout-seconds=\"10\" >\n" +
+                "            <access-key>sample-access-key</access-key>\n" +
+                "            <secret-key>sample-secret-key</secret-key>\n" +
+                "            <iam-role>sample-role</iam-role>\n" +
+                "            <region>sample-region</region>\n" +
+                "            <host-header>sample-header</host-header>\n" +
+                "            <security-group-name>sample-group</security-group-name>\n" +
+                "            <tag-key>sample-tag-key</tag-key>\n" +
+                "            <tag-value>sample-tag-value</tag-value>\n" +
+                "         </aws>\n" +
+                "         <discovery-strategies>\n" +
+                "            <node-filter class=\"DummyFilterClass\" />\n" +
+                "            <discovery-strategy class=\"DummyDiscoveryStrategy1\" enabled=\"true\">\n" +
+                "               <properties>\n" +
+                "                  <property name=\"key-string\">foo</property>\n" +
+                "                  <property name=\"key-int\">123</property>\n" +
+                "                  <property name=\"key-boolean\">true</property>\n" +
+                "               </properties>\n" +
+                "            </discovery-strategy>\n" +
+                "         </discovery-strategies>\n" +
+                "         <properties>\n" +
+                "            <property name=\"custom.prop.publisher\">prop.publisher</property>\n" +
+                "            <property name=\"discovery.period\">5</property>\n" +
+                "            <property name=\"maxEndpoints\">2</property>\n" +
+                "         </properties>\n" +
+                "      </wan-publisher>\n" +
+                "      <wan-publisher group-name=\"ankara\">\n" +
+                "         <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>\n" +
+                "         <queue-full-behavior>THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE</queue-full-behavior>\n" +
+                "      </wan-publisher>\n" +
+                "      <wan-consumer>\n" +
+                "         <class-name>com.hazelcast.wan.custom.WanConsumer</class-name>\n" +
+                "         <properties>\n" +
+                "            <property name=\"custom.prop.consumer\">prop.consumer</property>\n" +
+                "         </properties>\n" +
+                "      </wan-consumer>\n" +
+                "   </wan-replication>"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
@@ -1033,6 +1098,11 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(21, publisherConfig1.getQueueCapacity());
         Map<String, Comparable> pubProperties = publisherConfig1.getProperties();
         assertEquals("prop.publisher", pubProperties.get("custom.prop.publisher"));
+        assertEquals("5", pubProperties.get("discovery.period"));
+        assertEquals("2", pubProperties.get("maxEndpoints"));
+        assertFalse(publisherConfig1.getAwsConfig().isEnabled());
+        assertAwsConfig(publisherConfig1.getAwsConfig());
+        assertDiscoveryConfig(publisherConfig1.getDiscoveryConfig());
 
         WanPublisherConfig publisherConfig2 = publisherConfigs.get(1);
         assertEquals("ankara", publisherConfig2.getGroupName());
@@ -1042,6 +1112,29 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("com.hazelcast.wan.custom.WanConsumer", consumerConfig.getClassName());
         Map<String, Comparable> consProperties = consumerConfig.getProperties();
         assertEquals("prop.consumer", consProperties.get("custom.prop.consumer"));
+    }
+
+    private void assertDiscoveryConfig(DiscoveryConfig c) {
+        assertEquals("DummyFilterClass", c.getNodeFilterClass());
+        assertEquals(1, c.getDiscoveryStrategyConfigs().size());
+        final DiscoveryStrategyConfig config = c.getDiscoveryStrategyConfigs().iterator().next();
+        assertEquals("DummyDiscoveryStrategy1", config.getClassName());
+        final Map<String, Comparable> props = config.getProperties();
+        assertEquals("foo", props.get("key-string"));
+        assertEquals("123", props.get("key-int"));
+        assertEquals("true", props.get("key-boolean"));
+    }
+
+    private void assertAwsConfig(AwsConfig aws) {
+        assertEquals(10, aws.getConnectionTimeoutSeconds());
+        assertEquals("sample-access-key", aws.getAccessKey());
+        assertEquals("sample-secret-key", aws.getSecretKey());
+        assertEquals("sample-region", aws.getRegion());
+        assertEquals("sample-header", aws.getHostHeader());
+        assertEquals("sample-group", aws.getSecurityGroupName());
+        assertEquals("sample-tag-key", aws.getTagKey());
+        assertEquals("sample-tag-value", aws.getTagValue());
+        assertEquals("sample-role", aws.getIamRole());
     }
 
     @Test

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -66,8 +66,30 @@
             <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>
             <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>
             <queue-capacity>10000</queue-capacity>
+            <aws enabled="false" connection-timeout-seconds="10">
+                <access-key>sample-access-key</access-key>
+                <secret-key>sample-secret-key</secret-key>
+                <iam-role>sample-role</iam-role>
+                <region>sample-region</region>
+                <host-header>sample-header</host-header>
+                <security-group-name>sample-group</security-group-name>
+                <tag-key>sample-tag-key</tag-key>
+                <tag-value>sample-tag-value</tag-value>
+            </aws>
+            <discovery-strategies>
+                <node-filter class="DummyFilterClass" />
+                <discovery-strategy class="DummyDiscoveryStrategy1" enabled="true">
+                    <properties>
+                        <property name="key-string">foo</property>
+                        <property name="key-int">123</property>
+                        <property name="key-boolean">true</property>
+                    </properties>
+                </discovery-strategy>
+            </discovery-strategies>
             <properties>
                 <property name="custom.prop.publisher">prop.publisher</property>
+                <property name="discovery.period">5</property>
+                <property name="maxEndpoints">2</property>
             </properties>
         </wan-publisher>
         <wan-consumer>


### PR DESCRIPTION
Change WAN connection manager, publisher configuration and implementation  to support discovery SPI. The current mechanism of defining endpoints is turned into an implementation of the discovery SPI. The connection manager now reruns discovery on a periodic basis and adds the discovered nodes to the available list. The size of the list can be limited.

Notes:
- the striped executor in the WanBatchReplication is sized according to the number of target endpoints when sending the first event and does not resize afterwards
- the AbstractWanReplication implementation of isConnected has changed - previously it checked that there were no failed connections, now it checks if there are any discovered endpoints
- the periodic discovery task does not attempt to connect to the target endpoint before adding it to the list

EE part : https://github.com/hazelcast/hazelcast-enterprise/pull/1390