### PR TITLE
BounceMemberRule logging & fixes, smaller cluster in QueryBounceTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
@@ -113,20 +113,23 @@ public class QueryBounceTest {
         }
     }
 
-    // Thread-safe querying runnable
     public static class QueryRunnable implements Runnable {
 
-        private final IMap map;
+        private final HazelcastInstance hazelcastInstance;
         // query age min-max range, min is randomized, max = min+1000
         private final Random random = new Random();
         private final int numberOfResults = 1000;
+        private IMap map;
 
-        public QueryRunnable(HazelcastInstance hz) {
-            this.map = hz.getMap(TEST_MAP_NAME);
+        public QueryRunnable(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
         }
 
         @Override
         public void run() {
+            if (map == null) {
+                map = hazelcastInstance.getMap(TEST_MAP_NAME);
+            }
             int min, max;
             min = random.nextInt(COUNT_ENTRIES - numberOfResults);
             max = min + numberOfResults;

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
@@ -52,7 +52,9 @@ public class QueryBounceTest {
     private IMap<String, SampleObjects.Employee> map;
 
     @Rule
-    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getConfig()).build();
+    public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getConfig())
+                                                               .clusterSize(4)
+                                                               .driverCount(4).build();
 
     @Rule
     public JitterRule jitterRule = new JitterRule();

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
@@ -511,9 +511,9 @@ public class BounceMemberRule implements TestRule {
             try {
                 while (testRunning.get()) {
                     if (bounceTestConfig.isUseTerminate()) {
-                        instances[i].getLifecycleService().terminate();
+                        members.get(i).getLifecycleService().terminate();
                     } else {
-                        instances[i].shutdown();
+                        members.get(i).shutdown();
                     }
                     nextInstance = i % divisor + 1;
                     sleepSeconds(2);

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/DriverFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/DriverFactory.java
@@ -25,7 +25,8 @@ import com.hazelcast.core.HazelcastInstance;
 public interface DriverFactory {
 
     /**
-     * @return HazelcastInstances to be used in bouncing members test tasks to be executed by given {@code BounceMemberRule}
+     * @return HazelcastInstances to be used in bouncing members test tasks to be executed by given {@code BounceMemberRule}.
+     *          The returned array must have {@link BounceTestConfiguration#driverCount} elements.
      */
     HazelcastInstance[] createTestDrivers(BounceMemberRule rule);
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/MemberDriverFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/MemberDriverFactory.java
@@ -19,11 +19,13 @@ package com.hazelcast.test.bounce;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 
+import java.util.Arrays;
+
 import static com.hazelcast.test.HazelcastTestSupport.waitAllForSafeState;
 
 /**
- * Default member-side test driver factory. When test driver is {@code ALWAYS_UP_MEMBER}, returns a single test driver
- * set to the always-up member of the cluster as returned by {@link BounceMemberRule#getSteadyMember()}. When test driver
+ * Default member-side test driver factory. When test driver is {@code ALWAYS_UP_MEMBER}, returns the steady member of
+ * the cluster as returned by {@link BounceMemberRule#getSteadyMember()} as test driver. When test driver
  * is {@code MEMBER}, the configured number of test drivers are created. Otherwise, an {@code AssertionError} is thrown.
  */
 public class MemberDriverFactory implements DriverFactory {
@@ -31,11 +33,12 @@ public class MemberDriverFactory implements DriverFactory {
     @Override
     public HazelcastInstance[] createTestDrivers(BounceMemberRule rule) {
         BounceTestConfiguration testConfiguration = rule.getBounceTestConfig();
+        HazelcastInstance[] drivers = new HazelcastInstance[testConfiguration.getDriverCount()];
         switch (testConfiguration.getDriverType()) {
             case ALWAYS_UP_MEMBER:
-                return new HazelcastInstance[]{rule.getSteadyMember()};
+                Arrays.fill(drivers, rule.getSteadyMember());
+                return drivers;
             case MEMBER:
-                HazelcastInstance[] drivers = new HazelcastInstance[testConfiguration.getDriverCount()];
                 for (int i = 0; i < drivers.length; i++) {
                     drivers[i] = rule.getFactory().newHazelcastInstance(getConfig());
                 }


### PR DESCRIPTION
- Smaller cluster and test drivers size (4 member & 4 test drivers instead of 6 & 5 respectively) in QueryBounceTest to reduce probability of timeout. In local debugging, sometimes initial cluster was formed after 1 minute which does count towards the timeout defined in `@Test(timeout=...)`.
- Added logging in BounceMemberRule for easier troubleshooting
- Bounced members and test drivers are now accessed with volatile semantics, as they are used by several threads:
  - Cluster setup is executed in the thread that initializes the `AbstractHazelcastClassRunner` (eg when running within the IDE this is the `main` thread)
  - The `FailOnTimeoutStatement` that wraps every test to enforce the timeout spawns a separate thread that invokes the test method. `BounceMemberRule.test*` will be invoked from this thread and will typically need to obtain at least a test driver `HazelcastInstance`
  - Another thread is spawned from `BounceMemberRule` that executes the member bouncing logic and updates the current cluster members in `BounceMemberRule.members`