### PR TITLE
Fixed NPE in NearCachedClientCacheProxy on putAll()

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -261,18 +261,21 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy {
             // cache or invalidate Near Cache
             for (int partitionId = 0; partitionId < entriesPerPartition.length; partitionId++) {
                 List<Map.Entry<Data, Data>> entries = entriesPerPartition[partitionId];
-                for (Map.Entry<Data, Data> entry : entries) {
-                    cacheOrInvalidate(entry.getKey(), entry.getValue(), null);
+                if (entries != null) {
+                    for (Map.Entry<Data, Data> entry : entries) {
+                        cacheOrInvalidate(entry.getKey(), entry.getValue(), null);
+                    }
                 }
             }
         } catch (Throwable t) {
             for (int partitionId = 0; partitionId < entriesPerPartition.length; partitionId++) {
                 List<Map.Entry<Data, Data>> entries = entriesPerPartition[partitionId];
-                for (Map.Entry<Data, Data> entry : entries) {
-                    invalidateNearCache(entry.getKey());
+                if (entries != null) {
+                    for (Map.Entry<Data, Data> entry : entries) {
+                        invalidateNearCache(entry.getKey());
+                    }
                 }
             }
-
             throw rethrow(t);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -43,6 +43,7 @@ import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Provides utility methods for unified Near Cache tests.
@@ -127,6 +128,16 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
         MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
 
         return service.getMapServiceContext().getMapNearCacheManager();
+    }
+
+    /**
+     * Assumes that the given {@link NearCacheConfig} has
+     * {@link com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy#CACHE_ON_UPDATE} configured.
+     *
+     * @param nearCacheConfig the {@link NearCacheConfig} to test
+     */
+    public static void assumeThatLocalUpdatePolicyIsCacheOnUpdate(NearCacheConfig nearCacheConfig) {
+        assumeTrue(isCacheOnUpdate(nearCacheConfig));
     }
 
     /**


### PR DESCRIPTION
* fixed NPE in `putAll()` hook when there are no entries
  for all partitions being added
* added unified Near Cache tests for entry adding methods
  when `CACHE_ON_UPDATE` is configured
* added convenience method `assumeThatLocalUpdatePolicyIsCacheOnUpdate()`
  to `NearCacheTestUtils`


Depends on https://github.com/hazelcast/hazelcast/pull/10178

Part of https://github.com/hazelcast/hazelcast/issues/10127