### PR TITLE
Allows checking if an entry is locked within an EntryProcessor

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -22,6 +22,7 @@ import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.QueryCache;
 import com.hazelcast.map.QueryResultSizeExceededException;
 import com.hazelcast.map.impl.LegacyAsyncMap;
+import com.hazelcast.map.LockAware;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.map.listener.MapPartitionLostListener;
 import com.hazelcast.mapreduce.JobTracker;
@@ -72,6 +73,25 @@ import java.util.concurrent.TimeUnit;
  * </ul>
  * </p>
  * <p>This class does <em>not</em> allow <tt>null</tt> to be used as a key or value.</p>
+ *
+ * <p>Entry Processing</p>
+ * The following operations are lock-aware, since they operate on a single key only.
+ * If the key is locked the EntryProcessor will wait until it acquires the lock.
+ * <ul>
+ * <li> {@link IMap#executeOnKey(Object, EntryProcessor)} </li>
+ * <li> {@link IMap#submitToKey(Object, EntryProcessor)} </li>
+ * <li> {@link IMap#submitToKey(Object, EntryProcessor, ExecutionCallback)} </li>
+ * </ul>
+ * There are however following methods that run the EntryProcessor on more than one entry. These operations are not lock-aware.
+ * The EntryProcessor will process the entries no matter if they are locked or not.
+ * The user may however check if an entry is locked by casting the {@link java.util.Map.Entry} to ]
+ * {@link LockAware} and invoking the {@link LockAware#isLocked()} method.
+ * <ul>
+ * <li> {@link IMap#executeOnEntries(EntryProcessor)} </li>
+ * <li> {@link IMap#executeOnEntries(EntryProcessor, Predicate)} </li>
+ * <li> {@link IMap#executeOnKeys(Set, EntryProcessor)} </li>
+ * </ul>
+ * This applies to both EntryProcessor and backup EntryProcessor.
  *
  * @param <K> key
  * @param <V> value

--- a/hazelcast/src/main/java/com/hazelcast/map/LockAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/LockAware.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+/**
+ * Determines if the object implementing this interface is locked or not.
+ */
+public interface LockAware {
+
+    /**
+     * @return true if the object is locked, false otherwise, null if N/A
+     */
+    Boolean isLocked();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LockAwareLazyMapEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LockAwareLazyMapEntry.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.map.LockAware;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.getters.Extractors;
+
+/**
+ * Specialization of the LazyMapEntry that is LockAware. Used in EntryProcessor.
+ * If serialized the locked property will be nullified, since it's volatile and valid only when on partition-thread.
+ */
+public class LockAwareLazyMapEntry extends LazyMapEntry implements LockAware {
+
+    // not to be serialized, if serialized should return null
+    private final transient Boolean locked;
+
+    public LockAwareLazyMapEntry() {
+        this.locked = null;
+    }
+
+    public LockAwareLazyMapEntry(Data key, Object value, InternalSerializationService serializationService,
+                                 Extractors extractors, Boolean locked) {
+        super(key, value, serializationService, extractors);
+        this.locked = locked;
+    }
+
+    @Override
+    public Boolean isLocked() {
+        return locked;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.LOCK_AWARE_LAZY_MAP_ENTRY;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -285,8 +285,9 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int REMOVE_FROM_LOAD_ALL = 134;
     public static final int ENTRY_REMOVING_PROCESSOR = 135;
     public static final int ENTRY_OFFLOADABLE_SET_UNLOCK = 136;
+    public static final int LOCK_AWARE_LAZY_MAP_ENTRY = 137;
 
-    private static final int LEN = ENTRY_OFFLOADABLE_SET_UNLOCK + 1;
+    private static final int LEN = LOCK_AWARE_LAZY_MAP_ENTRY + 1;
 
     @Override
     public int getFactoryId() {
@@ -960,6 +961,11 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[ENTRY_OFFLOADABLE_SET_UNLOCK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new EntryOffloadableSetUnlockOperation();
+            }
+        };
+        constructors[LOCK_AWARE_LAZY_MAP_ENTRY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new LockAwareLazyMapEntry();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.LocalMapStatsProvider;
+import com.hazelcast.map.impl.LockAwareLazyMapEntry;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.record.Record;
@@ -67,7 +68,8 @@ abstract class AbstractMultipleEntryOperation extends MapOperation implements Mu
     protected Map.Entry createMapEntry(Data key, Object value) {
         InternalSerializationService serializationService
                 = ((InternalSerializationService) getNodeEngine().getSerializationService());
-        return new LazyMapEntry(key, value, serializationService, mapContainer.getExtractors());
+        boolean locked = recordStore.isLocked(key);
+        return new LockAwareLazyMapEntry(key, value, serializationService, mapContainer.getExtractors(), locked);
     }
 
     protected boolean hasRegisteredListenerForThisMap() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MutatingKeyBasedMapOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.LazyMapEntry;
 import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapServiceContext;
@@ -80,12 +79,6 @@ public abstract class MutatingKeyBasedMapOperation extends MapOperation
     protected boolean noOp(Map.Entry entry, Object oldValue) {
         final LazyMapEntry mapEntrySimple = (LazyMapEntry) entry;
         return !mapEntrySimple.isModified() || (oldValue == null && entry.getValue() == null);
-    }
-
-    protected Map.Entry createMapEntry(Data key, Object value) {
-        InternalSerializationService serializationService
-                = ((InternalSerializationService) getNodeEngine().getSerializationService());
-        return new LazyMapEntry(key, value, serializationService, mapContainer.getExtractors());
     }
 
     protected long getNow() {

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorLockTest.java
@@ -1,0 +1,217 @@
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Offloadable;
+import com.hazelcast.core.ReadOnly;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.map.impl.LockAwareLazyMapEntry;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class EntryProcessorLockTest extends HazelcastTestSupport {
+
+    public static final String MAP_NAME = "EntryProcessorLockTest";
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        return asList(new Object[][]{
+                {BINARY}, {OBJECT}
+        });
+    }
+
+    @Override
+    public Config getConfig() {
+        Config config = super.getConfig();
+        MapConfig mapConfig = new MapConfig(MAP_NAME);
+        mapConfig.setInMemoryFormat(inMemoryFormat);
+        config.addMapConfig(mapConfig);
+        return config;
+    }
+
+    private IMap<String, String> getInitializedMap() {
+        HazelcastInstance instance = createHazelcastInstance(getConfig());
+        IMap<String, String> map = instance.getMap(MAP_NAME);
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        return map;
+    }
+
+    @Test
+    public void test_executeOnEntries() {
+        IMap<String, String> map = getInitializedMap();
+
+        map.lock("key1");
+        Map<String, Object> result = map.executeOnEntries(new TestNonOffloadableEntryProcessor());
+
+        assertTrue((Boolean) result.get("key1"));
+        assertFalse((Boolean) result.get("key2"));
+    }
+
+    @Test
+    public void test_executeOnEntries_withPredicate() {
+        IMap<String, String> map = getInitializedMap();
+
+        map.lock("key1");
+        Map<String, Object> result = map.executeOnEntries(new TestNonOffloadableEntryProcessor(), TruePredicate.INSTANCE);
+
+        assertTrue((Boolean) result.get("key1"));
+        assertFalse((Boolean) result.get("key2"));
+    }
+
+    @Test
+    public void test_executeOnKeys() {
+        IMap<String, String> map = getInitializedMap();
+
+        map.lock("key1");
+        Map<String, Object> result = map.executeOnKeys(new HashSet<String>(asList("key1", "key2")),
+                new TestNonOffloadableEntryProcessor());
+
+        assertTrue((Boolean) result.get("key1"));
+        assertFalse((Boolean) result.get("key2"));
+    }
+
+    @Test
+    public void test_executeOnKey_notOffloadable() {
+        IMap<String, String> map = getInitializedMap();
+
+        Boolean result = (Boolean) map.executeOnKey("key1", new TestNonOffloadableEntryProcessor());
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void test_executeOnKey_Offloadable() {
+        IMap<String, String> map = getInitializedMap();
+
+        Boolean result = (Boolean) map.executeOnKey("key1", new TestOffloadableEntryProcessor());
+
+        assertNull(result);
+    }
+
+    @Test
+    public void test_executeOnKey_Offloadable_ReadOnly() {
+        IMap<String, String> map = getInitializedMap();
+
+        Boolean result = (Boolean) map.executeOnKey("key1", new TestOffloadableReadOnlyEntryProcessor());
+
+        assertNull(result);
+    }
+
+    @Test
+    public void test_submitToKey_notOffloadable() throws ExecutionException, InterruptedException {
+        IMap<String, String> map = getInitializedMap();
+
+        Boolean result = (Boolean) map.submitToKey("key1", new TestNonOffloadableEntryProcessor()).get();
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void test_submitToKey_Offloadable() throws ExecutionException, InterruptedException {
+        IMap<String, String> map = getInitializedMap();
+
+        Boolean result = (Boolean) map.submitToKey("key1", new TestOffloadableEntryProcessor()).get();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void test_submitToKey_Offloadable_ReadOnly() throws ExecutionException, InterruptedException {
+        IMap<String, String> map = getInitializedMap();
+
+        Boolean result = (Boolean) map.submitToKey("key1", new TestOffloadableReadOnlyEntryProcessor()).get();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void test_Serialization_LockAwareLazyMapEntry_deserializesAs_LazyMapEntry() throws ExecutionException, InterruptedException {
+        InternalSerializationService ss = getSerializationService(createHazelcastInstance(getConfig()));
+        LockAwareLazyMapEntry entry = new LockAwareLazyMapEntry(ss.toData("key"), "value", ss, Extractors.empty(), false);
+
+        LockAwareLazyMapEntry deserializedEntry = ss.toObject(ss.toData(entry));
+
+        assertEquals(LockAwareLazyMapEntry.class, deserializedEntry.getClass());
+        assertEquals("key", deserializedEntry.getKey());
+        assertEquals("value", deserializedEntry.getValue());
+        assertEquals(null, deserializedEntry.isLocked());
+    }
+
+    private static class TestNonOffloadableEntryProcessor implements EntryProcessor {
+        @Override
+        public Object process(Map.Entry entry) {
+            return ((LockAware) entry).isLocked();
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+    }
+
+    private static class TestOffloadableEntryProcessor implements EntryProcessor, Offloadable {
+        @Override
+        public String getExecutorName() {
+            return OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public Object process(Map.Entry entry) {
+            return ((LockAware) entry).isLocked();
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+    }
+
+    private static class TestOffloadableReadOnlyEntryProcessor implements EntryProcessor, Offloadable, ReadOnly {
+        @Override
+        public String getExecutorName() {
+            return OFFLOADABLE_EXECUTOR;
+        }
+
+        @Override
+        public Object process(Map.Entry entry) {
+            return ((LockAware) entry).isLocked();
+        }
+
+        @Override
+        public EntryBackupProcessor getBackupProcessor() {
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
Allows checking if an entry is locked within an EntryProcessor

Issues to discuss:

- don't know if the entry within EntryBackupProcessor should be LockAware - the EP may send a delta, or it may check for locks too - the only problem is if the operations get the out-of-order, but that problem exists even without this optimisation, so I would allow the user to check for locks on backup too. If no out-of-order -> then it's the same as on the main partition. If out-of-order than the problem exists anyway.
- Offloadable (and not ReadOnly) will lock the entry -> so the user has to be aware of that, otherwise they may be surprise that the `isLocked` method returns true always.

Related to #10065