### PR TITLE
Added missing unified Near Cache invalidation tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
@@ -40,8 +40,6 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -148,11 +146,5 @@ public class ClientCacheNearCacheBasicTest extends AbstractNearCacheBasicTest<Da
         }
 
         return cacheConfig;
-    }
-
-    @Test
-    @Override
-    @Ignore(value = "The NearCachedClientCacheProxy is missing `invalidateNearCache(keyData)` calls")
-    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -117,7 +117,13 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
     @Test
     @Override
     @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
-    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+    public void whenSetIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
+    public void whenPutIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
     }
 
     @Test
@@ -130,5 +136,11 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
     @Override
     @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
     public void whenRemoveIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
+    }
+
+    @Test
+    @Override
+    @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
+    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -41,6 +41,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCach
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSizeEventually;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheStats;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assumeThatLocalUpdatePolicyIsCacheOnUpdate;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assumeThatLocalUpdatePolicyIsInvalidate;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assumeThatMethodIsAvailable;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getFuture;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.isCacheOnUpdate;
@@ -331,42 +332,45 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
     }
 
     /**
-     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#PUT_ALL} is used.
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#SET} is used.
      *
      * This variant uses the {@link NearCacheTestContext#nearCacheAdapter}, so there is no Near Cache invalidation necessary.
      */
     @Test
-    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
-        whenPutAllIsUsed_thenNearCacheShouldBeInvalidated(true);
+    public void whenSetIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.SET);
     }
 
     /**
-     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#PUT_ALL} is used.
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#SET} is used.
      *
      * This variant uses the {@link NearCacheTestContext#dataAdapter}, so we need to configure Near Cache invalidation.
      */
     @Test
-    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
+    public void whenSetIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
         nearCacheConfig.setInvalidateOnChange(true);
-        whenPutAllIsUsed_thenNearCacheShouldBeInvalidated(false);
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.SET);
     }
 
-    private void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated(boolean useNearCacheAdapter) {
-        NearCacheTestContext<Integer, String, NK, NV> context = createContext();
+    /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#PUT} is used.
+     *
+     * This variant uses the {@link NearCacheTestContext#nearCacheAdapter}, so there is no Near Cache invalidation necessary.
+     */
+    @Test
+    public void whenPutIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.PUT);
+    }
 
-        populateMap(context);
-        populateNearCache(context);
-
-        Map<Integer, String> invalidationMap = new HashMap<Integer, String>(DEFAULT_RECORD_COUNT);
-        for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            invalidationMap.put(i, "newValue-" + i);
-        }
-
-        // this should invalidate the Near Cache
-        DataStructureAdapter<Integer, String> adapter = useNearCacheAdapter ? context.nearCacheAdapter : context.dataAdapter;
-        adapter.putAll(invalidationMap);
-
-        assertNearCacheSizeEventually(context, 0, "Invalidation is not working on putAll()");
+    /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#PUT} is used.
+     *
+     * This variant uses the {@link NearCacheTestContext#dataAdapter}, so we need to configure Near Cache invalidation.
+     */
+    @Test
+    public void whenPutIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
+        nearCacheConfig.setInvalidateOnChange(true);
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.PUT);
     }
 
     /**
@@ -376,7 +380,7 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
      */
     @Test
     public void whenReplaceIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
-        whenReplaceIsUsed_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.REPLACE);
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.REPLACE);
     }
 
     /**
@@ -387,7 +391,7 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
     @Test
     public void whenReplaceIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
         nearCacheConfig.setInvalidateOnChange(true);
-        whenReplaceIsUsed_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.REPLACE);
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.REPLACE);
     }
 
     /**
@@ -397,7 +401,7 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
      */
     @Test
     public void whenReplaceWithOldValueIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
-        whenReplaceIsUsed_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.REPLACE_WITH_OLD_VALUE);
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.REPLACE_WITH_OLD_VALUE);
     }
 
     /**
@@ -408,10 +412,33 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
     @Test
     public void whenReplaceWithOldValueIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
         nearCacheConfig.setInvalidateOnChange(true);
-        whenReplaceIsUsed_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.REPLACE_WITH_OLD_VALUE);
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.REPLACE_WITH_OLD_VALUE);
     }
 
-    private void whenReplaceIsUsed_thenNearCacheShouldBeInvalidated(boolean useNearCacheAdapter, DataStructureMethods method) {
+    /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#PUT_ALL} is used.
+     *
+     * This variant uses the {@link NearCacheTestContext#nearCacheAdapter}, so there is no Near Cache invalidation necessary.
+     */
+    @Test
+    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnNearCacheAdapter() {
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.PUT_ALL);
+    }
+
+    /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#PUT_ALL} is used.
+     *
+     * This variant uses the {@link NearCacheTestContext#dataAdapter}, so we need to configure Near Cache invalidation.
+     */
+    @Test
+    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_withUpdateOnDataAdapter() {
+        nearCacheConfig.setInvalidateOnChange(true);
+        whenEntryIsChanged_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.PUT_ALL);
+    }
+
+    private void whenEntryIsChanged_thenNearCacheShouldBeInvalidated(boolean useNearCacheAdapter, DataStructureMethods method) {
+        assumeThatLocalUpdatePolicyIsInvalidate(nearCacheConfig);
+
         NearCacheTestContext<Integer, String, NK, NV> context = createContext();
         DataStructureAdapter<Integer, String> adapter = useNearCacheAdapter ? context.nearCacheAdapter : context.dataAdapter;
         assumeThatMethodIsAvailable(adapter, method);
@@ -420,17 +447,36 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
         populateNearCache(context);
 
         // this should invalidate the Near Cache
+        Map<Integer, String> invalidationMap = new HashMap<Integer, String>(DEFAULT_RECORD_COUNT);
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            if (method == DataStructureMethods.REPLACE_WITH_OLD_VALUE) {
-                assertTrue(adapter.replace(i, "value-" + i, "newValue-" + i));
-            } else {
-                assertEquals("value-" + i, adapter.replace(i, "newValue-" + i));
+            String value = "value-" + i;
+            String newValue = "newValue-" + i;
+            switch (method) {
+                case SET:
+                    adapter.set(i, newValue);
+                    break;
+                case PUT:
+                    assertEquals(value, adapter.put(i, newValue));
+                    break;
+                case REPLACE:
+                    assertEquals(value, adapter.replace(i, newValue));
+                    break;
+                case REPLACE_WITH_OLD_VALUE:
+                    assertTrue(adapter.replace(i, value, newValue));
+                    break;
+                case PUT_ALL:
+                    invalidationMap.put(i, newValue);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unexpected method: " + method);
             }
         }
+        if (method == DataStructureMethods.PUT_ALL) {
+            adapter.putAll(invalidationMap);
+        }
 
-        int expectedNearCacheSize = useNearCacheAdapter && isCacheOnUpdate(nearCacheConfig) ? DEFAULT_RECORD_COUNT : 0;
         String message = format("Invalidation is not working on %s()", method.getMethodName());
-        assertNearCacheSizeEventually(context, expectedNearCacheSize, message);
+        assertNearCacheSizeEventually(context, 0, message);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -42,6 +42,7 @@ import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UP
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
@@ -128,6 +129,16 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
         MapService service = nodeEngine.getService(MapService.SERVICE_NAME);
 
         return service.getMapServiceContext().getMapNearCacheManager();
+    }
+
+    /**
+     * Assumes that the given {@link NearCacheConfig} has
+     * {@link com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy#INVALIDATE} configured.
+     *
+     * @param nearCacheConfig the {@link NearCacheConfig} to test
+     */
+    public static void assumeThatLocalUpdatePolicyIsInvalidate(NearCacheConfig nearCacheConfig) {
+        assumeFalse(isCacheOnUpdate(nearCacheConfig));
     }
 
     /**


### PR DESCRIPTION
* added missing unified Near Cache tests for entry changing methods
  when `LocalUpdatePolicy.INVALIDATE` is configured
* added convenience method `assumeThatLocalUpdatePolicyIsInvalidate()`
  to `NearCacheTestUtils`
* removed unnecessary `@Override` method in `ClientCacheNearCacheBasicTest`

Depends on https://github.com/hazelcast/hazelcast/pull/10178

Part of https://github.com/hazelcast/hazelcast/issues/10127