### PR TITLE
Fixed possible race in serialization count tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
@@ -174,7 +174,9 @@ public class ClientCacheNearCacheSerializationCountTest extends AbstractNearCach
     private <K, V> CacheConfig<K, V> createCacheConfig(InMemoryFormat inMemoryFormat) {
         CacheConfig<K, V> cacheConfig = new CacheConfig<K, V>()
                 .setName(DEFAULT_NEAR_CACHE_NAME)
-                .setInMemoryFormat(inMemoryFormat);
+                .setInMemoryFormat(inMemoryFormat)
+                .setBackupCount(0)
+                .setAsyncBackupCount(0);
 
         if (inMemoryFormat == NATIVE) {
             cacheConfig.getEvictionConfig()

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
@@ -109,7 +109,9 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         Config config = getConfig();
         config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
-                .setInMemoryFormat(mapInMemoryFormat);
+                .setInMemoryFormat(mapInMemoryFormat)
+                .setBackupCount(0)
+                .setAsyncBackupCount(0);
         prepareSerializationConfig(config.getSerializationConfig());
 
         ClientConfig clientConfig = getClientConfig();

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheSerializationCountTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheSizeEventually;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.isCacheOnUpdate;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.warmupPartitionsAndWaitForAllSafeState;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
@@ -108,6 +109,8 @@ public abstract class AbstractNearCacheSerializationCountTest<NK, NV> extends Ha
     @Test
     public void testSerializationCounts() {
         NearCacheTestContext<String, SerializationCountingData, NK, NV> context = createContext();
+        warmupPartitionsAndWaitForAllSafeState(context);
+
         String key = randomString();
         SerializationCountingData value = new SerializationCountingData();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -205,6 +205,18 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
     }
 
     /**
+     * Calls {@link HazelcastTestSupport#warmUpPartitions(HazelcastInstance...)} and
+     * {@link HazelcastTestSupport#waitAllForSafeState(HazelcastInstance...)} on the instances of the given
+     * {@link NearCacheTestContext}.
+     *
+     * @param context the given {@link NearCacheTestContext} to retrieve the Hazelcast instances from
+     */
+    public static void warmupPartitionsAndWaitForAllSafeState(NearCacheTestContext<?, ?, ?, ?> context) {
+        warmUpPartitions(context.dataInstance, context.nearCacheInstance);
+        waitAllForSafeState(context.dataInstance, context.nearCacheInstance);
+    }
+
+    /**
      * Asserts the number of evicted entries of a {@link NearCache}.
      *
      * @param context       the {@link NearCacheTestContext} to retrieve the eviction count from

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
@@ -132,7 +132,9 @@ public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCa
         Config config = getConfig()
                 .setLiteMember(liteMember);
         MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
-                .setInMemoryFormat(mapInMemoryFormat);
+                .setInMemoryFormat(mapInMemoryFormat)
+                .setBackupCount(0)
+                .setAsyncBackupCount(0);
         if (nearCacheConfig != null) {
             mapConfig.setNearCacheConfig(nearCacheConfig);
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
@@ -77,9 +77,9 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
                 {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY},
                 {new int[]{1, 0, 0}, new int[]{0, 1, 0}, BINARY, OBJECT},
 
-                {new int[]{1, 1, 1}, new int[]{2, 1, 1}, OBJECT, null},
-                {new int[]{1, 1, 0}, new int[]{2, 1, 1}, OBJECT, BINARY},
-                {new int[]{1, 1, 0}, new int[]{2, 1, 0}, OBJECT, OBJECT},
+                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null},
+                {new int[]{1, 1, 0}, new int[]{1, 1, 1}, OBJECT, BINARY},
+                {new int[]{1, 1, 0}, new int[]{1, 1, 0}, OBJECT, OBJECT},
         });
     }
 
@@ -110,7 +110,9 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         Config config = getConfig();
         MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
-                .setInMemoryFormat(mapInMemoryFormat);
+                .setInMemoryFormat(mapInMemoryFormat)
+                .setBackupCount(0)
+                .setAsyncBackupCount(0);
         if (nearCacheConfig != null) {
             mapConfig.setNearCacheConfig(nearCacheConfig);
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
@@ -75,9 +75,9 @@ public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSeri
                 {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, BINARY,},
                 {new int[]{1, 0, 0}, new int[]{0, 1, 1}, BINARY, OBJECT,},
 
-                {new int[]{1, 1, 1}, new int[]{2, 1, 1}, OBJECT, null,},
-                {new int[]{1, 1, 1}, new int[]{2, 1, 1}, OBJECT, BINARY,},
-                {new int[]{1, 1, 1}, new int[]{2, 1, 1}, OBJECT, OBJECT,},
+                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, null,},
+                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, BINARY,},
+                {new int[]{1, 1, 1}, new int[]{1, 1, 1}, OBJECT, OBJECT,},
         });
     }
 
@@ -110,7 +110,9 @@ public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSeri
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         Config config = getConfig();
         MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
-                .setInMemoryFormat(mapInMemoryFormat);
+                .setInMemoryFormat(mapInMemoryFormat)
+                .setBackupCount(0)
+                .setAsyncBackupCount(0);
         if (nearCacheConfig != null) {
             mapConfig.setNearCacheConfig(nearCacheConfig);
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -611,11 +611,10 @@ public abstract class HazelcastTestSupport {
 
     public static void waitAllForSafeState(HazelcastInstance... nodes) {
         if (nodes.length == 0) {
-            throw new IllegalArgumentException("waitAllForSafeState(HazelcastInstance... nodes) cannot be called with " +
-                    "an empty array. " +
-                    "It's too easy to mistake it for the old argument-less waitAllForSafeState(). " +
-                    "The old version was removed as it was implemented via Hazelcast.getAllHazelcastInstances() " +
-                    "- this uses a static map internally and it's causing issues when tests are running in parallel.");
+            throw new IllegalArgumentException("waitAllForSafeState(HazelcastInstance... nodes) cannot be called with"
+                    + " an empty array. It's too easy to mistake it for the old argument-less waitAllForSafeState()."
+                    + " The old version was removed as it was implemented via Hazelcast.getAllHazelcastInstances()"
+                    + " which uses a static map internally and it's causing issues when tests are running in parallel.");
         }
         waitAllForSafeState(asList(nodes));
     }


### PR DESCRIPTION
There are very spurious failures on the serialization count tests, due to a `MapReplicationOperation` which triggers an additional serialization. This PR removes backups from the tests, waits for the partition initialization and a safe cluster state. This should prevent those random partition migrations during the test.

Example of a failure on `com.hazelcast.map.impl.nearcache.MapNearCacheSerializationCountTest.testSerializationCounts[mapFormat:OBJECT nearCacheFormat:OBJECT]`:
```
serializeCount on put(): expected 1, but was 2
[com.hazelcast.nio.serialization.HazelcastSerializationException: invoked serialization
 at com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest$SerializationCountingData.getStackTrace(AbstractNearCacheSerializationCountTest.java:191)
 at com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest$SerializationCountingData.writePortable(AbstractNearCacheSerializationCountTest.java:179)
 at com.hazelcast.internal.serialization.impl.PortableSerializer.writeInternal(PortableSerializer.java:69)
 at com.hazelcast.internal.serialization.impl.PortableSerializer.write(PortableSerializer.java:60)
 at com.hazelcast.internal.serialization.impl.PortableSerializer.write(PortableSerializer.java:34)
 at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.write(StreamSerializerAdapter.java:43)
 at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:151)
 at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:135)
 at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toData(AbstractSerializationService.java:119)
 at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toData(AbstractSerializationService.java:107)
 at com.hazelcast.spi.impl.NodeEngineImpl.toData(NodeEngineImpl.java:350)
 at com.hazelcast.spi.AbstractDistributedObject.toData(AbstractDistributedObject.java:67)
 at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:127)
 at com.hazelcast.map.impl.proxy.MapProxyImpl.put(MapProxyImpl.java:118)
 at com.hazelcast.internal.adapter.IMapDataStructureAdapter.put(IMapDataStructureAdapter.java:46)
 at com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest.testSerializationCounts(AbstractNearCacheSerializationCountTest.java:114)
 at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
 at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
 at java.lang.reflect.Method.invoke(Method.java:597)
 at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
 at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
 at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
 at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
 at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:105)
 at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:97)
 at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
 at java.util.concurrent.FutureTask.run(FutureTask.java:138)
 at java.lang.Thread.run(Thread.java:662)
, com.hazelcast.nio.serialization.HazelcastSerializationException: invoked serialization
 at com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest$SerializationCountingData.getStackTrace(AbstractNearCacheSerializationCountTest.java:191)
 at com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest$SerializationCountingData.writePortable(AbstractNearCacheSerializationCountTest.java:179)
 at com.hazelcast.internal.serialization.impl.PortableSerializer.writeInternal(PortableSerializer.java:69)
 at com.hazelcast.internal.serialization.impl.PortableSerializer.write(PortableSerializer.java:60)
 at com.hazelcast.internal.serialization.impl.PortableSerializer.write(PortableSerializer.java:34)
 at com.hazelcast.internal.serialization.impl.StreamSerializerAdapter.write(StreamSerializerAdapter.java:43)
 at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:151)
 at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toBytes(AbstractSerializationService.java:135)
 at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toData(AbstractSerializationService.java:119)
 at com.hazelcast.internal.serialization.impl.AbstractSerializationService.toData(AbstractSerializationService.java:107)
 at com.hazelcast.spi.impl.NodeEngineImpl.toData(NodeEngineImpl.java:350)
 at com.hazelcast.map.impl.MapServiceContextImpl.toData(MapServiceContextImpl.java:461)
 at com.hazelcast.map.impl.operation.MapReplicationOperation.createRecordReplicationInfo(MapReplicationOperation.java:89)
 at com.hazelcast.map.impl.operation.MapReplicationStateHolder.prepare(MapReplicationStateHolder.java:86)
 at com.hazelcast.map.impl.operation.MapReplicationOperation.<init>(MapReplicationOperation.java:54)
 at com.hazelcast.map.impl.MapMigrationAwareService.prepareReplicationOperation(MapMigrationAwareService.java:68)
 at com.hazelcast.spi.impl.CountingMigrationAwareService.prepareReplicationOperation(CountingMigrationAwareService.java:49)
 at com.hazelcast.map.impl.MapService.prepareReplicationOperation(MapService.java:117)
 at com.hazelcast.internal.partition.operation.ReplicaSyncRequest.createReplicationOperations(ReplicaSyncRequest.java:168)
 at com.hazelcast.internal.partition.operation.ReplicaSyncRequest.run(ReplicaSyncRequest.java:97)
 at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:186)
 at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:401)
 at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:117)
 at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.run(OperationThread.java:102)
] expected:<1> but was:<2>
```
https://hazelcast-l337.ci.cloudbees.com/job/new-lab-fast-pr/7933/testReport/junit/com.hazelcast.map.impl.nearcache/MapNearCacheSerializationCountTest/testSerializationCounts_mapFormat_OBJECT_nearCacheFormat_OBJECT_/

This also fixed the expected serialization counts for `OBJECT` in-memory-format for `IMap` and `TransactionalMap`. The intent of these tests were to count the serializations in the proxies, not the surrounding infrastructure.