### PR TITLE
Fixed assertion on same NearCacheStats instance

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -1261,7 +1261,6 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
                            Collection<UUID> partitionUuids, Collection<Long> sequences) {
         }
 
-
         @Override
         public void beforeListenerRegister() {
         }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/NearCacheStatsImpl.java
@@ -66,6 +66,24 @@ public class NearCacheStatsImpl implements NearCacheStats {
         this.creationTime = Clock.currentTimeMillis();
     }
 
+    public NearCacheStatsImpl(NearCacheStats nearCacheStats) {
+        NearCacheStatsImpl stats = (NearCacheStatsImpl) nearCacheStats;
+        creationTime = stats.creationTime;
+        ownedEntryCount = stats.ownedEntryCount;
+        ownedEntryMemoryCost = stats.ownedEntryMemoryCost;
+        hits = stats.hits;
+        misses = stats.misses;
+        evictions = stats.evictions;
+        expirations = stats.expirations;
+
+        persistenceCount = stats.persistenceCount;
+        lastPersistenceTime = stats.lastPersistenceTime;
+        lastPersistenceDuration = stats.lastPersistenceDuration;
+        lastPersistenceWrittenBytes = stats.lastPersistenceWrittenBytes;
+        lastPersistenceKeyCount = stats.lastPersistenceKeyCount;
+        lastPersistenceFailure = stats.lastPersistenceFailure;
+    }
+
     @Override
     public long getCreationTime() {
         return creationTime;

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -30,6 +30,7 @@ import com.hazelcast.internal.adapter.ReplicatedMapDataStructureAdapter;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -307,7 +308,7 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
     public static void assertNearCacheStats(NearCacheTestContext<?, ?, ?, ?> context,
                                             long expectedOwnedEntryCount, long expectedHits, long expectedMisses,
                                             long expectedEvictions, long expectedExpirations) {
-        NearCacheStats stats = context.stats;
+        NearCacheStats stats = new NearCacheStatsImpl(context.stats);
 
         assertEqualsFormat("Near Cache entry count should be %d, but was %d (%s)",
                 expectedOwnedEntryCount, stats.getOwnedEntryCount(), stats);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
@@ -259,7 +259,6 @@ public class NearCacheTest extends NearCacheTestSupport {
         // make some hits
         populateNearCache(map, mapSize);
 
-        stats = getNearCacheStats(map);
         long hits = stats.getHits();
         misses = stats.getMisses();
         long hitsAndMisses = hits + misses;

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/NearCacheStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/NearCacheStatsImplTest.java
@@ -78,6 +78,13 @@ public class NearCacheStatsImplTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testCopyConstructor() {
+        NearCacheStatsImpl copy = new NearCacheStatsImpl(nearCacheStats);
+
+        assertNearCacheStats(copy, 1, 200, 300, 400, false);
+    }
+
+    @Test
     public void testSerialization() {
         NearCacheStatsImpl deserialized = serializeAndDeserializeNearCacheStats(nearCacheStats);
 


### PR DESCRIPTION
We had the following spurious failure in `com.hazelcast.client.map.impl.nearcache.ClientMapNearCacheTest.testNearCacheMaxIdleRecordsExpired[batchInvalidationEnabled:true]`:
```
we expected to have all map entries in the Near Cache or already expired (NearCacheStatsImpl{ownedEntryCount=3530, ownedEntryMemoryCost=494200, creationTime=1491229736166, hits=0, misses=5000, ratio=0.0%, evictions=0, expirations=1469, lastPersistenceTime=0, persistenceCount=0, lastPersistenceDuration=0, lastPersistenceWrittenBytes=0, lastPersistenceKeyCount=0, lastPersistenceFailure=''})
```
https://hazelcast-l337.ci.cloudbees.com/job/new-lab-fast-pr/7972/testReport/junit/com.hazelcast.client.map.impl.nearcache/ClientMapNearCacheTest/testNearCacheMaxIdleRecordsExpired_batchInvalidationEnabled_true_/

I think we have two issues with this test:

* The `map.getLocalMapStats().getNearCacheStats()` always returns the same instance of the `NearCacheStatsImpl`. So it makes no sense to get a "before something" `NearCacheStats` and compare the same field with an instance which is fetched later. To fix this I've added a copy constructor to the `NearCacheStatsImpl` and fixed the tests accordingly. I've added the method `getNearCacheStatsCopy()` for convenient access.

* The other issue is that two values in the stats are never updated in an atomic operation. In the test we have eviction enabled, so at some point in time we decrease the `ownedEntryCount` and increase the `evictionCount` after each other. We also read those two values after each other for the assert. So in the given failure we had a total value of 4999 instead of the wanted 5000. To fix this I used `assertTrueEventually()` to check for the summed value.