### PR TITLE
Added forced cleanup of LeakingApplication in ThreadLocalLeakTest

### DIFF
--- a/hazelcast/src/test/java/classloading/LeakingApplication.java
+++ b/hazelcast/src/test/java/classloading/LeakingApplication.java
@@ -28,8 +28,12 @@ public final class LeakingApplication {
     public static void init(Boolean doCleanup) {
         ThreadLocalRandom.localRandom.get();
         if (doCleanup) {
-            ThreadLocalRandom.localRandom.remove();
+            cleanup();
         }
+    }
+
+    public static void cleanup() {
+        ThreadLocalRandom.localRandom.remove();
     }
 
     private static class ThreadLocalRandom extends Random {


### PR DESCRIPTION
I seems that the new `ThreadLocalLeakTest` crashes the master build with a `PermGen space OOME`. This PR adds a forced cleanup of the `LeakingApplication`.