### PR TITLE
Added unified Near Cache tests for EntryProcessor methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
@@ -20,6 +20,9 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.monitor.LocalMapStats;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,6 +53,12 @@ public interface DataStructureAdapter<K, V> {
 
     ICompletableFuture<V> removeAsync(K key);
 
+    <T> T invoke(K key, EntryProcessor<K, V, T> entryProcessor, Object... arguments) throws EntryProcessorException;
+
+    Object executeOnKey(K key, com.hazelcast.map.EntryProcessor entryProcessor);
+
+    Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor);
+
     boolean containsKey(K key);
 
     Map<K, V> getAll(Set<K> keys);
@@ -59,6 +68,9 @@ public interface DataStructureAdapter<K, V> {
     void removeAll();
 
     void removeAll(Set<K> keys);
+
+    <T> Map<K, EntryProcessorResult<T>> invokeAll(Set<? extends K> keys, EntryProcessor<K, V, T> entryProcessor,
+                                                  Object... arguments);
 
     void clear();
 
@@ -79,11 +91,15 @@ public interface DataStructureAdapter<K, V> {
         REMOVE("remove", Object.class),
         REMOVE_WITH_OLD_VALUE("remove", Object.class, Object.class),
         REMOVE_ASYNC("removeAsync", Object.class),
+        INVOKE("invoke", Object.class, EntryProcessor.class, Object[].class),
+        EXECUTE_ON_KEY("executeOnKey", Object.class, com.hazelcast.map.EntryProcessor.class),
+        EXECUTE_ON_KEYS("executeOnKeys", Set.class, com.hazelcast.map.EntryProcessor.class),
         CONTAINS_KEY("containsKey", Object.class),
         GET_ALL("getAll", Set.class),
         PUT_ALL("putAll", Map.class),
         REMOVE_ALL("removeAll"),
         REMOVE_ALL_WITH_KEYS("removeAll", Set.class),
+        INVOKE_ALL("invokeAll", Set.class, EntryProcessor.class, Object[].class),
         CLEAR("clear"),
         GET_LOCAL_MAP_STATS("getLocalMapStats");
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
@@ -20,6 +20,9 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.monitor.LocalMapStats;
 
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
 
@@ -87,6 +90,23 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     }
 
     @Override
+    public <T> T invoke(K key, EntryProcessor<K, V, T> entryProcessor, Object... arguments) throws EntryProcessorException {
+        return cache.invoke(key, entryProcessor, arguments);
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Object executeOnKey(K key, com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
     public boolean containsKey(K key) {
         return cache.containsKey(key);
     }
@@ -109,6 +129,12 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     @Override
     public void removeAll(Set<K> keys) {
         cache.removeAll(keys);
+    }
+
+    @Override
+    public <T> Map<K, EntryProcessorResult<T>> invokeAll(Set<? extends K> keys, EntryProcessor<K, V, T> entryProcessor,
+                                                         Object... arguments) {
+        return cache.invokeAll(keys, entryProcessor, arguments);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
@@ -21,6 +21,9 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.TruePredicate;
 
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.EntryProcessorResult;
 import java.util.Map;
 import java.util.Set;
 
@@ -89,6 +92,22 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     }
 
     @Override
+    @MethodNotAvailable
+    public <T> T invoke(K key, EntryProcessor<K, V, T> entryProcessor, Object... arguments) throws EntryProcessorException {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    public Object executeOnKey(K key, com.hazelcast.map.EntryProcessor entryProcessor) {
+        return map.executeOnKey(key, entryProcessor);
+    }
+
+    @Override
+    public Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor) {
+        return map.executeOnKeys(keys, entryProcessor);
+    }
+
+    @Override
     public boolean containsKey(K key) {
         return map.containsKey(key);
     }
@@ -112,6 +131,13 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     @Override
     @MethodNotAvailable
     public void removeAll(final Set<K> keys) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public <T> Map<K, EntryProcessorResult<T>> invokeAll(Set<? extends K> keys, EntryProcessor<K, V, T> entryProcessor,
+                                                         Object... arguments) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -20,6 +20,9 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.monitor.LocalMapStats;
 
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.EntryProcessorResult;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -94,6 +97,24 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     }
 
     @Override
+    @MethodNotAvailable
+    public <T> T invoke(K key, EntryProcessor<K, V, T> entryProcessor, Object... arguments) throws EntryProcessorException {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Object executeOnKey(K key, com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
     public boolean containsKey(K key) {
         return map.containsKey(key);
     }
@@ -121,6 +142,13 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     @Override
     @MethodNotAvailable
     public void removeAll(Set<K> keys) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public <T> Map<K, EntryProcessorResult<T>> invokeAll(Set<? extends K> keys, EntryProcessor<K, V, T> entryProcessor,
+                                                         Object... arguments) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
@@ -22,6 +22,9 @@ import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.transaction.TransactionContext;
 
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.EntryProcessorResult;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -120,6 +123,24 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
     }
 
     @Override
+    @MethodNotAvailable
+    public <T> T invoke(K key, EntryProcessor<K, V, T> entryProcessor, Object... arguments) throws EntryProcessorException {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Object executeOnKey(K key, com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public Map<K, Object> executeOnKeys(Set<K> keys, com.hazelcast.map.EntryProcessor entryProcessor) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
     public Map<K, V> getAll(Set<K> keys) {
         begin();
         Map<K, V> result = new HashMap<K, V>(keys.size());
@@ -148,6 +169,13 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
     @Override
     @MethodNotAvailable
     public void removeAll(Set<K> keys) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
+    public <T> Map<K, EntryProcessorResult<T>> invokeAll(Set<? extends K> keys, EntryProcessor<K, V, T> entryProcessor,
+                                                         Object... arguments) {
         throw new MethodNotAvailableException();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheReplaceEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ICacheReplaceEntryProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.adapter;
+
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.MutableEntry;
+import java.io.Serializable;
+
+public class ICacheReplaceEntryProcessor implements EntryProcessor<Integer, String, String>, Serializable {
+
+    private static final long serialVersionUID = -396575576353368113L;
+
+    @Override
+    public String process(MutableEntry<Integer, String> entry, Object... arguments) throws EntryProcessorException {
+        String value = entry.getValue();
+        if (value == null) {
+            return null;
+        }
+
+        String oldString = (String) arguments[0];
+        String newString = (String) arguments[1];
+        String result = value.replace(oldString, newString);
+        entry.setValue(result);
+        return result;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapReplaceEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapReplaceEntryProcessor.java
@@ -1,0 +1,36 @@
+package com.hazelcast.internal.adapter;
+
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
+
+import java.util.Map;
+
+public class IMapReplaceEntryProcessor implements EntryProcessor<Integer, String> {
+
+    private static final long serialVersionUID = -4826323876651981295L;
+
+    private final String oldString;
+    private final String newString;
+
+    public IMapReplaceEntryProcessor(String oldString, String newString) {
+        this.oldString = oldString;
+        this.newString = newString;
+    }
+
+    @Override
+    public Object process(Map.Entry<Integer, String> entry) {
+        String value = entry.getValue();
+        if (value == null) {
+            return null;
+        }
+
+        String result = value.replace(oldString, newString);
+        entry.setValue(result);
+        return result;
+    }
+
+    @Override
+    public EntryBackupProcessor<Integer, String> getBackupProcessor() {
+        return null;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
@@ -29,8 +29,11 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -121,6 +124,22 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
         adapter.removeAsync(23);
     }
 
+    @Test(expected = MethodNotAvailableException.class)
+    public void testInvoke() {
+        adapter.invoke(23, new ICacheReplaceEntryProcessor(), "value", "newValue");
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnKey() {
+        adapter.executeOnKey(23, new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnKeys() {
+        Set<Integer> keys = new HashSet<Integer>(singleton(23));
+        adapter.executeOnKeys(keys, new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
     @Test
     public void testContainsKey() {
         map.put(23, "value-23");
@@ -164,6 +183,12 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
     @Test(expected = MethodNotAvailableException.class)
     public void testRemoveAllWithKeys() {
         adapter.removeAll(singleton(42));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testInvokeAll() {
+        Set<Integer> keys = new HashSet<Integer>(asList(23, 65, 88));
+        adapter.invokeAll(keys, new ICacheReplaceEntryProcessor(), "value", "newValue");
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapterTest.java
@@ -29,8 +29,11 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -144,6 +147,22 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
         adapter.removeAsync(23);
     }
 
+    @Test(expected = MethodNotAvailableException.class)
+    public void testInvoke() {
+        adapter.invoke(23, new ICacheReplaceEntryProcessor(), "value", "newValue");
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnKey() {
+        adapter.executeOnKey(23, new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testExecuteOnKeys() {
+        Set<Integer> keys = new HashSet<Integer>(singleton(23));
+        adapter.executeOnKeys(keys, new IMapReplaceEntryProcessor("value", "newValue"));
+    }
+
     @Test
     public void testContainsKey() {
         map.put(23, "value-23");
@@ -187,6 +206,12 @@ public class TransactionalMapDataStructureAdapterTest extends HazelcastTestSuppo
     @Test(expected = MethodNotAvailableException.class)
     public void testRemoveAllWithKeys() {
         adapter.removeAll(singleton(42));
+    }
+
+    @Test(expected = MethodNotAvailableException.class)
+    public void testInvokeAll() {
+        Set<Integer> keys = new HashSet<Integer>(asList(23, 65, 88));
+        adapter.invokeAll(keys, new ICacheReplaceEntryProcessor(), "value", "newValue");
     }
 
     @Test


### PR DESCRIPTION
* added `EntryProcessor` related methods to `DataStructureAdapter`
* added unified Near Cache tests for invalidations via `EntryProcessor`s
* added unified Near Cache tests for population via `EntryProcessor`s

To ease the review I kept the original three commits.

Part of https://github.com/hazelcast/hazelcast/issues/10127