### PR TITLE
Add projection and filtering support for map iterator

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapPartitionIterator.java
@@ -24,12 +24,20 @@ import com.hazelcast.client.proxy.ClientMapProxy;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
+import com.hazelcast.core.IMap;
 import com.hazelcast.map.impl.iterator.AbstractMapPartitionIterator;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.List;
 
+/**
+ * Iterator for iterating map entries in the {@code partitionId}. The values are not fetched one-by-one but rather in batches.
+ * <b>NOTE</b>
+ * Iterating the map should be done only when the {@link IMap} is not being
+ * mutated and the cluster is stable (there are no migrations or membership changes).
+ * In other cases, the iterator may not return some entries or may return an entry twice.
+ */
 public class ClientMapPartitionIterator<K, V> extends AbstractMapPartitionIterator<K, V> {
 
     private final ClientMapProxy<K, V> mapProxy;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapQueryPartitionIterator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/ClientMapQueryPartitionIterator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl;
+
+import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapFetchWithQueryCodec;
+import com.hazelcast.client.proxy.ClientMapProxy;
+import com.hazelcast.client.spi.ClientContext;
+import com.hazelcast.client.spi.impl.ClientInvocation;
+import com.hazelcast.client.spi.impl.ClientInvocationFuture;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.iterator.AbstractMapQueryPartitionIterator;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+/**
+ * Iterator for iterating map entries in the {@code partitionId}. The values are not fetched one-by-one but rather in batches.
+ * The {@link Iterator#remove()} method is not supported and will throw an {@link UnsupportedOperationException}.
+ * <b>NOTE</b>
+ * Iterating the map should be done only when the {@link IMap} is not being
+ * mutated and the cluster is stable (there are no migrations or membership changes).
+ * In other cases, the iterator may not return some entries or may return an entry twice.
+ */
+public class ClientMapQueryPartitionIterator<K, V, R> extends AbstractMapQueryPartitionIterator<K, V, R> {
+
+    private final ClientMapProxy<K, V> mapProxy;
+    private final ClientContext context;
+
+    public ClientMapQueryPartitionIterator(ClientMapProxy<K, V> mapProxy, ClientContext context, int fetchSize,
+                                           int partitionId, Predicate<K, V> predicate, Projection<Entry<K, V>, R> projection) {
+        super(mapProxy, fetchSize, partitionId, predicate, projection);
+        this.mapProxy = mapProxy;
+        this.context = context;
+    }
+
+    @Override
+    protected List<Data> fetch() {
+        final HazelcastClientInstanceImpl client = (HazelcastClientInstanceImpl) context.getHazelcastInstance();
+        final ClientMessage request = MapFetchWithQueryCodec.encodeRequest(mapProxy.getName(), lastTableIndex, fetchSize,
+                getSerializationService().toData(query.getProjection()),
+                getSerializationService().toData(query.getPredicate()));
+        final ClientInvocation clientInvocation = new ClientInvocation(client, request, partitionId);
+        try {
+            final ClientInvocationFuture f = clientInvocation.invoke();
+            final MapFetchWithQueryCodec.ResponseParameters responseParameters = MapFetchWithQueryCodec.decodeResponse(f.get());
+
+            final List<Data> results = responseParameters.results;
+
+            setLastTableIndex(results, responseParameters.nextTableIndexToReadFrom);
+            return results;
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
+        }
+    }
+
+    @Override
+    protected SerializationService getSerializationService() {
+        return context.getSerializationService();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapQueryPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractMapQueryPartitionIteratorTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.proxy.ClientMapProxy;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractMapQueryPartitionIteratorTest extends HazelcastTestSupport {
+
+    protected TestHazelcastFactory factory;
+    protected HazelcastInstance server;
+    protected HazelcastInstance client;
+
+    @After
+    public void teardown() {
+        factory.terminateAll();
+    }
+
+
+    @Test(expected = NoSuchElementException.class)
+    public void test_next_Throws_Exception_On_EmptyPartition() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate()).next();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_null_projection_throws_exception() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        proxy.iterator(10, 1, null, TruePredicate.<String, String>truePredicate());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_null_predicate_throws_exception() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        proxy.iterator(10, 1, new TestProjection(), null);
+    }
+
+    @Test
+    public void test_HasNext_Returns_False_On_EmptyPartition() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void test_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        String key = generateKeyForPartition(server, 1);
+        String value = randomString();
+        proxy.put(key, value);
+
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new GetValueProjection<String>(), TruePredicate.<String, String>truePredicate());
+        final String next = iterator.next();
+        assertEquals(value, next);
+    }
+
+    @Test
+    public void test_Next_Returns_Value_On_NonEmptyPartition_and_HasNext_Returns_False_when_Item_Consumed() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        String key = generateKeyForPartition(server, 1);
+        String value = randomString();
+        proxy.put(key, value);
+
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new GetValueProjection<String>(), TruePredicate.<String, String>truePredicate());
+        final String next = iterator.next();
+        assertEquals(value, next);
+        boolean hasNext = iterator.hasNext();
+        assertFalse(hasNext);
+    }
+
+    @Test
+    public void test_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        final String key = generateKeyForPartition(server, 1);
+        final String value = randomString();
+        proxy.put(key, value);
+
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate());
+        assertTrue(iterator.hasNext());
+    }
+
+
+    @Test
+    public void test_with_projection_and_true_predicate() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        for (int i = 0; i < 100; i++) {
+            String key = generateKeyForPartition(server, 1);
+            proxy.put(key, randomString());
+        }
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate());
+
+        final ArrayList<String> projected = collectAll(iterator);
+
+        final Collection<String> actualValues = proxy.values();
+        assertEquals(actualValues.size(), projected.size());
+
+        for (String value : actualValues) {
+            assertTrue(projected.contains("dummy" + value));
+        }
+    }
+
+    @Test
+    public void test_with_projection_and_predicate() throws Exception {
+        final ClientMapProxy<String, Integer> intMap = getMapProxy();
+
+        for (int i = 0; i < 100; i++) {
+            String key = generateKeyForPartition(server, 1);
+            intMap.put(key, i);
+        }
+
+        final Iterator<Map.Entry<String, Integer>> iterator = intMap.iterator(10, 1,
+                new IdentityProjection<Entry<String, Integer>>(),
+                new EvenPredicate());
+
+        final ArrayList<Map.Entry<String, Integer>> projected = collectAll(iterator);
+        for (Map.Entry<String, Integer> i : projected) {
+            assertTrue(i.getValue() % 2 == 0);
+        }
+
+
+        final Collection<Integer> actualValues = intMap.values();
+        assertEquals(actualValues.size() / 2, projected.size());
+
+
+        for (Entry<String, Integer> e : intMap.entrySet()) {
+            if (e.getValue() % 2 == 0) {
+                assertTrue(projected.contains(e));
+            }
+        }
+    }
+
+    private <T> ArrayList<T> collectAll(Iterator<T> iterator) {
+        final ArrayList<T> projected = new ArrayList<T>();
+        while (iterator.hasNext()) {
+            projected.add(iterator.next());
+        }
+        return projected;
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void test_remove_Throws_Exception() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate());
+
+        iterator.remove();
+    }
+
+    @Test
+    public void test_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
+        final ClientMapProxy<String, String> proxy = getMapProxy();
+        String value = randomString();
+        for (int i = 0; i < 100; i++) {
+            String key = generateKeyForPartition(server, 1);
+            proxy.put(key, value);
+        }
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new GetValueProjection<String>(), TruePredicate.<String, String>truePredicate());
+        for (int i = 0; i < 100; i++) {
+            String val = iterator.next();
+            assertEquals(value, val);
+        }
+    }
+
+    private <K, V> ClientMapProxy<K, V> getMapProxy() {
+        String mapName = randomString();
+        return (ClientMapProxy<K, V>) client.getMap(mapName);
+    }
+
+    private static class EvenPredicate implements Predicate<String, Integer> {
+        @Override
+        public boolean apply(Entry<String, Integer> mapEntry) {
+            return mapEntry.getValue() % 2 == 0;
+        }
+    }
+
+    private static class TestProjection extends Projection<Entry<String, String>, String> {
+        @Override
+        public String transform(Map.Entry<String, String> input) {
+            return "dummy" + input.getValue();
+        }
+    }
+
+    private static class GetValueProjection<T> extends Projection<Entry<String, T>, T> {
+        @Override
+        public T transform(Map.Entry<String, T> input) {
+            return input.getValue();
+        }
+    }
+
+    private static class IdentityProjection<T> extends Projection<T, T> {
+        @Override
+        public T transform(T input) {
+            return input;
+        }
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapQueryPartitionIteratorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMapQueryPartitionIteratorTest extends AbstractMapQueryPartitionIteratorTest {
+
+    @Before
+    public void setup() {
+        Config config = getConfig();
+        factory = new TestHazelcastFactory();
+        server = factory.newHazelcastInstance(config);
+        client = factory.newHazelcastClient();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapQueryPartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/DummyClientMapQueryPartitionIteratorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DummyClientMapQueryPartitionIteratorTest extends AbstractMapQueryPartitionIteratorTest {
+
+    @Before
+    public void setup() {
+        factory = new TestHazelcastFactory();
+
+        Config config = getConfig();
+        server = factory.newHazelcastInstance(config);
+        factory.newHazelcastInstance(config);
+
+        client = factory.newHazelcastClient(getClientConfig(server));
+    }
+
+    private static ClientConfig getClientConfig(HazelcastInstance instance) {
+        Address address = instance.getCluster().getLocalMember().getAddress();
+        String addressString = address.getHost() + ":" + address.getPort();
+        ClientConfig clientConfig = new ClientConfig();
+        ClientNetworkConfig networkConfig = new ClientNetworkConfig();
+        networkConfig.setSmartRouting(false);
+        networkConfig.addAddress(addressString);
+        clientConfig.setNetworkConfig(networkConfig);
+        return clientConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -1595,6 +1595,11 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
                 return new MapProjectionWithPredicateMessageTask(clientMessage, node, connection);
             }
         };
+        factories[com.hazelcast.client.impl.protocol.codec.MapFetchWithQueryCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new com.hazelcast.client.impl.protocol.task.map.MapFetchWithQueryMessageTask(clientMessage, node, connection);
+            }
+        };
 //endregion
 //region ----------  REGISTRATION FOR com.hazelcast.client.impl.protocol.task
         factories[com.hazelcast.client.impl.protocol.codec.ClientAddPartitionLostListenerCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchEntriesMessageTask.java
@@ -53,7 +53,7 @@ public class MapFetchEntriesMessageTask extends AbstractMapPartitionMessageTask<
         }
         MapEntriesWithCursor mapEntriesWithCursor = (MapEntriesWithCursor) response;
         return MapFetchEntriesCodec.encodeResponse(mapEntriesWithCursor.getNextTableIndexToReadFrom(),
-                mapEntriesWithCursor.getEntries());
+                mapEntriesWithCursor.getBatch());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchKeysMessageTask.java
@@ -51,7 +51,7 @@ public class MapFetchKeysMessageTask extends AbstractMapPartitionMessageTask<Map
             return MapFetchKeysCodec.encodeResponse(0, Collections.<Data>emptyList());
         }
         MapKeysWithCursor mapKeysWithCursor = (MapKeysWithCursor) response;
-        return MapFetchKeysCodec.encodeResponse(mapKeysWithCursor.getNextTableIndexToReadFrom(), mapKeysWithCursor.getKeys());
+        return MapFetchKeysCodec.encodeResponse(mapKeysWithCursor.getNextTableIndexToReadFrom(), mapKeysWithCursor.getBatch());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchWithQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchWithQueryMessageTask.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.map;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapFetchWithQueryCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.operation.MapOperationProvider;
+import com.hazelcast.map.impl.query.Query;
+import com.hazelcast.map.impl.query.QueryResult;
+import com.hazelcast.map.impl.query.QueryResultRow;
+import com.hazelcast.map.impl.query.ResultSegment;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.MapPermission;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.util.IterationType;
+
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Fetches by query a batch of items from a single partition ID for a map. The query is run by the query
+ * engine which means it supports projections and filtering.
+ *
+ * @see com.hazelcast.map.impl.proxy.MapProxyImpl#iterator(int, int, Projection, Predicate)
+ * @since 3.9
+ */
+public class MapFetchWithQueryMessageTask extends AbstractMapPartitionMessageTask<MapFetchWithQueryCodec.RequestParameters> {
+    public MapFetchWithQueryMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
+            throw new UnsupportedOperationException("Iterate map by query is available when cluster version is 3.9 or higher");
+        }
+        final MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
+        final Projection<?, ?> projection = nodeEngine.getSerializationService().toObject(parameters.projection);
+        final Predicate predicate = nodeEngine.getSerializationService().toObject(parameters.predicate);
+        final Query query = Query.of()
+                                 .mapName(parameters.name)
+                                 .iterationType(IterationType.VALUE)
+                                 .predicate(predicate)
+                                 .projection(projection)
+                                 .build();
+
+        return operationProvider.createFetchWithQueryOperation(parameters.name, parameters.tableIndex, parameters.batch, query);
+    }
+
+    @Override
+    protected MapFetchWithQueryCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return MapFetchWithQueryCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        final ResultSegment resp = (ResultSegment) response;
+        final QueryResult queryResult = (QueryResult) resp.getResult();
+
+        final List<Data> serialized = new ArrayList<Data>(queryResult.size());
+        for (QueryResultRow row : queryResult) {
+            serialized.add(row.getValue());
+        }
+
+        return MapFetchWithQueryCodec.encodeResponse(serialized, resp.getNextTableIndexToReadFrom());
+    }
+
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return new MapPermission(parameters.name, ActionConstants.ACTION_READ);
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "iterator";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{parameters.batch, getPartitionId(), parameters.projection, parameters.predicate};
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -60,6 +60,7 @@ import com.hazelcast.map.impl.operation.LoadAllOperation;
 import com.hazelcast.map.impl.operation.LoadMapOperation;
 import com.hazelcast.map.impl.operation.MapFetchEntriesOperation;
 import com.hazelcast.map.impl.operation.MapFetchKeysOperation;
+import com.hazelcast.map.impl.operation.MapFetchWithQueryOperation;
 import com.hazelcast.map.impl.operation.MapFlushBackupOperation;
 import com.hazelcast.map.impl.operation.MapFlushOperation;
 import com.hazelcast.map.impl.operation.MapFlushOperationFactory;
@@ -114,6 +115,7 @@ import com.hazelcast.map.impl.query.QueryOperation;
 import com.hazelcast.map.impl.query.QueryPartitionOperation;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
+import com.hazelcast.map.impl.query.ResultSegment;
 import com.hazelcast.map.impl.query.Target;
 import com.hazelcast.map.impl.querycache.subscriber.operation.DestroyQueryCacheOperation;
 import com.hazelcast.map.impl.querycache.subscriber.operation.MadePublishableOperation;
@@ -286,8 +288,10 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int ENTRY_REMOVING_PROCESSOR = 135;
     public static final int ENTRY_OFFLOADABLE_SET_UNLOCK = 136;
     public static final int LOCK_AWARE_LAZY_MAP_ENTRY = 137;
+    public static final int FETCH_WITH_QUERY = 138;
+    public static final int RESULT_SEGMENT = 139;
 
-    private static final int LEN = LOCK_AWARE_LAZY_MAP_ENTRY + 1;
+    private static final int LEN = RESULT_SEGMENT + 1;
 
     @Override
     public int getFactoryId() {
@@ -966,6 +970,16 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[LOCK_AWARE_LAZY_MAP_ENTRY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new LockAwareLazyMapEntry();
+            }
+        };
+        constructors[FETCH_WITH_QUERY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MapFetchWithQueryOperation();
+            }
+        };
+        constructors[RESULT_SEGMENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new ResultSegment();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/AbstractCursor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.iterator;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Base class for a cursor class holding a collection of items and the next position from which to resume fetching.
+ *
+ * @param <T> the type of item being iterated
+ */
+public abstract class AbstractCursor<T> implements IdentifiedDataSerializable {
+    private List<T> objects;
+    private int nextTableIndexToReadFrom;
+
+    public AbstractCursor() {
+    }
+
+    public AbstractCursor(List<T> entries, int nextTableIndexToReadFrom) {
+        this.objects = entries;
+        this.nextTableIndexToReadFrom = nextTableIndexToReadFrom;
+    }
+
+    public List<T> getBatch() {
+        return objects;
+    }
+
+    public int getNextTableIndexToReadFrom() {
+        return nextTableIndexToReadFrom;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    abstract void writeElement(ObjectDataOutput out, T element) throws IOException;
+
+    abstract T readElement(ObjectDataInput in) throws IOException;
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(nextTableIndexToReadFrom);
+        int size = objects.size();
+        out.writeInt(size);
+        for (T entry : objects) {
+            writeElement(out, entry);
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        nextTableIndexToReadFrom = in.readInt();
+        int size = in.readInt();
+        objects = new ArrayList<T>(size);
+        for (int i = 0; i < size; i++) {
+            objects.add(readElement(in));
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapKeysWithCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/iterator/MapKeysWithCursor.java
@@ -20,65 +20,37 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
-public class MapKeysWithCursor implements IdentifiedDataSerializable {
-
-    private int nextTableIndexToReadFrom;
-    private List<Data> keys;
+/**
+ * Container class for a collection of keys along with an offset from which new keys can be fetched.
+ * This class is usually used when iterating the map keys.
+ *
+ * @see com.hazelcast.map.impl.proxy.MapProxyImpl#iterator
+ */
+public class MapKeysWithCursor extends AbstractCursor<Data> {
 
     public MapKeysWithCursor() {
     }
 
     public MapKeysWithCursor(List<Data> keys, int nextTableIndexToReadFrom) {
-        this.keys = keys;
-        this.nextTableIndexToReadFrom = nextTableIndexToReadFrom;
-    }
-
-    public int getNextTableIndexToReadFrom() {
-        return nextTableIndexToReadFrom;
-    }
-
-    public List<Data> getKeys() {
-        return keys;
+        super(keys, nextTableIndexToReadFrom);
     }
 
     public int getCount() {
-        return keys != null ? keys.size() : 0;
-    }
-
-    public Data getKey(int index) {
-        return keys != null ? keys.get(index) : null;
+        return getBatch() != null ? getBatch().size() : 0;
     }
 
     @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeInt(nextTableIndexToReadFrom);
-        int size = keys.size();
-        out.writeInt(size);
-        for (Data o : keys) {
-            out.writeData(o);
-        }
+    void writeElement(ObjectDataOutput out, Data element) throws IOException {
+        out.writeData(element);
     }
 
     @Override
-    public void readData(ObjectDataInput in) throws IOException {
-        nextTableIndexToReadFrom = in.readInt();
-        int size = in.readInt();
-        keys = new ArrayList<Data>(size);
-        for (int i = 0; i < size; i++) {
-            Data data = in.readData();
-            keys.add(data);
-        }
-    }
-
-    @Override
-    public int getFactoryId() {
-        return MapDataSerializerHook.F_ID;
+    Data readElement(ObjectDataInput in) throws IOException {
+        return in.readData();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.tx.TxnDeleteOperation;
 import com.hazelcast.map.impl.tx.TxnLockAndGetOperation;
 import com.hazelcast.map.impl.tx.TxnSetOperation;
@@ -244,4 +245,8 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
         return new MapFetchEntriesOperation(name, lastTableIndex, fetchSize);
     }
 
+    @Override
+    public MapOperation createFetchWithQueryOperation(String name, int lastTableIndex, int fetchSize, Query query) {
+        return new MapFetchWithQueryOperation(name, lastTableIndex, fetchSize, query);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapFetchEntriesOperation.java
@@ -24,6 +24,12 @@ import com.hazelcast.spi.ReadonlyOperation;
 
 import java.io.IOException;
 
+/**
+ * Operation for fetching a chunk of entries from a single {@link com.hazelcast.core.IMap} partition.
+ * The starting offset is defined by the {@link #lastTableIndex} and the soft limit is defined by the {@link #fetchSize}.
+ *
+ * @see com.hazelcast.map.impl.proxy.MapProxyImpl#iterator(int, int, boolean)
+ */
 public class MapFetchEntriesOperation extends MapOperation implements ReadonlyOperation {
 
     private int fetchSize;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
@@ -92,6 +93,14 @@ public interface MapOperationProvider {
     MapOperation createFetchKeysOperation(String name, int lastTableIndex, int fetchSize);
 
     MapOperation createFetchEntriesOperation(String name, int lastTableIndex, int fetchSize);
+
+    /**
+     * Creates an operation for fetching a segment of a query result from a single partition.
+     *
+     * @see com.hazelcast.map.impl.proxy.MapProxyImpl#iterator(int, int, com.hazelcast.projection.Projection, Predicate)
+     * @since 3.9
+     */
+    MapOperation createFetchWithQueryOperation(String name, int lastTableIndex, int fetchSize, Query query);
 
     OperationFactory createPartitionWideEntryOperationFactory(String name, EntryProcessor entryProcessor);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
@@ -239,5 +240,10 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
     @Override
     public MapOperation createFetchEntriesOperation(String name, int lastTableIndex, int fetchSize) {
         return getDelegate().createFetchEntriesOperation(name, lastTableIndex, fetchSize);
+    }
+
+    @Override
+    public MapOperation createFetchWithQueryOperation(String name, int lastTableIndex, int fetchSize, Query query) {
+        return getDelegate().createFetchWithQueryOperation(name, lastTableIndex, fetchSize, query);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.QueryableEntriesSegment;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 
@@ -55,5 +56,10 @@ public class CallerRunsPartitionScanExecutor implements PartitionScanExecutor {
             throw storedException;
         }
         return result;
+    }
+
+    @Override
+    public QueryableEntriesSegment execute(String mapName, Predicate predicate, int partitionId, int tableIndex, int fetchSize) {
+        return partitionScanRunner.run(mapName, predicate, partitionId, tableIndex, fetchSize);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutor.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.QueryableEntriesSegment;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.util.executor.ManagedExecutorService;
 
@@ -59,6 +60,15 @@ public class ParallelPartitionScanExecutor implements PartitionScanExecutor {
             result = getSortedSubList(result, (PagingPredicate) predicate, nearestAnchorEntry);
         }
         return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     * Parallel execution for a partition chunk query is not supported.
+     */
+    @Override
+    public QueryableEntriesSegment execute(String mapName, Predicate predicate, int partitionId, int tableIndex, int fetchSize) {
+        return partitionScanRunner.run(mapName, predicate, partitionId, tableIndex, fetchSize);
     }
 
     protected List<QueryableEntry> runUsingPartitionScanWithoutPaging(

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanExecutor.java
@@ -16,7 +16,9 @@
 
 package com.hazelcast.map.impl.query;
 
+import com.hazelcast.core.IMap;
 import com.hazelcast.query.Predicate;
+import com.hazelcast.query.impl.QueryableEntriesSegment;
 import com.hazelcast.query.impl.QueryableEntry;
 
 import java.util.Collection;
@@ -28,4 +30,25 @@ import java.util.Collection;
 public interface PartitionScanExecutor {
 
     Collection<QueryableEntry> execute(String mapName, Predicate predicate, Collection<Integer> partitions);
+
+    /**
+     * Executes the predicate on a partition chunk. The offset in the partition is defined by the {@code tableIndex}
+     * and the soft limit is defined by the {@code fetchSize}. The method returns the matched entries and an
+     * index from which new entries can be fetched which allows for efficient iteration of query results.
+     * <p>
+     * <b>NOTE</b>
+     * Iterating the query results using the returned next table index should be done
+     * only when the {@link IMap} is not being mutated and the cluster is
+     * stable (there are no migrations or membership changes).
+     * In other cases, entries are rearranged and the you may get the same query result twice or
+     * may miss some query results that match the predicate.
+     *
+     * @param mapName     the map name
+     * @param predicate   the predicate which the entries must match
+     * @param partitionId the partition which is queried
+     * @param tableIndex  the index from which entries are queried
+     * @param fetchSize   the soft limit for the number of entries to fetch
+     * @return entries matching the predicate and a table index from which new entries can be fetched
+     */
+    QueryableEntriesSegment execute(String mapName, Predicate predicate, int partitionId, int tableIndex, int fetchSize);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Contains the result of a query or projection evaluation.
@@ -40,7 +41,7 @@ import java.util.LinkedList;
  */
 public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializable, Iterable<QueryResultRow> {
 
-    private final Collection<QueryResultRow> rows = new LinkedList<QueryResultRow>();
+    private final List<QueryResultRow> rows = new LinkedList<QueryResultRow>();
 
     private Collection<Integer> partitionIds;
 
@@ -144,7 +145,7 @@ public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializa
         this.partitionIds = new ArrayList<Integer>(partitionIds);
     }
 
-    public Collection<QueryResultRow> getRows() {
+    public List<QueryResultRow> getRows() {
         return rows;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultSegment.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * Represents a partial query result on a segment of the map.
+ * The remaining query results may be retrieved using
+ * the {@link #nextTableIndexToReadFrom} which signifies the next query result.
+ */
+public class ResultSegment implements IdentifiedDataSerializable {
+    private Result result;
+    private int nextTableIndexToReadFrom;
+
+    public ResultSegment() {
+    }
+
+    public ResultSegment(Result result, int nextTableIndexToReadFrom) {
+        this.result = result;
+        this.nextTableIndexToReadFrom = nextTableIndexToReadFrom;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    public int getNextTableIndexToReadFrom() {
+        return nextTableIndexToReadFrom;
+    }
+
+    public void setNextTableIndexToReadFrom(int nextTableIndexToReadFrom) {
+        this.nextTableIndexToReadFrom = nextTableIndexToReadFrom;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.RESULT_SEGMENT;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(result);
+        out.writeInt(nextTableIndexToReadFrom);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        result = in.readObject();
+        nextTableIndexToReadFrom = in.readInt();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
@@ -74,8 +74,32 @@ public interface Storage<K, R> {
      */
     Iterable<LazyEntryViewFromRecord> getRandomSamples(int sampleCount);
 
+    /**
+     * Fetch minimally {@code size} keys from the {@code tableIndex} position. The key is fetched on-heap.
+     * <p>
+     * NOTE: The implementation is free to return more than {@code size} items. This can happen if we cannot easily resume
+     * from the last returned item by receiving the {@code tableIndex} of the last item. The index can represent a bucket
+     * with multiple items and in this case the returned object will contain all items in that bucket, regardless if we exceed
+     * the requested {@code size}.
+     *
+     * @param tableIndex the index (position) from which to resume
+     * @param size       the minimal count of returned items
+     * @return fetched keys and the table index for keys AFTER the last returned key
+     */
     MapKeysWithCursor fetchKeys(int tableIndex, int size);
 
+    /**
+     * Fetch minimally {@code size} items from the {@code tableIndex} position. Both the key and value are fetched on-heap.
+     * <p>
+     * NOTE: The implementation is free to return more than {@code size} items. This can happen if we cannot easily resume
+     * from the last returned item by receiving the {@code tableIndex} of the last item. The index can represent a bucket
+     * with multiple items and in this case the returned object will contain all items in that bucket, regardless if we exceed
+     * the requested {@code size}.
+     *
+     * @param tableIndex the index (position) from which to resume
+     * @param size       the minimal count of returned items
+     * @return fetched entries and the table index for entries AFTER the last returned entry
+     */
     MapEntriesWithCursor fetchEntries(int tableIndex, int size, SerializationService serializationService);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/TruePredicate.java
@@ -27,14 +27,22 @@ import java.util.Map;
 
 /**
  * A {@link com.hazelcast.query.Predicate} which always returns true.
+ *
+ * @param <K> map key type
+ * @param <V> map value type
  */
 @BinaryInterface
-public class TruePredicate implements IdentifiedDataSerializable, Predicate {
+public class TruePredicate<K, V> implements IdentifiedDataSerializable, Predicate<K, V> {
 
     /**
      * An instance of the TruePredicate.
      */
     public static final TruePredicate INSTANCE = new TruePredicate();
+
+    @SuppressWarnings("unchecked")
+    public static <K, V> TruePredicate<K, V> truePredicate() {
+        return INSTANCE;
+    }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntriesSegment.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntriesSegment.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import java.util.Collection;
+
+/**
+ * Holder class for a collection of queried entries and the index from which new items can be fetched.
+ * It can be used when fetching query results in chunks (e.g. efficient paging).
+ */
+public class QueryableEntriesSegment {
+
+    private final Collection<QueryableEntry> entries;
+    private final int nextTableIndexToReadFrom;
+
+    public QueryableEntriesSegment(Collection<QueryableEntry> entries, int nextTableIndexToReadFrom) {
+        this.entries = entries;
+        this.nextTableIndexToReadFrom = nextTableIndexToReadFrom;
+    }
+
+    public Collection<QueryableEntry> getEntries() {
+        return entries;
+    }
+
+    public int getNextTableIndexToReadFrom() {
+        return nextTableIndexToReadFrom;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/MapQueryPartitionIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapQueryPartitionIteratorTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+import com.hazelcast.projection.Projection;
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapQueryPartitionIteratorTest extends HazelcastTestSupport {
+
+    private HazelcastInstance instance;
+    private MapProxyImpl<String, String> proxy;
+
+    @Before
+    public void init() {
+        this.instance = createHazelcastInstance();
+        this.proxy = (MapProxyImpl<String, String>) instance.<String, String>getMap(randomMapName());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void test_next_Throws_Exception_On_EmptyPartition() throws Exception {
+        proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate()).next();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_null_projection_throws_exception() throws Exception {
+        proxy.iterator(10, 1, null, TruePredicate.<String, String>truePredicate());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_null_predicate_throws_exception() throws Exception {
+        proxy.iterator(10, 1, new TestProjection(), null);
+    }
+
+    @Test
+    public void test_HasNext_Returns_False_On_EmptyPartition() throws Exception {
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void test_Next_Returns_Value_On_NonEmptyPartition() throws Exception {
+        String value = randomString();
+        fillMap(proxy, 1, 1, value);
+
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new GetValueProjection<String>(), TruePredicate.<String, String>truePredicate());
+        final String next = iterator.next();
+        assertEquals(value, next);
+    }
+
+    @Test
+    public void test_Next_Returns_Value_On_NonEmptyPartition_and_HasNext_Returns_False_when_Item_Consumed() throws Exception {
+        String value = randomString();
+        fillMap(proxy, 1, 1, value);
+
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new GetValueProjection<String>(), TruePredicate.<String, String>truePredicate());
+        final String next = iterator.next();
+        assertEquals(value, next);
+        boolean hasNext = iterator.hasNext();
+        assertFalse(hasNext);
+    }
+
+    @Test
+    public void test_HasNext_Returns_True_On_NonEmptyPartition() throws Exception {
+        fillMap(proxy, 1, 1, randomString());
+
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate());
+        assertTrue(iterator.hasNext());
+    }
+
+
+    @Test
+    public void test_with_projection_and_true_predicate() throws Exception {
+        fillMap(proxy, 1, 100, randomString());
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate());
+        final ArrayList<String> projected = collectAll(iterator);
+
+        final Collection<String> actualValues = proxy.values();
+        assertEquals(actualValues.size(), projected.size());
+
+        for (String value : actualValues) {
+            assertTrue(projected.contains("dummy" + value));
+        }
+    }
+
+    @Test
+    public void test_with_projection_and_predicate() throws Exception {
+        final MapProxyImpl<String, Integer> intMap =
+                (MapProxyImpl<String, Integer>) instance.<String, Integer>getMap(randomMapName());
+        fillMap(intMap, 1, 100);
+        final Iterator<Map.Entry<String, Integer>> iterator = intMap.iterator(10, 1,
+                new IdentityProjection<Map.Entry<String, Integer>>(),
+                new EvenPredicate());
+        final ArrayList<Map.Entry<String, Integer>> projected = collectAll(iterator);
+
+        for (Map.Entry<String, Integer> i : projected) {
+            assertTrue(i.getValue() % 2 == 0);
+        }
+        final Collection<Integer> actualValues = intMap.values();
+        assertEquals(actualValues.size() / 2, projected.size());
+
+        for (Entry<String, Integer> e : intMap.entrySet()) {
+            if (e.getValue() % 2 == 0) {
+                assertTrue(projected.contains(e));
+            }
+        }
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void test_remove_Throws_Exception() throws Exception {
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new TestProjection(), TruePredicate.<String, String>truePredicate());
+
+        iterator.remove();
+    }
+
+    @Test
+    public void test_Next_Returns_Values_When_FetchSizeExceeds_On_NonEmptyPartition() throws Exception {
+        String value = randomString();
+        fillMap(proxy, 1, 100, value);
+        final Iterator<String> iterator = proxy.iterator(10, 1,
+                new GetValueProjection<String>(), TruePredicate.<String, String>truePredicate());
+
+        for (int i = 0; i < 100; i++) {
+            String val = iterator.next();
+            assertEquals(value, val);
+        }
+    }
+
+    private void fillMap(IMap<String, String> map, int partitionId, int count, String value) {
+        for (int i = 0; i < count; i++) {
+            String key = generateKeyForPartition(instance, partitionId);
+            map.put(key, value);
+        }
+    }
+
+    private void fillMap(IMap<String, Integer> map, int partitionId, int count) {
+        for (int i = 0; i < count; i++) {
+            String key = generateKeyForPartition(instance, partitionId);
+            map.put(key, i);
+        }
+    }
+
+    private <T> ArrayList<T> collectAll(Iterator<T> iterator) {
+        final ArrayList<T> projected = new ArrayList<T>();
+        while (iterator.hasNext()) {
+            projected.add(iterator.next());
+        }
+        return projected;
+    }
+
+    private static class EvenPredicate implements Predicate<String, Integer> {
+        @Override
+        public boolean apply(Entry<String, Integer> mapEntry) {
+            return mapEntry.getValue() % 2 == 0;
+        }
+    }
+
+    private static class TestProjection extends Projection<Entry<String, String>, String> {
+        @Override
+        public String transform(Map.Entry<String, String> input) {
+            return "dummy" + input.getValue();
+        }
+    }
+
+    private static class GetValueProjection<T> extends Projection<Entry<String, T>, T> {
+        @Override
+        public T transform(Map.Entry<String, T> input) {
+            return input.getValue();
+        }
+    }
+
+    private static class IdentityProjection<T> extends Projection<T, T> {
+        @Override
+        public T transform(T input) {
+            return input;
+        }
+    }
+}


### PR DESCRIPTION
The added projection and filtering support reuses the query engine but
allows running the query on chunk within a single partition. This
allows iteration with predicates and projections. Currently iterating
the indexes is not supported, the predicate will be run on each entry.
Also, the projection does not support the Offloadable which means that
it is invoked on the partition thread.

Changed the type of the entry which is provided to the predicate from
CachedQueryEntry to LazyMapEntry to allow the identity projection -
previously it failed when being serialized since CachedQueryEntry is
not serializable.

Also added some more generics and javadocs.

EE part : https://github.com/hazelcast/hazelcast-enterprise/pull/1398
Client protocol : https://github.com/hazelcast/hazelcast-client-protocol/pull/66