### PR TITLE
Cleanup of Near Cache invalidateOnChange usage

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -84,10 +84,10 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
     protected static final String NULL_KEY_IS_NOT_ALLOWED = "Null key is not allowed!";
     protected static final String NULL_VALUE_IS_NOT_ALLOWED = "Null value is not allowed!";
 
+    private int targetPartitionId;
+
     private volatile NearCache nearCache;
     private volatile String invalidationListenerId;
-
-    private int targetPartitionId;
 
     public ClientReplicatedMapProxy(String serviceName, String objectName) {
         super(serviceName, objectName);
@@ -108,7 +108,7 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
             return;
         }
         nearCache = context.getNearCacheManager().getOrCreateNearCache(name, nearCacheConfig);
-        if (nearCache.isInvalidatedOnChange()) {
+        if (nearCacheConfig.isInvalidateOnChange()) {
             addNearCacheInvalidateListener();
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -81,7 +81,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
     // eventually consistent Near Cache can only be used with server versions >= 3.8
     private final int minConsistentNearCacheSupportingServerVersion = calculateVersion("3.8");
-    private boolean invalidateOnChange;
+
     private NearCache<Object, Object> nearCache;
     private ILogger logger;
 
@@ -101,9 +101,8 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         NearCacheManager nearCacheManager = context.getNearCacheManager();
         IMapDataStructureAdapter<K, V> adapter = new IMapDataStructureAdapter<K, V>(this);
         nearCache = nearCacheManager.getOrCreateNearCache(name, nearCacheConfig, adapter);
-        invalidateOnChange = nearCache.isInvalidatedOnChange();
 
-        if (invalidateOnChange) {
+        if (nearCacheConfig.isInvalidateOnChange()) {
             addNearCacheInvalidationListener(new ConnectedServerVersionAwareNearCacheEventHandler());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
@@ -83,13 +83,6 @@ public interface NearCache<K, V> extends InitializingObject {
     boolean remove(K key);
 
     /**
-     * Checks if values are invalidated on changes.
-     *
-     * @return {@code true} if values are invalidated on changes, {@code false} otherwise
-     */
-    boolean isInvalidatedOnChange();
-
-    /**
      * Removes all stored values.
      */
     void clear();

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
@@ -128,11 +128,6 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     }
 
     @Override
-    public boolean isInvalidatedOnChange() {
-        return nearCacheConfig.isInvalidateOnChange();
-    }
-
-    @Override
     public void clear() {
         nearCacheRecordStore.clear();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -62,8 +62,9 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
 
     private boolean cacheLocalEntries;
     private boolean invalidateOnChange;
-    private NearCache<Object, Object> nearCache;
+
     private MapNearCacheManager mapNearCacheManager;
+    private NearCache<Object, Object> nearCache;
     private RepairingHandler repairingHandler;
 
     private volatile String invalidationListenerId;
@@ -76,12 +77,12 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     public void initialize() {
         super.initialize();
 
-        mapNearCacheManager = mapServiceContext.getMapNearCacheManager();
-        cacheLocalEntries = getMapConfig().getNearCacheConfig().isCacheLocalEntries();
         NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
-        nearCache = mapNearCacheManager.getOrCreateNearCache(name, nearCacheConfig);
-        invalidateOnChange = nearCache.isInvalidatedOnChange();
+        cacheLocalEntries = nearCacheConfig.isCacheLocalEntries();
+        invalidateOnChange = nearCacheConfig.isInvalidateOnChange();
 
+        mapNearCacheManager = mapServiceContext.getMapNearCacheManager();
+        nearCache = mapNearCacheManager.getOrCreateNearCache(name, nearCacheConfig);
         if (invalidateOnChange) {
             addNearCacheInvalidateListener();
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
@@ -62,11 +62,6 @@ public class NearCacheTest extends NearCacheTestSupport {
     }
 
     @Test
-    public void configureInvalidateOnChangeForNearCache() {
-        doConfigureInvalidateOnChangeForNearCache();
-    }
-
-    @Test
     public void clearNearCache() {
         doClearNearCache();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
@@ -146,21 +146,6 @@ public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
         assertEquals(nearCache.size(), managedNearCacheRecordStore.latestSize);
     }
 
-    protected void doConfigureInvalidateOnChangeForNearCache() {
-        NearCacheConfig config1 = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME + "-1", DEFAULT_MEMORY_FORMAT);
-        NearCacheConfig config2 = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME + "-2", DEFAULT_MEMORY_FORMAT);
-
-        config1.setInvalidateOnChange(false);
-        config2.setInvalidateOnChange(true);
-
-        NearCache nearCache1 = createNearCache(config1.getName(), config1, createManagedNearCacheRecordStore());
-        NearCache nearCache2 = createNearCache(config2.getName(), config2, createManagedNearCacheRecordStore());
-
-        // show that NearCache gets "isInvalidateOnChange" configuration from specified NearCacheConfig
-        assertFalse(nearCache1.isInvalidatedOnChange());
-        assertTrue(nearCache2.isInvalidatedOnChange());
-    }
-
     protected void doClearNearCache() {
         ManagedNearCacheRecordStore managedNearCacheRecordStore = createManagedNearCacheRecordStore();
         NearCache<Integer, String> nearCache = createNearCache(DEFAULT_NEAR_CACHE_NAME, managedNearCacheRecordStore);


### PR DESCRIPTION
Actually the Near Cache itself doesn't care about invalidations, that handling is all done in the proxies. We already have a distinct field for the invalidation state in most Near Cache proxies. But in some cases we retrieved this info from the Near Cache instead from the config.

Actually my motivation for this PR was this little mess:
```
        cacheLocalEntries = getMapConfig().getNearCacheConfig().isCacheLocalEntries();
        NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
        nearCache = mapNearCacheManager.getOrCreateNearCache(name, nearCacheConfig);
        invalidateOnChange = nearCache.isInvalidatedOnChange();
```
get the Near Cache config via `getMapConfig()`
get it again via `mapConfig` 🙄
create the Near Cache
get a configuration setting from the Near Cache instead of the Near Cache config 😱