### PR TITLE
Enabled optimized selector by default

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingIOThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingIOThread.java
@@ -127,7 +127,8 @@ public class NonBlockingIOThread extends Thread implements OperationHostileThrea
     private static Selector newSelector(ILogger logger) {
         try {
             Selector selector = Selector.open();
-            if (Boolean.getBoolean("tcp.optimizedselector")) {
+            boolean optimize = Boolean.parseBoolean(System.getProperty("hazelcast.io.optimizeselector", "true"));
+            if (optimize) {
                 optimize(selector, logger);
             }
             return selector;


### PR DESCRIPTION
Various other projects like Netty, Agrona do this be default as well.

There is a switch to disable it, and if something fails while trying
to modify, it will fallback on the non optimized version anyway.

The optimization is that no litter is created for the sake of selection keys.