### PR TITLE
Cleanup of unified Near Cache tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -118,7 +118,7 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
         assumeThatMethodIsAvailable(context.nearCacheAdapter, method);
 
         // populate the data structure
-        populateMap(context);
+        populateDataAdapter(context);
         assertNearCacheSize(context, 0);
         assertNearCacheStats(context, 0, 0, 0);
 


### PR DESCRIPTION
* pulled out some methods to `NearCacheTestUtils`
* added asserts of Near Cache content
* renamed some methods and comments from `map` to `data structure`
* fixed Near Cache key retrieval for `ReplicatedMap`

Part of https://github.com/hazelcast/hazelcast/issues/10127