### PR TITLE
Removed contended counter in OperationRunnerImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -49,6 +49,11 @@ public interface OperationExecutor extends PacketHandler {
     int getPriorityQueueSize();
 
     /**
+     * Returns the number of executed operations.
+     */
+    long getExecutedOperationCount();
+
+    /**
      * Returns the number of partition threads.
      *
      * @return number of partition threads.
@@ -175,4 +180,5 @@ public interface OperationExecutor extends PacketHandler {
      * Shuts down this OperationExecutor. Any pending tasks are discarded.
      */
     void shutdown();
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
@@ -43,6 +43,8 @@ public abstract class OperationRunner {
         this.partitionId = partitionId;
     }
 
+    public abstract long executedOperationsCount();
+
     public abstract void run(Packet packet) throws Exception;
 
     public abstract void run(Runnable task);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -303,6 +303,21 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
         return genericQueue.prioritySize();
     }
 
+    @Probe(name = "completedCount", level = MANDATORY)
+    public long getExecutedOperationCount() {
+        long result = adHocOperationRunner.executedOperationsCount();
+
+        for (OperationRunner runner : genericOperationRunners) {
+            result += runner.executedOperationsCount();
+        }
+
+        for (OperationRunner runner : partitionOperationRunners) {
+            result += runner.executedOperationsCount();
+        }
+
+        return result;
+    }
+
     @Override
     @Probe
     public int getPartitionThreadCount() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerFactoryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerFactoryImpl.java
@@ -24,6 +24,7 @@ import static com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.A
 
 class OperationRunnerFactoryImpl implements OperationRunnerFactory {
     private OperationServiceImpl operationService;
+    private int genericId;
 
     OperationRunnerFactoryImpl(OperationServiceImpl operationService) {
         this.operationService = operationService;
@@ -31,16 +32,16 @@ class OperationRunnerFactoryImpl implements OperationRunnerFactory {
 
     @Override
     public OperationRunner createAdHocRunner() {
-        return new OperationRunnerImpl(operationService, AD_HOC_PARTITION_ID, null);
+        return new OperationRunnerImpl(operationService, AD_HOC_PARTITION_ID, 0, null);
     }
 
     @Override
     public OperationRunner createPartitionRunner(int partitionId) {
-        return new OperationRunnerImpl(operationService, partitionId, operationService.failedBackupsCount);
+        return new OperationRunnerImpl(operationService, partitionId, 0, operationService.failedBackupsCount);
     }
 
     @Override
     public OperationRunner createGenericRunner() {
-        return new OperationRunnerImpl(operationService, GENERIC_PARTITION_ID, null);
+        return new OperationRunnerImpl(operationService, GENERIC_PARTITION_ID, genericId++, null);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -59,7 +59,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
@@ -103,9 +102,6 @@ public final class OperationServiceImpl implements InternalOperationService, Met
 
     final InvocationRegistry invocationRegistry;
     final OperationExecutor operationExecutor;
-
-    @Probe(name = "completedCount", level = MANDATORY)
-    final AtomicLong completedOperationsCount = new AtomicLong();
 
     @Probe(name = "operationTimeoutCount", level = MANDATORY)
     final MwCounter operationTimeoutCount = newMwCounter();
@@ -219,7 +215,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
 
     @Override
     public long getExecutedOperationCount() {
-        return completedOperationsCount.get();
+        return operationExecutor.getExecutedOperationCount();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -228,6 +228,11 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
         }
 
         @Override
+        public long executedOperationsCount() {
+            return 0;
+        }
+
+        @Override
         public void run(Runnable task) {
             tasks.add(task);
             task.run();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
@@ -65,7 +65,7 @@ public class OperationRunnerImplTest extends HazelcastTestSupport {
         remote = cluster[1];
         operationService = (OperationServiceImpl) getOperationService(local);
         clusterService = getClusterService(local);
-        operationRunner = new OperationRunnerImpl(operationService, getPartitionId(local), newSwCounter());
+        operationRunner = new OperationRunnerImpl(operationService, getPartitionId(local), 0, newSwCounter());
         responseHandler = mock(OperationResponseHandler.class);
     }
 


### PR DESCRIPTION
All Operation threads are contend are contending on an 'executed operations'
AtomicLong. This causes contention for no good reason.

So each operation runner has been given its own SwCounter; only the ad hoc runner gets a MwCounter.

As a bonus:
 *  we now also get metrics on number of operations executed
per generic operation runner and for the ad hoc operation runner.
* simplified logic in the `public void run(Operation op) {' method 