### PR TITLE
Moved deserialization of response from response thread

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
@@ -25,18 +25,24 @@ import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PacketHandler;
-import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
-import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
-import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
-import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
+
+import java.nio.ByteOrder;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.spi.impl.SpiDataSerializerHook.BACKUP_ACK_RESPONSE;
+import static com.hazelcast.spi.impl.SpiDataSerializerHook.CALL_TIMEOUT_RESPONSE;
+import static com.hazelcast.spi.impl.SpiDataSerializerHook.ERROR_RESPONSE;
+import static com.hazelcast.spi.impl.SpiDataSerializerHook.NORMAL_RESPONSE;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse.OFFSET_BACKUP_ACKS;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.Response.OFFSET_CALL_ID;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.Response.OFFSET_TYPE_ID;
 
 /**
  * Responsible for handling responses for invocations. Based on the content of the response packet, it will lookup the
@@ -58,12 +64,14 @@ public final class InboundResponseHandler implements PacketHandler, MetricsProvi
     private final SwCounter responsesError = newSwCounter();
     @Probe(name = "responses[missing]", level = MANDATORY)
     private final MwCounter responsesMissing = newMwCounter();
+    private final boolean useBigEndian;
 
     InboundResponseHandler(ILogger logger,
                            InternalSerializationService serializationService,
                            InvocationRegistry invocationRegistry,
                            NodeEngineImpl nodeEngine) {
         this.logger = logger;
+        this.useBigEndian = serializationService.getByteOrder() == ByteOrder.BIG_ENDIAN;
         this.serializationService = serializationService;
         this.invocationRegistry = invocationRegistry;
         this.nodeEngine = nodeEngine;
@@ -76,28 +84,28 @@ public final class InboundResponseHandler implements PacketHandler, MetricsProvi
 
     @Override
     public void handle(Packet packet) throws Exception {
-        Response response = serializationService.toObject(packet);
+        byte[] bytes = packet.toByteArray();
+        int typeId = Bits.readInt(bytes, OFFSET_TYPE_ID, useBigEndian);
+        long callId = Bits.readLong(bytes, OFFSET_CALL_ID, useBigEndian);
         Address sender = packet.getConn().getEndPoint();
         try {
-            if (response instanceof NormalResponse) {
-                NormalResponse normalResponse = (NormalResponse) response;
-                notifyNormalResponse(
-                        normalResponse.getCallId(),
-                        normalResponse.getValue(),
-                        normalResponse.getBackupAcks(),
-                        sender);
-            } else if (response instanceof BackupAckResponse) {
-                notifyBackupComplete(response.getCallId());
-            } else if (response instanceof CallTimeoutResponse) {
-                notifyCallTimeout(response.getCallId(), sender);
-            } else if (response instanceof ErrorResponse) {
-                ErrorResponse errorResponse = (ErrorResponse) response;
-                notifyErrorResponse(
-                        errorResponse.getCallId(),
-                        errorResponse.getCause(),
-                        sender);
-            } else {
-                logger.severe("Unrecognized response: " + response);
+            switch (typeId) {
+                case NORMAL_RESPONSE:
+                    byte backupAcks = bytes[OFFSET_BACKUP_ACKS];
+                    notifyNormalResponse(callId, packet, backupAcks, sender);
+                    break;
+                case BACKUP_ACK_RESPONSE:
+                    notifyBackupComplete(callId);
+                    break;
+                case CALL_TIMEOUT_RESPONSE:
+                    notifyCallTimeout(callId, sender);
+                    break;
+                case ERROR_RESPONSE:
+                    ErrorResponse errorResponse = serializationService.toObject(packet);
+                    notifyErrorResponse(callId, errorResponse.getCause(), sender);
+                    break;
+                default:
+                    logger.severe("Unrecognized type: " + typeId);
             }
         } catch (Throwable e) {
             logger.severe("While processing response...", e);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -17,8 +17,10 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.AbstractInvocationFuture;
+import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -89,6 +91,7 @@ final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
         }
     }
 
+    @SuppressWarnings("checkstyle:npathcomplexity")
     @Override
     protected Object resolve(Object unresolved) {
         if (unresolved == null) {
@@ -99,6 +102,9 @@ final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
             return newOperationTimeoutException(false);
         } else if (unresolved == HEARTBEAT_TIMEOUT) {
             return newOperationTimeoutException(true);
+        } else if (unresolved.getClass() == Packet.class) {
+            NormalResponse response = invocation.context.serializationService.toObject(unresolved);
+            unresolved = response.getValue();
         }
 
         Object value = unresolved;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
@@ -39,6 +39,7 @@ import static com.hazelcast.spi.impl.SpiDataSerializerHook.NORMAL_RESPONSE;
  * @author mdogan 4/10/13
  */
 public class NormalResponse extends Response {
+    public static final int OFFSET_BACKUP_ACKS = 26;
 
     private Object value;
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
@@ -37,6 +37,9 @@ import java.io.IOException;
  */
 public abstract class Response implements IdentifiedDataSerializable {
 
+    public static final int OFFSET_TYPE_ID = 13;
+    public static final int OFFSET_CALL_ID = 17;
+
     protected long callId;
     protected boolean urgent;
 


### PR DESCRIPTION
Before this change, when a response-packet is received, it is first deserialized
to a (Normal)Response on the response thread. And then handed over to
the calling thread to do the real deserialization if needed. The problem
is that this puts a lot of pressure on the response thread and it becomes
a scalability bottleneck; especially with larger responses since there is 
only a single response thread.

This pr changes this behavior so that instead of deserializing the response,
we poke in the bytes to get call id/type of response without needing to 
deserialize and handover the Packet to the invocation future which will 
do these 2 consequtive deserializations
packet -> NormalResponse -> payload.

In case of backup ack response and call timeout, no response object is created at all. 
So we already have some litter reduction here.

In a follow up PR, this intermediate deserialization of NormalResponse
will be fully removed. Removing more unwanted litter.

See https://github.com/hazelcast/hazelcast/issues/10205