### PR TITLE
Fix unwanted toByteArray to determine message size

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ParameterUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ParameterUtil.java
@@ -25,22 +25,28 @@ public final class ParameterUtil {
 
     static final int UTF8_MAX_BYTES_PER_CHAR = 3;
 
-    private ParameterUtil() { }
+    private ParameterUtil() {
+    }
 
     public static int calculateDataSize(String string) {
         return Bits.INT_SIZE_IN_BYTES + string.length() * UTF8_MAX_BYTES_PER_CHAR;
     }
 
     public static int calculateDataSize(Data data) {
-        return calculateDataSize(data.toByteArray());
+        return addByteArrayLengthHeader(data.totalSize());
     }
 
     public static int calculateDataSize(Map.Entry<Data, Data> entry) {
-        return calculateDataSize(entry.getKey().toByteArray()) + calculateDataSize(entry.getValue().toByteArray());
+        return addByteArrayLengthHeader(entry.getKey().totalSize())
+                + addByteArrayLengthHeader(entry.getValue().totalSize());
     }
 
     public static int calculateDataSize(byte[] bytes) {
-        return Bits.INT_SIZE_IN_BYTES + bytes.length;
+        return addByteArrayLengthHeader(bytes.length);
+    }
+
+    private static int addByteArrayLengthHeader(int length) {
+        return Bits.INT_SIZE_IN_BYTES + length;
     }
 
     public static int calculateDataSize(Integer data) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/HeapDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/HeapDataTest.java
@@ -1,0 +1,33 @@
+package com.hazelcast.internal.serialization.impl;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class HeapDataTest {
+
+    @Test
+    public void totalSize_whenNonEmpty(){
+        HeapData heapData = new HeapData(new byte[10]);
+        assertEquals(10, heapData.totalSize());
+    }
+
+    @Test
+    public void totalSize_whenEmpty(){
+        HeapData heapData = new HeapData(new byte[0]);
+        assertEquals(0, heapData.totalSize());
+    }
+
+    @Test
+    public void totalSize_whenNullByteArray(){
+        HeapData heapData = new HeapData(null);
+        assertEquals(0, heapData.totalSize());
+    }
+}


### PR DESCRIPTION
I have verified that for:
- heap data the 'totalSize' is the length of the byte array.
- for offheap data the 'totalSize' is the length used to otherwise create the byte array
  for the sake of the 'toByteArray'

fix #10278