### PR TITLE
NativeMemoryData.toByteArray prevention

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/MessageFlyweight.java
@@ -103,8 +103,10 @@ public class MessageFlyweight {
     }
 
     public MessageFlyweight set(Data data) {
-        final byte[] bytes = data.toByteArray();
-        set(bytes);
+        int length = data.totalSize();
+        set(length);
+        data.copyTo(buffer.byteArray(), index);
+        index += length;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -33,6 +33,8 @@ import static com.hazelcast.nio.Bits.SHORT_SIZE_IN_BYTES;
 
 class ByteArrayObjectDataInput extends VersionedObjectDataInput implements BufferObjectDataInput {
 
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
     byte[] data;
 
     int size;
@@ -393,7 +395,7 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
             readFully(b);
             return b;
         }
-        return new byte[0];
+        return EMPTY_BYTE_ARRAY;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -372,8 +372,13 @@ class ByteArrayObjectDataOutput extends VersionedObjectDataOutput implements Buf
 
     @Override
     public void writeData(Data data) throws IOException {
-        byte[] payload = data != null ? data.toByteArray() : null;
-        writeByteArray(payload);
+        int len = data == null ? NULL_ARRAY_LENGTH : data.totalSize();
+        writeInt(len);
+        if (len > 0) {
+            ensureAvailable(len);
+            data.copyTo(buffer, pos);
+            pos += len;
+        }
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
@@ -65,6 +65,13 @@ public class HeapData implements Data {
     }
 
     @Override
+    public void copyTo(byte[] dest, int destPos) {
+        if (totalSize() > 0) {
+            System.arraycopy(payload, 0, dest, destPos, payload.length);
+        }
+    }
+
+    @Override
     public int getPartitionHash() {
         if (hasPartitionHash()) {
             return Bits.readIntB(payload, PARTITION_HASH_OFFSET);

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
@@ -50,6 +50,20 @@ public interface Data {
     int totalSize();
 
     /**
+     * Copies the payload contained in the Data to the destination buffer.
+     *
+     * The dest byte-buffer needs to be large enough to contain the payload. Otherwise an exception is thrown.
+     *
+     * The reason this method exists instead of relying on the {@link #toByteArray()} is the existence of the NativeMemoryData.
+     * With the NativeMemoryData it would lead to a temporary byte-array. This method prevents this temporary byte-array needing
+     * to be created.
+      *
+     * @param dest to byte-buffer to write to
+     * @param destPos the position in the destination buffer.
+     */
+    void copyTo(byte[] dest, int destPos);
+
+    /**
      * Returns size of internal binary data in bytes
      *
      * @return internal data size

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/ToHeapDataConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/invalidation/ToHeapDataConverterTest.java
@@ -56,6 +56,10 @@ public class ToHeapDataConverterTest {
         }
 
         @Override
+        public void copyTo(byte[] dest, int destPos) {
+        }
+
+        @Override
         public int totalSize() {
             return 0;
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/HeapDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/HeapDataTest.java
@@ -14,20 +14,30 @@ import static org.junit.Assert.assertEquals;
 public class HeapDataTest {
 
     @Test
-    public void totalSize_whenNonEmpty(){
+    public void totalSize_whenNonEmpty() {
         HeapData heapData = new HeapData(new byte[10]);
         assertEquals(10, heapData.totalSize());
     }
 
     @Test
-    public void totalSize_whenEmpty(){
+    public void totalSize_whenEmpty() {
         HeapData heapData = new HeapData(new byte[0]);
         assertEquals(0, heapData.totalSize());
     }
 
     @Test
-    public void totalSize_whenNullByteArray(){
+    public void totalSize_whenNullByteArray() {
         HeapData heapData = new HeapData(null);
         assertEquals(0, heapData.totalSize());
+    }
+
+    @Test
+    public void copyTo() {
+        byte[] inputBytes = "12345678890".getBytes();
+        HeapData heap = new HeapData(inputBytes);
+        byte[] bytes = new byte[inputBytes.length];
+        heap.copyTo(bytes, 0);
+
+        assertEquals(new String(inputBytes), new String(bytes));
     }
 }


### PR DESCRIPTION
This is the first step where NativeMemoryData.toByteArray is prevented.
This method is being used to copy data from offheap into a byte array
and then it is being copied into the final byte array, e.g a response
for members, or a client response.

This causes litter (especially with larger values) and unwanted copying.

In this PR the ByteArrayDataOutputStream is optimized and
the ClientMessage.

fix https://github.com/hazelcast/hazelcast/issues/10277
fix https://github.com/hazelcast/hazelcast/issues/10281

This PR introduces no threading issues where e.g. offheap is now leaking into the wrong thread. The only thing which is done is to replace the 'toByteArray' by 'copyTo'. 

In combination with this #10279, the allocation pressure for an offheap map.get and a 1kb value, goes down from 3kb to 1kb per invocation from a client.

For the enterprise side:
https://github.com/hazelcast/hazelcast-enterprise/pull/1401