### PR TITLE
Fix spurious Durable Executor test failure on killed owner

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableRetrieveResultTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableRetrieveResultTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -117,30 +116,33 @@ public class DurableRetrieveResultTest extends ExecutorServiceTestSupport {
     }
 
     @Test
-    @Ignore(value = "https://github.com/hazelcast/hazelcast/issues/10033")
     public void testSingleExecution_WhenMigratedAfterCompletion_WhenOwnerMemberKilled() throws Exception {
-        String name = randomString();
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
-        HazelcastInstance instance2 = factory.newHazelcastInstance();
-        factory.newHazelcastInstance();
 
-        waitAllForSafeState(factory.getAllHazelcastInstances());
+        HazelcastInstance[] instances = factory.newInstances();
+        HazelcastInstance first = instances[0];
+        HazelcastInstance second = instances[1];
 
-        String key = generateKeyOwnedBy(instance1);
+        waitAllForSafeState(instances);
+
+        String key = generateKeyOwnedBy(first);
 
         String runCounterName = "runCount";
-        IAtomicLong runCount = instance2.getAtomicLong(runCounterName);
+        IAtomicLong runCount = second.getAtomicLong(runCounterName);
 
-        DurableExecutorService executorService = instance1.getDurableExecutorService(name);
+        String name = randomString();
+        DurableExecutorService executorService = first.getDurableExecutorService(name);
         IncrementAtomicLongRunnable task = new IncrementAtomicLongRunnable(runCounterName);
         DurableExecutorServiceFuture future = executorService.submitToKeyOwner(task, key);
 
         future.get(); // Wait for it to finish
 
-        instance1.getLifecycleService().terminate();
+        // Avoid race between PutResult & SHUTDOWN
+        sleepSeconds(3);
 
-        executorService = instance2.getDurableExecutorService(name);
+        first.getLifecycleService().terminate();
+
+        executorService = second.getDurableExecutorService(name);
         Future<Object> newFuture = executorService.retrieveResult(future.getTaskId());
         newFuture.get(); // Make sure its completed
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -351,7 +351,7 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
 
         private final String name;
 
-        private HazelcastInstance instance;
+        private transient HazelcastInstance instance;
 
         public IncrementAtomicLongRunnable(String name) {
             this.name = name;


### PR DESCRIPTION
Suspected that this could be due to a race between PutResult and Shutdown.
A delay filter was added on the `MockConnectionManager` and verified that it fails almost always even in my local environment.

Sleep was added to optimistically wait until the result is replicated before killing the node.

Fix #10033