### PR TITLE
[BACKPORT] Fix spurious Durable Executor test failure on killed owner

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -351,7 +351,7 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
 
         private final String name;
 
-        private HazelcastInstance instance;
+        private transient HazelcastInstance instance;
 
         public IncrementAtomicLongRunnable(String name) {
             this.name = name;


### PR DESCRIPTION
(cherry picked from commit 2d4519cf7c9be0fdaced47e4f69372548b750e61)