### PR TITLE
Fixed racy Near Cache test in AbstractNearCacheBasicTest

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -137,6 +137,6 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
     @Test
     @Override
     @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
-    public void whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onNearCacheAdapter() {
+    public void whenNearCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onNearCacheAdapter() {
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -169,12 +169,12 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
     @Test
     @Override
     @Ignore(value = "This test doesn't work with the TransactionalMap due to its limited implementation")
-    public void whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onNearCacheAdapter() {
+    public void whenNearCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onNearCacheAdapter() {
     }
 
     @Test
     @Override
     @Ignore(value = "This test doesn't work with the TransactionalMap due to its limited implementation")
-    public void whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onDataAdapter() {
+    public void whenNearCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onDataAdapter() {
     }
 }


### PR DESCRIPTION
Fixes a spurious failure of `ClientMapNearCacheBasicTest.whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onDataAdapter()`

```
java.lang.AssertionError: Near Cache hits should be 1, but were 0 (NearCacheStatsImpl{ownedEntryCount=500, ownedEntryMemoryCost=74406, creationTime=1491856188683, hits=0, misses=2201, ratio=0.0%, evictions=0, expirations=0, lastPersistenceTime=0, persistenceCount=0, lastPersistenceDuration=0, lastPersistenceWrittenBytes=0, lastPersistenceKeyCount=0, lastPersistenceFailure=''}) expected:<1> but was:<0>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at com.hazelcast.internal.nearcache.NearCacheTestUtils.assertEqualsFormat(NearCacheTestUtils.java:341)
	at com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheStats(NearCacheTestUtils.java:303)
	at com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheStats(NearCacheTestUtils.java:283)
	at com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest$3.run(AbstractNearCacheBasicTest.java:938)
	at com.hazelcast.test.HazelcastTestSupport.assertTrueEventually(HazelcastTestSupport.java:977)
	at com.hazelcast.test.HazelcastTestSupport.assertTrueEventually(HazelcastTestSupport.java:994)
	at com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest.whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onDataAdapter(AbstractNearCacheBasicTest.java:929)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
	at java.lang.reflect.Method.invoke(Method.java:597)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:105)
	at com.hazelcast.test.FailOnTimeoutStatement$CallableStatement.call(FailOnTimeoutStatement.java:97)
	at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
	at java.util.concurrent.FutureTask.run(FutureTask.java:138)
	at java.lang.Thread.run(Thread.java:662)
```
https://hazelcast-l337.ci.cloudbees.com/job/new-lab-fast-pr/8152/testReport/junit/com.hazelcast.client.map.impl.nearcache/ClientMapNearCacheBasicTest/whenCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onDataAdapter_format_BINARY__serializeKeys_true_/