### PR TITLE
Add delta for long running durable task test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -185,17 +185,19 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
     static class ICountdownLatchRunnableTask
             implements Runnable, Serializable, HazelcastInstanceAware {
 
-        final String runsCountlatchName;
+        final String[] runsCounterlatchNames;
 
         transient HazelcastInstance instance;
 
-        ICountdownLatchRunnableTask(String runsCountlatchName) {
-            this.runsCountlatchName = runsCountlatchName;
+        ICountdownLatchRunnableTask(String... runsCounterlatchNames) {
+            this.runsCounterlatchNames = runsCounterlatchNames;
         }
 
         @Override
         public void run() {
-            instance.getCountDownLatch(runsCountlatchName).countDown();
+            for (String runsCounterLatchName : runsCounterlatchNames) {
+                instance.getCountDownLatch(runsCounterLatchName).countDown();
+            }
         }
 
         @Override


### PR DESCRIPTION
Can't see anything wrong with the test or functionality.
There is a small chance of delays + sleep time to add up to yet another schedule of the task, and cause the wrong assertion. With the delta we expect a minimum of 6 and maximum of 7.

Improved the implementation by removing the sleep and using a second latch.

Fix #10071
