### PR TITLE
Infrastructure for compatibility tests

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -459,12 +459,5 @@
             <version>2.1.4</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>${bytebuddy.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
@@ -224,7 +224,7 @@ public final class ClassLoaderUtil {
         return false;
     }
 
-    private static Class<?>[] getAllInterfaces(Class<?> clazz) {
+    public static Class<?>[] getAllInterfaces(Class<?> clazz) {
         Collection<Class<?>> interfaces = new HashSet<Class<?>>();
         addOwnInterfaces(clazz, interfaces);
         addInterfacesOfSuperclasses(clazz, interfaces);

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -65,8 +65,8 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelTest.class})
 public class BasicMapTest extends HazelcastTestSupport {
 
-    private static final int INSTANCE_COUNT = 3;
-    private static final Random RANDOM = new Random();
+    static final int INSTANCE_COUNT = 3;
+    static final Random RANDOM = new Random();
 
     HazelcastInstance[] instances;
 
@@ -994,6 +994,8 @@ public class BasicMapTest extends HazelcastTestSupport {
 
     private static class StartsWithPredicate implements Predicate<Object, Object>, Serializable {
 
+        private static final long serialVersionUID = 4193947125511602220L;
+
         String pref;
 
         StartsWithPredicate(String pref) {
@@ -1566,6 +1568,8 @@ public class BasicMapTest extends HazelcastTestSupport {
 
     private static class SampleEntryProcessor implements EntryProcessor<Integer, Integer>, EntryBackupProcessor<Integer, Integer>,
             Serializable {
+
+        private static final long serialVersionUID = -5735493325953375570L;
 
         @Override
         public Object process(Map.Entry<Integer, Integer> entry) {

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -72,43 +72,7 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
     private static final boolean THREAD_CONTENTION_INFO_AVAILABLE;
 
     static {
-        if (isRunningCompatibilityTest()) {
-            // When running a compatibility test, all com.hazelcast.* classes are transformed so that none are
-            // loaded with final modifier to allow subclass proxying.
-            Instrumentation instrumentation = ByteBuddyAgent.install();
-            new AgentBuilder.Default()
-                    .type(new ElementMatcher<TypeDescription>() {
-                        @Override
-                        public boolean matches(TypeDescription target) {
-                            return target.getName().startsWith("com.hazelcast");
-                        }
-                    })
-                    .transform(new AgentBuilder.Transformer() {
-                        @Override
-                        public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder,
-                                                                TypeDescription typeDescription,
-                                                                ClassLoader classLoader, JavaModule module) {
-                            int actualModifiers = typeDescription.getActualModifiers(false);
-                            // unset final modifier
-                            int nonFinalModifiers = actualModifiers & ~Opcodes.ACC_FINAL;
-                            return builder.modifiers(nonFinalModifiers);
-                        }
-                    })
-                    .installOn(instrumentation);
-            System.out.println("Running compatibility tests.");
-            // Mock network cannot be used for compatibility testing
-            System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "true");
-        } else {
-            TestLoggingUtils.initializeLogging();
-            if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
-                System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
-            }
-        }
-        System.setProperty("hazelcast.phone.home.enabled", "false");
-        System.setProperty("hazelcast.mancenter.enabled", "false");
-        System.setProperty("hazelcast.wait.seconds.before.join", "1");
-        System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
-        System.setProperty("java.net.preferIPv4Stack", "true");
+        initialize();
 
         final String threadDumpOnFailure = System.getProperty("hazelcast.test.threadDumpOnFailure");
         THREAD_DUMP_ON_FAILURE = threadDumpOnFailure != null
@@ -144,6 +108,51 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
             }
         }
         THREAD_CONTENTION_INFO_AVAILABLE = threadContentionInfoAvailable;
+    }
+
+    // initialize environment, logging and attach a final-modifier removing agent if required
+    private static void initialize() {
+        if (isRunningCompatibilityTest()) {
+            attachFinalRemovalAgent();
+            System.out.println("Running compatibility tests.");
+            // Mock network cannot be used for compatibility testing
+            System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "true");
+        } else {
+            TestLoggingUtils.initializeLogging();
+            if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
+                System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
+            }
+        }
+        System.setProperty("hazelcast.phone.home.enabled", "false");
+        System.setProperty("hazelcast.mancenter.enabled", "false");
+        System.setProperty("hazelcast.wait.seconds.before.join", "1");
+        System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
+        System.setProperty("java.net.preferIPv4Stack", "true");
+    }
+
+    // When running a compatibility test, all com.hazelcast.* classes are transformed so that none are
+    // loaded with final modifier to allow subclass proxying.
+    private static void attachFinalRemovalAgent() {
+        Instrumentation instrumentation = ByteBuddyAgent.install();
+        new AgentBuilder.Default()
+                .type(new ElementMatcher<TypeDescription>() {
+                    @Override
+                    public boolean matches(TypeDescription target) {
+                        return target.getName().startsWith("com.hazelcast");
+                    }
+                })
+                .transform(new AgentBuilder.Transformer() {
+                    @Override
+                    public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder,
+                                                            TypeDescription typeDescription,
+                                                            ClassLoader classLoader, JavaModule module) {
+                        int actualModifiers = typeDescription.getActualModifiers(false);
+                        // unset final modifier
+                        int nonFinalModifiers = actualModifiers & ~Opcodes.ACC_FINAL;
+                        return builder.modifiers(nonFinalModifiers);
+                    }
+                })
+                .installOn(instrumentation);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -21,6 +21,13 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.test.bounce.BounceMemberRule;
 import com.hazelcast.util.EmptyStatement;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.utility.JavaModule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +41,7 @@ import org.junit.runners.model.Statement;
 import org.junit.runners.model.TestClass;
 
 import java.lang.annotation.Annotation;
+import java.lang.instrument.Instrumentation;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -46,6 +54,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.test.TestEnvironment.isRunningCompatibilityTest;
 import static java.lang.Integer.getInteger;
 
 /**
@@ -63,9 +72,37 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
     private static final boolean THREAD_CONTENTION_INFO_AVAILABLE;
 
     static {
-        TestLoggingUtils.initializeLogging();
-        if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
-            System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
+        if (isRunningCompatibilityTest()) {
+            // When running a compatibility test, all com.hazelcast.* classes are transformed so that none are
+            // loaded with final modifier to allow subclass proxying.
+            Instrumentation instrumentation = ByteBuddyAgent.install();
+            new AgentBuilder.Default()
+                    .type(new ElementMatcher<TypeDescription>() {
+                        @Override
+                        public boolean matches(TypeDescription target) {
+                            return target.getName().startsWith("com.hazelcast");
+                        }
+                    })
+                    .transform(new AgentBuilder.Transformer() {
+                        @Override
+                        public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder,
+                                                                TypeDescription typeDescription,
+                                                                ClassLoader classLoader, JavaModule module) {
+                            int actualModifiers = typeDescription.getActualModifiers(false);
+                            // unset final modifier
+                            int nonFinalModifiers = actualModifiers & ~Opcodes.ACC_FINAL;
+                            return builder.modifiers(nonFinalModifiers);
+                        }
+                    })
+                    .installOn(instrumentation);
+            System.out.println("Running compatibility tests.");
+            // Mock network cannot be used for compatibility testing
+            System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "true");
+        } else {
+            TestLoggingUtils.initializeLogging();
+            if (System.getProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK) == null) {
+                System.setProperty(TestEnvironment.HAZELCAST_TEST_USE_NETWORK, "false");
+            }
         }
         System.setProperty("hazelcast.phone.home.enabled", "false");
         System.setProperty("hazelcast.mancenter.enabled", "false");

--- a/hazelcast/src/test/java/com/hazelcast/test/TestEnvironment.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestEnvironment.java
@@ -19,11 +19,19 @@ package com.hazelcast.test;
 public final class TestEnvironment {
 
     public static final String HAZELCAST_TEST_USE_NETWORK = "hazelcast.test.use.network";
+    public static final String EXECUTE_COMPATIBILITY_TESTS = "hazelcast.test.compatibility";
 
     private TestEnvironment() {
     }
 
     public static boolean isMockNetwork() {
         return !Boolean.getBoolean(HAZELCAST_TEST_USE_NETWORK);
+    }
+
+    /**
+     * @return {@code true} when compatibility tests are to be executed on a mixed version cluster
+     */
+    public static boolean isRunningCompatibilityTest() {
+        return Boolean.getBoolean(EXECUTE_COMPATIBILITY_TESTS);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -47,6 +47,8 @@ import static java.util.Collections.unmodifiableCollection;
 
 public class TestHazelcastInstanceFactory {
 
+    protected final TestNodeRegistry registry;
+
     private static final AtomicInteger PORTS = new AtomicInteger(5000);
 
     private final ConcurrentMap<Integer, Address> addressMap = new ConcurrentHashMap<Integer, Address>();
@@ -54,7 +56,6 @@ public class TestHazelcastInstanceFactory {
     private final AtomicInteger nodeIndex = new AtomicInteger();
 
     private final int count;
-    private final TestNodeRegistry registry;
 
     public TestHazelcastInstanceFactory() {
         this(0);

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/CompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/CompatibilityTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.annotation;
+
+import com.hazelcast.test.TestEnvironment;
+
+/**
+ * Mark a test as a compatibility test, suitable to be executed on a cluster with mixed Hazelcast versions.
+ * To actually perform a compatibility test, you need to start test execution with system property
+ * "hazelcast.test.compatibility=true".
+ *
+ * @see TestEnvironment#isRunningCompatibilityTest()
+ */
+public final class CompatibilityTest {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1050,5 +1050,17 @@
             <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${bytebuddy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-agent</artifactId>
+            <version>${bytebuddy.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
When property `hazelcast.test.compatibility` is `true`, attaches an agent that removes `final` modifier from `com.hazelcast` classes being loaded.