### PR TITLE
Fix NPE in setMasterAddress()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -696,7 +696,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         try {
             if (isJoined()) {
                 Address currentMasterAddress = getMasterAddress();
-                if (!master.equals(currentMasterAddress)) {
+                if (!currentMasterAddress.equals(master)) {
                     logger.warning("Cannot set master address to " + master
                             + " because node is already joined! Current master: " + currentMasterAddress);
                 } else {


### PR DESCRIPTION
setMasterAddress() can be invoked with null argument. The node is guaranteed to have its master address set when it is joined. So we should do the equals check in the correct order.