### PR TITLE
Outbound BackupAckResponse instance creation skipped

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandler.java
@@ -25,12 +25,28 @@ import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
+import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.Response;
 
+import java.nio.ByteOrder;
+
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.CONSTANT_TYPE_DATA_SERIALIZABLE;
+import static com.hazelcast.nio.Bits.writeInt;
+import static com.hazelcast.nio.Bits.writeIntB;
+import static com.hazelcast.nio.Bits.writeLong;
 import static com.hazelcast.nio.Packet.FLAG_OP_RESPONSE;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;
+import static com.hazelcast.nio.Packet.Type.OPERATION;
+import static com.hazelcast.spi.impl.SpiDataSerializerHook.BACKUP_ACK_RESPONSE;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse.BACKUP_RESPONSE_SIZE_IN_BYTES;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.Response.OFFSET_CALL_ID;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.Response.OFFSET_IDENTIFIED;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.Response.OFFSET_SERIALIZER_TYPE_ID;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.Response.OFFSET_TYPE_FACTORY_ID;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.Response.OFFSET_TYPE_ID;
+import static com.hazelcast.spi.impl.operationservice.impl.responses.Response.OFFSET_URGENT;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -42,6 +58,7 @@ public final class OutboundResponseHandler implements OperationResponseHandler {
 
     private final Address thisAddress;
     private final InternalSerializationService serializationService;
+    private final boolean useBigEndian;
     private final ILogger logger;
     // it sucks we need to pass in Node as argument; but this is due to the ConnectionManager which is created after
     // the OperationService is created.
@@ -53,6 +70,7 @@ public final class OutboundResponseHandler implements OperationResponseHandler {
                             ILogger logger) {
         this.thisAddress = thisAddress;
         this.serializationService = serializationService;
+        this.useBigEndian = serializationService.getByteOrder() == ByteOrder.BIG_ENDIAN;
         this.node = node;
         this.logger = logger;
     }
@@ -86,16 +104,55 @@ public final class OutboundResponseHandler implements OperationResponseHandler {
         }
 
         byte[] bytes = serializationService.toBytes(response);
-        Packet packet = new Packet(bytes, -1)
-                .setPacketType(Packet.Type.OPERATION)
-                .raiseFlags(FLAG_OP_RESPONSE);
 
-        if (response.isUrgent()) {
-            packet.raiseFlags(FLAG_URGENT);
-        }
+        Packet packet = newResponsePacket(bytes, response.isUrgent());
 
         ConnectionManager connectionManager = node.getConnectionManager();
         Connection connection = connectionManager.getOrConnect(target);
         return connectionManager.transmit(packet, connection);
+    }
+
+    public void sendBackupAck(Address target, long callId, boolean urgent) {
+        checkNotNull(target, "Target is required!");
+
+        if (thisAddress.equals(target)) {
+            throw new IllegalArgumentException("Target is this node! -> " + target);
+        }
+
+        byte[] bytes = new byte[BACKUP_RESPONSE_SIZE_IN_BYTES];
+
+        writeResponseEpilogueBytes(bytes, BACKUP_ACK_RESPONSE, callId, urgent);
+
+        Packet packet = newResponsePacket(bytes, urgent);
+
+        ConnectionManager connectionManager = node.getConnectionManager();
+        Connection connection = connectionManager.getOrConnect(target);
+        connectionManager.transmit(packet, connection);
+    }
+
+    private void writeResponseEpilogueBytes(byte[] bytes, int typeId, long callId, boolean urgent) {
+        // data-serializable type (this is always written with big endian)
+        writeIntB(bytes, OFFSET_SERIALIZER_TYPE_ID, CONSTANT_TYPE_DATA_SERIALIZABLE);
+        // identified or not
+        bytes[OFFSET_IDENTIFIED] = 1;
+        // factory id
+        writeInt(bytes, OFFSET_TYPE_FACTORY_ID, SpiDataSerializerHook.F_ID, useBigEndian);
+        // type id
+        writeInt(bytes, OFFSET_TYPE_ID, typeId, useBigEndian);
+        // call id
+        writeLong(bytes, OFFSET_CALL_ID, callId, useBigEndian);
+        // urgent
+        bytes[OFFSET_URGENT] = (byte) (urgent ? 1 : 0);
+    }
+
+    private Packet newResponsePacket(byte[] bytes, boolean urgent) {
+        Packet packet = new Packet(bytes, -1)
+                .setPacketType(OPERATION)
+                .raiseFlags(FLAG_OP_RESPONSE);
+
+        if (urgent) {
+            packet.raiseFlags(FLAG_URGENT);
+        }
+        return packet;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -31,7 +31,6 @@ import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
-import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.util.Clock;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -151,8 +150,7 @@ public final class Backup extends Operation implements BackupOperation, Identifi
         if (nodeEngine.getThisAddress().equals(originalCaller)) {
             operationService.getInboundResponseHandler().notifyBackupComplete(callId);
         } else {
-            BackupAckResponse backupAckResponse = new BackupAckResponse(callId, backupOp.isUrgent());
-            operationService.getOutboundResponseHandler().send(backupAckResponse, originalCaller);
+            operationService.getOutboundResponseHandler().sendBackupAck(originalCaller, callId, backupOp.isUrgent());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupAckResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/BackupAckResponse.java
@@ -27,6 +27,9 @@ import static com.hazelcast.spi.impl.SpiDataSerializerHook.BACKUP_ACK_RESPONSE;
  */
 public final class BackupAckResponse extends Response {
 
+    // the length of a backup-ack response in bytes.
+    public static final int BACKUP_RESPONSE_SIZE_IN_BYTES = RESPONSE_SIZE_IN_BYTES;
+
     public BackupAckResponse() {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/Response.java
@@ -23,6 +23,9 @@ import com.hazelcast.spi.impl.SpiDataSerializerHook;
 
 import java.io.IOException;
 
+import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
+import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
+
 /**
  * A {@link Response} is a result of an {@link com.hazelcast.spi.Operation} being executed.
  * There are different types of responses:
@@ -37,8 +40,13 @@ import java.io.IOException;
  */
 public abstract class Response implements IdentifiedDataSerializable {
 
-    public static final int OFFSET_TYPE_ID = 13;
-    public static final int OFFSET_CALL_ID = 17;
+    public static final int OFFSET_SERIALIZER_TYPE_ID = 4;
+    public static final int OFFSET_IDENTIFIED = OFFSET_SERIALIZER_TYPE_ID + INT_SIZE_IN_BYTES;
+    public static final int OFFSET_TYPE_FACTORY_ID = OFFSET_IDENTIFIED + 1;
+    public static final int OFFSET_TYPE_ID = OFFSET_TYPE_FACTORY_ID + INT_SIZE_IN_BYTES;
+    public static final int OFFSET_CALL_ID = OFFSET_TYPE_ID + INT_SIZE_IN_BYTES;
+    public static final int OFFSET_URGENT = OFFSET_CALL_ID + LONG_SIZE_IN_BYTES;
+    public static final int RESPONSE_SIZE_IN_BYTES = OFFSET_URGENT + 1;
 
     protected long callId;
     protected boolean urgent;


### PR DESCRIPTION
So instead of creating a BackupAckResponse and recording the content in some byte-array and then making a new packet-byte array where the content gets copied to, we immediately create the packet-byte array without additional copy and skipping the BackupAckResponse.

So this optimization provides the following benefits:
- skip an intermediate data-copy
- prevents an BackupAckResponse from being created on every backup member.

The is a no difference in the data-send over the wire; it is bit for bit the same as in the old situation.

There will be a follow up PR where the NormalResponse will also be skipped. One of the big advantages of the latter optimization is that if the response value is 'Data', the content will immediately be copied into a correctly sized packet-bytearray instead of having an intermediate copy into a ByteArrayObjectDataOutput.