### PR TITLE
Outbound NormalResponse optimizations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/InternalSerializationService.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.serialization;
 
-import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.BufferObjectDataOutput;
 import com.hazelcast.nio.Disposable;
@@ -33,13 +32,27 @@ public interface InternalSerializationService extends SerializationService, Disp
 
     byte VERSION_1 = 1;
 
+    /**
+     * Writes the obj to a byte array. This call is exactly the same as calling {@link #toData(Object)} and
+     * then calling {@link Data#toByteArray()}. But it doesn't force a HeapData object being created.
+     */
     byte[] toBytes(Object obj);
 
-    byte[] toBytes(int padding, Object obj);
-
-    byte[] toBytes(Object obj, PartitioningStrategy strategy);
-
-    byte[] toBytes(int padding, Object obj, PartitioningStrategy strategy);
+    /**
+     * Writes an object to a byte-array.
+     *
+     * It allows for configurable padding on the left.
+     *
+     * The padded bytes are not zero'd out since they will be written by the caller. Zero'ing them out would be waste of
+     * time.
+     *
+     * If you want to convert an object to a Data (or its byte representation) then you want to have the partition hash, because
+     * that is part of the Data-definition.
+     *
+     * But if you want to serialize an object to a byte-array and don't care for the Data partition-hash, the hash can be
+     * disabled.
+     */
+    byte[] toBytes(Object obj, int leftPadding, boolean insertPartitionHash);
 
     void writeObject(ObjectDataOutput out, Object obj);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -410,7 +410,7 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         } catch (Throwable throwable) {
             // If exception happens we need to extract the callId from the bytes directly!
             long callId = extractOperationCallId(packet);
-            outboundResponseHandler.send(new ErrorResponse(throwable, callId, packet.isUrgent()), caller);
+            outboundResponseHandler.send(caller, new ErrorResponse(throwable, callId, packet.isUrgent()));
             logOperationDeserializationException(throwable, callId);
             throw ExceptionUtil.rethrow(throwable);
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/NormalResponse.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 
+import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.spi.impl.SpiDataSerializerHook.NORMAL_RESPONSE;
 
 /**
@@ -39,7 +40,11 @@ import static com.hazelcast.spi.impl.SpiDataSerializerHook.NORMAL_RESPONSE;
  * @author mdogan 4/10/13
  */
 public class NormalResponse extends Response {
-    public static final int OFFSET_BACKUP_ACKS = 26;
+    public static final int OFFSET_BACKUP_ACKS = RESPONSE_SIZE_IN_BYTES;
+    public static final int OFFSET_IS_DATA = OFFSET_BACKUP_ACKS + 1;
+    public static final int OFFSET_NOT_DATA = OFFSET_IS_DATA + 1;
+    public static final int OFFSET_DATA_LENGTH = OFFSET_IS_DATA + 1;
+    public static final int OFFSET_DATA_PAYLOAD = OFFSET_DATA_LENGTH + INT_SIZE_IN_BYTES;
 
     private Object value;
 
@@ -81,6 +86,7 @@ public class NormalResponse extends Response {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
+
         // acks fit in a byte.
         out.writeByte(backupAcks);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -71,15 +71,10 @@ public class AbstractSerializationServiceTest {
         int padding = 10;
 
         byte[] unpadded = abstractSerializationService.toBytes(payload);
-        byte[] padded = abstractSerializationService.toBytes(10, payload);
+        byte[] padded = abstractSerializationService.toBytes(payload, 10, true);
 
         // make sure the size is expected
         assertEquals(unpadded.length + padding, padded.length);
-
-        // check if the header is zero'ed and doesn't contains anything unexpected
-        for (int k = 0; k < padding; k++) {
-            assertEquals(0, padded[k]);
-        }
 
         // check if the actual content is the same
         for (int k = 0; k < unpadded.length; k++) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
@@ -1,0 +1,300 @@
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.nio.serialization.SerializationConcurrencyTest;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+
+import static com.hazelcast.spi.OperationAccessor.setCallId;
+import static com.hazelcast.spi.OperationAccessor.setCallerAddress;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OutboundResponseHandlerTest {
+
+    private OutboundResponseHandler handler;
+    private Address thisAddress;
+    private InternalSerializationService serializationService;
+    private ILogger logger = Logger.getLogger(OutboundResponseHandlerTest.class);
+    private Node node;
+    private Address thatAddress;
+    private ConnectionManager connectionManager;
+
+    @Before
+    public void setup() throws Exception {
+        thisAddress = new Address("127.0.0.1", 5701);
+        thatAddress = new Address("127.0.0.1", 5702);
+        serializationService = new DefaultSerializationServiceBuilder().build();
+        node = mock(Node.class);
+        connectionManager = mock(ConnectionManager.class);
+        when(node.getConnectionManager()).thenReturn(connectionManager);
+        handler = new OutboundResponseHandler(thisAddress, serializationService, node, logger);
+    }
+
+    @Test
+    public void sendResponse_whenNormalResponse() {
+        NormalResponse response = new NormalResponse("foo", 10, 1, false);
+        Operation op = new DummyOperation();
+        setCallId(op, response.getCallId());
+        setCallerAddress(op, thatAddress);
+
+        ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
+        Connection connection = mock(Connection.class);
+        when(connectionManager.getOrConnect(thatAddress)).thenReturn(connection);
+        when(connectionManager.transmit(argument.capture(), eq(connection))).thenReturn(true);
+
+        // make the call
+        handler.sendResponse(op, response);
+
+        // verify that the right object was send
+        assertEquals(serializationService.toData(response), argument.getValue());
+    }
+
+    @Test
+    public void sendResponse_whenPortable() {
+        Object response = new PortableAddress("Sesame Street",1);
+        Operation op = new DummyOperation();
+        setCallId(op, 10);
+        setCallerAddress(op, thatAddress);
+
+        ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
+        Connection connection = mock(Connection.class);
+        when(connectionManager.getOrConnect(thatAddress)).thenReturn(connection);
+        when(connectionManager.transmit(argument.capture(), eq(connection))).thenReturn(true);
+
+        // make the call
+        handler.sendResponse(op, response);
+
+        // verify that the right object was send
+        NormalResponse expected = new NormalResponse(response, op.getCallId(), 0, op.isUrgent());
+        assertEquals(serializationService.toData(expected), argument.getValue());
+    }
+
+    @Test
+    public void sendResponse_whenOrdinaryValue() {
+        Object response = "foobar";
+        Operation op = new DummyOperation();
+        setCallId(op, 10);
+        setCallerAddress(op, thatAddress);
+
+        ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
+        Connection connection = mock(Connection.class);
+        when(connectionManager.getOrConnect(thatAddress)).thenReturn(connection);
+        when(connectionManager.transmit(argument.capture(), eq(connection))).thenReturn(true);
+
+        // make the call
+        handler.sendResponse(op, response);
+
+        // verify that the right object was send
+        NormalResponse expected = new NormalResponse(response, op.getCallId(), 0, op.isUrgent());
+        assertEquals(serializationService.toData(expected), argument.getValue());
+    }
+
+    @Test
+    public void sendResponse_whenNull() {
+        Operation op = new DummyOperation();
+        setCallId(op, 10);
+        setCallerAddress(op, thatAddress);
+
+        ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
+        Connection connection = mock(Connection.class);
+        when(connectionManager.getOrConnect(thatAddress)).thenReturn(connection);
+        when(connectionManager.transmit(argument.capture(), eq(connection))).thenReturn(true);
+
+        // make the call
+        handler.sendResponse(op, null);
+
+        // verify that the right object was send
+        NormalResponse expected = new NormalResponse(null, op.getCallId(), 0, op.isUrgent());
+        assertEquals(serializationService.toData(expected), argument.getValue());
+    }
+
+    @Test
+    public void sendResponse_whenTimeoutResponse() {
+        CallTimeoutResponse response = new CallTimeoutResponse(10, false);
+
+        Operation op = new DummyOperation();
+        setCallId(op, 10);
+        setCallerAddress(op, thatAddress);
+
+        ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
+        Connection connection = mock(Connection.class);
+        when(connectionManager.getOrConnect(thatAddress)).thenReturn(connection);
+        when(connectionManager.transmit(argument.capture(), eq(connection))).thenReturn(true);
+
+        // make the call
+        handler.sendResponse(op, response);
+
+        // verify that the right object was send
+        assertEquals(serializationService.toData(response), argument.getValue());
+    }
+
+    @Test
+    public void sendResponse_whenErrorResponse() {
+        ErrorResponse response = new ErrorResponse(new Exception(), 10, false);
+
+        Operation op = new DummyOperation();
+        setCallId(op, 10);
+        setCallerAddress(op, thatAddress);
+
+        ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
+        Connection connection = mock(Connection.class);
+        when(connectionManager.getOrConnect(thatAddress)).thenReturn(connection);
+        when(connectionManager.transmit(argument.capture(), eq(connection))).thenReturn(true);
+
+        // make the call
+        handler.sendResponse(op, response);
+
+        // verify that the right object was send
+        assertEquals(serializationService.toData(response), argument.getValue());
+    }
+
+    @Test
+    public void sendResponse_whenThrowable() {
+        Exception exception = new Exception();
+
+        Operation op = new DummyOperation();
+        setCallId(op, 10);
+        setCallerAddress(op, thatAddress);
+
+        ArgumentCaptor<Packet> argument = ArgumentCaptor.forClass(Packet.class);
+        Connection connection = mock(Connection.class);
+        when(connectionManager.getOrConnect(thatAddress)).thenReturn(connection);
+        when(connectionManager.transmit(argument.capture(), eq(connection))).thenReturn(true);
+
+        // make the call
+        handler.sendResponse(op, exception);
+
+        // verify that the right object was send
+        ErrorResponse expectedResponse = new ErrorResponse(exception, op.getCallId(), op.isUrgent());
+        assertEquals(serializationService.toData(expectedResponse), argument.getValue());
+    }
+
+
+    @Test
+    public void toBackupAckPacket() {
+        testToBackupAckPacket(1, false);
+        testToBackupAckPacket(2, true);
+    }
+
+    private void testToBackupAckPacket(int callId, boolean urgent) {
+        Packet packet = handler.toBackupAckPacket(callId, urgent);
+        HeapData expected = serializationService.toData(new BackupAckResponse(callId, urgent));
+        assertEquals(expected, new HeapData(packet.toByteArray()));
+    }
+
+    @Test
+    public void toNormalResponsePacket_whenNormalValues() {
+        testToNormalResponsePacket("foo", 1, 0, false);
+        testToNormalResponsePacket("foo", 2, 0, true);
+        testToNormalResponsePacket("foo", 3, 2, false);
+    }
+
+    @Test
+    public void toNormalResponsePacket_whenNullValue() {
+        testToNormalResponsePacket(null, 1, 2, false);
+    }
+
+    @Test
+    public void toNormalResponsePacket_whenDataValue() {
+        testToNormalResponsePacket(serializationService.toBytes("foobar"), 1, 2, false);
+    }
+
+    private void testToNormalResponsePacket(Object value, int callId, int backupAcks, boolean urgent) {
+        Packet packet = handler.toNormalResponsePacket(callId, backupAcks, urgent, value);
+        HeapData expected = serializationService.toData(new NormalResponse(value, callId, backupAcks, urgent));
+        assertEquals(expected, new HeapData(packet.toByteArray()));
+    }
+
+    static class PortableAddress implements Portable {
+
+        private String street;
+
+        private int no;
+
+        public PortableAddress() {
+        }
+
+        public PortableAddress(String street, int no) {
+            this.street = street;
+            this.no = no;
+        }
+
+        @Override
+        public int getClassId() {
+            return 2;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeInt("no", no);
+            writer.writeUTF("street", street);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            street = reader.readUTF("street");
+            no = reader.readInt("no");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            PortableAddress that = (PortableAddress) o;
+            if (no != that.no) {
+                return false;
+            }
+            if (street != null ? !street.equals(that.street) : that.street != null) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = street != null ? street.hashCode() : 0;
+            result = 31 * result + no;
+            return result;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
This PR contains the following optimizations

- for an operation that doesn't require backup acks (e.g. map.get or a map.put with async backup_ the NormalResponse instance is skipped (less litter)
- if the response is data, the intermediate copy of the data into a ByteArrayObjectDataOutput is skipped. A byte array with the right size to store the whole response is created and the data is copied into this  byte-array directly. So we get a packet-bytearray with a single copy of data instead of multiple copies.

This PR is native-memory friendly; it doesn't force the NativeMemoryData to create a copy onheap. 

This is a follow up PR for 
https://github.com/hazelcast/hazelcast/pull/10317

There is no change in the data that goes over the wire. So there will not be any minor version incompatibilities.

fix #10285