### PR TITLE
[BACKPORT] Fixed a missing SOURCE_NOT_AVAILABLE in AbstractCacheRecordStore.loadAll()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -1398,7 +1398,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                 Data key = entry.getKey();
                 Object value = entry.getValue();
                 if (value != null) {
-                    put(key, value, null, null, false, true, IGNORE_COMPLETION);
+                    put(key, value, null, SOURCE_NOT_AVAILABLE, false, true, IGNORE_COMPLETION);
                     keysLoaded.add(key);
                 }
             }


### PR DESCRIPTION
(cherry picked from commit 8ecaa79)

Backport of https://github.com/hazelcast/hazelcast/pull/10329