### PR TITLE
Only queue SplitBrainJoinMessages for processing on master node

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -118,7 +118,7 @@ public class MulticastJoiner extends AbstractJoiner {
                             logger.fine("Ignoring merge join response, since " + joinInfo.getAddress()
                                     + " is already a member.");
                         }
-                        return;
+                        continue;
                     }
 
                     if (joinInfo.getMemberCount() == 1) {
@@ -144,8 +144,20 @@ public class MulticastJoiner extends AbstractJoiner {
     }
 
     @Override
+    public void reset() {
+        super.reset();
+        // since this node is going to merge with a detected cluster, clear the queued split brain join messages (if any)
+        splitBrainJoinMessages.clear();
+    }
+
+    @Override
     public String getType() {
         return "multicast";
+    }
+
+    // for tests only
+    public int getSplitBrainMessagesCount() {
+        return splitBrainJoinMessages.size();
     }
 
     void onReceivedJoinRequest(JoinRequest joinRequest) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainMulticastListener.java
@@ -40,7 +40,8 @@ public class SplitBrainMulticastListener implements MulticastListener {
         if (msg instanceof SplitBrainJoinMessage) {
             SplitBrainJoinMessage joinRequest = (SplitBrainJoinMessage) msg;
             Address thisAddress = node.getThisAddress();
-            if (!thisAddress.equals(joinRequest.getAddress())) {
+            // only master nodes execute the SplitBrainHandler that processes SplitBrainJoinMessages
+            if (!thisAddress.equals(joinRequest.getAddress()) && node.isMaster()) {
                 deque.addFirst(joinRequest);
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SlowMulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SlowMulticastJoinTest.java
@@ -16,9 +16,17 @@
 
 package com.hazelcast.cluster;
 
+import com.hazelcast.cluster.SplitBrainHandlerTest.MergedEventLifeCycleListener;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.MemberAttributeEvent;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.internal.cluster.impl.MulticastJoiner;
 import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.After;
@@ -28,7 +36,11 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
@@ -54,6 +66,85 @@ public class SlowMulticastJoinTest extends AbstractJoinTest {
         Config config2 = newConfig("*.*.*.*"); //matching everything
 
         testJoin(config2);
+    }
+
+    @Test
+    public void testSplitBrainMessagesNotAccumulated_whenClusterIsStableOrNodeIsNotMaster() throws Exception {
+        final int clusterSize = 3;
+        Config config = new Config();
+        config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
+        config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "10");
+        config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "15");
+
+        final HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+        final MulticastJoiner[] joiners = new MulticastJoiner[clusterSize];
+
+        for (int i = 0; i < clusterSize; i++) {
+            instances[i] = Hazelcast.newHazelcastInstance(config);
+            joiners[i] = (MulticastJoiner) getNode(instances[i]).getJoiner();
+        }
+
+        assertEquals(clusterSize, instances[0].getCluster().getMembers().size());
+
+        // we will split the cluster to subclusters (0, 1), (2)
+        final CountDownLatch splitLatch = new CountDownLatch(2);
+        instances[2].getCluster().addMembershipListener(new MembershipListener() {
+            @Override
+            public void memberAdded(MembershipEvent membershipEvent) {
+            }
+
+            @Override
+            public void memberRemoved(MembershipEvent membershipEvent) {
+                splitLatch.countDown();
+            }
+
+            @Override
+            public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+            }
+        });
+
+        final CountDownLatch mergeLatch = new CountDownLatch(1);
+        instances[2].getLifecycleService().addLifecycleListener(new MergedEventLifeCycleListener(mergeLatch));
+
+        // while cluster is stable, split brain join messages should not be accumulated.
+        // the master member for the 10 seconds duration of assertion may have up to as many as other members
+        // in the cluster (clusterSize-1) messages in its queue which will be ignored by the SplitBrainHandler.
+        assertSplitBrainMessagesCount(clusterSize, instances, joiners);
+
+        // split cluster
+        closeConnectionBetween(instances[0], instances[2]);
+        closeConnectionBetween(instances[1], instances[2]);
+
+        assertTrue(splitLatch.await(10, TimeUnit.SECONDS));
+
+        // while cluster is split, no split brain join messages should be accumulated in the non-master member 1
+        assertSplitBrainMessagesCount(clusterSize, new HazelcastInstance[] {instances[1]},
+                new MulticastJoiner[] {joiners[1]});
+
+        assertTrue(mergeLatch.await(30, TimeUnit.SECONDS));
+        assertEquals(clusterSize, instances[0].getCluster().getMembers().size());
+
+        // cluster is merged & stable again, split brain join messages should not be accumulated.
+        assertSplitBrainMessagesCount(clusterSize, instances, joiners);
+    }
+
+    private void assertSplitBrainMessagesCount(final int clusterSize, final HazelcastInstance[] instances,
+                                               final MulticastJoiner[] joiners) {
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                for (int i = 0; i < instances.length; i++) {
+                    // a master can have at most (clusterSize-1) split brain join messages
+                    if (getNode(instances[i]).isMaster()) {
+                        assertTrue(joiners[i].getSplitBrainMessagesCount() < clusterSize);
+                    } else {
+                        // other members should not have any split brain join messages
+                        assertEquals(0, joiners[i].getSplitBrainMessagesCount());
+                    }
+                }
+            }
+        }, 10);
     }
 
     private Config newConfig(String trustedInterface) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -855,7 +855,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         return (FirewallingConnectionManager) getConnectionManager(hz);
     }
 
-    private static class MergedEventLifeCycleListener
+    public static class MergedEventLifeCycleListener
             implements LifecycleListener {
 
         private final CountDownLatch mergeLatch;


### PR DESCRIPTION
The `SplitBrainMulticastListener` is registered on every member, however only master needs to actually queue `SplitBrainJoinMessage`s, as it is the only member that executes the `SplitBrainHandler`. This was (implicitly) the case before #9328 was merged, because the split brain multicast listener was only created & registered during the execution of `SplitBrainHandler`.

Fixes #10325 in `master`, a backport for 3.8.2 will be created once reviewed & merged.