### PR TITLE
Use newUnsecureUUID() for metadata UUID

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcherTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcherTest.java
@@ -69,7 +69,7 @@ public class ClientCacheMetaDataFetcherTest extends HazelcastTestSupport {
         String cacheName = "test";
         int partition = 1;
         long givenSequence = getInt(1, MAX_VALUE);
-        UUID givenUuid = UuidUtil.newSecureUUID();
+        UUID givenUuid = UuidUtil.newUnsecureUUID();
 
         RepairingTask repairingTask = getRepairingTask(cacheName, partition, givenSequence, givenUuid);
         MetaDataFetcher metaDataFetcher = repairingTask.getMetaDataFetcher();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
@@ -209,7 +209,7 @@ public class InvalidationMetadataDistortionTest extends ClientNearCacheTestSuppo
         CacheEventHandler cacheEventHandler = service.getCacheEventHandler();
         MetaDataGenerator metaDataGenerator = cacheEventHandler.getMetaDataGenerator();
 
-        UUID uuid = UuidUtil.newSecureUUID();
+        UUID uuid = UuidUtil.newUnsecureUUID();
         int randomPartition = getInt(partitionCount);
         metaDataGenerator.setUuid(randomPartition, uuid);
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcherTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcherTest.java
@@ -66,7 +66,7 @@ public class ClientMapMetaDataFetcherTest extends HazelcastTestSupport {
         String mapName = "test";
         int partition = 1;
         long givenSequence = getInt(1, Integer.MAX_VALUE);
-        UUID givenUuid = UuidUtil.newSecureUUID();
+        UUID givenUuid = UuidUtil.newUnsecureUUID();
 
         RepairingTask repairingTask = getRepairingTask(mapName, partition, givenSequence, givenUuid);
         MetaDataFetcher metaDataFetcher = repairingTask.getMetaDataFetcher();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
@@ -208,7 +208,7 @@ public class InvalidationMetadataDistortionTest extends NearCacheTestSupport {
         Invalidator invalidator = mapNearCacheManager.getInvalidator();
         MetaDataGenerator metaDataGenerator = invalidator.getMetaDataGenerator();
 
-        metaDataGenerator.setUuid(partitionId, UuidUtil.newSecureUUID());
+        metaDataGenerator.setUuid(partitionId, UuidUtil.newUnsecureUUID());
     }
 
     protected HazelcastClientInstanceImpl getHazelcastClientInstanceImpl(HazelcastInstance client) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLongArray;
 
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
-import static com.hazelcast.util.UuidUtil.newSecureUUID;
+import static com.hazelcast.util.UuidUtil.newUnsecureUUID;
 
 /**
  * Responsible for partition-sequence and partition-uuid generation.
@@ -52,7 +52,7 @@ public class MetaDataGenerator {
             = new ConstructorFunction<Integer, UUID>() {
         @Override
         public UUID createNew(Integer partitionId) {
-            return newSecureUUID();
+            return newUnsecureUUID();
         }
     };
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/InvalidationMetadataDistortionTest.java
@@ -198,6 +198,6 @@ public class InvalidationMetadataDistortionTest extends NearCacheTestSupport {
         Invalidator invalidator = mapNearCacheManager.getInvalidator();
         MetaDataGenerator metaDataGenerator = invalidator.getMetaDataGenerator();
 
-        metaDataGenerator.setUuid(partitionId, UuidUtil.newSecureUUID());
+        metaDataGenerator.setUuid(partitionId, UuidUtil.newUnsecureUUID());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapMetaDataFetcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/MemberMapMetaDataFetcherTest.java
@@ -63,7 +63,7 @@ public class MemberMapMetaDataFetcherTest extends HazelcastTestSupport {
         String mapName = "test";
         int partition = 1;
         long givenSequence = getInt(1, Integer.MAX_VALUE);
-        UUID givenUuid = UuidUtil.newSecureUUID();
+        UUID givenUuid = UuidUtil.newUnsecureUUID();
 
         RepairingTask repairingTask = getRepairingTask(mapName, partition, givenSequence, givenUuid);
         MetaDataFetcher metaDataFetcher = repairingTask.getMetaDataFetcher();


### PR DESCRIPTION
We only need unique IDs, but not necessary random.
Secure UUIDs cause contention.