### PR TITLE
Alligning exception delivered to callback of client with server

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -45,7 +45,6 @@ import com.hazelcast.version.MemberVersion;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferService.TOPIC_RB_PREFIX;
@@ -272,7 +271,7 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
                 return;
             }
 
-            if (t instanceof ExecutionException && t.getCause() instanceof StaleSequenceException) {
+            if (t instanceof StaleSequenceException) {
                 // StaleSequenceException.getHeadSeq() is not available on the client-side, see #7317
                 long remoteHeadSeq = ringbuffer.headSequence();
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -63,19 +63,6 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
     }
 
     @Override
-    protected Throwable unwrap(Throwable throwable) {
-        return throwable;
-    }
-
-    @Override
-    protected Object resolve(Object value) {
-        if (value instanceof Throwable) {
-            return new ExecutionException((Throwable) value);
-        }
-        return value;
-    }
-
-    @Override
     public void andThen(ExecutionCallback<ClientMessage> callback) {
         isNotNull(callback, "callback");
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -247,7 +247,7 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         service.submit(new FailingTestTask(), callback);
 
         assertOpenEventually(callback.getLatch());
-        assertTrue(callback.getResult() instanceof Throwable);
+        assertTrue(callback.getResult() instanceof IllegalStateException);
     }
 
     /* ############ submit(Runnable) ############ */


### PR DESCRIPTION
`ExecutionCallback.onFailure` registered to `ICompletableFuture.andThen`
was wrapped to ExecutionException on client while on server exception
is directly passed to `onFailure` wihout wrapping.

Client behaviour is changed as servers.

fixes #10335