### PR TITLE
Server socket-buffer size increase from 32KB to 128KB

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -219,11 +219,11 @@ public final class GroupProperty {
 
     // number of kilobytes
     public static final HazelcastProperty SOCKET_RECEIVE_BUFFER_SIZE
-            = new HazelcastProperty("hazelcast.socket.receive.buffer.size", 32);
+            = new HazelcastProperty("hazelcast.socket.receive.buffer.size", 128);
 
     // number of kilobytes
     public static final HazelcastProperty SOCKET_SEND_BUFFER_SIZE
-            = new HazelcastProperty("hazelcast.socket.send.buffer.size", 32);
+            = new HazelcastProperty("hazelcast.socket.send.buffer.size", 128);
 
     /**
      * If the bytebuffers used in the socket should be a direct bytebuffer (true) or a regular bytebuffer (false).


### PR DESCRIPTION
32kb are only useful with small payloads or when there no clients doing a lot of backups. So the member socket buffers have been increased to 128kb by default.

We see a lot of usage with 1/10kb values and increasing the buffers can have a significant impact on throughput and latency. 

The above images are from a 2 lite member + 2 member cluster on 4 machines using 1kb/10kb values with 40 threads per lite member.

![throughput](https://cloud.githubusercontent.com/assets/105243/25011051/b014fafe-2074-11e7-8857-2afd05fb1718.png)

It seems that 128KB gives the biggest bang for the buck.

![latency_distribution_get](https://cloud.githubusercontent.com/assets/105243/25011068/c1b4f9d0-2074-11e7-9025-0f5cc8072014.png)
Above of the latency distribution.

For small payloads it doesn't seam to have a negative impact.You can see that in the diagram below:

![throughput](https://cloud.githubusercontent.com/assets/105243/25011151/124f3a36-2075-11e7-98cc-a3e098ee6d55.png)

for the whole benchmark report see:
[bench-member-buffersize.zip](https://github.com/hazelcast/hazelcast/files/920109/bench-member-buffersize.zip)


Also the serverside client buffers have been increased to 128 (since they by default to it due to the server buffers). Only with an extreme number of clients this could be an issue, e.g. with 1000 clients you go from 128mb to 512mb for clients socket-buffers; so an increase of 384mb which isn't the end of the world for most server machines. For those non standard cases they can easily reserve more memory or reduce the size of the serverside client buffers.

