### PR TITLE
[BACKPORT] Apply minor improvements in migration tests

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -614,7 +614,15 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     private boolean applyNewState(PartitionRuntimeState partitionState, Address sender) {
-        lock.lock();
+        try {
+            if (!lock.tryLock(PTABLE_SYNC_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                return false;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+
         try {
             final int newVersion = partitionState.getVersion();
             final int currentVersion = partitionStateManager.getVersion();

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionMigrationListenerTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
@@ -56,12 +57,20 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), String.valueOf(partitionCount));
 
         HazelcastInstance instance = factory.newHazelcastInstance(config);
-        final CountingMigrationListener migrationListener = new CountingMigrationListener(partitionCount);
+
+        CountDownLatch migrationStartLatch = new CountDownLatch(1);
+
+        final CountingMigrationListener migrationListener = new CountingMigrationListener(migrationStartLatch, partitionCount);
         instance.getPartitionService().addMigrationListener(migrationListener);
 
         warmUpPartitions(instance);
 
-        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        final HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+
+        assertNodeStartedEventually(instance2);
+
+        migrationStartLatch.countDown();
+
         waitAllForSafeState(instance2, instance);
 
         assertTrueEventually(new AssertTask() {
@@ -98,7 +107,7 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
     @Test
     public void testAddMigrationListener_whenListenerRegisteredTwice() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
         PartitionService partitionService = hz1.getPartitionService();
 
         MigrationListener listener = mock(MigrationListener.class);
@@ -131,7 +140,7 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
     @Test
     public void testRemoveMigrationListener() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz1 = factory.newHazelcastInstance(new Config());
         PartitionService partitionService = hz1.getPartitionService();
 
         MigrationListener listener = mock(MigrationListener.class);
@@ -140,9 +149,8 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
         boolean removed = partitionService.removeMigrationListener(id);
 
         assertTrue(removed);
-
         // now we add a member
-        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance(new Config());
         warmUpPartitions(hz1, hz2);
 
         // and verify that the listener isn't called.
@@ -158,11 +166,14 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
 
     private static class CountingMigrationListener implements MigrationListener {
 
+        CountDownLatch migrationStartLatch;
+
         AtomicInteger[] migrationStarted;
         AtomicInteger[] migrationCompleted;
         AtomicInteger[] migrationFailed;
 
-        CountingMigrationListener(int partitionCount) {
+        CountingMigrationListener(CountDownLatch migrationStartLatch, int partitionCount) {
+            this.migrationStartLatch = migrationStartLatch;
             migrationStarted = new AtomicInteger[partitionCount];
             migrationCompleted = new AtomicInteger[partitionCount];
             migrationFailed = new AtomicInteger[partitionCount];
@@ -175,6 +186,7 @@ public class PartitionMigrationListenerTest extends HazelcastTestSupport {
 
         @Override
         public void migrationStarted(MigrationEvent migrationEvent) {
+            assertOpenEventually(migrationStartLatch);
             migrationStarted[migrationEvent.getPartitionId()].incrementAndGet();
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.Partition;
 import com.hazelcast.core.PartitionService;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.metrics.MetricsRegistry;
@@ -625,6 +626,21 @@ public abstract class HazelcastTestSupport {
         }
 
         assertTrue("Instances not in safe state! " + nonSafeStates, nonSafeStates.isEmpty());
+    }
+
+    public static void assertNodeStarted(HazelcastInstance instance) {
+        NodeExtension nodeExtension = getNode(instance).getNodeExtension();
+        assertTrue(nodeExtension.isStartCompleted());
+    }
+
+    public static void assertNodeStartedEventually(final HazelcastInstance instance) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertNodeStarted(instance);
+            }
+        });
     }
 
     // ################################


### PR DESCRIPTION
Occasionally, migration tests fail in slow build environment because of same false alarms. For instance, a migration starts and immediately fails because a new member joins to the cluster but doesn't complete the start process yet.
Changes here make the tests less fragile for similar cases.

Backport of #10343 