### PR TITLE
Handle HazelcastClientNotActiveException in ClientReliableTopicProxy

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -732,10 +732,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         proxyManager.destroy();
         connectionManager.shutdown();
         clusterService.shutdown();
-        executionService.shutdown();
         partitionService.stop();
         transactionManager.shutdown();
         invocationService.shutdown();
+        executionService.shutdown();
         listenerService.shutdown();
         nearCacheManager.destroyAllNearCaches();
         if (discoveryService != null) {


### PR DESCRIPTION
Because of shutdown order of events, invocation was getting
RejectedExecutionException from EventService rather than
HazelcastClientNotActiveException.
Both the shutdown order fix and handling the Exception is added to pr.

fixes #10291
backport of https://github.com/hazelcast/hazelcast/pull/10348