### PR TITLE
Minor AbstractHandler.unregisterOp optimization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/AbstractHandler.java
@@ -109,7 +109,10 @@ public abstract class AbstractHandler
 
     final void unregisterOp(int operation) throws IOException {
         SelectionKey selectionKey = getSelectionKey();
-        selectionKey.interestOps(selectionKey.interestOps() & ~operation);
+        int interestOps = selectionKey.interestOps();
+        if ((interestOps & operation) != 0) {
+            selectionKey.interestOps(interestOps & ~operation);
+        }
     }
 
     @Override


### PR DESCRIPTION
So instead of always calling interestOps(...), it is only done when there is actually a change.

Comes from: http://normanmaurer.me/presentations/2013-jax-networking-on-jvm/#/27