### PR TITLE
Packet not extending HeapData any longer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
@@ -84,7 +84,7 @@ public final class InboundResponseHandler implements PacketHandler, MetricsProvi
 
     @Override
     public void handle(Packet packet) throws Exception {
-        byte[] bytes = packet.toByteArray();
+        byte[] bytes = packet.getPayload();
         int typeId = Bits.readInt(bytes, OFFSET_TYPE_ID, useBigEndian);
         long callId = Bits.readLong(bytes, OFFSET_CALL_ID, useBigEndian);
         Address sender = packet.getConn().getEndPoint();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.partition.InternalPartition;
+import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.serialization.impl.SerializationServiceV1;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.logging.ILogger;
@@ -35,7 +36,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.Packet;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.quorum.QuorumException;
 import com.hazelcast.quorum.impl.QuorumServiceImpl;
 import com.hazelcast.spi.BlockingOperation;
@@ -426,9 +426,9 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
      * <p>
      * It makes an assumption that the callId is the first long field in the serialized operation.
      */
-    private long extractOperationCallId(Data data) throws IOException {
+    private long extractOperationCallId(Packet packet) throws IOException {
         ObjectDataInput input = ((SerializationServiceV1) node.getSerializationService())
-                .initDataSerializableInputAndSkipTheHeader(data);
+                .initDataSerializableInputAndSkipTheHeader(new HeapData(packet.getPayload()));
         return input.readLong();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/PacketTransportTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/PacketTransportTest.java
@@ -115,6 +115,6 @@ public class PacketTransportTest extends HazelcastTestSupport {
 
     private static void assertPacketEquals(Packet originalPacket, Packet clonedPacket) {
         assertEquals(originalPacket.getFlags(), clonedPacket.getFlags());
-        assertArrayEquals(originalPacket.toByteArray(), clonedPacket.toByteArray());
+        assertArrayEquals(originalPacket.getPayload(), clonedPacket.getPayload());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/OperationPacketFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/OperationPacketFilter.java
@@ -18,6 +18,7 @@ package com.hazelcast.nio.tcp;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.Packet;
@@ -41,7 +42,7 @@ public abstract class OperationPacketFilter implements PacketFilter {
 
     private boolean allowOperation(Packet packet, Address endpoint) {
         try {
-            ObjectDataInput input = serializationService.createObjectDataInput(packet);
+            ObjectDataInput input = serializationService.createObjectDataInput(new HeapData(packet.getPayload()));
             byte header = input.readByte();
             boolean identified = (header & 1) != 0;
             if (identified) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImplTest.java
@@ -217,7 +217,7 @@ public class OperationRunnerImplTest extends HazelcastTestSupport {
         setCallId(op, 1000 * 1000);
 
         Packet packet = toPacket(local, remote, op);
-        byte[] bytes = packet.toByteArray();
+        byte[] bytes = packet.getPayload();
         for (int k = 0; k < bytes.length; k++) {
             bytes[k]++;
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
@@ -209,7 +209,7 @@ public class OutboundResponseHandlerTest {
     private void testToBackupAckPacket(int callId, boolean urgent) {
         Packet packet = handler.toBackupAckPacket(callId, urgent);
         HeapData expected = serializationService.toData(new BackupAckResponse(callId, urgent));
-        assertEquals(expected, new HeapData(packet.toByteArray()));
+        assertEquals(expected, new HeapData(packet.getPayload()));
     }
 
     @Test
@@ -232,7 +232,7 @@ public class OutboundResponseHandlerTest {
     private void testToNormalResponsePacket(Object value, int callId, int backupAcks, boolean urgent) {
         Packet packet = handler.toNormalResponsePacket(callId, backupAcks, urgent, value);
         HeapData expected = serializationService.toData(new NormalResponse(value, callId, backupAcks, urgent));
-        assertEquals(expected, new HeapData(packet.toByteArray()));
+        assertEquals(expected, new HeapData(packet.getPayload()));
     }
 
     static class PortableAddress implements Portable {


### PR DESCRIPTION
This optimization was added some time ago to prevent creating and
HeapData and Packet; but with the recent response optimizations
this 'ugly' design isn't needed any longer.

No Enterprise PR needed. 

Doesn't change anything that goes over the wire; so no minor upgrade incompatibility.
