### PR TITLE
Introduced the OutboundOperationHandler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -162,7 +162,9 @@ public abstract class Invocation implements OperationResponseHandler {
     final long tryPauseMillis;
     final long callTimeoutMillis;
 
-    /** Refer to {@link com.hazelcast.spi.InvocationBuilder#setDoneCallback(Runnable)} for an explanation */
+    /**
+     * Refer to {@link com.hazelcast.spi.InvocationBuilder#setDoneCallback(Runnable)} for an explanation
+     */
     private final Runnable taskDoneCallback;
 
     Invocation(Context context, Operation op, Runnable taskDoneCallback, int tryCount, long tryPauseMillis,
@@ -536,7 +538,7 @@ public abstract class Invocation implements OperationResponseHandler {
     }
 
     private void doInvokeRemote() {
-        if (!context.operationService.send(op, invTarget)) {
+        if (!context.outboundOperationHandler.send(op, invTarget)) {
             notifyError(new RetryableIOException("Packet not send to -> " + invTarget));
         }
     }
@@ -753,25 +755,27 @@ public abstract class Invocation implements OperationResponseHandler {
         final MwCounter retryCount;
         final InternalSerializationService serializationService;
         final Address thisAddress;
+        final OutboundOperationHandler outboundOperationHandler;
 
         @SuppressWarnings("checkstyle:parameternumber")
         Context(ManagedExecutorService asyncExecutor,
-                       ClusterClock clusterClock,
-                       ClusterService clusterService,
-                       ConnectionManager connectionManager,
-                       InternalExecutionService executionService,
-                       long defaultCallTimeoutMillis,
-                       InvocationRegistry invocationRegistry,
-                       InvocationMonitor invocationMonitor,
-                       ILogger logger,
-                       Node node,
-                       NodeEngine nodeEngine,
-                       InternalPartitionService partitionService,
-                       OperationServiceImpl operationService,
-                       OperationExecutor operationExecutor,
-                       MwCounter retryCount,
-                       InternalSerializationService serializationService,
-                       Address thisAddress) {
+                ClusterClock clusterClock,
+                ClusterService clusterService,
+                ConnectionManager connectionManager,
+                InternalExecutionService executionService,
+                long defaultCallTimeoutMillis,
+                InvocationRegistry invocationRegistry,
+                InvocationMonitor invocationMonitor,
+                ILogger logger,
+                Node node,
+                NodeEngine nodeEngine,
+                InternalPartitionService partitionService,
+                OperationServiceImpl operationService,
+                OperationExecutor operationExecutor,
+                MwCounter retryCount,
+                InternalSerializationService serializationService,
+                Address thisAddress,
+                OutboundOperationHandler outboundOperationHandler) {
             this.asyncExecutor = asyncExecutor;
             this.clusterClock = clusterClock;
             this.clusterService = clusterService;
@@ -789,6 +793,7 @@ public abstract class Invocation implements OperationResponseHandler {
             this.retryCount = retryCount;
             this.serializationService = serializationService;
             this.thisAddress = thisAddress;
+            this.outboundOperationHandler = outboundOperationHandler;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -37,12 +37,12 @@ import static java.lang.Math.min;
 final class OperationBackupHandler {
 
     private final Node node;
-    private final OperationServiceImpl operationService;
     private final NodeEngineImpl nodeEngine;
     private final BackpressureRegulator backpressureRegulator;
+    private final OutboundOperationHandler outboundOperationHandler;
 
-    OperationBackupHandler(OperationServiceImpl operationService) {
-        this.operationService = operationService;
+    OperationBackupHandler(OperationServiceImpl operationService, OutboundOperationHandler outboundOperationHandler) {
+        this.outboundOperationHandler = outboundOperationHandler;
         this.node = operationService.node;
         this.nodeEngine = operationService.nodeEngine;
         this.backpressureRegulator = operationService.backpressureRegulator;
@@ -207,7 +207,7 @@ final class OperationBackupHandler {
             boolean isSyncBackup = syncBackups == 1;
 
             Backup backup = newBackup(backupAwareOp, backupOp, replicaVersions, 1, isSyncBackup);
-            operationService.send(backup, target);
+            outboundOperationHandler.send(backup, target);
 
             if (isSyncBackup) {
                 return 1;
@@ -234,7 +234,7 @@ final class OperationBackupHandler {
             boolean isSyncBackup = replicaIndex <= syncBackups;
 
             Backup backup = newBackup(backupAwareOp, backupOpData, replicaVersions, replicaIndex, isSyncBackup);
-            operationService.send(backup, target);
+            outboundOperationHandler.send(backup, target);
 
             if (isSyncBackup) {
                 sendSyncBackups++;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundOperationHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OutboundOperationHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.spi.Operation;
+
+import static com.hazelcast.nio.Packet.FLAG_URGENT;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Responsible for sending Operations to another member.
+ */
+public class OutboundOperationHandler {
+    private final Address thisAddress;
+    private final InternalSerializationService serializationService;
+    private final Node node;
+
+    public OutboundOperationHandler(Node node, Address thisAddress, InternalSerializationService serializationService) {
+        this.node = node;
+        this.thisAddress = thisAddress;
+        this.serializationService = serializationService;
+    }
+
+    public boolean send(Operation op, Address target) {
+        checkNotNull(target, "Target is required!");
+
+        if (thisAddress.equals(target)) {
+            throw new IllegalArgumentException("Target is this node! -> " + target + ", op: " + op);
+        }
+
+        byte[] bytes = serializationService.toBytes(op);
+        int partitionId = op.getPartitionId();
+        Packet packet = new Packet(bytes, partitionId).setPacketType(Packet.Type.OPERATION);
+
+        if (op.isUrgent()) {
+            packet.raiseFlags(FLAG_URGENT);
+        }
+
+        ConnectionManager connectionManager = node.getConnectionManager();
+        Connection connection = connectionManager.getOrConnect(target);
+        return connectionManager.transmit(packet, connection);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -59,7 +59,7 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
 
     private Invocation newInvocation(Operation op) {
         Invocation.Context context = new Context(null, null, null, null, null,
-                1000, invocationRegistry, null, logger, null, null, null, null, null, null, null, null);
+                1000, invocationRegistry, null, logger, null, null, null, null, null, null, null, null, null);
         return new PartitionInvocation(context, op, 0, 0, 0, false);
     }
 


### PR DESCRIPTION
The logic of converting an Operation to packet and sending it to the
connection has now been pulled into a separate class. 

The OutboundOperationHandler is comparable to the OutboundResponseHandler.