### PR TITLE
Io balancing improvements

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -156,6 +156,10 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         this.credentials = client.getCredentials();
     }
 
+    public NonBlockingIOThreadingModel getIoThreadingModel() {
+        return ioThreadingModel;
+    }
+
     protected void initIOThreads(HazelcastClientInstanceImpl client) {
         HazelcastProperties properties = client.getProperties();
         boolean directBuffer = properties.getBoolean(SOCKET_CLIENT_BUFFER_DIRECT);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -28,6 +28,7 @@ import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
 import com.hazelcast.client.impl.client.DistributedObjectInfo;
 import com.hazelcast.client.impl.protocol.ClientExceptionFactory;
 import com.hazelcast.client.impl.protocol.ClientMessage;
@@ -99,6 +100,7 @@ import com.hazelcast.instance.HazelcastThreadGroup;
 import com.hazelcast.internal.diagnostics.ConfigPropertiesPlugin;
 import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.diagnostics.MetricsPlugin;
+import com.hazelcast.internal.diagnostics.NetworkingPlugin;
 import com.hazelcast.internal.diagnostics.SystemLogPlugin;
 import com.hazelcast.internal.diagnostics.SystemPropertiesPlugin;
 import com.hazelcast.internal.metrics.ProbeLevel;
@@ -402,6 +404,14 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         diagnostics.register(
                 new SystemLogPlugin(properties, connectionManager, this, loggingService.getLogger(SystemLogPlugin.class)));
 
+        if (connectionManager instanceof ClientConnectionManagerImpl) {
+            ClientConnectionManagerImpl clientConnectionManager = (ClientConnectionManagerImpl) connectionManager;
+            diagnostics.register(
+                    new NetworkingPlugin(
+                            properties,
+                            clientConnectionManager.getIoThreadingModel(),
+                            loggingService.getLogger(NetworkingPlugin.class)));
+        }
         metricsRegistry.collectMetrics(listenerService);
 
         try {

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingPlugin.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.internal.networking.IOThreadingModel;
+import com.hazelcast.internal.networking.nonblocking.NonBlockingIOThread;
+import com.hazelcast.internal.networking.nonblocking.NonBlockingIOThreadingModel;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.nio.tcp.TcpIpConnectionManager;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
+
+import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * The {@link NetworkingPlugin} is an experimental plugin meant for detecting imbalance in the io system. This plugin will
+ * probably mostly be used for internal purposes to get a better understanding of imbalances. Normally imbalances are taken
+ * care of by the IOBalancer; but we need to make sure it makes the right choice.
+ *
+ * This plugin can be used on server and client side.
+ */
+public class NetworkingPlugin extends DiagnosticsPlugin {
+
+    /**
+     * The period in seconds this plugin runs.
+     *
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty(PREFIX + ".networking.seconds", 0, SECONDS);
+
+    private static final double HUNDRED = 100d;
+
+    private final NonBlockingIOThreadingModel ioThreadingModel;
+    private final long periodMillis;
+
+    public NetworkingPlugin(NodeEngineImpl nodeEngine) {
+        this(nodeEngine.getProperties(), getThreadingModel(nodeEngine), nodeEngine.getLogger(NetworkingPlugin.class));
+    }
+
+    public NetworkingPlugin(HazelcastProperties properties, IOThreadingModel threadingModel, ILogger logger) {
+        super(logger);
+
+        if (threadingModel instanceof NonBlockingIOThreadingModel) {
+            this.ioThreadingModel = (NonBlockingIOThreadingModel) threadingModel;
+        } else {
+            this.ioThreadingModel = null;
+        }
+        this.periodMillis = ioThreadingModel == null ? 0 : properties.getMillis(PERIOD_SECONDS);
+    }
+
+    private static IOThreadingModel getThreadingModel(NodeEngineImpl nodeEngine) {
+        ConnectionManager connectionManager = nodeEngine.getNode().getConnectionManager();
+        if (!(connectionManager instanceof TcpIpConnectionManager)) {
+            return null;
+        }
+        return ((TcpIpConnectionManager) connectionManager).getIoThreadingModel();
+    }
+
+    @Override
+    public long getPeriodMillis() {
+        return periodMillis;
+    }
+
+    @Override
+    public void onStart() {
+        logger.info("Plugin:active: period-millis:" + periodMillis);
+    }
+
+    @Override
+    public void run(DiagnosticsLogWriter writer) {
+        writer.startSection("Networking");
+
+        writer.startSection("InputThreads");
+        render(writer, ioThreadingModel.getInputThreads());
+        writer.endSection();
+
+        writer.startSection("OutputThreads");
+        render(writer, ioThreadingModel.getOutputThreads());
+        writer.endSection();
+
+        writer.endSection();
+    }
+
+    private void render(DiagnosticsLogWriter writer, NonBlockingIOThread[] threads) {
+        if (threads == null) {
+            // this can become null due to stopping of the system.
+            return;
+        }
+
+        long totalPriorityFramesReceived = 0;
+        long totalFramesReceived = 0;
+        long totalBytesReceived = 0;
+        long totalEvents = 0;
+        long totalTaskCount = 0;
+        long totalHandleCount = 0;
+
+        for (NonBlockingIOThread thread : threads) {
+            totalBytesReceived += thread.bytesTransceived();
+            totalFramesReceived += thread.framesTransceived();
+            totalPriorityFramesReceived += thread.priorityFramesTransceived();
+            totalEvents += thread.eventCount();
+            totalTaskCount += thread.completedTaskCount();
+            totalHandleCount += thread.handleCount();
+        }
+
+        for (NonBlockingIOThread thread : threads) {
+            writer.startSection(thread.getName());
+            writer.writeKeyValueEntry("frames", toPercentage(thread.framesTransceived(), totalFramesReceived));
+            writer.writeKeyValueEntry("priority-frames",
+                    toPercentage(thread.priorityFramesTransceived(), totalPriorityFramesReceived));
+            writer.writeKeyValueEntry("bytes", toPercentage(thread.bytesTransceived(), totalBytesReceived));
+            writer.writeKeyValueEntry("events", toPercentage(thread.eventCount(), totalEvents));
+            writer.writeKeyValueEntry("handle-count", toPercentage(thread.handleCount(), totalHandleCount));
+            writer.writeKeyValueEntry("tasks", toPercentage(thread.completedTaskCount(), totalTaskCount));
+            writer.endSection();
+        }
+    }
+
+    private String toPercentage(long amount, long total) {
+        double percentage = (HUNDRED * amount) / total;
+        return String.format("%1$,.2f", percentage) + " %";
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -53,6 +53,11 @@ import java.util.concurrent.TimeUnit;
 public interface MetricsRegistry {
 
     /**
+     * Returns the minimum ProbeLevel this MetricsRegistry is recording.
+     */
+    ProbeLevel minimumLevel();
+
+    /**
      * Creates a LongGauge for a given metric name.
      *
      * If no gauge exists for the name, it will be created but no probe is set. The reason to do so is that you don't want to

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -89,6 +89,11 @@ public class MetricsRegistryImpl implements MetricsRegistry {
         }
     }
 
+    @Override
+    public ProbeLevel minimumLevel() {
+        return minimumLevel;
+    }
+
     long modCount() {
         return sortedProbeInstancesRef.get().mod;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/AbstractHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/AbstractHandler.java
@@ -33,8 +33,11 @@ import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
 public abstract class AbstractHandler
         implements SelectionHandler, MigratableHandler {
 
-    @Probe(name = "eventCount")
-    protected final SwCounter eventCount = newSwCounter();
+    // for the time being we configure using a int until we have decided which load strategy to use.
+    protected static final int LOAD_TYPE = Integer.getInteger("io.load", 0);
+
+    @Probe(name = "handleCount")
+    protected final SwCounter handleCount = newSwCounter();
     protected final ILogger logger;
     protected final SocketChannelWrapper socketChannel;
     protected final SocketConnection connection;
@@ -67,11 +70,6 @@ public abstract class AbstractHandler
 
     public SocketChannelWrapper getSocketChannel() {
         return socketChannel;
-    }
-
-    @Override
-    public long getEventCount() {
-        return eventCount.get();
     }
 
     @Probe(level = DEBUG)
@@ -114,6 +112,8 @@ public abstract class AbstractHandler
             selectionKey.interestOps(interestOps & ~operation);
         }
     }
+
+    protected abstract void publish();
 
     @Override
     public void onFailure(Throwable e) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingIOThreadingModel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingIOThreadingModel.java
@@ -31,12 +31,16 @@ import com.hazelcast.logging.LoggingService;
 import com.hazelcast.util.concurrent.BackoffIdleStrategy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.networking.nonblocking.SelectorMode.SELECT;
 import static com.hazelcast.internal.networking.nonblocking.SelectorMode.SELECT_NOW_STRING;
 import static com.hazelcast.util.HashUtil.hashToIndex;
 import static com.hazelcast.util.concurrent.BackoffIdleStrategy.createBackoffIdleStrategy;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.INFO;
 
@@ -51,8 +55,8 @@ import static java.util.logging.Level.INFO;
 public class NonBlockingIOThreadingModel
         implements IOThreadingModel {
 
-    private final NonBlockingIOThread[] inputThreads;
-    private final NonBlockingIOThread[] outputThreads;
+    private volatile NonBlockingIOThread[] inputThreads;
+    private volatile NonBlockingIOThread[] outputThreads;
     private final AtomicInteger nextInputThreadIndex = new AtomicInteger();
     private final AtomicInteger nextOutputThreadIndex = new AtomicInteger();
     private final ILogger logger;
@@ -63,6 +67,10 @@ public class NonBlockingIOThreadingModel
     private final int balanceIntervalSeconds;
     private final SocketWriterInitializer socketWriterInitializer;
     private final SocketReaderInitializer socketReaderInitializer;
+    private final int inputThreadCount;
+    private final int outputThreadCount;
+    private final Map<SocketConnection, SocketConnection> connections
+            = new ConcurrentHashMap<SocketConnection, SocketConnection>();
 
     // The selector mode determines how IO threads will block (or not) on the Selector:
     //  select:         this is the default mode, uses Selector.select(long timeout)
@@ -73,9 +81,9 @@ public class NonBlockingIOThreadingModel
     // See issue: https://github.com/hazelcast/hazelcast/issues/7943
     // In Hazelcast 3.8, selector mode must be set via HazelcastProperties
     private SelectorMode selectorMode;
+    private BackoffIdleStrategy idleStrategy;
     private volatile IOBalancer ioBalancer;
     private boolean selectorWorkaroundTest = Boolean.getBoolean("hazelcast.io.selector.workaround.test");
-    private BackoffIdleStrategy idleStrategy;
 
     public NonBlockingIOThreadingModel(
             LoggingService loggingService,
@@ -90,9 +98,9 @@ public class NonBlockingIOThreadingModel
         this.hazelcastThreadGroup = hazelcastThreadGroup;
         this.metricsRegistry = metricsRegistry;
         this.loggingService = loggingService;
+        this.inputThreadCount = inputThreadCount;
+        this.outputThreadCount = outputThreadCount;
         this.logger = loggingService.getLogger(NonBlockingIOThreadingModel.class);
-        this.inputThreads = new NonBlockingIOThread[inputThreadCount];
-        this.outputThreads = new NonBlockingIOThread[outputThreadCount];
         this.oomeHandler = oomeHandler;
         this.balanceIntervalSeconds = balanceIntervalSeconds;
         this.socketWriterInitializer = socketWriterInitializer;
@@ -147,12 +155,13 @@ public class NonBlockingIOThreadingModel
     public void start() {
         if (logger.isFineEnabled()) {
             logger.fine("TcpIpConnectionManager configured with Non Blocking IO-threading model: "
-                    + inputThreads.length + " input threads and "
-                    + outputThreads.length + " output threads");
+                    + inputThreadCount + " input threads and "
+                    + outputThreads + " output threads");
         }
 
-        logger.log(getSelectorMode() != SELECT ? INFO : FINE, "IO threads selector mode is " + getSelectorMode());
 
+        logger.log(getSelectorMode() != SELECT ? INFO : FINE, "IO threads selector mode is " + getSelectorMode());
+        this.inputThreads = new NonBlockingIOThread[inputThreadCount];
 
         for (int i = 0; i < inputThreads.length; i++) {
             NonBlockingIOThread thread = new NonBlockingIOThread(
@@ -169,6 +178,7 @@ public class NonBlockingIOThreadingModel
             thread.start();
         }
 
+        this.outputThreads = new NonBlockingIOThread[outputThreadCount];
         for (int i = 0; i < outputThreads.length; i++) {
             NonBlockingIOThread thread = new NonBlockingIOThread(
                     hazelcastThreadGroup.getInternalThreadGroup(),
@@ -184,10 +194,45 @@ public class NonBlockingIOThreadingModel
             thread.start();
         }
         startIOBalancer();
+
+        if (metricsRegistry.minimumLevel().isEnabled(DEBUG)) {
+            metricsRegistry.scheduleAtFixedRate(new PublishAllTask(), 1, SECONDS);
+        }
+    }
+
+    private class PublishAllTask implements Runnable {
+        @Override
+        public void run() {
+            for (SocketConnection connection : connections.values()) {
+                final NonBlockingSocketReader reader = (NonBlockingSocketReader) connection.getSocketReader();
+                NonBlockingIOThread inputThread = reader.getOwner();
+                if (inputThread != null) {
+                    inputThread.addTaskAndWakeup(new Runnable() {
+                        @Override
+                        public void run() {
+                            reader.publish();
+                        }
+                    });
+                }
+
+                final NonBlockingSocketWriter writer = (NonBlockingSocketWriter) connection.getSocketWriter();
+                NonBlockingIOThread outputThread = writer.getOwner();
+                if (outputThread != null) {
+                    outputThread.addTaskAndWakeup(new Runnable() {
+                        @Override
+                        public void run() {
+                            writer.publish();
+                        }
+                    });
+                }
+            }
+        }
     }
 
     @Override
     public void onConnectionAdded(SocketConnection connection) {
+        connections.put(connection, connection);
+
         MigratableHandler reader = (MigratableHandler) connection.getSocketReader();
         MigratableHandler writer = (MigratableHandler) connection.getSocketWriter();
         ioBalancer.connectionAdded(reader, writer);
@@ -195,6 +240,8 @@ public class NonBlockingIOThreadingModel
 
     @Override
     public void onConnectionRemoved(SocketConnection connection) {
+        connections.remove(connection);
+
         MigratableHandler reader = (MigratableHandler) connection.getSocketReader();
         MigratableHandler writer = (MigratableHandler) connection.getSocketWriter();
         ioBalancer.connectionRemoved(reader, writer);
@@ -216,30 +263,31 @@ public class NonBlockingIOThreadingModel
         }
 
         shutdown(inputThreads);
+        inputThreads = null;
         shutdown(outputThreads);
+        outputThreads = null;
     }
 
     private void shutdown(NonBlockingIOThread[] threads) {
-        for (int i = 0; i < threads.length; i++) {
-            NonBlockingIOThread ioThread = threads[i];
-            if (ioThread != null) {
-                ioThread.shutdown();
-            }
-            threads[i] = null;
+        if (threads == null) {
+            return;
+        }
+        for (NonBlockingIOThread thread : threads) {
+            thread.shutdown();
         }
     }
 
     @Override
     public SocketWriter newSocketWriter(SocketConnection connection) {
-        int index = hashToIndex(nextOutputThreadIndex.getAndIncrement(), outputThreads.length);
-        NonBlockingIOThread outputThread = outputThreads[index];
-        if (outputThread == null) {
+        int index = hashToIndex(nextOutputThreadIndex.getAndIncrement(), outputThreadCount);
+        NonBlockingIOThread[] threads = outputThreads;
+        if (threads == null) {
             throw new IllegalStateException("IO thread is closed!");
         }
 
         return new NonBlockingSocketWriter(
                 connection,
-                outputThread,
+                threads[index],
                 loggingService.getLogger(NonBlockingSocketWriter.class),
                 ioBalancer,
                 socketWriterInitializer);
@@ -247,15 +295,15 @@ public class NonBlockingIOThreadingModel
 
     @Override
     public SocketReader newSocketReader(SocketConnection connection) {
-        int index = hashToIndex(nextInputThreadIndex.getAndIncrement(), inputThreads.length);
-        NonBlockingIOThread inputThread = inputThreads[index];
-        if (inputThread == null) {
+        int index = hashToIndex(nextInputThreadIndex.getAndIncrement(), inputThreadCount);
+        NonBlockingIOThread[] threads = inputThreads;
+        if (threads == null) {
             throw new IllegalStateException("IO thread is closed!");
         }
 
         return new NonBlockingSocketReader(
                 connection,
-                inputThread,
+                threads[index],
                 loggingService.getLogger(NonBlockingSocketReader.class),
                 ioBalancer,
                 socketReaderInitializer);

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingSocketWriter.java
@@ -81,6 +81,11 @@ public final class NonBlockingSocketWriter
     // This prevents running into an NonBlockingIOThread that is migrating.
     private NonBlockingIOThread newOwner;
 
+    private long bytesReadLastPublish;
+    private long normalFramesReadLastPublish;
+    private long priorityFramesReadLastPublish;
+    private long eventsLastPublish;
+
     public NonBlockingSocketWriter(SocketConnection connection,
                                    NonBlockingIOThread ioThread,
                                    ILogger logger,
@@ -88,6 +93,20 @@ public final class NonBlockingSocketWriter
                                    SocketWriterInitializer initializer) {
         super(connection, ioThread, OP_WRITE, logger, balancer);
         this.initializer = initializer;
+    }
+
+    @Override
+    public long getEventCount() {
+        switch (LOAD_TYPE) {
+            case 0:
+                return handleCount.get();
+            case 1:
+                return bytesWritten.get() + priorityFramesWritten.get();
+            case 2:
+                return normalFramesWritten.get() + priorityFramesWritten.get();
+            default:
+                throw new RuntimeException();
+        }
     }
 
     @Override
@@ -282,7 +301,7 @@ public final class NonBlockingSocketWriter
     @Override
     @SuppressWarnings("unchecked")
     public void handle() throws Exception {
-        eventCount.inc();
+        handleCount.inc();
         lastWriteTime = currentTimeMillis();
 
         if (writeHandler == null) {
@@ -451,6 +470,19 @@ public final class NonBlockingSocketWriter
 
             newOwner = theNewOwner;
         }
+    }
+
+    @Override
+    protected void publish() {
+        ioThread.bytesTransceived += bytesWritten.get() - bytesReadLastPublish;
+        ioThread.framesTransceived += normalFramesWritten.get() - normalFramesReadLastPublish;
+        ioThread.priorityFramesTransceived += priorityFramesWritten.get() - priorityFramesReadLastPublish;
+        ioThread.handleCount += handleCount.get() - eventsLastPublish;
+
+        bytesReadLastPublish = bytesWritten.get();
+        normalFramesReadLastPublish = normalFramesWritten.get();
+        priorityFramesReadLastPublish = priorityFramesWritten.get();
+        eventsLastPublish = handleCount.get();
     }
 
     private class CloseTask implements Runnable {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -30,6 +30,7 @@ import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.diagnostics.InvocationPlugin;
 import com.hazelcast.internal.diagnostics.MemberHazelcastInstanceInfoPlugin;
 import com.hazelcast.internal.diagnostics.MetricsPlugin;
+import com.hazelcast.internal.diagnostics.NetworkingPlugin;
 import com.hazelcast.internal.diagnostics.OverloadedConnectionsPlugin;
 import com.hazelcast.internal.diagnostics.PendingInvocationsPlugin;
 import com.hazelcast.internal.diagnostics.SlowOperationPlugin;
@@ -252,6 +253,7 @@ public class NodeEngineImpl implements NodeEngine {
         diagnostics.register(new MemberHazelcastInstanceInfoPlugin(this));
         diagnostics.register(new SystemLogPlugin(this));
         diagnostics.register(new StoreLatencyPlugin(this));
+        diagnostics.register(new NetworkingPlugin(this));
     }
 
     public Diagnostics getDiagnostics() {


### PR DESCRIPTION
This pr contains a few things

1: there is some undefined behavior in the NonBlockingThreadingModel where on shutdown the io threads array elements get nilled. This has been changed by just setting the whole array to null. This way the array remains effectively immutable.

2: a new diagnostics networking plugin that currently renders information about io threads. This should help to spot networking problems. This plugin works for both server and client.

2:  modifications to the non blocking io threads so it contains the total number of bytes, frames etc. This is done with a zero overhead on the fast path. So instead of having contented counters, periodically a task is written to each read/write handler to publish information to its owning io thread. This is disabled by default and only works when debug metrics level is enabled.

3: the non blocking readers/writers have a configurable mechanism for returning 'load'. So byte based,frame based, handle-method-count etc. The old behavior was always handle method count, but this doesnt' seem to give the best results. Byte based seems to be more reliable. Currently these properties are only configurable through a 'hidden' system property. In the 3.9 release we need to pick a better one and use that be default. But at least we can now experiment with the different policies.

Example output from the diagnostics plugin

```
17-4-2017 17:20:30 Networking[
                          InputThreads[
                                  hz._hzInstance_1_workers.IO.thread-in-0[
                                          frames=34.22 %
                                          priorityFrames=34.22 %
                                          bytes=33.96 %
                                          events=11.53 %
                                          handle-events=36.26 %
                                          tasks=38.66 %]
                                  hz._hzInstance_1_workers.IO.thread-in-1[
                                          frames=31.53 %
                                          priorityFrames=31.53 %
                                          bytes=31.48 %
                                          events=10.09 %
                                          handle-events=31.72 %
                                          tasks=30.16 %]
                                  hz._hzInstance_1_workers.IO.thread-in-2[
                                          frames=34.25 %
                                          priorityFrames=34.25 %
                                          bytes=34.57 %
                                          events=10.19 %
                                          handle-events=32.03 %
                                          tasks=31.18 %]]
                          OutputThreads[
                                  hz._hzInstance_1_workers.IO.thread-out-0[
                                          frames=32.46 %
                                          priorityFrames=32.46 %
                                          bytes=32.82 %
                                          events=0.00 %
                                          handle-events=33.25 %
                                          tasks=33.25 %]
                                  hz._hzInstance_1_workers.IO.thread-out-1[
                                          frames=33.85 %
                                          priorityFrames=33.85 %
                                          bytes=33.80 %
                                          events=0.00 %
                                          handle-events=33.36 %
                                          tasks=33.36 %]
                                  hz._hzInstance_1_workers.IO.thread-out-2[
                                          frames=33.68 %
                                          priorityFrames=33.68 %
                                          bytes=33.38 %
                                          events=0.00 %
                                          handle-events=33.40 %
                                          tasks=33.40 %]]]
```

The above output contains a bug in the events, which already has been addressed.