### PR TITLE
NonBlockingSocketWriter volatile write reduction

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingSocketWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/NonBlockingSocketWriter.java
@@ -73,7 +73,7 @@ public final class NonBlockingSocketWriter
     private final SwCounter priorityFramesWritten = newSwCounter();
     private WriteHandler writeHandler;
 
-    private volatile OutboundFrame currentFrame;
+    private OutboundFrame currentFrame;
     private volatile long lastWriteTime;
 
     // this field will be accessed by the NonBlockingIOThread or
@@ -346,33 +346,22 @@ public final class NonBlockingSocketWriter
     /**
      * Fills the outBuffer with frames. This is done till there are no more frames or till there is no more space in the
      * outputBuffer.
-     *
-     * @throws Exception
      */
     private void fillOutputBuffer() throws Exception {
-        for (; ; ) {
-            if (!outputBuffer.hasRemaining()) {
-                // The buffer is completely filled, we are done.
-                return;
-            }
+        if (currentFrame == null) {
+            // there is no pending frame, lets poll one.
+            currentFrame = poll();
+        }
 
-            // If there currently is not frame sending, lets try to get one.
-            if (currentFrame == null) {
-                currentFrame = poll();
-                if (currentFrame == null) {
-                    // There is no frames to write, we are done.
-                    return;
-                }
-            }
-
+        while (currentFrame != null) {
             // Lets write the currentFrame to the outputBuffer.
             if (!writeHandler.onWrite(currentFrame, outputBuffer)) {
-                // We are done for this round because not all data of the current frame fits in the outputBuffer
+                // We are done for this round because not all data of the currentFrame fits in the outputBuffer
                 return;
             }
 
-            // The current frame has been written completely. So lets null it and lets try to write another frame.
-            currentFrame = null;
+            // The current frame has been written completely. So lets poll for another one.
+            currentFrame = poll();
         }
     }
 


### PR DESCRIPTION
currentFrame is no longer volatile since it will only be accessed by the NonBlockingIOThread.

Also minor simplification in the fillOutputBuffer; no longer a check if there is space in the
outputBuffer; this is alread done by the writeHandler. So no need for duplication.