### PR TITLE
Client invocation exception made more verbose when timed out

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
@@ -106,7 +107,7 @@ public class ClientClusterStateTest {
         factory.newHazelcastClient();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = OperationTimeoutException.class)
     public void testClient_canNotExecuteWriteOperations_whenClusterState_passive() {
         warmUpPartitions(instances);
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientNodeExtensionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientNodeExtensionTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.DefaultNodeExtension;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
@@ -98,7 +99,7 @@ public class ClientNodeExtensionTest
         factory.newHazelcastClient(clientConfig);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = OperationTimeoutException.class)
     public void test_canGetFromMap_whenNodeExtensionIsNotComplete() {
         IMap<Object, Object> map = null;
         ManagedExtensionNodeContext nodeContext = null;


### PR DESCRIPTION
We were setting last exception to user future when invocation
timed out. That was making it harder to reason about what is going
on. OperationTimeoutException is used to differentiate cases.

PR is prepared especially to understand following issue: https://github.com/hazelcast/hazelcast/issues/9696