### PR TITLE
Nearcache doEvictionIfRequired key-argument

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
@@ -96,7 +96,7 @@ public interface NearCacheRecordStore<K, V> extends InitializingObject {
      * Does eviction as specified configuration {@link com.hazelcast.config.EvictionConfig}
      * in {@link com.hazelcast.config.NearCacheConfig}.
      */
-    void doEvictionIfRequired();
+    void doEvictionIfRequired(K key);
 
     /**
      * Does eviction as specified configuration {@link com.hazelcast.config.EvictionConfig}

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
@@ -115,7 +115,7 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     public void put(K key, V value) {
         checkNotNull(key, "key cannot be null on put!");
 
-        nearCacheRecordStore.doEvictionIfRequired();
+        nearCacheRecordStore.doEvictionIfRequired(key);
 
         nearCacheRecordStore.put(key, value);
     }
@@ -195,7 +195,7 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
 
     @Override
     public long tryReserveForUpdate(K key) {
-        nearCacheRecordStore.doEvictionIfRequired();
+        nearCacheRecordStore.doEvictionIfRequired(key);
 
         return nearCacheRecordStore.tryReserveForUpdate(key);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStore.java
@@ -430,7 +430,7 @@ public abstract class AbstractNearCacheRecordStore<K, V, KS, R extends NearCache
     }
 
     @Override
-    public void doEvictionIfRequired() {
+    public void doEvictionIfRequired(K key) {
         checkAvailable();
 
         if (isEvictionEnabled()) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTest.java
@@ -165,7 +165,7 @@ public class NearCacheRecordStoreTest extends NearCacheRecordStoreTestSupport {
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             nearCacheRecordStore.put(i, "Record-" + i);
-            nearCacheRecordStore.doEvictionIfRequired();
+            nearCacheRecordStore.doEvictionIfRequired(i);
             assertTrue(maxSize >= nearCacheRecordStore.size());
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
@@ -349,7 +349,7 @@ public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
         }
 
         @Override
-        public void doEvictionIfRequired() {
+        public void doEvictionIfRequired(Integer key) {
             if (expectedKeyValueMappings == null) {
                 throw new IllegalStateException("Near-Cache is already destroyed");
             }


### PR DESCRIPTION
A key argument has been added to the doEvictionIfRequired so for HZ enterprise so that the nearcache eviction can be done on a single segment instead of all segments.