### PR TITLE
Reduced complexity in AbstractNearCacheRecordStore

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -200,6 +200,7 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
         return this;
     }
 
+    @Override
     public EvictionPolicy getEvictionPolicy() {
         return evictionPolicy;
     }
@@ -234,18 +235,22 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
         return EvictionStrategyType.DEFAULT_EVICTION_STRATEGY;
     }
 
-    @Override
+    /**
+     * @deprecated since 3.9, use {@link #getEvictionPolicy()} instead
+     */
+    @Deprecated
     public EvictionPolicyType getEvictionPolicyType() {
-        if (evictionPolicy == EvictionPolicy.LFU) {
-            return EvictionPolicyType.LFU;
-        } else if (evictionPolicy == EvictionPolicy.LRU) {
-            return EvictionPolicyType.LRU;
-        } else if (evictionPolicy == EvictionPolicy.RANDOM) {
-            return EvictionPolicyType.RANDOM;
-        } else if (evictionPolicy == EvictionPolicy.NONE) {
-            return EvictionPolicyType.NONE;
-        } else {
-            return null;
+        switch (evictionPolicy) {
+            case LFU:
+                return EvictionPolicyType.LFU;
+            case LRU:
+                return EvictionPolicyType.LRU;
+            case RANDOM:
+                return EvictionPolicyType.RANDOM;
+            case NONE:
+                return EvictionPolicyType.NONE;
+            default:
+                return null;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionConfiguration.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionConfiguration.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.eviction;
 
+import com.hazelcast.config.EvictionPolicy;
+
 /**
  * Interface for configuration information about eviction.
  */
@@ -29,10 +31,19 @@ public interface EvictionConfiguration {
     EvictionStrategyType getEvictionStrategyType();
 
     /**
+     * Gets the eviction policy.
+     *
+     * @return the eviction policy
+     */
+    EvictionPolicy getEvictionPolicy();
+
+    /**
      * Gets the type of eviction policy.
      *
      * @return the type of eviction policy
+     * @deprecated since 3.9, use {@link #getEvictionPolicy()} instead
      */
+    @Deprecated
     EvictionPolicyType getEvictionPolicyType();
 
     /**
@@ -48,5 +59,4 @@ public interface EvictionConfiguration {
      * @return instance of the configured {@link EvictionPolicyComparator} implementation.
      */
     EvictionPolicyComparator getComparator();
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyType.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/EvictionPolicyType.java
@@ -18,7 +18,9 @@ package com.hazelcast.internal.eviction;
 
 /**
  * Enum for eviction policy types.
+ * @deprecated since 3.9, use {@link com.hazelcast.config.EvictionPolicy} instead
  */
+@Deprecated
 public enum EvictionPolicyType {
 
     /**
@@ -40,6 +42,4 @@ public enum EvictionPolicyType {
      * Doesn't evict entries (will not add new entries to the Near Cache when it's full)
      */
     NONE,
-
-    // TODO: maybe another "CUSTOM" type for user defined eviction policies
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/EvictionPolicyEvaluator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/impl/evaluator/EvictionPolicyEvaluator.java
@@ -22,7 +22,7 @@ import com.hazelcast.internal.eviction.EvictionPolicyComparator;
 import com.hazelcast.internal.eviction.Expirable;
 import com.hazelcast.util.Clock;
 
-import java.util.Collections;
+import static java.util.Collections.singleton;
 
 /**
  * Default {@link EvictionPolicyEvaluator} implementation.
@@ -48,7 +48,6 @@ public class EvictionPolicyEvaluator<A, E extends Evictable> {
      * on the given input set of candidates.
      *
      * @param evictionCandidates Multiple {@link com.hazelcast.internal.eviction.EvictionCandidate} to be evicted
-     *
      * @return multiple {@link com.hazelcast.internal.eviction.EvictionCandidate} these are available to be evicted
      */
     public <C extends EvictionCandidate<A, E>> Iterable<C> evaluate(Iterable<C> evictionCandidates) {
@@ -59,7 +58,6 @@ public class EvictionPolicyEvaluator<A, E extends Evictable> {
                 selectedEvictionCandidate = currentEvictionCandidate;
             } else {
                 E evictable = currentEvictionCandidate.getEvictable();
-
                 if (isExpired(now, evictable)) {
                     return returnEvictionCandidate(currentEvictionCandidate);
                 }
@@ -77,21 +75,18 @@ public class EvictionPolicyEvaluator<A, E extends Evictable> {
         if (evictionCandidate == null) {
             return null;
         } else {
-            return evictionCandidate instanceof Iterable
-                    ? (Iterable<C>) evictionCandidate
-                    : Collections.singleton(evictionCandidate);
+            return evictionCandidate instanceof Iterable ? (Iterable<C>) evictionCandidate : singleton(evictionCandidate);
         }
     }
 
     private boolean isExpired(long now, Evictable evictable) {
         boolean expired = false;
-        // If evictable is also an expirable
+        // check if evictable is also an expirable
         if (evictable instanceof Expirable) {
             Expirable expirable = (Expirable) evictable;
-            // If there is an expired candidate, let's evict that one immediately
+            // if there is an expired candidate, let's evict that one immediately
             expired = expirable.isExpiredAt(now);
         }
         return expired;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/BaseHeapNearCacheRecordStore.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.serialization.SerializationService;
 import java.util.Map;
 
 import static com.hazelcast.internal.nearcache.NearCacheRecord.READ_PERMITTED;
+import static java.lang.String.format;
 
 /**
  * Base implementation of {@link AbstractNearCacheRecordStore} for on-heap Near Caches.
@@ -58,18 +59,13 @@ public abstract class BaseHeapNearCacheRecordStore<K, V, R extends NearCacheReco
     }
 
     @Override
-    protected EvictionChecker createNearCacheEvictionChecker(EvictionConfig evictionConfig,
-                                                             NearCacheConfig nearCacheConfig) {
+    protected EvictionChecker createNearCacheEvictionChecker(EvictionConfig evictionConfig, NearCacheConfig nearCacheConfig) {
         MaxSizePolicy maxSizePolicy = evictionConfig.getMaximumSizePolicy();
-        if (maxSizePolicy == null) {
-            throw new IllegalArgumentException("Max-Size policy cannot be null");
+        if (maxSizePolicy != MaxSizePolicy.ENTRY_COUNT) {
+            throw new IllegalArgumentException(format("Invalid max-size policy (%s) for %s! Only %s is supported.",
+                    maxSizePolicy, getClass().getName(), MaxSizePolicy.ENTRY_COUNT));
         }
-        if (maxSizePolicy == MaxSizePolicy.ENTRY_COUNT) {
-            return new EntryCountNearCacheEvictionChecker(evictionConfig.getSize(), records);
-        }
-        throw new IllegalArgumentException("Invalid max-size policy "
-                + '(' + maxSizePolicy + ") for " + getClass().getName() + "! Only "
-                + MaxSizePolicy.ENTRY_COUNT + " is supported.");
+        return new EntryCountNearCacheEvictionChecker(evictionConfig.getSize(), records);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NearCacheConfigTest.java
@@ -154,6 +154,7 @@ public class NearCacheConfigTest {
 
         EvictionConfig evictionConfig = config.getEvictionConfig();
         assertEquals(123, evictionConfig.getSize());
+        assertEquals(EvictionPolicy.LFU, evictionConfig.getEvictionPolicy());
         assertEquals(EvictionPolicyType.LFU, evictionConfig.getEvictionPolicyType());
         assertEquals(ENTRY_COUNT, evictionConfig.getMaximumSizePolicy());
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionPolicyEvaluatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionPolicyEvaluatorTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.eviction;
 
 import com.hazelcast.cache.impl.record.CacheObjectRecord;
+import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.internal.eviction.impl.evaluator.EvictionPolicyEvaluator;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -82,7 +83,6 @@ public class EvictionPolicyEvaluatorTest extends HazelcastTestSupport {
         public long getAccessHit() {
             return getEvictable().getAccessHit();
         }
-
     }
 
     @Test
@@ -104,6 +104,11 @@ public class EvictionPolicyEvaluatorTest extends HazelcastTestSupport {
             @Override
             public EvictionStrategyType getEvictionStrategyType() {
                 return null;
+            }
+
+            @Override
+            public EvictionPolicy getEvictionPolicy() {
+                return EvictionPolicy.LRU;
             }
 
             @Override
@@ -185,6 +190,11 @@ public class EvictionPolicyEvaluatorTest extends HazelcastTestSupport {
             @Override
             public EvictionStrategyType getEvictionStrategyType() {
                 return null;
+            }
+
+            @Override
+            public EvictionPolicy getEvictionPolicy() {
+                return EvictionPolicy.LFU;
             }
 
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionStrategyTest.java
@@ -117,27 +117,6 @@ public class EvictionStrategyTest<K, V extends Evictable, S extends SampleableEv
         ICacheService cacheService = node.getNodeEngine().getService(ICacheService.SERVICE_NAME);
         CacheContext cacheContext = cacheService.getOrCreateCacheContext("MyCache");
 
-        EvictionConfiguration evictionConfig = new EvictionConfiguration() {
-            @Override
-            public EvictionStrategyType getEvictionStrategyType() {
-                return EvictionStrategyType.SAMPLING_BASED_EVICTION;
-            }
-
-            @Override
-            public EvictionPolicyType getEvictionPolicyType() {
-                return null;
-            }
-
-            @Override
-            public String getComparatorClassName() {
-                return null;
-            }
-
-            @Override
-            public EvictionPolicyComparator getComparator() {
-                return null;
-            }
-        };
         SamplingEvictionStrategy<K, V, S> evictionStrategy = SamplingEvictionStrategy.INSTANCE;
         CacheRecordHashMap cacheRecordMap = new CacheRecordHashMap(serializationService, 1000, cacheContext);
         CacheObjectRecord expectedEvictedRecord = null;


### PR DESCRIPTION
* deprecated `EvictionPolicyType`
* removed non overridden methods in `AbstractNearCacheRecordStore`
* removed `null` checks for `EvictionConfig` fields

`EvictionPolicyType` was just used internally. Originally it had less fields than `EvictionPolicy`, but they are equal now, so there cannot be an `EvictionPolicyType` of `null` anymore. So `EvictionPolicy` can be used as replacement to reduce duplication and complexity.