### PR TITLE
Ensuring owner connection available moved to more centralized place

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -67,8 +67,9 @@ public interface ClientConnectionManager extends ConnectionListenable {
      * @param address to be connected
      * @param asOwner true if connection should be authenticated as owner, false otherwise
      * @return associated connection if available, returns null and triggers new connection creation otherwise
+     * @throws IOException if connection is not able to triggered
      */
-    Connection getOrTriggerConnect(Address address, boolean asOwner);
+    Connection getOrTriggerConnect(Address address, boolean asOwner) throws IOException;
 
     /**
      * Handles incoming network package

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -31,6 +31,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientAuthenticationCodec;
 import com.hazelcast.client.impl.protocol.codec.ClientAuthenticationCustomCodec;
 import com.hazelcast.client.impl.protocol.codec.ClientPingCodec;
+import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientInvocationService;
 import com.hazelcast.client.spi.impl.ClientClusterServiceImpl;
 import com.hazelcast.client.spi.impl.ClientExecutionServiceImpl;
@@ -304,7 +305,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     @Override
-    public Connection getOrTriggerConnect(Address target, boolean asOwner) {
+    public Connection getOrTriggerConnect(Address target, boolean asOwner) throws IOException {
         Connection connection = getConnection(target, asOwner);
         if (connection != null) {
             return connection;
@@ -313,7 +314,11 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         return null;
     }
 
-    private Connection getConnection(Address target, boolean asOwner) {
+    private Connection getConnection(Address target, boolean asOwner) throws IOException {
+        if (!asOwner) {
+            ensureOwnerConnectionAvailable();
+        }
+
         target = addressTranslator.translate(target);
 
         if (target == null) {
@@ -331,6 +336,18 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             }
         }
         return null;
+    }
+
+    private void ensureOwnerConnectionAvailable() throws IOException {
+        ClientClusterService clusterService = client.getClientClusterService();
+        Address ownerAddress = clusterService.getOwnerConnectionAddress();
+
+        boolean isOwnerConnectionAvailable = ownerAddress != null
+                && getConnection(ownerAddress) != null;
+
+        if (!isOwnerConnectionAvailable) {
+            throw new IOException("Not able to setup owner connection!");
+        }
     }
 
     private AuthenticationFuture triggerConnect(Address target, boolean asOwner) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -19,8 +19,6 @@ package com.hazelcast.client.spi.impl;
 import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
-import com.hazelcast.client.spi.ClientClusterService;
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -82,7 +80,6 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
     }
 
     private Connection getOrTriggerConnect(Address target) throws IOException {
-        ensureOwnerConnectionAvailable();
         Connection connection = connectionManager.getOrTriggerConnect(target, false);
         if (connection == null) {
             throw new IOException("No available connection to address " + target);
@@ -91,27 +88,11 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
     }
 
     private Connection getOrConnect(Address target) throws IOException {
-        ensureOwnerConnectionAvailable();
         Connection connection = connectionManager.getOrConnect(target, false);
         if (connection == null) {
             throw new IOException("No available connection to address " + target);
         }
         return connection;
-    }
-
-    private void ensureOwnerConnectionAvailable() throws IOException {
-        ClientClusterService clientClusterService = client.getClientClusterService();
-        Address ownerConnectionAddress = clientClusterService.getOwnerConnectionAddress();
-
-        boolean isOwnerConnectionAvailable = ownerConnectionAddress != null
-                && connectionManager.getConnection(ownerConnectionAddress) != null;
-
-        if (!isOwnerConnectionAvailable) {
-            if (isShutdown()) {
-                throw new HazelcastException("ConnectionManager is not active!");
-            }
-            throw new IOException("Not able to setup owner connection!");
-        }
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/ClientSmartListenerService.java
@@ -172,7 +172,11 @@ public class ClientSmartListenerService extends ClientListenerServiceImpl
             public void run() {
                 Collection<Member> memberList = clientClusterService.getMemberList();
                 for (Member member : memberList) {
-                    clientConnectionManager.getOrTriggerConnect(member.getAddress(), false);
+                    try {
+                        clientConnectionManager.getOrTriggerConnect(member.getAddress(), false);
+                    } catch (IOException e) {
+                        return;
+                    }
                 }
             }
         }, 1, 1, TimeUnit.SECONDS);


### PR DESCRIPTION
It is moved from invocationService to ConnectionManager.
Since clientSmartListener service was using ConnectionManager directly
it was skipping owner connection avaliable check. It was making auth
request and constantly getting credentials failed.

Came across to this when working following test:
`ClientReconnectTest.testReconnectToNewInstanceAtSameAddress`

backport of https://github.com/hazelcast/hazelcast/pull/10374