### PR TITLE
Remove group password validation during ConfigCheck

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -39,6 +39,7 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
 
     private String groupName;
 
+    @Deprecated
     private String groupPassword;
 
     private String joinerType;
@@ -98,7 +99,6 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
             return false;
         }
 
-        verifyGroupPassword(found);
         verifyJoiner(found);
         verifyPartitionGroup(found);
         verifyPartitionCount(found);
@@ -111,12 +111,6 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
             return false;
         }
         return true;
-    }
-
-    private void verifyGroupPassword(ConfigCheck found) {
-        if (!equals(groupPassword, found.groupPassword)) {
-            throw new ConfigMismatchException("Incompatible group password!");
-        }
     }
 
     private void verifyApplicationValidationToken(ConfigCheck found) {
@@ -208,7 +202,7 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         groupName = in.readUTF();
-        groupPassword = in.readUTF();
+        in.readUTF();
         joinerType = in.readUTF();
         partitionGroupEnabled = in.readBoolean();
         if (partitionGroupEnabled) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterJoinConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterJoinConfigCheckTest.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test that the Hazelcast infrastructure can deal correctly with {@link com.hazelcast.internal.cluster.impl.ConfigCheck} violations.
@@ -49,28 +48,6 @@ public class ClusterJoinConfigCheckTest {
     @After
     public void killAllHazelcastInstances() throws IOException {
         Hazelcast.shutdownAll();
-    }
-
-    @Test
-    public void tcp_whenGroupPasswordMismatch_thenNewNodeIsShutDown() {
-        whenGroupPasswordMismatch_thenNewNodeIsShutDown(true);
-    }
-
-    @Test
-    public void multicast_whenGroupPasswordMismatch_thenNewNodeIsShutDown() {
-        whenGroupPasswordMismatch_thenNewNodeIsShutDown(false);
-    }
-
-    private void whenGroupPasswordMismatch_thenNewNodeIsShutDown(boolean tcp) {
-        Config config1 = new Config();
-        config1.getGroupConfig().setName("foo");
-        config1.getGroupConfig().setPassword("password");
-
-        Config config2 = new Config();
-        config2.getGroupConfig().setName("foo");
-        config2.getGroupConfig().setPassword("badpassword");
-
-        assertIncompatible(config1, config2, tcp);
     }
 
     @Test
@@ -103,25 +80,6 @@ public class ClusterJoinConfigCheckTest {
 
         assertTrue(hz2.getLifecycleService().isRunning());
         assertEquals(1, hz2.getCluster().getMembers().size());
-    }
-
-    private void assertIncompatible(Config config1, Config config2, boolean tcp) {
-        if (tcp) {
-            enableTcp(config1);
-            enableTcp(config2);
-        }
-
-        HazelcastInstance hz1 = Hazelcast.newHazelcastInstance(config1);
-
-        try {
-            Hazelcast.newHazelcastInstance(config2);
-            fail();
-        } catch (IllegalStateException e) {
-
-        }
-
-        assertTrue(hz1.getLifecycleService().isRunning());
-        assertEquals(1, hz1.getCluster().getMembers().size());
     }
 
     private void enableTcp(Config config) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ConfigCheckTest.java
@@ -50,19 +50,6 @@ public class ConfigCheckTest {
     }
 
     @Test
-    public void whenGroupNameSameButPasswordDifferent_thenConfigMismatchException() {
-        Config config1 = new Config();
-        config1.getGroupConfig().setName("group").setPassword("password1");
-        Config config2 = new Config();
-        config2.getGroupConfig().setName("group").setPassword("password2");
-
-        ConfigCheck configCheck1 = new ConfigCheck(config1, "joiner");
-        ConfigCheck configCheck2 = new ConfigCheck(config2, "joiner");
-
-        assertIsCompatibleThrowsConfigMismatchException(configCheck1, configCheck2);
-    }
-
-    @Test
     public void whenJoinerTypeDifferent_thenConfigMismatchException() {
         Config config1 = new Config();
         Config config2 = new Config();

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
@@ -112,27 +112,6 @@ public class MulticastJoinTest extends AbstractJoinTest {
     }
 
     @Test
-    public void test_whenSameGroupNamesButDifferentPassword() throws Exception {
-        Config config1 = new Config();
-        config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
-        config1.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "3");
-        config1.getGroupConfig().setName("group").setPassword("password1");
-        config1.getNetworkConfig().getJoin().getMulticastConfig()
-                .setEnabled(true).setMulticastTimeoutSeconds(3);
-        config1.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
-
-        Config config2 = new Config();
-        config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
-        config2.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "3");
-        config2.getGroupConfig().setName("group").setPassword("password2");
-        config2.getNetworkConfig().getJoin().getMulticastConfig()
-                .setEnabled(true).setMulticastTimeoutSeconds(3);
-        config2.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(false);
-
-        assertIncompatible(config1, config2);
-    }
-
-    @Test
     public void test_whenIncompatiblePartitionGroups() throws Exception {
         Config config1 = new Config();
         config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");

--- a/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/TcpIpJoinTest.java
@@ -160,25 +160,31 @@ public class TcpIpJoinTest extends AbstractJoinTest {
     }
 
     @Test
-    public void test_whenSameGroupNamesButDifferentPassword() throws Exception {
+    public void test_whenSameGroupNamesButDifferentPassword()
+            throws Exception {
         Config config1 = new Config();
         config1.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
         config1.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "3");
         config1.getGroupConfig().setPassword("pass1");
         config1.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
-        config1.getNetworkConfig().getJoin().getTcpIpConfig()
-                .setEnabled(true).setConnectionTimeoutSeconds(3).addMember("127.0.0.1");
+        config1.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).setConnectionTimeoutSeconds(3)
+               .addMember("127.0.0.1");
 
         Config config2 = new Config();
         config2.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
         config2.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "3");
         config2.getGroupConfig().setPassword("pass2");
         config2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
-        config2.getNetworkConfig().getJoin().getTcpIpConfig()
-                .setEnabled(true).setConnectionTimeoutSeconds(3).addMember("127.0.0.1");
+        config2.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).setConnectionTimeoutSeconds(3)
+               .addMember("127.0.0.1");
 
-        assertIncompatible(config1, config2);
+        HazelcastInstance hz1 = Hazelcast.newHazelcastInstance(config1);
+        HazelcastInstance hz2 = Hazelcast.newHazelcastInstance(config2);
+
+        assertClusterSize(2, hz1);
+        assertClusterSize(2, hz2);
     }
+
 
     @Test
     public void test_whenIncompatiblePartitionGroups() throws Exception {


### PR DESCRIPTION
Group password leaked in the multicast datagram is considered a security flaw.
Starting from 3.8.2 it will get deprecated from the multicast protocol, and validation will be removed allowing future releases to completely remove this piece of information from the protocol. 

Group name is not affected by this change, and also any form of Authentication relying on the password is not affected either.