### PR TITLE
Fixes spurious failures in QuorumTests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -34,10 +34,11 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.generateRandomString;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
-import static org.junit.Assert.assertEquals;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -132,11 +133,11 @@ public class PartitionedCluster {
         splitCluster();
 
         assertTrue(splitLatch.await(30, TimeUnit.SECONDS));
-        assertEquals(3, h1.getCluster().getMembers().size());
-        assertEquals(3, h2.getCluster().getMembers().size());
-        assertEquals(3, h3.getCluster().getMembers().size());
-        assertEquals(2, h4.getCluster().getMembers().size());
-        assertEquals(2, h5.getCluster().getMembers().size());
+        assertClusterSizeEventually(3, h1);
+        assertClusterSizeEventually(3, h2);
+        assertClusterSizeEventually(3, h3);
+        assertClusterSizeEventually(2, h4);
+        assertClusterSizeEventually(2, h5);
         assertTrueEventually(new AssertTask() {
             @Override
             public void run()


### PR DESCRIPTION
Reasoning: #10137 changes failure detector mechanism.
Non-master members can just suspect other member is down,
but under normal circumstances they are not allowed
to remove a suspicious member from a member-list.

It's up to the master to remove suspicious members. Hence non-master
members will see the split-brain eventually and not immediately
after the suspectMember() is called.