### PR TITLE
Fix for testReconnectToNewInstanceAtSameAddress

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -79,7 +79,9 @@ public class ClientReconnectTest extends HazelcastTestSupport {
     public void testReconnectToNewInstanceAtSameAddress() throws InterruptedException {
         HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
         Address localAddress = instance.getCluster().getLocalMember().getAddress();
-        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         final CountDownLatch memberRemovedLatch = new CountDownLatch(1);
         client.getCluster().addMembershipListener(new MembershipAdapter() {


### PR DESCRIPTION
Test was failing because client was shutting down when member removal
takes a little bit longer than expected. Postponed client shutdown to
make test more resilient.

fixes #10390