### PR TITLE
Suspect members with both address & uuid

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -468,7 +468,7 @@ public class ClusterHeartbeatManager {
                             + " Now: %s, last heartbeat time was %s", member, maxNoHeartbeatMillis,
                     timeToString(now), timeToString(heartbeatTime));
             logger.warning(reason);
-            clusterService.suspectMember(member.getAddress(), reason, true);
+            clusterService.suspectMember(member, reason, true);
             return true;
         }
         if (logger.isFineEnabled() && (now - heartbeatTime) > heartbeatIntervalMillis * HEART_BEAT_INTERVAL_FACTOR) {
@@ -500,7 +500,7 @@ public class ClusterHeartbeatManager {
                     timeToString(now),
                     timeToString(lastConfirmation));
             logger.warning(reason);
-            clusterService.suspectMember(member.getAddress(), reason, true);
+            clusterService.suspectMember(member, reason, true);
             return true;
         }
         return false;
@@ -557,17 +557,17 @@ public class ClusterHeartbeatManager {
     }
 
     /**
-     * Tries to ping the {@code memberImpl} and removes the member if it is unreachable. The actual method of determining
+     * Tries to ping the {@code member} and removes the member if it is unreachable. The actual method of determining
      * reachability is defined by the privileges and does not need to be an ICMP packet
      * (see {@link java.net.InetAddress#isReachable(NetworkInterface, int, int)}).
      *
-     * @param memberImpl the member for which we need to determine reachability
+     * @param member the member for which we need to determine reachability
      */
-    private void ping(final MemberImpl memberImpl) {
+    private void ping(final Member member) {
         nodeEngine.getExecutionService().execute(ExecutionService.SYSTEM_EXECUTOR, new Runnable() {
             public void run() {
                 try {
-                    Address address = memberImpl.getAddress();
+                    Address address = member.getAddress();
                     logger.warning(format("%s will ping %s", node.getThisAddress(), address));
                     for (int i = 0; i < MAX_PING_RETRY_COUNT; i++) {
                         try {
@@ -583,7 +583,7 @@ public class ClusterHeartbeatManager {
                     // host not reachable
                     String reason = format("%s could not ping %s", node.getThisAddress(), address);
                     logger.warning(reason);
-                    clusterService.suspectMember(address, reason, true);
+                    clusterService.suspectMember(member, reason, true);
                 } catch (Throwable ignored) {
                     EmptyStatement.ignore(ignored);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -632,7 +632,7 @@ public class ClusterJoinManager {
                     + " Removing old member and processing join request...", member);
             logger.warning(msg);
 
-            clusterService.suspectMember(target, msg, false);
+            clusterService.suspectMember(member, msg, false);
             Connection existing = node.connectionManager.getConnection(target);
             if (existing != connection) {
                 if (existing != null) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -144,9 +144,7 @@ public class NodeIOService implements IOService {
         nodeEngine.getExecutionService().execute(ExecutionService.IO_EXECUTOR, new Runnable() {
             @Override
             public void run() {
-                // we can safely pass null because removeEndpoint is triggered from the connectionManager after
-                // the connection is closed. So a reason is already set.
-                node.clusterService.suspectMember(endPoint, null, true);
+                node.clusterService.suspectAddressIfNotConnected(endPoint);
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -482,8 +482,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         cm1.block(n3.address);
 
         // remove and block n1 on n2 & n3
-        n2.clusterService.suspectMember(n1.address, null, true);
-        n3.clusterService.suspectMember(n1.address, null, true);
+        n2.clusterService.suspectMember(n1.getLocalMember(), null, true);
+        n3.clusterService.suspectMember(n1.getLocalMember(), null, true);
         cm2.block(n1.address);
         cm3.block(n1.address);
 
@@ -665,7 +665,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     }
 
     private void disconnect(final HazelcastInstance source, final HazelcastInstance target) {
-        getNode(source).clusterService.suspectMember(getNode(target).address, null, true);
+        getNode(source).clusterService.suspectMember(getNode(target).getLocalMember(), null, true);
     }
 
 
@@ -733,8 +733,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         cm3.block(n1.address);
         cm3.block(n2.address);
 
-        n1.clusterService.suspectMember(n3.address, null, true);
-        n2.clusterService.suspectMember(n3.address, null, true);
+        n1.clusterService.suspectMember(n3.getLocalMember(), null, true);
+        n2.clusterService.suspectMember(n3.getLocalMember(), null, true);
         cm1.block(n3.address);
         cm2.block(n3.address);
 
@@ -821,8 +821,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         cm1.block(n2.address);
         cm1.block(n3.address);
 
-        n2.clusterService.suspectMember(n1.address, null, true);
-        n3.clusterService.suspectMember(n1.address, null, true);
+        n2.clusterService.suspectMember(n1.getLocalMember(), null, true);
+        n3.clusterService.suspectMember(n1.getLocalMember(), null, true);
         cm2.block(n1.address);
         cm3.block(n1.address);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -835,7 +835,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     private void suspectMember(HazelcastInstance suspectingInstance, HazelcastInstance suspectedInstance) {
         ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(suspectingInstance);
         Member suspectedMember = suspectedInstance.getCluster().getLocalMember();
-        clusterService.suspectMember(suspectedMember.getAddress(), suspectedMember.getUuid(), "test", false);
+        clusterService.suspectMember(suspectedMember, "test", false);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -194,21 +194,21 @@ public class PartitionedCluster {
         cm5.block(n2.address);
         cm5.block(n3.address);
 
-        n4.clusterService.suspectMember(n1.address, null, true);
-        n4.clusterService.suspectMember(n2.address, null, true);
-        n4.clusterService.suspectMember(n3.address, null, true);
+        n4.clusterService.suspectMember(n1.getLocalMember(), null, true);
+        n4.clusterService.suspectMember(n2.getLocalMember(), null, true);
+        n4.clusterService.suspectMember(n3.getLocalMember(), null, true);
 
-        n5.clusterService.suspectMember(n1.address, null, true);
-        n5.clusterService.suspectMember(n2.address, null, true);
-        n5.clusterService.suspectMember(n3.address, null, true);
+        n5.clusterService.suspectMember(n1.getLocalMember(), null, true);
+        n5.clusterService.suspectMember(n2.getLocalMember(), null, true);
+        n5.clusterService.suspectMember(n3.getLocalMember(), null, true);
 
-        n1.clusterService.suspectMember(n4.address, null, true);
-        n2.clusterService.suspectMember(n4.address, null, true);
-        n3.clusterService.suspectMember(n4.address, null, true);
+        n1.clusterService.suspectMember(n4.getLocalMember(), null, true);
+        n2.clusterService.suspectMember(n4.getLocalMember(), null, true);
+        n3.clusterService.suspectMember(n4.getLocalMember(), null, true);
 
-        n1.clusterService.suspectMember(n5.address, null, true);
-        n2.clusterService.suspectMember(n5.address, null, true);
-        n3.clusterService.suspectMember(n5.address, null, true);
+        n1.clusterService.suspectMember(n5.getLocalMember(), null, true);
+        n2.clusterService.suspectMember(n5.getLocalMember(), null, true);
+        n3.clusterService.suspectMember(n5.getLocalMember(), null, true);
     }
 
     private static FirewallingConnectionManager getConnectionManager(Node node) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -224,10 +224,10 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
         @Override
         public void run(final Node node1, final Node node2, final Node node3) {
             // Artificially create a network-split
-            node1.clusterService.suspectMember(node3.address, null, true);
+            node1.clusterService.suspectMember(node3.getLocalMember(), null, true);
 
-            node3.clusterService.suspectMember(node1.address, null, true);
-            node3.clusterService.suspectMember(node2.address, null, true);
+            node3.clusterService.suspectMember(node1.getLocalMember(), null, true);
+            node3.clusterService.suspectMember(node2.getLocalMember(), null, true);
 
             assertTrueEventually(new AssertTask() {
                 @Override
@@ -247,7 +247,7 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
             // Artificially create a partial network-split;
             // node1 and node2 will be split from node3
             // but node 3 will not be able to detect that.
-            node1.clusterService.suspectMember(node3.address, null, true);
+            node1.clusterService.suspectMember(node3.getLocalMember(), null, true);
 
             assertTrueEventually(new AssertTask() {
                 @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -505,8 +505,8 @@ public abstract class HazelcastTestSupport {
         Node n1 = TestUtil.getNode(h1);
         Node n2 = TestUtil.getNode(h2);
         if (n1 != null && n2 != null) {
-            n1.clusterService.suspectMember(n2.address, null, true);
-            n2.clusterService.suspectMember(n1.address, null, true);
+            n1.clusterService.suspectMember(n2.getLocalMember(), null, true);
+            n2.clusterService.suspectMember(n1.getLocalMember(), null, true);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -91,7 +91,7 @@ public class MockConnectionManager implements ConnectionManager {
         node.getNodeEngine().getExecutionService().execute(ExecutionService.IO_EXECUTOR, new Runnable() {
             @Override
             public void run() {
-                node.getClusterService().suspectMember(address, address + " is already left", false);
+                node.getClusterService().suspectAddressIfNotConnected(address);
             }
         });
     }
@@ -148,8 +148,7 @@ public class MockConnectionManager implements ConnectionManager {
                 logger.fine(otherNode.getThisAddress() + " is instructed to suspect from " + thisAddress);
                 try {
                     ClusterServiceImpl clusterService = otherNode.getClusterService();
-                    clusterService.suspectMember(localMember.getAddress(), localMember.getUuid(),
-                            "Connection manager is stopped on " + localMember, true);
+                    clusterService.suspectMember(localMember, "Connection manager is stopped on " + localMember, true);
                 } catch (Throwable e) {
                     ILogger otherLogger = otherNode.getLogger(MockConnectionManager.class);
                     otherLogger.warning("While removing " + thisAddress, e);


### PR DESCRIPTION
Replaced `ClusterService.suspectMember(address, ...)` method with
`ClusterService.suspectMember(member, ...)`. Member is identified by
both address and uuid together.
A delayed suspect request can cause a member restarted with same address
to be removed accidentally.

Suspicions caused by network failures do not know member uuid
but they should explicitly check whether an active connection doesn't exist
to that endpoint. This will guarantee that suspected address is not joining yet.

Fixes https://github.com/hazelcast/hazelcast/issues/7004