### PR TITLE
Do not retry TargetNotMemberException when invocation made on target

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientClusterStateTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
@@ -106,7 +107,7 @@ public class ClientClusterStateTest {
         factory.newHazelcastClient();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = OperationTimeoutException.class)
     public void testClient_canNotExecuteWriteOperations_whenClusterState_passive() {
         warmUpPartitions(instances);
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientNodeExtensionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cluster/ClientNodeExtensionTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.DefaultNodeExtension;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
@@ -98,7 +99,7 @@ public class ClientNodeExtensionTest
         factory.newHazelcastClient(clientConfig);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = OperationTimeoutException.class)
     public void test_canGetFromMap_whenNodeExtensionIsNotComplete() {
         IMap<Object, Object> map = null;
         ManagedExtensionNodeContext nodeContext = null;


### PR DESCRIPTION
Invocation made `ProxyManager.initialize(ClientProxy)` was on connection
to be able to prevent it from retrying. It was a workaround that does not
comply with ClientInvocation API hence failed today.

In this pr, I made the proxy creation invocation on address as intended.
And I changed invocation exception handling so that it will not be retried
when given address not a member anymore. Retrying does not make sense in
this case.

ClientLockWithTerminationTest.testLockOnClient_withNodeCrash was failing
because it was retrying creating proxy on closed member until
clientInvocationTimeout(120 seconds) hit and then throws OperationTimeoutException.

This pr https://github.com/hazelcast/hazelcast/pull/10370 made issue apparent.
It was waiting for 120 seconds unncessarily, then throwing a
retryableException(instead OperationTimeoutException). Because of retyable
exception there issue was hidden.

because fix needs changes there.

fixes #3422