### PR TITLE
Do not retry TargetNotMemberException when invocation made on target

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -24,7 +24,6 @@ import com.hazelcast.client.LoadBalancer;
 import com.hazelcast.client.cache.impl.ClientCacheProxyFactory;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ProxyFactoryConfig;
-import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientAddDistributedObjectListenerCodec;
@@ -78,7 +77,6 @@ import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.multimap.impl.MultiMapService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
-import com.hazelcast.nio.Connection;
 import com.hazelcast.replicatedmap.impl.ReplicatedMapService;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService;
@@ -347,35 +345,15 @@ public final class ProxyManager {
     }
 
     private void initialize(ClientProxy clientProxy) throws Exception {
-        final Address initializationTarget = findNextAddressToSendCreateRequest();
-        final Connection connection = getTargetOrOwnerConnection(initializationTarget);
-        final ClientMessage clientMessage = ClientCreateProxyCodec.encodeRequest(clientProxy.getDistributedObjectName(),
+        Address initializationTarget = findNextAddressToSendCreateRequest();
+        if (initializationTarget == null) {
+            throw new IOException("Not able to find a member to create proxy on!");
+        }
+        ClientMessage clientMessage = ClientCreateProxyCodec.encodeRequest(clientProxy.getDistributedObjectName(),
                 clientProxy.getServiceName(), initializationTarget);
-        new ClientInvocation(client, clientMessage, connection).invoke().get();
+        new ClientInvocation(client, clientMessage, initializationTarget).invoke().get();
         clientProxy.setContext(context);
         clientProxy.onInitialize();
-    }
-
-    private Connection getTargetOrOwnerConnection(final Address target) throws IOException {
-        if (target == null) {
-            throw new IOException("Not able to setup owner connection!");
-        }
-
-        final ClientConnectionManager connectionManager = client.getConnectionManager();
-        Connection connection = connectionManager.getConnection(target);
-        if (connection == null) {
-            final Address ownerConnectionAddress = client.getClientClusterService().getOwnerConnectionAddress();
-            if (ownerConnectionAddress == null) {
-                throw new IOException("Not able to setup owner connection!");
-            }
-
-            connection = connectionManager.getConnection(ownerConnectionAddress);
-            if (connection == null) {
-                throw new IOException("Client is not connected to member " + target);
-            }
-        }
-
-        return connection;
     }
 
     public Address findNextAddressToSendCreateRequest() {


### PR DESCRIPTION
Invocation made `ProxyManager.initialize(ClientProxy)` was on connection
to be able to prevent it from retrying. It was a workaround that does not
comply with ClientInvocation API hence failed today.

In this pr, I made the proxy creation invocation on address as intended.
And I changed invocation exception handling so that it will not be retried
when given address not a member anymore. Retrying does not make sense in
this case.

ClientLockWithTerminationTest.testLockOnClient_withNodeCrash was failing
because it was retrying creating proxy on closed member until
clientInvocationTimeout(120 seconds) hit and then throws OperationTimeoutException.

This pr https://github.com/hazelcast/hazelcast/pull/10370 made issue apparent.
It was waiting for 120 seconds unncessarily, then throwing a
retryableException(instead OperationTimeoutException). Because of retyable
exception there issue was hidden.

fixes #3422