### PR TITLE
Cleanup of NearCacheConfig and EvictionConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -761,12 +761,12 @@ public class ConfigXmlGenerator {
         if (e == null) {
             return;
         }
-        final String comparatorClass = !isNullOrEmpty(e.getComparatorClassName()) ? e.getComparatorClassName() : null;
+        final String comparatorClassName = !isNullOrEmpty(e.getComparatorClassName()) ? e.getComparatorClassName() : null;
         gen.node("eviction", null,
+                "size", e.getSize(),
                 "max-size-policy", e.getMaximumSizePolicy(),
                 "eviction-policy", e.getEvictionPolicy(),
-                "size", e.getSize(),
-                "comparator-class-name", comparatorClass);
+                "comparator-class-name", comparatorClassName);
     }
 
     private static void multicastConfigXmlGenerator(XmlGenerator gen, JoinConfig join) {

--- a/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EvictionConfig.java
@@ -34,6 +34,14 @@ import static com.hazelcast.util.Preconditions.checkPositive;
 /**
  * Configuration for eviction.
  * You can set a limit for number of entries or total memory cost of entries.
+ * <p/>
+ * The default values of the eviction configuration are
+ * <ul>
+ * <li>{@link EvictionPolicy#LRU} as eviction policy</li>
+ * <li>{@link EvictionConfig.MaxSizePolicy#ENTRY_COUNT} as max size policy</li>
+ * <li>{@value DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP} as maximum size for on-heap {@link com.hazelcast.core.IMap}</li>
+ * <li>{@value DEFAULT_MAX_ENTRY_COUNT} as maximum size for all other data structures and configurations</li>
+ * </ul>
  */
 @BinaryInterface
 public class EvictionConfig implements EvictionConfiguration, DataSerializable, Serializable {
@@ -57,88 +65,6 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
      * Default Eviction Policy.
      */
     public static final EvictionPolicy DEFAULT_EVICTION_POLICY = EvictionPolicy.LRU;
-
-    protected int size = DEFAULT_MAX_ENTRY_COUNT;
-    protected MaxSizePolicy maxSizePolicy = DEFAULT_MAX_SIZE_POLICY;
-    protected EvictionPolicy evictionPolicy = DEFAULT_EVICTION_POLICY;
-    protected String comparatorClassName;
-    protected EvictionPolicyComparator comparator;
-
-    protected EvictionConfig readOnly;
-
-    /**
-     * Used by the {@link NearCacheConfigAccessor} to initialize the proper default value for on-heap maps.
-     */
-    boolean sizeConfigured;
-
-    public EvictionConfig() {
-    }
-
-    public EvictionConfig(int size, MaxSizePolicy maxSizePolicy, EvictionPolicy evictionPolicy) {
-        /**
-         * ===== NOTE =====
-         *
-         * Do not use setters, because they are overridden in the readonly version of this config and
-         * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
-         */
-
-        this.sizeConfigured = true;
-        this.size = checkPositive(size, "Size must be positive number!");
-        this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
-        this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
-    }
-
-    public EvictionConfig(int size, MaxSizePolicy maxSizePolicy, String comparatorClassName) {
-        /**
-         * ===== NOTE =====
-         *
-         * Do not use setters, because they are overridden in the readonly version of this config and
-         * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
-         */
-
-        this.sizeConfigured = true;
-        this.size = checkPositive(size, "Size must be positive number!");
-        this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
-        this.comparatorClassName = checkNotNull(comparatorClassName, "Comparator classname cannot be null!");
-    }
-
-    public EvictionConfig(int size, MaxSizePolicy maxSizePolicy, EvictionPolicyComparator comparator) {
-        /**
-         * ===== NOTE =====
-         *
-         * Do not use setters, because they are overridden in the readonly version of this config and
-         * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
-         */
-
-        this.sizeConfigured = true;
-        this.size = checkPositive(size, "Size must be positive number!");
-        this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
-        this.comparator = checkNotNull(comparator, "Comparator cannot be null!");
-    }
-
-    public EvictionConfig(EvictionConfig config) {
-        /**
-         * ===== NOTE =====
-         *
-         * Do not use setters, because they are overridden in readonly version of this config and
-         * cause "UnsupportedOperationException". So just set directly if value is valid.
-         */
-
-        this.sizeConfigured = true;
-        this.size = checkPositive(config.size, "Size must be positive number!");
-        this.maxSizePolicy = checkNotNull(config.maxSizePolicy, "Max-Size policy cannot be null!");
-        if (config.evictionPolicy != null) {
-            this.evictionPolicy = config.evictionPolicy;
-        }
-        // Eviction policy comparator class name is not allowed to be null
-        if (config.comparatorClassName != null) {
-            this.comparatorClassName = config.comparatorClassName;
-        }
-        // Eviction policy comparator is not allowed to be null
-        if (config.comparator != null) {
-            this.comparator = config.comparator;
-        }
-    }
 
     /**
      * Maximum Size Policy
@@ -168,6 +94,60 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
         FREE_NATIVE_MEMORY_PERCENTAGE
     }
 
+    protected int size = DEFAULT_MAX_ENTRY_COUNT;
+    protected MaxSizePolicy maxSizePolicy = DEFAULT_MAX_SIZE_POLICY;
+    protected EvictionPolicy evictionPolicy = DEFAULT_EVICTION_POLICY;
+    protected String comparatorClassName;
+    protected EvictionPolicyComparator comparator;
+
+    protected EvictionConfig readOnly;
+
+    /**
+     * Used by the {@link NearCacheConfigAccessor} to initialize the proper default value for on-heap maps.
+     */
+    boolean sizeConfigured;
+
+    public EvictionConfig() {
+    }
+
+    public EvictionConfig(int size, MaxSizePolicy maxSizePolicy, EvictionPolicy evictionPolicy) {
+        this.sizeConfigured = true;
+        this.size = checkPositive(size, "Size must be positive number!");
+        this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
+        this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
+    }
+
+    public EvictionConfig(int size, MaxSizePolicy maxSizePolicy, String comparatorClassName) {
+        this.sizeConfigured = true;
+        this.size = checkPositive(size, "Size must be positive number!");
+        this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
+        this.comparatorClassName = checkNotNull(comparatorClassName, "Comparator classname cannot be null!");
+    }
+
+    public EvictionConfig(int size, MaxSizePolicy maxSizePolicy, EvictionPolicyComparator comparator) {
+        this.sizeConfigured = true;
+        this.size = checkPositive(size, "Size must be positive number!");
+        this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
+        this.comparator = checkNotNull(comparator, "Comparator cannot be null!");
+    }
+
+    public EvictionConfig(EvictionConfig config) {
+        this.sizeConfigured = true;
+        this.size = checkPositive(config.size, "Size must be positive number!");
+        this.maxSizePolicy = checkNotNull(config.maxSizePolicy, "Max-Size policy cannot be null!");
+        if (config.evictionPolicy != null) {
+            this.evictionPolicy = config.evictionPolicy;
+        }
+        // Eviction policy comparator class name is not allowed to be null
+        if (config.comparatorClassName != null) {
+            this.comparatorClassName = config.comparatorClassName;
+        }
+        // Eviction policy comparator is not allowed to be null
+        if (config.comparator != null) {
+            this.comparator = config.comparator;
+        }
+    }
+
     /**
      * Gets immutable version of this configuration.
      *
@@ -181,62 +161,89 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
         return readOnly;
     }
 
+    /**
+     * Returns the size which is used by the {@link MaxSizePolicy}.
+     * <p/>
+     * The interpretation of the value depends on the configured {@link MaxSizePolicy}.
+     *
+     * @return the size which is used by the {@link MaxSizePolicy}
+     */
     public int getSize() {
         return size;
     }
 
+    /**
+     * Sets the size which is used by the {@link MaxSizePolicy}.
+     * <p/>
+     * The interpretation of the value depends on the configured {@link MaxSizePolicy}.
+     * <p/>
+     * Accepts any positive number. The default value is {@value #DEFAULT_MAX_ENTRY_COUNT}.
+     *
+     * @param size the size which is used by the {@link MaxSizePolicy}
+     * @return this EvictionConfig instance
+     */
     public EvictionConfig setSize(int size) {
         this.sizeConfigured = true;
-        this.size = checkPositive(size, "Size must be positive number!");
+        this.size = checkPositive(size, "size must be positive number!");
         return this;
     }
 
+    /**
+     * Returns the {@link MaxSizePolicy} of this eviction configuration.
+     *
+     * @return the {@link MaxSizePolicy} of this eviction configuration
+     */
     public MaxSizePolicy getMaximumSizePolicy() {
         return maxSizePolicy;
     }
 
+    /**
+     * Sets the {@link MaxSizePolicy} of this eviction configuration.
+     *
+     * @param maxSizePolicy the {@link MaxSizePolicy} of this eviction configuration
+     * @return this EvictionConfig instance
+     */
     public EvictionConfig setMaximumSizePolicy(MaxSizePolicy maxSizePolicy) {
-        this.maxSizePolicy = checkNotNull(maxSizePolicy, "Max-Size policy cannot be null!");
+        this.maxSizePolicy = checkNotNull(maxSizePolicy, "maxSizePolicy cannot be null!");
         return this;
     }
 
+    /**
+     * Returns the {@link EvictionPolicy} of this eviction configuration.
+     *
+     * @return the {@link EvictionPolicy} of this eviction configuration
+     */
     @Override
     public EvictionPolicy getEvictionPolicy() {
         return evictionPolicy;
     }
 
+    /**
+     * Sets the {@link EvictionPolicy} of this eviction configuration.
+     *
+     * @param evictionPolicy the {@link EvictionPolicy} of this eviction configuration
+     * @return this EvictionConfig instance
+     */
     public EvictionConfig setEvictionPolicy(EvictionPolicy evictionPolicy) {
         this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
         return this;
     }
 
-    @Override
-    public String getComparatorClassName() {
-        return comparatorClassName;
-    }
-
-    public EvictionConfig setComparatorClassName(String comparatorClassName) {
-        this.comparatorClassName = checkNotNull(comparatorClassName, "Eviction policy comparator class name cannot be null!");
-        return this;
-    }
-
-    @Override
-    public EvictionPolicyComparator getComparator() {
-        return comparator;
-    }
-
-    public EvictionConfig setComparator(EvictionPolicyComparator comparator) {
-        this.comparator = checkNotNull(comparator, "Eviction policy comparator cannot be null!");
-        return this;
-    }
-
+    /**
+     * Returns the {@link EvictionStrategyType} of this eviction configuration.
+     *
+     * @return the {@link EvictionStrategyType} of this eviction configuration
+     */
     @Override
     public EvictionStrategyType getEvictionStrategyType() {
         return EvictionStrategyType.DEFAULT_EVICTION_STRATEGY;
     }
 
     /**
-     * @deprecated since 3.9, use {@link #getEvictionPolicy()} instead
+     * Returns the {@link EvictionPolicyType} of this eviction configuration.
+     *
+     * @return the {@link EvictionPolicyType} of this eviction configuration
+     * @deprecated since 3.9, please use {@link #getEvictionPolicy()}
      */
     @Deprecated
     public EvictionPolicyType getEvictionPolicyType() {
@@ -252,6 +259,52 @@ public class EvictionConfig implements EvictionConfiguration, DataSerializable, 
             default:
                 return null;
         }
+    }
+
+    /**
+     * Returns the class name of the configured {@link EvictionPolicyComparator} implementation.
+     *
+     * @return the class name of the configured {@link EvictionPolicyComparator} implementation
+     */
+    @Override
+    public String getComparatorClassName() {
+        return comparatorClassName;
+    }
+
+    /**
+     * Sets the class name of the configured {@link EvictionPolicyComparator} implementation.
+     * <p/>
+     * Only one of the {@code comparator class name} and {@code comparator} can be configured in the eviction configuration.
+     *
+     * @param comparatorClassName the class name of the configured {@link EvictionPolicyComparator} implementation
+     * @return this EvictionConfig instance
+     */
+    public EvictionConfig setComparatorClassName(String comparatorClassName) {
+        this.comparatorClassName = checkNotNull(comparatorClassName, "Eviction policy comparator class name cannot be null!");
+        return this;
+    }
+
+    /**
+     * Returns the instance of the configured {@link EvictionPolicyComparator} implementation.
+     *
+     * @return the instance of the configured {@link EvictionPolicyComparator} implementation
+     */
+    @Override
+    public EvictionPolicyComparator getComparator() {
+        return comparator;
+    }
+
+    /**
+     * Sets the instance of the configured {@link EvictionPolicyComparator} implementation.
+     * <p/>
+     * Only one of the {@code comparator class name} and {@code comparator} can be configured in the eviction configuration.
+     *
+     * @param comparator the instance of the configured {@link EvictionPolicyComparator} implementation
+     * @return this EvictionConfig instance
+     */
+    public EvictionConfig setComparator(EvictionPolicyComparator comparator) {
+        this.comparator = checkNotNull(comparator, "Eviction policy comparator cannot be null!");
+        return this;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -31,17 +31,8 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 /**
  * Contains the configuration for a Near Cache.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public class NearCacheConfig implements IdentifiedDataSerializable, Serializable {
-
-    /**
-     * Default value of the time to live in seconds.
-     */
-    public static final int DEFAULT_TTL_SECONDS = 0;
-
-    /**
-     * Default value of the idle time for eviction in seconds.
-     */
-    public static final int DEFAULT_MAX_IDLE_SECONDS = 0;
 
     /**
      * Default value for the in-memory format.
@@ -49,10 +40,21 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     public static final InMemoryFormat DEFAULT_MEMORY_FORMAT = InMemoryFormat.BINARY;
 
     /**
+     * Default value of the time to live in seconds.
+     */
+    public static final int DEFAULT_TTL_SECONDS = 0;
+
+    /**
+     * Default value of the maximum idle time for eviction in seconds.
+     */
+    public static final int DEFAULT_MAX_IDLE_SECONDS = 0;
+
+    /**
      * Default value of the maximum size.
      *
      * @deprecated since 3.8, please use {@link EvictionConfig#DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP}
      */
+    @Deprecated
     public static final int DEFAULT_MAX_SIZE = EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP;
 
     /**
@@ -60,50 +62,47 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
      *
      * @deprecated since 3.8, please use {@link EvictionConfig#DEFAULT_EVICTION_POLICY}
      */
+    @Deprecated
     public static final String DEFAULT_EVICTION_POLICY = EvictionConfig.DEFAULT_EVICTION_POLICY.name();
 
     /**
-     * Used to decide how to reflect local updates to Near Cache.
+     * Defines how to reflect local updates to the Near Cache.
      */
     public enum LocalUpdatePolicy {
         /**
-         * Local put and local remove immediately invalidates Near Cache.
+         * A local put and local remove immediately invalidates the Near Cache.
          */
         INVALIDATE,
 
         /**
-         * Local put immediately adds new value to Near Cache. Local remove works as in INVALIDATE mode.
+         * A local put immediately adds the new value to the Near Cache.
+         * A local remove works as in INVALIDATE mode.
          */
         CACHE_ON_UPDATE,
 
         /**
-         * Subject to remove in further releases. Instead of this use {@link LocalUpdatePolicy#CACHE_ON_UPDATE}.
+         * A local put immediately adds the new value to the Near Cache.
+         * A local remove works as in INVALIDATE mode.
+         *
+         * @deprecated since 3.8, please use {@link LocalUpdatePolicy#CACHE_ON_UPDATE}
          */
         @Deprecated
         CACHE
     }
 
-    private boolean cacheLocalEntries;
+    private String name = "default";
+    private InMemoryFormat inMemoryFormat = DEFAULT_MEMORY_FORMAT;
     private boolean invalidateOnChange = true;
     private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
     private int maxIdleSeconds = DEFAULT_MAX_IDLE_SECONDS;
     private int maxSize = EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP;
-    private String name = "default";
     private String evictionPolicy = EvictionConfig.DEFAULT_EVICTION_POLICY.name();
-    private InMemoryFormat inMemoryFormat = DEFAULT_MEMORY_FORMAT;
-    private LocalUpdatePolicy localUpdatePolicy = LocalUpdatePolicy.INVALIDATE;
-    private NearCacheConfigReadOnly readOnly;
-
-    /**
-     * Default value of eviction config is
-     * <ul>
-     * <li>ENTRY_COUNT as max size policy</li>
-     * <li>10000 as maximum size</li>
-     * <li>LRU as eviction policy</li>
-     * </ul>
-     */
     private EvictionConfig evictionConfig = new EvictionConfig();
+    private boolean cacheLocalEntries;
+    private LocalUpdatePolicy localUpdatePolicy = LocalUpdatePolicy.INVALIDATE;
     private NearCachePreloaderConfig preloaderConfig = new NearCachePreloaderConfig();
+
+    private NearCacheConfigReadOnly readOnly;
 
     public NearCacheConfig() {
     }
@@ -112,47 +111,47 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
         this.name = name;
     }
 
-    public NearCacheConfig(int timeToLiveSeconds, int maxIdleSeconds, boolean invalidateOnChange,
-                           InMemoryFormat inMemoryFormat) {
+    public NearCacheConfig(int timeToLiveSeconds, int maxIdleSeconds, boolean invalidateOnChange, InMemoryFormat inMemoryFormat) {
         this(timeToLiveSeconds, maxIdleSeconds, invalidateOnChange, inMemoryFormat, null);
     }
 
-    public NearCacheConfig(int timeToLiveSeconds, int maxIdleSeconds, boolean invalidateOnChange,
-                           InMemoryFormat inMemoryFormat, EvictionConfig evictionConfig) {
-        this.timeToLiveSeconds = timeToLiveSeconds;
-        this.maxSize = calculateMaxSize(maxSize);
-        this.maxIdleSeconds = maxIdleSeconds;
-        this.invalidateOnChange = invalidateOnChange;
+    public NearCacheConfig(int timeToLiveSeconds, int maxIdleSeconds, boolean invalidateOnChange, InMemoryFormat inMemoryFormat,
+                           EvictionConfig evictionConfig) {
         this.inMemoryFormat = inMemoryFormat;
+        this.invalidateOnChange = invalidateOnChange;
+        this.timeToLiveSeconds = timeToLiveSeconds;
+        this.maxIdleSeconds = maxIdleSeconds;
+        this.maxSize = calculateMaxSize(maxSize);
         // EvictionConfig is not allowed to be null
         if (evictionConfig != null) {
-            this.evictionConfig = evictionConfig;
-            this.evictionPolicy = evictionConfig.getEvictionPolicy().toString();
             this.maxSize = evictionConfig.getSize();
+            this.evictionPolicy = evictionConfig.getEvictionPolicy().toString();
+            this.evictionConfig = evictionConfig;
         }
     }
 
     /**
-     * @deprecated since 3.8,
-     * please use {@link NearCacheConfig#NearCacheConfig(int, int, boolean, InMemoryFormat)}
+     * @deprecated since 3.8, please use {@link NearCacheConfig#NearCacheConfig(int, int, boolean, InMemoryFormat)}
      */
+    @Deprecated
     public NearCacheConfig(int timeToLiveSeconds, int maxSize, String evictionPolicy, int maxIdleSeconds,
                            boolean invalidateOnChange, InMemoryFormat inMemoryFormat) {
         this(timeToLiveSeconds, maxSize, evictionPolicy, maxIdleSeconds, invalidateOnChange, inMemoryFormat, null);
     }
 
     /**
-     * @deprecated since 3.8,
-     * please use {@link NearCacheConfig#NearCacheConfig(int, int, boolean, InMemoryFormat, EvictionConfig)}
+     * @deprecated since 3.8, please use
+     * {@link NearCacheConfig#NearCacheConfig(int, int, boolean, InMemoryFormat, EvictionConfig)}
      */
+    @Deprecated
     public NearCacheConfig(int timeToLiveSeconds, int maxSize, String evictionPolicy, int maxIdleSeconds,
                            boolean invalidateOnChange, InMemoryFormat inMemoryFormat, EvictionConfig evictionConfig) {
+        this.inMemoryFormat = inMemoryFormat;
+        this.invalidateOnChange = invalidateOnChange;
         this.timeToLiveSeconds = timeToLiveSeconds;
+        this.maxIdleSeconds = maxIdleSeconds;
         this.maxSize = calculateMaxSize(maxSize);
         this.evictionPolicy = evictionPolicy;
-        this.maxIdleSeconds = maxIdleSeconds;
-        this.invalidateOnChange = invalidateOnChange;
-        this.inMemoryFormat = inMemoryFormat;
         // EvictionConfig is not allowed to be null
         if (evictionConfig != null) {
             this.evictionConfig = evictionConfig;
@@ -164,19 +163,19 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     }
 
     public NearCacheConfig(NearCacheConfig config) {
-        name = config.getName();
-        evictionPolicy = config.getEvictionPolicy();
-        inMemoryFormat = config.getInMemoryFormat();
-        invalidateOnChange = config.isInvalidateOnChange();
-        maxIdleSeconds = config.getMaxIdleSeconds();
-        maxSize = config.getMaxSize();
-        timeToLiveSeconds = config.getTimeToLiveSeconds();
-        cacheLocalEntries = config.isCacheLocalEntries();
-        localUpdatePolicy = config.localUpdatePolicy;
+        name = config.name;
+        inMemoryFormat = config.inMemoryFormat;
+        invalidateOnChange = config.invalidateOnChange;
+        timeToLiveSeconds = config.timeToLiveSeconds;
+        maxIdleSeconds = config.maxIdleSeconds;
+        maxSize = config.maxSize;
+        evictionPolicy = config.evictionPolicy;
         // EvictionConfig is not allowed to be null
         if (config.evictionConfig != null) {
             this.evictionConfig = config.evictionConfig;
         }
+        cacheLocalEntries = config.cacheLocalEntries;
+        localUpdatePolicy = config.localUpdatePolicy;
         // NearCachePreloaderConfig is not allowed to be null
         if (config.preloaderConfig != null) {
             this.preloaderConfig = config.preloaderConfig;
@@ -184,11 +183,12 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     }
 
     /**
-     * Gets immutable version of this configuration.
+     * Returns an immutable version of this configuration.
      *
-     * @return Immutable version of this configuration.
+     * @return immutable version of this configuration
      * @deprecated this method will be removed in 4.0; it is meant for internal usage only.
      */
+    @Deprecated
     public NearCacheConfigReadOnly getAsReadOnly() {
         if (readOnly == null) {
             readOnly = new NearCacheConfigReadOnly(this);
@@ -197,9 +197,9 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     }
 
     /**
-     * Gets the name of the Near Cache.
+     * Returns the name of the Near Cache.
      *
-     * @return The name of the Near Cache.
+     * @return the name of the Near Cache
      */
     public String getName() {
         return name;
@@ -208,8 +208,8 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     /**
      * Sets the name of the Near Cache.
      *
-     * @param name The name of the Near Cache.
-     * @return This Near Cache config instance.
+     * @param name the name of the Near Cache
+     * @return this Near Cache config instance
      */
     public NearCacheConfig setName(String name) {
         this.name = name;
@@ -217,153 +217,17 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     }
 
     /**
-     * Gets the maximum number of seconds for each entry to stay in the Near Cache. Entries that are
-     * older than time-to-live-seconds will get automatically evicted from the Near Cache.
-     *
-     * @return The maximum number of seconds for each entry to stay in the Near Cache.
-     */
-    public int getTimeToLiveSeconds() {
-        return timeToLiveSeconds;
-    }
-
-    /**
-     * Sets the maximum number of seconds for each entry to stay in the Near Cache. Entries that are
-     * older than time-to-live-seconds will get automatically evicted from the Near Cache.
-     * Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
-     *
-     * @param timeToLiveSeconds The maximum number of seconds for each entry to stay in the Near Cache.
-     * @return This Near Cache config instance.
-     */
-    public NearCacheConfig setTimeToLiveSeconds(int timeToLiveSeconds) {
-        this.timeToLiveSeconds = checkNotNegative(timeToLiveSeconds, "TTL seconds cannot be negative!");
-        return this;
-    }
-
-    /**
-     * Gets the maximum size of the Near Cache. When max size is reached,
-     * cache is evicted based on the policy defined.
-     *
-     * @return The maximum size of the Near Cache.
-     * @deprecated since 3.8, use {@link #getEvictionConfig()} and {@link EvictionConfig#getSize()} instead
-     */
-    public int getMaxSize() {
-        return maxSize;
-    }
-
-    /**
-     * Sets the maximum size of the Near Cache. When max size is reached,
-     * cache is evicted based on the policy defined.
-     * Any integer between 0 and Integer.MAX_VALUE. 0 means
-     * Integer.MAX_VALUE. Default is 0.
-     *
-     * @param maxSize The maximum number of seconds for each entry to stay in the Near Cache.
-     * @return This Near Cache config instance.
-     * @deprecated since 3.8, use {@link #setEvictionConfig(EvictionConfig)} and {@link EvictionConfig#setSize(int)} instead
-     */
-    public NearCacheConfig setMaxSize(int maxSize) {
-        checkNotNegative(maxSize, "maxSize cannot be a negative number!");
-        this.maxSize = calculateMaxSize(maxSize);
-        this.evictionConfig.setSize(this.maxSize);
-        this.evictionConfig.setMaximumSizePolicy(ENTRY_COUNT);
-        return this;
-    }
-
-    /**
-     * Returns the eviction policy for the Near Cache.
-     *
-     * @return The eviction policy for the Near Cache.
-     * @deprecated since 3.8, use {@link #getEvictionConfig()} and {@link EvictionConfig#getEvictionPolicy()} instead
-     */
-    public String getEvictionPolicy() {
-        return evictionPolicy;
-    }
-
-    /**
-     * Sets the eviction policy.
-     *
-     * Valid values are:
-     * LRU  (Least Recently Used)
-     * LFU  (Least Frequently Used)
-     * NONE (no extra eviction, time-to-live-seconds or max-idle-seconds may still apply)
-     * RANDOM (random entry)
-     *
-     * LRU is the default.
-     * Regardless of the eviction policy used, time-to-live-seconds and max-idle-seconds will still apply.
-     *
-     * @param evictionPolicy The eviction policy for the Near Cache.
-     * @return This Near Cache config instance.
-     * @deprecated since 3.8, use {@link #setEvictionConfig(EvictionConfig)}
-     * and {@link EvictionConfig#setEvictionPolicy(EvictionPolicy)} instead
-     */
-    public NearCacheConfig setEvictionPolicy(String evictionPolicy) {
-        this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
-        this.evictionConfig.setEvictionPolicy(EvictionPolicy.valueOf(evictionPolicy));
-        this.evictionConfig.setMaximumSizePolicy(ENTRY_COUNT);
-        return this;
-    }
-
-    /**
-     * Maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
-     * Entries that are not read (touched) more than max-idle-seconds value will get removed
-     * from the Near Cache.
-     *
-     * @return Maximum number of seconds each entry can stay in the Near Cache as
-     * untouched (not-read).
-     */
-    public int getMaxIdleSeconds() {
-        return maxIdleSeconds;
-    }
-
-    /**
-     * Maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
-     * Entries that are not read (touched) more than max-idle-seconds value will get removed
-     * from the Near Cache.
-     * Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
-     *
-     * @param maxIdleSeconds Maximum number of seconds each entry can stay in the Near Cache as
-     *                       untouched (not-read).
-     * @return This Near Cache config instance.
-     */
-    public NearCacheConfig setMaxIdleSeconds(int maxIdleSeconds) {
-        this.maxIdleSeconds = checkNotNegative(maxIdleSeconds, "Max-Idle seconds cannot be negative!");
-        return this;
-    }
-
-    /**
-     * True to evict the cached entries if the entries are changed (updated or removed).
-     *
-     * When true, the member listens for cluster-wide changes on the entries and invalidates
-     * them on change. Changes done on the local member always invalidate the cache.
-     *
-     * @return This Near Cache config instance.
-     */
-    public boolean isInvalidateOnChange() {
-        return invalidateOnChange;
-    }
-
-    /**
-     * True to evict the cached entries if the entries are changed (updated or removed).
-     *
-     * If set to true, the member will listen for cluster-wide changes on the entries and invalidate
-     * them on change. Changes done on the local member always invalidate the cache.
-     *
-     * @param invalidateOnChange True to evict the cached entries if the entries are
-     *                           changed (updated or removed), false otherwise.
-     * @return This Near Cache config instance.
-     */
-    public NearCacheConfig setInvalidateOnChange(boolean invalidateOnChange) {
-        this.invalidateOnChange = invalidateOnChange;
-        return this;
-    }
-
-    /**
-     * Gets the data type used to store entries.
+     * Returns the data type used to store entries.
+     * <p/>
      * Possible values:
-     * BINARY (default): keys and values are stored as binary data.
-     * OBJECT: values are stored in their object forms.
-     * NATIVE: keys and values are stored in native memory.
+     * <ul>
+     * <li>{@code BINARY}: keys and values are stored as binary data</li>
+     * <li>{@code OBJECT}: values are stored in their object forms</li>
+     * <li>{@code NATIVE}: keys and values are stored in native memory</li>
+     * </ul>
+     * The default value is {@code BINARY}.
      *
-     * @return The data type used to store entries.
+     * @return the data type used to store entries
      */
     public InMemoryFormat getInMemoryFormat() {
         return inMemoryFormat;
@@ -371,47 +235,20 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
 
     /**
      * Sets the data type used to store entries.
+     * <p/>
      * Possible values:
-     * BINARY (default): keys and values are stored as binary data.
-     * OBJECT: values are stored in their object forms.
-     * NATIVE: keys and values are stored in native memory.
+     * <ul>
+     * <li>{@code BINARY}: keys and values are stored as binary data</li>
+     * <li>{@code OBJECT}: values are stored in their object forms</li>
+     * <li>{@code NATIVE}: keys and values are stored in native memory</li>
+     * </ul>
+     * The default value is {@code BINARY}.
      *
-     * @param inMemoryFormat The data type used to store entries.
-     * @return This Near Cache config instance.
+     * @param inMemoryFormat the data type used to store entries
+     * @return this Near Cache config instance
      */
     public NearCacheConfig setInMemoryFormat(InMemoryFormat inMemoryFormat) {
         this.inMemoryFormat = isNotNull(inMemoryFormat, "In-Memory format cannot be null!");
-        return this;
-    }
-
-    /**
-     * If true, cache local entries also.
-     * This is useful when in-memory-format for Near Cache is different than the map's one.
-     *
-     * @return True if local entries are cached also.
-     */
-    public boolean isCacheLocalEntries() {
-        return cacheLocalEntries;
-    }
-
-    /**
-     * True to cache local entries also.
-     * This is useful when in-memory-format for Near Cache is different than the map's one.
-     *
-     * @param cacheLocalEntries True to cache local entries also.
-     * @return This Near Cache config instance.
-     */
-    public NearCacheConfig setCacheLocalEntries(boolean cacheLocalEntries) {
-        this.cacheLocalEntries = cacheLocalEntries;
-        return this;
-    }
-
-    public LocalUpdatePolicy getLocalUpdatePolicy() {
-        return localUpdatePolicy;
-    }
-
-    public NearCacheConfig setLocalUpdatePolicy(LocalUpdatePolicy localUpdatePolicy) {
-        this.localUpdatePolicy = checkNotNull(localUpdatePolicy, "Local update policy cannot be null!");
         return this;
     }
 
@@ -424,29 +261,246 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     }
 
     /**
-     * The eviction configuration.
+     * Checks if Near Cache entries are invalidated when the entries in the backing data structure are changed
+     * (updated or removed).
+     * <p/>
+     * When this setting is enabled, a Hazelcast instance with a Near Cache listens for cluster-wide changes
+     * on the entries of the backing data structure and invalidates its corresponding Near Cache entries.
+     * Changes done on the local Hazelcast instance always invalidate the Near Cache immediately.
      *
-     * @return The eviction configuration.
+     * @return {@code true} if Near Cache invalidations are enabled on changes, {@code false} otherwise
+     */
+    public boolean isInvalidateOnChange() {
+        return invalidateOnChange;
+    }
+
+    /**
+     * Sets if Near Cache entries are invalidated when the entries in the backing data structure are changed
+     * (updated or removed).
+     * <p/>
+     * When this setting is enabled, a Hazelcast instance with a Near Cache listens for cluster-wide changes
+     * on the entries of the backing data structure and invalidates its corresponding Near Cache entries.
+     * Changes done on the local Hazelcast instance always invalidate the Near Cache immediately.
+     *
+     * @param invalidateOnChange {@code true} to enable Near Cache invalidations, {@code false} otherwise
+     * @return this Near Cache config instance
+     */
+    public NearCacheConfig setInvalidateOnChange(boolean invalidateOnChange) {
+        this.invalidateOnChange = invalidateOnChange;
+        return this;
+    }
+
+    /**
+     * Returns the maximum number of seconds for each entry to stay in the Near Cache (time to live).
+     * <p/>
+     * Entries that are older than {@code timeToLiveSeconds} will automatically be evicted from the Near Cache.
+     *
+     * @return the maximum number of seconds for each entry to stay in the Near Cache
+     */
+    public int getTimeToLiveSeconds() {
+        return timeToLiveSeconds;
+    }
+
+    /**
+     * Returns the maximum number of seconds for each entry to stay in the Near Cache (time to live).
+     * <p/>
+     * Entries that are older than {@code timeToLiveSeconds} will automatically be evicted from the Near Cache.
+     * <p/>
+     * Accepts any integer between {@code 0} and {@link Integer#MAX_VALUE}.
+     * The value {@code 0} means {@link Integer#MAX_VALUE}.
+     * The default is {@code 0}.
+     *
+     * @param timeToLiveSeconds the maximum number of seconds for each entry to stay in the Near Cache
+     * @return this Near Cache config instance
+     */
+    public NearCacheConfig setTimeToLiveSeconds(int timeToLiveSeconds) {
+        this.timeToLiveSeconds = checkNotNegative(timeToLiveSeconds, "TTL seconds cannot be negative!");
+        return this;
+    }
+
+    /**
+     * Returns the maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
+     * <p/>
+     * Entries that are not read (touched) more than {@code maxIdleSeconds} value will get removed from the Near Cache.
+     *
+     * @return maximum number of seconds each entry can stay in the Near Cache as untouched (not-read)
+     */
+    public int getMaxIdleSeconds() {
+        return maxIdleSeconds;
+    }
+
+    /**
+     * Set the maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
+     * <p/>
+     * Entries that are not read (touched) more than {@code maxIdleSeconds} value will get removed from the Near Cache.
+     * <p/>
+     * Accepts any integer between {@code 0} and {@link Integer#MAX_VALUE}.
+     * The value {@code 0} means {@link Integer#MAX_VALUE}.
+     * The default is {@code 0}.
+     *
+     * @param maxIdleSeconds maximum number of seconds each entry can stay in the Near Cache as untouched (not-read)
+     * @return this Near Cache config instance
+     */
+    public NearCacheConfig setMaxIdleSeconds(int maxIdleSeconds) {
+        this.maxIdleSeconds = checkNotNegative(maxIdleSeconds, "Max-Idle seconds cannot be negative!");
+        return this;
+    }
+
+    /**
+     * Returns the maximum size of the Near Cache.
+     * <p/>
+     * When the maxSize is reached, the Near Cache is evicted based on the policy defined.
+     *
+     * @return the maximum size of the Near Cache
+     * @deprecated since 3.8, please use {@link #getEvictionConfig()} and {@link EvictionConfig#getSize()}
+     */
+    @Deprecated
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    /**
+     * Sets the maximum size of the Near Cache.
+     * <p/>
+     * When the maxSize is reached, the Near Cache is evicted based on the policy defined.
+     * <p/>
+     * Accepts any integer between {@code 0} and {@link Integer#MAX_VALUE}.
+     * The value {@code 0} means {@link Integer#MAX_VALUE}.
+     * The default is {@code 0}.
+     *
+     * @param maxSize the maximum size of the Near Cache
+     * @return this Near Cache config instance
+     * @deprecated since 3.8, please use {@link #setEvictionConfig(EvictionConfig)} and {@link EvictionConfig#setSize(int)}
+     */
+    @Deprecated
+    public NearCacheConfig setMaxSize(int maxSize) {
+        checkNotNegative(maxSize, "maxSize cannot be a negative number!");
+        this.maxSize = calculateMaxSize(maxSize);
+        this.evictionConfig.setSize(this.maxSize);
+        this.evictionConfig.setMaximumSizePolicy(ENTRY_COUNT);
+        return this;
+    }
+
+    /**
+     * Returns the eviction policy for the Near Cache.
+     *
+     * @return the eviction policy for the Near Cache
+     * @deprecated since 3.8, please use {@link #getEvictionConfig()} and {@link EvictionConfig#getEvictionPolicy()}
+     */
+    @Deprecated
+    public String getEvictionPolicy() {
+        return evictionPolicy;
+    }
+
+    /**
+     * Sets the eviction policy.
+     * <p/>
+     * Valid values are:
+     * <ul>
+     * <li>{@code LRU} (Least Recently Used)</li>
+     * <li>{@code LFU} (Least Frequently Used)</li>
+     * <li>{@code NONE} (no extra eviction, time-to-live-seconds or max-idle-seconds may still apply)</li>
+     * <li>{@code RANDOM} (random entry)</li>
+     * </ul>
+     *
+     * {@code LRU} is the default.
+     * Regardless of the eviction policy used, time-to-live-seconds and max-idle-seconds will still apply.
+     *
+     * @param evictionPolicy the eviction policy for the Near Cache
+     * @return this Near Cache config instance
+     * @deprecated since 3.8, please use {@link #getEvictionConfig()} and {@link EvictionConfig#setEvictionPolicy(EvictionPolicy)}
+     */
+    @Deprecated
+    public NearCacheConfig setEvictionPolicy(String evictionPolicy) {
+        this.evictionPolicy = checkNotNull(evictionPolicy, "Eviction policy cannot be null!");
+        this.evictionConfig.setEvictionPolicy(EvictionPolicy.valueOf(evictionPolicy));
+        this.evictionConfig.setMaximumSizePolicy(ENTRY_COUNT);
+        return this;
+    }
+
+    /**
+     * Returns the eviction configuration for this Near Cache.
+     *
+     * @return the eviction configuration
      */
     public EvictionConfig getEvictionConfig() {
         return evictionConfig;
     }
 
     /**
-     * Sets the eviction configuration.
+     * Sets the eviction configuration for this Near Cache.
      *
-     * @param evictionConfig The eviction configuration.
-     * @return This Near Cache config instance.
+     * @param evictionConfig the eviction configuration
+     * @return this Near Cache config instance
      */
     public NearCacheConfig setEvictionConfig(EvictionConfig evictionConfig) {
         this.evictionConfig = checkNotNull(evictionConfig, "EvictionConfig cannot be null!");
         return this;
     }
 
+    /**
+     * Checks if local entries are also cached in the Near Cache.
+     * <p/>
+     * This is useful when the in-memory format of the Near Cache is different from the backing data structure.
+     * This setting has no meaning on Hazelcast clients, since they have no local entries.
+     *
+     * @return {@code true} if local entries are also cached, {@code false} otherwise
+     */
+    public boolean isCacheLocalEntries() {
+        return cacheLocalEntries;
+    }
+
+    /**
+     * Sets if local entries are also cached in the Near Cache.
+     * <p/>
+     * This is useful when the in-memory format of the Near Cache is different from the backing data structure.
+     * This setting has no meaning on Hazelcast clients, since they have no local entries.
+     *
+     * @param cacheLocalEntries {@code true} if local entries are also cached, {@code false} otherwise
+     * @return this Near Cache config instance
+     */
+    public NearCacheConfig setCacheLocalEntries(boolean cacheLocalEntries) {
+        this.cacheLocalEntries = cacheLocalEntries;
+        return this;
+    }
+
+    /**
+     * Returns the {@link LocalUpdatePolicy} of this Near Cache.
+     *
+     * @return the {@link LocalUpdatePolicy} of this Near Cache
+     */
+    public LocalUpdatePolicy getLocalUpdatePolicy() {
+        return localUpdatePolicy;
+    }
+
+    /**
+     * Sets the {@link LocalUpdatePolicy} of this Near Cache.
+     * <p/>
+     * This is only implemented for {@code JCache} data structures.
+     *
+     * @param localUpdatePolicy the {@link LocalUpdatePolicy} of this Near Cache
+     * @return this Near Cache config instance
+     */
+    public NearCacheConfig setLocalUpdatePolicy(LocalUpdatePolicy localUpdatePolicy) {
+        this.localUpdatePolicy = checkNotNull(localUpdatePolicy, "Local update policy cannot be null!");
+        return this;
+    }
+
+    /**
+     * Returns the {@link NearCachePreloaderConfig} of this Near Cache.
+     *
+     * @return the {@link NearCachePreloaderConfig} of this Near Cache
+     */
     public NearCachePreloaderConfig getPreloaderConfig() {
         return preloaderConfig;
     }
 
+    /**
+     * Sets the {@link NearCachePreloaderConfig} of this Near Cache.
+     *
+     * @param preloaderConfig the {@link NearCachePreloaderConfig} of this Near Cache
+     * @return this Near Cache config instance
+     */
     public NearCacheConfig setPreloaderConfig(NearCachePreloaderConfig preloaderConfig) {
         this.preloaderConfig = checkNotNull(preloaderConfig, "NearCachePreloaderConfig cannot be null!");
         return this;
@@ -496,20 +550,20 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     public String toString() {
         return "NearCacheConfig{"
                 + "name=" + name
+                + ", inMemoryFormat=" + inMemoryFormat
+                + ", invalidateOnChange=" + invalidateOnChange
                 + ", timeToLiveSeconds=" + timeToLiveSeconds
+                + ", maxIdleSeconds=" + maxIdleSeconds
                 + ", maxSize=" + maxSize
                 + ", evictionPolicy='" + evictionPolicy + '\''
-                + ", maxIdleSeconds=" + maxIdleSeconds
-                + ", invalidateOnChange=" + invalidateOnChange
-                + ", inMemoryFormat=" + inMemoryFormat
+                + ", evictionConfig=" + evictionConfig
                 + ", cacheLocalEntries=" + cacheLocalEntries
                 + ", localUpdatePolicy=" + localUpdatePolicy
-                + ", evictionConfig=" + evictionConfig
                 + ", preloaderConfig=" + preloaderConfig
                 + '}';
     }
 
-    private int calculateMaxSize(int maxSize) {
-        return (maxSize == 0) ? Integer.MAX_VALUE : checkNotNegative(maxSize, "Max-size cannot be negative!");
+    private static int calculateMaxSize(int maxSize) {
+        return (maxSize == 0) ? Integer.MAX_VALUE : checkNotNegative(maxSize, "maxSize cannot be negative!");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
@@ -56,35 +56,14 @@ public class NearCachePreloaderConfig implements IdentifiedDataSerializable, Ser
     }
 
     public NearCachePreloaderConfig(NearCachePreloaderConfig nearCachePreloaderConfig) {
-        /**
-         * ===== NOTE =====
-         *
-         * Do not use setters, because they are overridden in the readonly version of this config and
-         * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
-         */
-
         this(nearCachePreloaderConfig.enabled, nearCachePreloaderConfig.directory);
     }
 
     public NearCachePreloaderConfig(String directory) {
-        /**
-         * ===== NOTE =====
-         *
-         * Do not use setters, because they are overridden in the readonly version of this config and
-         * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
-         */
-
         this(true, directory);
     }
 
     public NearCachePreloaderConfig(boolean enabled, String directory) {
-        /**
-         * ===== NOTE =====
-         *
-         * Do not use setters, because they are overridden in the readonly version of this config and
-         * they cause an "UnsupportedOperationException". Just set directly if the value is valid.
-         */
-
         this.enabled = enabled;
         this.directory = checkNotNull(directory, "directory cannot be null!");
     }


### PR DESCRIPTION
* fixed JavaDoc of `NearCacheConfig` and `EvictionConfig`
* re-ordered fields of `NearCacheConfig` according to reference manual

No fields or logic has been changed, just re-ordering.

Pulled out from https://github.com/hazelcast/hazelcast/pull/10398