### PR TITLE
Eliminate unconditional waiting in node join/shutdown

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -50,7 +50,7 @@ class MockJoiner extends AbstractJoiner {
 
         Address previousJoinAddress = null;
         long joinAddressTimeout = 0;
-        while (shouldRetry() && (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis)) {
+        while (Clock.currentTimeMillis() - joinStartTime < maxJoinMillis) {
             synchronized (registry) {
                 Address joinAddress = getJoinAddress();
                 verifyInvariant(joinAddress != null, "joinAddress should not be null");
@@ -78,6 +78,9 @@ class MockJoiner extends AbstractJoiner {
                     joinAddressTimeout = 0;
                     clusterService.setMasterAddressToJoin(null);
                 }
+            }
+            if (!shouldRetry()) {
+                break;
             }
             try {
                 Thread.sleep(500);


### PR DESCRIPTION
When joining and shutting the node down there are some places where we
unconditionally wait before checking if we should wait any longer.
This has been eliminated, the check is done before the first wait as
well. 

NOTE : 
One risky change from an older version of this PR is already in master and now I see this PR as low-risk as the remaining changes are simple to reason about.