### PR TITLE
Fixed missing invalidations in ClientReplicatedMapProxy

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -33,8 +33,6 @@ import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -108,35 +106,5 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
 
     protected ClientConfig getClientConfig() {
         return new ClientConfig();
-    }
-
-    @Test
-    @Override
-    @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
-    public void whenSetIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter() {
-    }
-
-    @Test
-    @Override
-    @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
-    public void whenPutIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter() {
-    }
-
-    @Test
-    @Override
-    @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
-    public void whenPutAllIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter() {
-    }
-
-    @Test
-    @Override
-    @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
-    public void whenRemoveIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter() {
-    }
-
-    @Test
-    @Override
-    @Ignore(value = "The ClientReplicatedMapProxy is missing `invalidateNearCache(keyData)` calls")
-    public void whenNearCacheIsFull_thenPutOnSameKeyShouldUpdateValue_onNearCacheAdapter() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -48,8 +48,9 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
     }
 
     @Override
+    @MethodNotAvailable
     public void set(K key, V value) {
-        map.put(key, value);
+        throw new MethodNotAvailableException();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapterTest.java
@@ -69,11 +69,9 @@ public class ReplicatedMapDataStructureAdapterTest extends HazelcastTestSupport 
         adapter.getAsync(42);
     }
 
-    @Test
+    @Test(expected = MethodNotAvailableException.class)
     public void testSet() {
         adapter.set(23, "test");
-
-        assertEquals("test", map.get(23));
     }
 
     @Test


### PR DESCRIPTION
This fixes all known missing Near Cache invalidations for the `ReplicatedMap` on Hazelcast clients.

These are local invalidations when you directly update or remove an entry on the client side. In this case there is no invalidation event sent to the client, since it's expected that it invalidates the Near Cache by itself (like the other data structures do).