### PR TITLE
Fixes query performance regression for native

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -112,6 +112,7 @@ import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryEventFilter;
 import com.hazelcast.map.impl.query.QueryOperation;
 import com.hazelcast.map.impl.query.QueryPartitionOperation;
+import com.hazelcast.map.impl.query.QueryPartitionOperationFactory;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
 import com.hazelcast.map.impl.query.Target;
@@ -285,7 +286,8 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int REMOVE_FROM_LOAD_ALL = 134;
     public static final int ENTRY_REMOVING_PROCESSOR = 135;
     public static final int ENTRY_OFFLOADABLE_SET_UNLOCK = 136;
-    public static final int LOCK_AWARE_LAZY_MAP_ENTRY = 137;
+    public static final int QUERY_PARTITION_OP_FACTORY = 137;
+    public static final int LOCK_AWARE_LAZY_MAP_ENTRY = 138;
 
     private static final int LEN = LOCK_AWARE_LAZY_MAP_ENTRY + 1;
 
@@ -963,11 +965,17 @@ public final class MapDataSerializerHook implements DataSerializerHook {
                 return new EntryOffloadableSetUnlockOperation();
             }
         };
+        constructors[QUERY_PARTITION_OP_FACTORY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new QueryPartitionOperationFactory();
+            }
+        };
         constructors[LOCK_AWARE_LAZY_MAP_ENTRY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new LockAwareLazyMapEntry();
             }
         };
+
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.query;
 
-import com.hazelcast.core.HazelcastException;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.nio.ObjectDataInput;
@@ -25,7 +24,6 @@ import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 public class QueryPartitionOperation extends MapOperation implements PartitionAwareOperation, ReadonlyOperation {
 
@@ -41,15 +39,9 @@ public class QueryPartitionOperation extends MapOperation implements PartitionAw
     }
 
     @Override
-    public void run() {
+    public void run() throws Exception {
         QueryRunner queryRunner = mapServiceContext.getMapQueryRunner(getName());
-        try {
-            result = queryRunner.runPartitionScanQueryOnGivenOwnedPartition(query, getPartitionId());
-        } catch (ExecutionException e) {
-            throw new HazelcastException(e);
-        } catch (InterruptedException e) {
-            throw new HazelcastException(e);
-        }
+        result = queryRunner.runPartitionScanQueryOnGivenOwnedPartition(query, getPartitionId());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryPartitionOperationFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.query;
+
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static com.hazelcast.util.CollectionUtil.toIntArray;
+
+public class QueryPartitionOperationFactory extends PartitionAwareOperationFactory {
+
+    private Query query;
+
+    public QueryPartitionOperationFactory() {
+    }
+
+    public QueryPartitionOperationFactory(Query query, Collection<Integer> partitions) {
+        this.partitions = toIntArray(partitions);
+        this.query = query;
+    }
+
+    @Override
+    public Operation createPartitionOperation(int partitionId) {
+        QueryPartitionOperation op = new QueryPartitionOperation(query);
+        op.setPartitionId(partitionId);
+        return op;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return MapDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.QUERY_PARTITION_OP_FACTORY;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeIntArray(partitions);
+        out.writeObject(query);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.partitions = in.readIntArray();
+        this.query = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.List;
@@ -267,6 +268,11 @@ public final class PartitionIteratingOperation extends Operation implements Iden
             for (int i = 0; i < results.length; i++) {
                 partitionResults.put(partitions[i], results[i]);
             }
+        }
+
+        @SuppressFBWarnings("EI_EXPOSE_REP")
+        public Object[] getResults() {
+            return results;
         }
 
         @Override


### PR DESCRIPTION
before regression:
3.7.0, 10B, -> 19.5k ops

with regression:
3.8.0, 10B, ->  5.1k ops

after the fix:
3.9.0, 10B, -> 21.7k ops
