### PR TITLE
Enhancement to delay initialization until DistributedObjectFuture.get called

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
@@ -17,15 +17,19 @@
 package com.hazelcast.spi.impl.proxyservice.impl;
 
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.util.ExceptionUtil;
 
 public class DistributedObjectFuture {
 
-    volatile DistributedObject proxy;
-    volatile Throwable error;
+    private volatile DistributedObject proxy;
+    private volatile Throwable error;
+
+    // non-initialized distributed object
+    private volatile DistributedObject rawProxy;
 
     boolean isSet() {
-        return proxy != null;
+        return proxy != null || error != null || rawProxy != null;
     }
 
     public DistributedObject get() {
@@ -37,16 +41,7 @@ public class DistributedObjectFuture {
             throw ExceptionUtil.rethrow(error);
         }
 
-        boolean interrupted = false;
-        synchronized (this) {
-            while (proxy == null && error == null) {
-                try {
-                    wait();
-                } catch (InterruptedException e) {
-                    interrupted = true;
-                }
-            }
-        }
+        boolean interrupted = waitUntilSetAndInitialized();
 
         if (interrupted) {
             Thread.currentThread().interrupt();
@@ -58,12 +53,47 @@ public class DistributedObjectFuture {
         throw ExceptionUtil.rethrow(error);
     }
 
-    void set(DistributedObject o) {
+    private boolean waitUntilSetAndInitialized() {
+        boolean interrupted = false;
+        synchronized (this) {
+            while (proxy == null && error == null) {
+                if (rawProxy != null) {
+                    initialize();
+                    break;
+                }
+                try {
+                    wait();
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                }
+            }
+        }
+        return interrupted;
+    }
+
+    private void initialize() {
+        synchronized (this) {
+            try {
+                InitializingObject o = (InitializingObject) rawProxy;
+                o.initialize();
+                proxy = rawProxy;
+            } catch (Throwable e) {
+                error = e;
+            }
+            notifyAll();
+        }
+    }
+
+    void set(DistributedObject o, boolean initialized) {
         if (o == null) {
             throw new IllegalArgumentException("Proxy should not be null!");
         }
         synchronized (this) {
-            proxy = o;
+            if (!initialized && o instanceof InitializingObject) {
+                rawProxy = o;
+            } else {
+                proxy = o;
+            }
             notifyAll();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -144,7 +144,7 @@ public class ProxyServiceImpl
         checkObjectNameNotNull(name);
 
         ProxyRegistry registry = getOrCreateRegistry(serviceName);
-        return registry.getOrCreateProxy(name, true, true);
+        return registry.getOrCreateProxy(name, true);
     }
 
     @Override
@@ -203,7 +203,7 @@ public class ProxyServiceImpl
 
         ProxyRegistry registry = registries.get(serviceName);
         if (registry == null) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         } else {
             return registry.getDistributedObjectNames();
         }
@@ -237,8 +237,7 @@ public class ProxyServiceImpl
             try {
                 final ProxyRegistry registry = getOrCreateRegistry(serviceName);
                 if (!registry.contains(eventPacket.getName())) {
-                    registry.createProxy(eventPacket.getName(), false,
-                            true);
+                    registry.createProxy(eventPacket.getName(), false, true);
                     // listeners will be called if proxy is created here.
                 }
             } catch (HazelcastInstanceNotActiveException ignored) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFutureTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.proxyservice.impl;
+
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.spi.InitializingObject;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DistributedObjectFutureTest {
+
+    private DistributedObject object = mock(InitializingDistributedObject.class);
+    private DistributedObjectFuture future = new DistributedObjectFuture();
+
+    @Test
+    public void isSet_returnsFalse_whenNotSet() throws Exception {
+        assertFalse(future.isSet());
+    }
+
+    @Test
+    public void isSet_returnsTrue_whenSet() throws Exception {
+        future.set(object, true);
+        assertTrue(future.isSet());
+    }
+
+    @Test
+    public void isSet_returnsTrue_whenSetUninitialized() throws Exception {
+        future.set(object, false);
+        assertTrue(future.isSet());
+    }
+
+    @Test
+    public void isSet_returnsTrue_whenErrorSet() throws Exception {
+        future.setError(new Throwable());
+        assertTrue(future.isSet());
+    }
+
+    @Test
+    public void get_returnsObject_whenObjectSet() throws Exception {
+        future.set(object, true);
+        assertSame(object, future.get());
+
+        InitializingObject initializingObject = (InitializingObject) object;
+        verify(initializingObject, never()).initialize();
+    }
+
+    @Test
+    public void get_returnsInitializedObject_whenUninitializedObjectSet() throws Exception {
+        future.set(object, false);
+        assertSame(object, future.get());
+
+        InitializingObject initializingObject = (InitializingObject) object;
+        verify(initializingObject).initialize();
+    }
+
+    @Test
+    public void get_throwsGivenException_whenUncheckedExceptionSet() throws Exception {
+        Throwable error = new RuntimeException();
+        future.setError(error);
+
+        try {
+            future.get();
+        } catch (Exception e) {
+            assertSame(error, e);
+        }
+    }
+
+    @Test
+    public void get_throwsWrappedException_whenCheckedExceptionSet() throws Exception {
+        Throwable error = new Throwable();
+        future.setError(error);
+
+        try {
+            future.get();
+        } catch (Exception e) {
+            assertSame(error, e.getCause());
+        }
+    }
+
+    private interface InitializingDistributedObject extends DistributedObject, InitializingObject {
+    }
+}


### PR DESCRIPTION
Introduced ability to delay InitializingObject initialization until
DistributedObjectFuture.get() called.
This is needed especially when DistributedObject is created in partition threads but
initialization requires multi-partition access.