### PR TITLE
Rename DistributedObjectFuture isSet to isSetAndInitialized

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFuture.java
@@ -28,8 +28,8 @@ public class DistributedObjectFuture {
     // non-initialized distributed object
     private volatile DistributedObject rawProxy;
 
-    boolean isSet() {
-        return proxy != null || error != null || rawProxy != null;
+    boolean isSetAndInitialized() {
+        return proxy != null || error != null;
     }
 
     public DistributedObject get() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -94,7 +94,7 @@ public final class ProxyRegistry {
     public void getProxyInfos(Collection<ProxyInfo> result) {
         for (Map.Entry<String, DistributedObjectFuture> entry : proxies.entrySet()) {
             DistributedObjectFuture future = entry.getValue();
-            if (future.isSet()) {
+            if (future.isSetAndInitialized()) {
                 String proxyName = entry.getKey();
                 result.add(new ProxyInfo(serviceName, proxyName));
             }
@@ -256,7 +256,7 @@ public final class ProxyRegistry {
      */
     void destroy() {
         for (DistributedObjectFuture future : proxies.values()) {
-            if (!future.isSet()) {
+            if (!future.isSetAndInitialized()) {
                 continue;
             }
             DistributedObject distributedObject = future.get();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/proxyservice/impl/DistributedObjectFutureTest.java
@@ -41,25 +41,25 @@ public class DistributedObjectFutureTest {
 
     @Test
     public void isSet_returnsFalse_whenNotSet() throws Exception {
-        assertFalse(future.isSet());
+        assertFalse(future.isSetAndInitialized());
     }
 
     @Test
     public void isSet_returnsTrue_whenSet() throws Exception {
         future.set(object, true);
-        assertTrue(future.isSet());
+        assertTrue(future.isSetAndInitialized());
     }
 
     @Test
-    public void isSet_returnsTrue_whenSetUninitialized() throws Exception {
+    public void isSet_returnsFalse_whenSetUninitialized() throws Exception {
         future.set(object, false);
-        assertTrue(future.isSet());
+        assertFalse(future.isSetAndInitialized());
     }
 
     @Test
     public void isSet_returnsTrue_whenErrorSet() throws Exception {
         future.setError(new Throwable());
-        assertTrue(future.isSet());
+        assertTrue(future.isSetAndInitialized());
     }
 
     @Test


### PR DESCRIPTION
Uninitialized means DistributedObject is not retrieved from future yet.

Fix for bug created by https://github.com/hazelcast/hazelcast/pull/10428