### PR TITLE
ServiceNamespace can belong to multiple services

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/CheckReplicaVersionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/CheckReplicaVersionTask.java
@@ -127,7 +127,9 @@ final class CheckReplicaVersionTask implements PartitionSpecificRunnable, Urgent
         Set<ServiceNamespace> namespaces = new HashSet<ServiceNamespace>();
         for (FragmentedMigrationAwareService service : services) {
             Collection<ServiceNamespace> serviceNamespaces = service.getAllServiceNamespaces(event);
-            namespaces.addAll(serviceNamespaces);
+            if (serviceNamespaces != null) {
+                namespaces.addAll(serviceNamespaces);
+            }
         }
         namespaces.add(NonFragmentedServiceNamespace.INSTANCE);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/ReplicaSyncRequest.java
@@ -19,8 +19,8 @@ package com.hazelcast.internal.partition.operation;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
-import com.hazelcast.internal.partition.NonFragmentedServiceNamespace;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
+import com.hazelcast.internal.partition.NonFragmentedServiceNamespace;
 import com.hazelcast.internal.partition.PartitionReplicaVersionManager;
 import com.hazelcast.internal.partition.ReplicaErrorLogger;
 import com.hazelcast.internal.partition.impl.InternalPartitionImpl;
@@ -44,8 +44,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-
-import static java.util.Collections.singleton;
 
 /**
  * The request sent from a replica to the partition owner to synchronize the replica data. The partition owner can send a
@@ -114,8 +112,8 @@ public final class ReplicaSyncRequest extends AbstractPartitionOperation
                 }
 
                 for (ServiceNamespace namespace : allNamespaces) {
-                    Operation operation = createFragmentReplicationOperation(event, namespace);
-                    sendOperations(singleton(operation), namespace);
+                    Collection<Operation> operations = createFragmentReplicationOperations(event, namespace);
+                    sendOperations(operations, namespace);
                 }
             }
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/spi/FragmentedMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/FragmentedMigrationAwareService.java
@@ -48,6 +48,14 @@ public interface FragmentedMigrationAwareService extends MigrationAwareService {
     Collection<ServiceNamespace> getAllServiceNamespaces(PartitionReplicationEvent event);
 
     /**
+     * Returns true if namespace is known by this service, false otherwise
+     *
+     * @param namespace namespace
+     * @return true if namespace is known by this service, false otherwise
+     */
+    boolean isKnownServiceNamespace(ServiceNamespace namespace);
+
+    /**
      * Returns an operation to replicate service data and/or state for a specific partition replica and namespaces
      * on another cluster member. This method is very similar to
      * {@link #prepareReplicationOperation(PartitionReplicationEvent)},

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentedMigrationAwareService.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/service/fragment/TestFragmentedMigrationAwareService.java
@@ -83,6 +83,11 @@ public class TestFragmentedMigrationAwareService extends TestAbstractMigrationAw
     }
 
     @Override
+    public boolean isKnownServiceNamespace(ServiceNamespace namespace) {
+        return namespace instanceof TestServiceNamespace;
+    }
+
+    @Override
     public Operation prepareReplicationOperation(PartitionReplicationEvent event, Collection<ServiceNamespace> namespaces) {
         if (event.getReplicaIndex() > backupCount || namespaces.isEmpty()) {
             return null;


### PR DESCRIPTION
For example, locks can belong to lock service itself or map or multimap services.
Partition data belonging to a namespace should be replicated together.

FragmentedMigrationAwareService can return null namespaces.

Depends on https://github.com/hazelcast/hazelcast/pull/10434