### PR TITLE
Exclude shaded com.eclipsesource.* classes from Reflections in tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ReflectionsHelper.java
@@ -55,7 +55,8 @@ public class ReflectionsHelper {
             }
         }
         HierarchyTraversingSubtypesScanner subtypesScanner = new HierarchyTraversingSubtypesScanner();
-        subtypesScanner.setResultFilter(new FilterBuilder().exclude("java\\.lang\\.(Object|Enum)"));
+        subtypesScanner.setResultFilter(new FilterBuilder().exclude("java\\.lang\\.(Object|Enum)")
+                                                           .exclude("com\\.hazelcast\\.com\\.eclipsesource.*"));
         REFLECTIONS = new ReflectionsTransitive(new ConfigurationBuilder().addUrls(comHazelcastPackageURLs)
                 .addScanners(subtypesScanner, new TypeAnnotationsScanner())
                 .setMetadataAdapter(new JavaReflectionAdapter()));


### PR DESCRIPTION
`com.eclipsesource.json` classes are shaded in `com.hazelcast.com.eclipsesource.json` in the jar artifact and cause issues in EE side classpath scanning