### PR TITLE
Add unified Near Cache tests for destroy() method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/nearcache/MapNearCacheManager.java
@@ -134,13 +134,14 @@ public class MapNearCacheManager extends DefaultNearCacheManager {
      */
     @Override
     public boolean destroyNearCache(String mapName) {
-        if (!super.destroyNearCache(mapName)) {
-            return false;
-        }
-
         String uuid = nodeEngine.getLocalMember().getUuid();
-        invalidator.destroy(mapName, uuid);
-        return true;
+        invalidator.invalidateAllKeys(mapName, uuid);
+
+        if (super.destroyNearCache(mapName)) {
+            invalidator.destroy(mapName, uuid);
+            return true;
+        }
+        return false;
     }
 
     public Object getFromNearCache(String mapName, Data key) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -141,6 +141,16 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
     }
 
     @Override
+    protected boolean preDestroy() {
+        if (super.preDestroy()) {
+            ReplicatedMapEventPublishingService eventPublishingService = service.getEventPublishingService();
+            eventPublishingService.fireMapClearedEvent(size(), name);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public String getName() {
         return name;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -799,6 +799,22 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
     }
 
     /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#DESTROY)} is used.
+     */
+    @Test
+    public void whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter() {
+        whenEntryIsRemoved_thenNearCacheShouldBeInvalidated(false, DataStructureMethods.DESTROY);
+    }
+
+    /**
+     * Checks that the Near Cache is eventually invalidated when {@link DataStructureMethods#DESTROY)} is used.
+     */
+    @Test
+    public void whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onDataAdapter() {
+        whenEntryIsRemoved_thenNearCacheShouldBeInvalidated(true, DataStructureMethods.DESTROY);
+    }
+
+    /**
      * With the {@link NearCacheTestContext#dataAdapter} we have to set {@link NearCacheConfig#setInvalidateOnChange(boolean)}.
      * With the {@link NearCacheTestContext#nearCacheAdapter} Near Cache invalidations are not needed.
      */
@@ -832,6 +848,7 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
                         removeKeys.add(i);
                         break;
                     case CLEAR:
+                    case DESTROY:
                         break;
                     default:
                         throw new IllegalArgumentException("Unexpected method: " + method);
@@ -842,6 +859,8 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
             adapter.removeAll(removeKeys);
         } else if (method == DataStructureMethods.CLEAR) {
             adapter.clear();
+        } else if (method == DataStructureMethods.DESTROY) {
+            adapter.destroy();
         }
 
         String message = format("Invalidation is not working on %s()", method.getMethodName());


### PR DESCRIPTION
**MapNearCacheBasicTest**
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter()` works via `AbstractDistributedObject.destroy()` which calls `MapServiceContextImpl.destroyMap()` which destroys the Near Cache
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onDataAdapter()` works via `DistributedObjectDestroyOperation` which calls `MapServiceContextImpl.destroyMap()` which destroys the Near Cache

**LiteMemberMapNearCacheBasicTest**
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter()` works via `AbstractDistributedObject.destroy()` which calls `MapServiceContextImpl.destroyMap()` which destroys the Near Cache **[FIXED]**
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onDataAdapter()` works via `DistributedObjectDestroyOperation` which calls `MapServiceContextImpl.destroyMap()` which destroys the Near Cache

**TxnMapNearCacheTest**
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter()` works via `AbstractDistributedObject.destroy()` which calls `MapServiceContextImpl.destroyMap()` which destroys the Near Cache
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onDataAdapter()` works via `DistributedObjectDestroyOperation` which calls `MapServiceContextImpl.destroyMap()` which destroys the Near Cache

**ClientCacheNearCacheBasicTest**
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter()` works via `NearCachedClientCacheProxy.onDestroy()` which destroys the Near Cache
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onDataAdapter()` works via `AbstractCacheService.deleteCache()` which sends invalidation events which clear the Near Cache

**ClientMapNearCacheBasicTest**
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter()` works via `NearCachedClientMapProxy.onDestroy()` which destroys the Near Cache
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onDataAdapter()` works via `MapNearCacheManager.destroyNearCache()` which sends invalidation events which clear the Near Cache **[FIXED]**

**ClientReplicatedMapNearCacheBasicTest**
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onNearCacheAdapter()` works via `ClientReplicatedMapProxy.onDestroy()` which destroys the Near Cache
* `whenDestroyIsUsed_thenNearCacheShouldBeInvalidated_onDataAdapter()` works via `AbstractDistributedObject.destroy()` which calls `ReplicatedMapProxy.preDestroy()` which sends invalidation events which clear the Near Cache **[FIXED]**