### PR TITLE
IllegalStateException in optimized selector iterator.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/SelectorOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/SelectorOptimizer.java
@@ -138,7 +138,7 @@ public final class SelectorOptimizer {
         }
     }
 
-     static final class SelectionKeys {
+    static final class SelectionKeys {
         static final int INITIAL_CAPACITY = 32;
 
         SelectionKey[] keys = new SelectionKey[INITIAL_CAPACITY];
@@ -197,7 +197,7 @@ public final class SelectorOptimizer {
 
         @Override
         public void remove() {
-            if (index == -1 || index >= keys.length - 1 || keys[index] == null) {
+            if (index == -1 || index >= keys.length || keys[index] == null) {
                 throw new IllegalStateException();
             }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectionKeysSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectionKeysSetTest.java
@@ -145,4 +145,25 @@ public class SelectionKeysSetTest extends HazelcastTestSupport {
 
         it.remove();
     }
+
+    // see https://github.com/hazelcast/hazelcast/issues/10436
+    @Test
+    public void remove_whenLastItemFromArray() {
+        for (int k = 0; k < SelectionKeys.INITIAL_CAPACITY; k++) {
+            selectionKeysSet.add(mock(SelectionKey.class));
+        }
+
+        IteratorImpl it = (IteratorImpl) selectionKeysSet.iterator();
+        // we now next/remove all items apart from the last one.
+        for (int k = 0; k < SelectionKeys.INITIAL_CAPACITY - 1; k++) {
+            it.next();
+            it.remove();
+        }
+
+        // last item we next
+        it.next();
+        // and we remove; with the bug we would get a IllegalStateException
+        it.remove();
+        assertFalse(it.hasNext());
+    }
 }


### PR DESCRIPTION
The problem was that the illegalstate check does an index for the array check
which is one off. So if you have an array of 32 items and item at index 31 (last
item) needs to be removed, then it assumes it is an illegal state.

fix #10436