### PR TITLE
Throwing HazelcastException in case address is not resolved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.4.0-13</client.protocol.version>
+        <client.protocol.version>1.5.0-1</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
AddressCodec is used to catch UnkownHostException and return null.
With new hazelcast-client-protocol.jar, it sends exception wrapped
up to HazelcastException.

In authentication response, HazelcastException is catched to fail
correctly.

fixes #9884