### PR TITLE
Throwing HazelcastException in case address is not resolved

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -534,17 +534,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
     private void authenticate(final Address target, final ClientConnection connection, final boolean asOwner,
                               final AuthenticationFuture callback) {
-        SerializationService ss = client.getSerializationService();
         final ClientClusterServiceImpl clusterService = (ClientClusterServiceImpl) client.getClientClusterService();
         final ClientPrincipal principal = clusterService.getPrincipal();
-        byte serializationVersion = ((InternalSerializationService) client.getSerializationService()).getVersion();
-        String uuid = null;
-        String ownerUuid = null;
-        if (principal != null) {
-            uuid = principal.getUuid();
-            ownerUuid = principal.getOwnerUuid();
-        }
-        ClientMessage clientMessage = encodeAuthenticationRequest(asOwner, ss, serializationVersion, uuid, ownerUuid);
+        ClientMessage clientMessage = encodeAuthenticationRequest(asOwner, client.getSerializationService(), principal);
         ClientInvocation clientInvocation = new ClientInvocation(client, clientMessage, connection);
         ClientInvocationFuture future = clientInvocation.invokeUrgent();
         if (asOwner && clientInvocation.getSendConnection() != null) {
@@ -553,7 +545,13 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         future.andThen(new ExecutionCallback<ClientMessage>() {
             @Override
             public void onResponse(ClientMessage response) {
-                ClientAuthenticationCodec.ResponseParameters result = ClientAuthenticationCodec.decodeResponse(response);
+                ClientAuthenticationCodec.ResponseParameters result;
+                try {
+                    result = ClientAuthenticationCodec.decodeResponse(response);
+                } catch (HazelcastException exception) {
+                    onFailure(exception);
+                    return;
+                }
                 AuthenticationStatus authenticationStatus = AuthenticationStatus.getById(result.status);
                 switch (authenticationStatus) {
                     case AUTHENTICATED:
@@ -592,8 +590,14 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         });
     }
 
-    private ClientMessage encodeAuthenticationRequest(boolean asOwner, SerializationService ss, byte serializationVersion,
-                                                      String uuid, String ownerUuid) {
+    private ClientMessage encodeAuthenticationRequest(boolean asOwner, SerializationService ss, ClientPrincipal principal) {
+        byte serializationVersion = ((InternalSerializationService) ss).getVersion();
+        String uuid = null;
+        String ownerUuid = null;
+        if (principal != null) {
+            uuid = principal.getUuid();
+            ownerUuid = principal.getOwnerUuid();
+        }
         ClientMessage clientMessage;
         if (credentials.getClass().equals(UsernamePasswordCredentials.class)) {
             UsernamePasswordCredentials cr = (UsernamePasswordCredentials) credentials;

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.4.0</client.protocol.version>
+        <client.protocol.version>1.4.1</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
AddressCodec is used to catch UnkownHostException and return null.
With new hazelcast-client-protocol.jar, it sends exception wrapped
up to HazelcastException.

In authentication response, HazelcastException is catched to fail
correctly.

fixes #9884