### PR TITLE
Removed superfluous implements in AbstractCacheProxyBase

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxyBase.java
@@ -19,7 +19,6 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceAware;
-import com.hazelcast.core.PrefixedDistributedObject;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
@@ -58,7 +57,7 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
  */
 abstract class AbstractCacheProxyBase<K, V>
         extends AbstractDistributedObject<ICacheService>
-        implements ICacheInternal<K, V>, PrefixedDistributedObject {
+        implements ICacheInternal<K, V> {
 
     private static final int TIMEOUT = 10;
 


### PR DESCRIPTION
`PrefixedDistributedObject` is already implemented via `ICacheInternal`

This small PR helps to clean up our class proxy class hierarchy a bit by removing a superfluous line in this graph:
![proxies](https://cloud.githubusercontent.com/assets/4196298/25615605/6e2d8b92-2f38-11e7-9bf3-ffa7cbd06823.png)
