### PR TITLE
Changed MapProxySupport to already implement IMap

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -99,7 +99,7 @@ import static java.util.Collections.emptyMap;
  * @param <V> the value type of map.
  */
 @SuppressWarnings("checkstyle:classfanoutcomplexity")
-public class MapProxyImpl<K, V> extends MapProxySupport implements IMap<K, V> {
+public class MapProxyImpl<K, V> extends MapProxySupport<K, V> {
 
     public MapProxyImpl(String name, MapService mapService, NodeEngine nodeEngine, MapConfig mapConfig) {
         super(name, mapService, nodeEngine, mapConfig);


### PR DESCRIPTION
`MapProxySupport` already implements methods from `IMap`, but due to the
missing implements we cannot annotate those methods properly.
This also improved the generics handling between both classes.

The PR looks a bit messy, since I moved two overidden methods to the top and sorted the `initialize()` methods by their usage. But no internal logic has been changed.