### PR TITLE
Moved socket configure to IOService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -31,6 +31,8 @@ import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.annotation.PrivateApi;
 
+import java.net.Socket;
+import java.net.SocketException;
 import java.util.Collection;
 
 @PrivateApi
@@ -98,13 +100,9 @@ public interface IOService {
      */
     int getSocketClientSendBufferSize();
 
-    int getSocketLingerSeconds();
+    void configureSocket(Socket socket) throws SocketException;
 
     int getSocketConnectTimeoutSeconds();
-
-    boolean getSocketKeepAlive();
-
-    boolean getSocketNoDelay();
 
     int getInputSelectorThreadCount();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -40,6 +40,8 @@ import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.GroupProperty;
 
+import java.net.Socket;
+import java.net.SocketException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -227,7 +229,17 @@ public class NodeIOService implements IOService {
     }
 
     @Override
-    public int getSocketLingerSeconds() {
+    public void configureSocket(Socket socket) throws SocketException {
+        if (getSocketLingerSeconds() > 0) {
+            socket.setSoLinger(true, getSocketLingerSeconds());
+        }
+        socket.setKeepAlive(getSocketKeepAlive());
+        socket.setTcpNoDelay(getSocketNoDelay());
+        socket.setReceiveBufferSize(getSocketReceiveBufferSize() * KILO_BYTE);
+        socket.setSendBufferSize(getSocketSendBufferSize() * KILO_BYTE);
+    }
+
+    private int getSocketLingerSeconds() {
         return node.getProperties().getSeconds(GroupProperty.SOCKET_LINGER_SECONDS);
     }
 
@@ -236,13 +248,11 @@ public class NodeIOService implements IOService {
         return node.getProperties().getSeconds(GroupProperty.SOCKET_CONNECT_TIMEOUT_SECONDS);
     }
 
-    @Override
-    public boolean getSocketKeepAlive() {
+    private boolean getSocketKeepAlive() {
         return node.getProperties().getBoolean(GroupProperty.SOCKET_KEEP_ALIVE);
     }
 
-    @Override
-    public boolean getSocketNoDelay() {
+    private boolean getSocketNoDelay() {
         return node.getProperties().getBoolean(GroupProperty.SOCKET_NO_DELAY);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/InitConnectionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/InitConnectionTask.java
@@ -126,7 +126,7 @@ public class InitConnectionTask implements Runnable {
 
     private void tryToConnect(InetSocketAddress socketAddress, int timeout) throws Exception {
         SocketChannel socketChannel = SocketChannel.open();
-        connectionManager.initSocket(socketChannel.socket());
+        ioService.configureSocket(socketChannel.socket());
         if (ioService.isSocketBind()) {
             bindSocket(socketChannel);
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketAcceptorThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketAcceptorThread.java
@@ -236,7 +236,7 @@ public class SocketAcceptorThread extends Thread {
 
     private void configureAndAssignSocket(SocketChannelWrapper socketChannel) {
         try {
-            connectionManager.initSocket(socketChannel.socket());
+            ioService.configureSocket(socketChannel.socket());
             connectionManager.interceptSocket(socketChannel.socket(), true);
             socketChannel.configureBlocking(connectionManager.getIoThreadingModel().isBlocking());
             connectionManager.newConnection(socketChannel, null);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -59,7 +59,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
-import static com.hazelcast.nio.IOService.KILO_BYTE;
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.ThreadUtil.createThreadPoolName;
@@ -447,16 +446,6 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
                 }
             });
         }
-    }
-
-    protected void initSocket(Socket socket) throws Exception {
-        if (ioService.getSocketLingerSeconds() > 0) {
-            socket.setSoLinger(true, ioService.getSocketLingerSeconds());
-        }
-        socket.setKeepAlive(ioService.getSocketKeepAlive());
-        socket.setTcpNoDelay(ioService.getSocketNoDelay());
-        socket.setReceiveBufferSize(ioService.getSocketReceiveBufferSize() * KILO_BYTE);
-        socket.setSendBufferSize(ioService.getSocketSendBufferSize() * KILO_BYTE);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -44,6 +44,8 @@ import com.hazelcast.spi.impl.packetdispatcher.PacketDispatcher;
 
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
 import java.nio.channels.ServerSocketChannel;
 import java.util.Collection;
 import java.util.Collections;
@@ -198,23 +200,12 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public int getSocketLingerSeconds() {
-        return 0;
+    public void configureSocket(Socket socket) throws SocketException {
     }
 
     @Override
     public int getSocketConnectTimeoutSeconds() {
         return 0;
-    }
-
-    @Override
-    public boolean getSocketKeepAlive() {
-        return true;
-    }
-
-    @Override
-    public boolean getSocketNoDelay() {
-        return true;
     }
 
     @Override


### PR DESCRIPTION
This moves the logic of configuring a socket in a more
logical place. TcpIpConnectionManager is meant for more
high level tasks; not low level socket configuration.