### PR TITLE
Moved interceptSocket to IOService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -18,7 +18,6 @@ package com.hazelcast.nio;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.config.SSLConfig;
-import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.networking.IOOutOfMemoryHandler;
@@ -31,6 +30,7 @@ import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.annotation.PrivateApi;
 
+import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketException;
 import java.util.Collection;
@@ -51,8 +51,6 @@ public interface IOService {
     Address getThisAddress();
 
     void onFatalError(Exception e);
-
-    SocketInterceptorConfig getSocketInterceptorConfig();
 
     SymmetricEncryptionConfig getSymmetricEncryptionConfig();
 
@@ -101,6 +99,10 @@ public interface IOService {
     int getSocketClientSendBufferSize();
 
     void configureSocket(Socket socket) throws SocketException;
+
+    void interceptSocket(Socket socket, boolean onAccept) throws IOException;
+
+    boolean isSocketInterceptorEnabled();
 
     int getSocketConnectTimeoutSeconds();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/InitConnectionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/InitConnectionTask.java
@@ -36,7 +36,7 @@ import java.util.Collection;
 import java.util.logging.Level;
 
 /**
- * A Task that initiates a TcpConnection to be build. It does this be connecting the serverport and once completed,
+ * A Task that initiates a TcpConnection to be build. It does this by connecting the remote serverport and once completed,
  * it will send the protocol and a bind-message.
  */
 public class InitConnectionTask implements Runnable {
@@ -144,7 +144,7 @@ public class InitConnectionTask implements Runnable {
                 logger.finest("Successfully connected to: " + address + " using socket " + socketChannel.socket());
             }
             SocketChannelWrapper socketChannelWrapper = connectionManager.wrapSocketChannel(socketChannel, true);
-            connectionManager.interceptSocket(socketChannel.socket(), false);
+            ioService.interceptSocket(socketChannel.socket(), false);
 
             socketChannelWrapper.configureBlocking(false);
             TcpIpConnection connection = connectionManager.newConnection(socketChannelWrapper, address);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketAcceptorThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketAcceptorThread.java
@@ -221,7 +221,7 @@ public class SocketAcceptorThread extends Thread {
         if (socketChannelWrapper != null) {
             final SocketChannelWrapper socketChannel = socketChannelWrapper;
             logger.info("Accepting socket connection from " + socketChannel.socket().getRemoteSocketAddress());
-            if (connectionManager.isSocketInterceptorEnabled()) {
+            if (ioService.isSocketInterceptorEnabled()) {
                 configureAndAssignSocket(socketChannel);
             } else {
                 ioService.executeAsync(new Runnable() {
@@ -237,7 +237,7 @@ public class SocketAcceptorThread extends Thread {
     private void configureAndAssignSocket(SocketChannelWrapper socketChannel) {
         try {
             ioService.configureSocket(socketChannel.socket());
-            connectionManager.interceptSocket(socketChannel.socket(), true);
+            ioService.interceptSocket(socketChannel.socket(), true);
             socketChannel.configureBlocking(connectionManager.getIoThreadingModel().isBlocking());
             connectionManager.newConnection(socketChannel, null);
         } catch (Exception e) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.internal.cluster.impl.BindMessage;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
@@ -34,7 +33,6 @@ import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.IOService;
-import com.hazelcast.nio.MemberSocketInterceptor;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.util.ConcurrencyUtil;
@@ -43,7 +41,6 @@ import com.hazelcast.util.executor.StripedRunnable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
-import java.net.Socket;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
@@ -157,26 +154,6 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
 
     public IOThreadingModel getIoThreadingModel() {
         return ioThreadingModel;
-    }
-
-    public void interceptSocket(Socket socket, boolean onAccept) throws IOException {
-        if (!isSocketInterceptorEnabled()) {
-            return;
-        }
-        final MemberSocketInterceptor memberSocketInterceptor = ioService.getMemberSocketInterceptor();
-        if (memberSocketInterceptor == null) {
-            return;
-        }
-        if (onAccept) {
-            memberSocketInterceptor.onAccept(socket);
-        } else {
-            memberSocketInterceptor.onConnect(socket);
-        }
-    }
-
-    public boolean isSocketInterceptorEnabled() {
-        final SocketInterceptorConfig socketInterceptorConfig = ioService.getSocketInterceptorConfig();
-        return socketInterceptorConfig != null && socketInterceptorConfig.isEnabled();
     }
 
     // just for testing

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -42,6 +42,7 @@ import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.packetdispatcher.PacketDispatcher;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -104,11 +105,6 @@ public class MockIOService implements IOService {
 
     @Override
     public void onFatalError(Exception e) {
-    }
-
-    @Override
-    public SocketInterceptorConfig getSocketInterceptorConfig() {
-        return null;
     }
 
     @Override
@@ -201,6 +197,15 @@ public class MockIOService implements IOService {
 
     @Override
     public void configureSocket(Socket socket) throws SocketException {
+    }
+
+    @Override
+    public void interceptSocket(Socket socket, boolean onAccept) throws IOException {
+    }
+
+    @Override
+    public boolean isSocketInterceptorEnabled() {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
THis makes the ConnectionManager more consistent since it can focus
on higher level connection management instead of providing all kinds
of lower level socket functions.

And a good example of 'tell; don't ask'.

no enterprise pr needed