### PR TITLE
SocketChannelWrapper cleanup

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
@@ -38,7 +38,7 @@ import com.hazelcast.logging.Logger;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.SocketInterceptor;
-import com.hazelcast.nio.tcp.DefaultSocketChannelWrapperFactory;
+import com.hazelcast.nio.tcp.PlainSocketChannelWrapperFactory;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -106,7 +106,7 @@ public class DefaultClientExtension implements ClientExtension {
 
     @Override
     public SocketChannelWrapperFactory createSocketChannelWrapperFactory() {
-        return new DefaultSocketChannelWrapperFactory();
+        return new PlainSocketChannelWrapperFactory();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -45,7 +45,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;
-import com.hazelcast.nio.tcp.DefaultSocketChannelWrapperFactory;
+import com.hazelcast.nio.tcp.PlainSocketChannelWrapperFactory;
 import com.hazelcast.nio.tcp.MemberReadHandler;
 import com.hazelcast.nio.tcp.MemberWriteHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
@@ -195,7 +195,7 @@ public class DefaultNodeExtension implements NodeExtension {
 
     @Override
     public SocketChannelWrapperFactory getSocketChannelWrapperFactory() {
-        return new DefaultSocketChannelWrapperFactory();
+        return new PlainSocketChannelWrapperFactory();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/SocketChannelWrapperFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/SocketChannelWrapperFactory.java
@@ -24,6 +24,4 @@ import java.nio.channels.SocketChannel;
 public interface SocketChannelWrapperFactory {
 
     SocketChannelWrapper wrapSocketChannel(SocketChannel socketChannel, boolean client) throws Exception;
-
-    boolean isSSlEnabled();
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapper.java
@@ -28,11 +28,11 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 
-public class DefaultSocketChannelWrapper implements SocketChannelWrapper {
+public class PlainSocketChannelWrapper implements SocketChannelWrapper {
 
     protected final SocketChannel socketChannel;
 
-    public DefaultSocketChannelWrapper(SocketChannel socketChannel) {
+    public PlainSocketChannelWrapper(SocketChannel socketChannel) {
         this.socketChannel = socketChannel;
     }
 
@@ -101,6 +101,6 @@ public class DefaultSocketChannelWrapper implements SocketChannelWrapper {
 
     @Override
     public String toString() {
-        return "DefaultSocketChannelWrapper{socketChannel=" + socketChannel + '}';
+        return "PlainSocketChannelWrapper{socketChannel=" + socketChannel + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapperFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapperFactory.java
@@ -21,14 +21,10 @@ import com.hazelcast.internal.networking.SocketChannelWrapperFactory;
 
 import java.nio.channels.SocketChannel;
 
-public class DefaultSocketChannelWrapperFactory implements SocketChannelWrapperFactory {
-    @Override
-    public SocketChannelWrapper wrapSocketChannel(SocketChannel socketChannel, boolean client) throws Exception {
-        return new DefaultSocketChannelWrapper(socketChannel);
-    }
+public class PlainSocketChannelWrapperFactory implements SocketChannelWrapperFactory {
 
     @Override
-    public boolean isSSlEnabled() {
-        return false;
+    public SocketChannelWrapper wrapSocketChannel(SocketChannel socketChannel, boolean client) throws Exception {
+        return new PlainSocketChannelWrapper(socketChannel);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketReaderInitializerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SocketReaderInitializerImpl.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.config.SSLConfig;
 import com.hazelcast.internal.networking.ReadHandler;
 import com.hazelcast.internal.networking.SocketChannelWrapper;
 import com.hazelcast.internal.networking.SocketReader;
@@ -60,8 +61,8 @@ public class SocketReaderInitializerImpl implements SocketReaderInitializer<TcpI
             throw new EOFException("Could not read protocol type!");
         }
 
-        if (readBytes == 0 && connectionManager.isSSLEnabled()) {
-            // when using SSL, we can read 0 bytes since data read from socket can be handshake frames.
+        if (readBytes == 0 && isSslEnabled(ioService)) {
+            // when using SSL, we can read 0 bytes since data read from socket can be handshake data.
             return;
         }
 
@@ -111,5 +112,10 @@ public class SocketReaderInitializerImpl implements SocketReaderInitializer<TcpI
         }
 
         return inputBuffer;
+    }
+
+    private static boolean isSslEnabled(IOService ioService) {
+        SSLConfig config = ioService.getSSLConfig();
+        return config != null && config.isEnabled();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -206,10 +206,6 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
         return connectionsMap.size();
     }
 
-    public boolean isSSLEnabled() {
-        return socketChannelWrapperFactory.isSSlEnabled();
-    }
-
     public void incrementTextConnections() {
         allTextConnections.incrementAndGet();
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -352,7 +352,7 @@ public class MockIOService implements IOService {
 
     @Override
     public SocketChannelWrapperFactory getSocketChannelWrapperFactory() {
-        return new DefaultSocketChannelWrapperFactory();
+        return new PlainSocketChannelWrapperFactory();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapperFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapperFactoryTest.java
@@ -32,13 +32,13 @@ import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class DefaultSocketChannelWrapperFactoryTest extends HazelcastTestSupport {
+public class PlainSocketChannelWrapperFactoryTest extends HazelcastTestSupport {
 
-    private DefaultSocketChannelWrapperFactory factory;
+    private PlainSocketChannelWrapperFactory factory;
 
     @Before
     public void setup() {
-        factory = new DefaultSocketChannelWrapperFactory();
+        factory = new PlainSocketChannelWrapperFactory();
     }
 
     @Test
@@ -46,12 +46,6 @@ public class DefaultSocketChannelWrapperFactoryTest extends HazelcastTestSupport
         SocketChannel socketChannel = mock(SocketChannel.class);
         SocketChannelWrapper wrapper = factory.wrapSocketChannel(socketChannel, false);
 
-        assertInstanceOf(DefaultSocketChannelWrapper.class, wrapper);
-    }
-
-    @Test
-    public void isSSlEnabled() {
-        boolean result = factory.isSSlEnabled();
-        assertFalse(result);
+        assertInstanceOf(PlainSocketChannelWrapper.class, wrapper);
     }
 }


### PR DESCRIPTION
1: removed the method TcpIpConnectionManager.isSslEnabled; this can already be derived from
sslconfig.

2: removed SocketChannelWrapperFactory.isSslEnabled; for the same reasons as above

3: renamed DefaultSocketChannelWrapper(Factory) to PlainSocketChannelWrapper(Factory) to make
it clear that this implementation sends the data 'plain' over the wire.

Requires enterprise PR https://github.com/hazelcast/hazelcast-enterprise/pull/1455