### PR TITLE
Renamed TcpIpConnectionMonitor to TcpIpConnectionErrorHandler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nonblocking/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * Contains the non blocking {@link com.hazelcast.nio.tcp.TcpIpConnectionMonitor}. It relies
+ * Contains the non blocking {@link com.hazelcast.nio.tcp.TcpIpConnectionErrorHandler}. It relies
  * on {@link java.nio.channels.Selector} to be notified if there is something to read/write.
  */
 package com.hazelcast.internal.networking.nonblocking;

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -72,7 +72,7 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
 
     private Address endPoint;
 
-    private TcpIpConnectionMonitor monitor;
+    private TcpIpConnectionErrorHandler errorHandler;
 
     private volatile ConnectionType type = ConnectionType.NONE;
 
@@ -183,12 +183,12 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
         this.endPoint = endPoint;
     }
 
-    public void setMonitor(TcpIpConnectionMonitor monitor) {
-        this.monitor = monitor;
+    public void setErrorHandler(TcpIpConnectionErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
     }
 
-    public TcpIpConnectionMonitor getMonitor() {
-        return monitor;
+    public TcpIpConnectionErrorHandler getErrorHandler() {
+        return errorHandler;
     }
 
     public int getConnectionId() {
@@ -272,8 +272,8 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
 
         connectionManager.onConnectionClose(this);
         ioService.onDisconnect(endPoint, cause);
-        if (cause != null && monitor != null) {
-            monitor.onError(cause);
+        if (cause != null && errorHandler != null) {
+            errorHandler.onError(cause);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionErrorHandler.java
@@ -22,7 +22,7 @@ import com.hazelcast.nio.IOService;
 
 import static java.lang.System.currentTimeMillis;
 
-public class TcpIpConnectionMonitor {
+public class TcpIpConnectionErrorHandler {
 
     private final ILogger logger;
     private final IOService ioService;
@@ -32,7 +32,7 @@ public class TcpIpConnectionMonitor {
     private int faults;
     private long lastFaultTime;
 
-    public TcpIpConnectionMonitor(TcpIpConnectionManager connectionManager, Address endPoint) {
+    public TcpIpConnectionErrorHandler(TcpIpConnectionManager connectionManager, Address endPoint) {
         this.endPoint = endPoint;
         this.ioService = connectionManager.getIoService();
         this.minInterval = ioService.getConnectionMonitorInterval();


### PR DESCRIPTION
It doesn't actively monitor the state of the TcpIpConnection, it
gets triggered when an error occurrs and then handles it.