### PR TITLE
Mock network member should not use local member of another member

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -420,6 +420,7 @@ public class MembershipManager {
 
     void suspectMember(MemberImpl suspectedMember, String reason, boolean shouldCloseConn) {
         assert !suspectedMember.equals(clusterService.getLocalMember()) : "Cannot suspect from myself!";
+        assert !suspectedMember.localMember() : "Cannot be local member";
 
         final MembersView localMemberView;
         final Set<Member> membersToAsk;

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -482,8 +482,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         cm1.block(n3.address);
 
         // remove and block n1 on n2 & n3
-        n2.clusterService.suspectMember(n1.getLocalMember(), null, true);
-        n3.clusterService.suspectMember(n1.getLocalMember(), null, true);
+        suspectMember(n2, n1);
+        suspectMember(n3, n1);
         cm2.block(n1.address);
         cm3.block(n1.address);
 
@@ -665,7 +665,7 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
     }
 
     private void disconnect(final HazelcastInstance source, final HazelcastInstance target) {
-        getNode(source).clusterService.suspectMember(getNode(target).getLocalMember(), null, true);
+        suspectMember(getNode(source), getNode(target));
     }
 
 
@@ -733,8 +733,9 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         cm3.block(n1.address);
         cm3.block(n2.address);
 
-        n1.clusterService.suspectMember(n3.getLocalMember(), null, true);
-        n2.clusterService.suspectMember(n3.getLocalMember(), null, true);
+        suspectMember(n1, n3);
+        suspectMember(n2, n3);
+
         cm1.block(n3.address);
         cm2.block(n3.address);
 
@@ -821,8 +822,8 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         cm1.block(n2.address);
         cm1.block(n3.address);
 
-        n2.clusterService.suspectMember(n1.getLocalMember(), null, true);
-        n3.clusterService.suspectMember(n1.getLocalMember(), null, true);
+        suspectMember(n2, n1);
+        suspectMember(n3, n1);
         cm2.block(n1.address);
         cm3.block(n1.address);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.core.Member;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.properties.GroupProperty;
@@ -833,9 +832,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     }
 
     static void suspectMember(HazelcastInstance suspectingInstance, HazelcastInstance suspectedInstance) {
-        ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(suspectingInstance);
-        Member suspectedMember = suspectedInstance.getCluster().getLocalMember();
-        clusterService.suspectMember(suspectedMember, "test", false);
+        suspectMember(getNode(suspectingInstance), getNode(suspectedInstance));
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -53,7 +53,6 @@ import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.HEAR
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMBER_INFO_UPDATE;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.PROMOTE_LITE_MEMBER;
 import static com.hazelcast.internal.cluster.impl.MembershipFailureTest.assertMaster;
-import static com.hazelcast.internal.cluster.impl.MembershipFailureTest.suspectMember;
 import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.dropOperationsBetween;
 import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.dropOperationsFrom;
 import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.resetPacketFiltersFrom;
@@ -310,8 +309,8 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
 
         assertPromotionInvocationStarted(hz3);
 
-        suspectMember(hz3, hz1);
-        suspectMember(hz2, hz1);
+        suspectMember(getNode(hz3), getNode(hz1));
+        suspectMember(getNode(hz2), getNode(hz1));
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -39,6 +39,7 @@ import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.generateRandomString;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
 
+import static com.hazelcast.test.HazelcastTestSupport.suspectMember;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -200,21 +201,21 @@ public class PartitionedCluster {
         cm5.block(n2.address);
         cm5.block(n3.address);
 
-        n4.clusterService.suspectMember(n1.getLocalMember(), null, true);
-        n4.clusterService.suspectMember(n2.getLocalMember(), null, true);
-        n4.clusterService.suspectMember(n3.getLocalMember(), null, true);
+        suspectMember(n4, n1);
+        suspectMember(n4, n2);
+        suspectMember(n4, n3);
 
-        n5.clusterService.suspectMember(n1.getLocalMember(), null, true);
-        n5.clusterService.suspectMember(n2.getLocalMember(), null, true);
-        n5.clusterService.suspectMember(n3.getLocalMember(), null, true);
+        suspectMember(n5, n1);
+        suspectMember(n5, n2);
+        suspectMember(n5, n3);
 
-        n1.clusterService.suspectMember(n4.getLocalMember(), null, true);
-        n2.clusterService.suspectMember(n4.getLocalMember(), null, true);
-        n3.clusterService.suspectMember(n4.getLocalMember(), null, true);
+        suspectMember(n1, n4);
+        suspectMember(n2, n4);
+        suspectMember(n3, n4);
 
-        n1.clusterService.suspectMember(n5.getLocalMember(), null, true);
-        n2.clusterService.suspectMember(n5.getLocalMember(), null, true);
-        n3.clusterService.suspectMember(n5.getLocalMember(), null, true);
+        suspectMember(n1, n5);
+        suspectMember(n2, n5);
+        suspectMember(n3, n5);
     }
 
     private static FirewallingConnectionManager getConnectionManager(Node node) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -224,10 +224,10 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
         @Override
         public void run(final Node node1, final Node node2, final Node node3) {
             // Artificially create a network-split
-            node1.clusterService.suspectMember(node3.getLocalMember(), null, true);
+            suspectMember(node1, node3);
 
-            node3.clusterService.suspectMember(node1.getLocalMember(), null, true);
-            node3.clusterService.suspectMember(node2.getLocalMember(), null, true);
+            suspectMember(node3, node1);
+            suspectMember(node3, node2);
 
             assertTrueEventually(new AssertTask() {
                 @Override
@@ -247,8 +247,7 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
             // Artificially create a partial network-split;
             // node1 and node2 will be split from node3
             // but node 3 will not be able to detect that.
-            node1.clusterService.suspectMember(node3.getLocalMember(), null, true);
-
+            suspectMember(node1, node3);
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -504,10 +504,21 @@ public abstract class HazelcastTestSupport {
         }
         Node n1 = TestUtil.getNode(h1);
         Node n2 = TestUtil.getNode(h2);
-        if (n1 != null && n2 != null) {
-            n1.clusterService.suspectMember(n2.getLocalMember(), null, true);
-            n2.clusterService.suspectMember(n1.getLocalMember(), null, true);
+        suspectMember(n1, n2);
+        suspectMember(n2, n1);
+    }
+
+    public static void suspectMember(Node suspectingNode, Node suspectedNode, String reason) {
+        if (suspectingNode != null && suspectedNode != null) {
+            Member suspectedMember = suspectingNode.getClusterService().getMember(suspectedNode.getLocalMember().getAddress());
+            if (suspectedMember != null) {
+                suspectingNode.clusterService.suspectMember(suspectedMember, reason, true);
+            }
         }
+    }
+
+    public static void suspectMember(Node suspectingNode, Node suspectedNode) {
+        suspectMember(suspectingNode, suspectedNode, null);
     }
 
     private static void checkMemberCount(boolean generateOwnedKey, Cluster cluster) {

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnectionManager.java
@@ -19,7 +19,6 @@ package com.hazelcast.test.mocknetwork;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
@@ -38,6 +37,9 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.test.HazelcastTestSupport.suspectMember;
+
 
 public class MockConnectionManager implements ConnectionManager {
 
@@ -147,8 +149,7 @@ public class MockConnectionManager implements ConnectionManager {
             if (otherNode != null && otherNode.getState() != NodeState.SHUT_DOWN) {
                 logger.fine(otherNode.getThisAddress() + " is instructed to suspect from " + thisAddress);
                 try {
-                    ClusterServiceImpl clusterService = otherNode.getClusterService();
-                    clusterService.suspectMember(localMember, "Connection manager is stopped on " + localMember, true);
+                    suspectMember(otherNode, node, "Connection manager is stopped on " + localMember);
                 } catch (Throwable e) {
                     ILogger otherLogger = otherNode.getLogger(MockConnectionManager.class);
                     otherLogger.warning("While removing " + thisAddress, e);


### PR DESCRIPTION
Partially fixes https://github.com/hazelcast/hazelcast/issues/10410