### PR TITLE
Added final ClientContext and SerialiaztionService fields in ClientProxy

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -24,6 +24,7 @@ import com.hazelcast.client.impl.protocol.codec.CacheGetAllCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheGetCodec;
 import com.hazelcast.client.impl.protocol.codec.CachePutAllCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheSizeCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
@@ -76,8 +77,8 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
         }
     };
 
-    AbstractClientCacheProxy(CacheConfig<K, V> cacheConfig) {
-        super(cacheConfig);
+    AbstractClientCacheProxy(CacheConfig<K, V> cacheConfig, ClientContext context) {
+        super(cacheConfig, context);
     }
 
     protected V getSyncInternal(Data keyData, ExpiryPolicy expiryPolicy) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
@@ -95,8 +95,8 @@ abstract class AbstractClientCacheProxyBase<K, V> extends ClientProxy implements
 
     private final AtomicInteger completionIdCounter = new AtomicInteger();
 
-    protected AbstractClientCacheProxyBase(CacheConfig<K, V> cacheConfig) {
-        super(ICacheService.SERVICE_NAME, cacheConfig.getName());
+    protected AbstractClientCacheProxyBase(CacheConfig<K, V> cacheConfig, ClientContext context) {
+        super(ICacheService.SERVICE_NAME, cacheConfig.getName(), context);
         this.name = cacheConfig.getName();
         this.nameWithPrefix = cacheConfig.getNameWithPrefix();
         this.cacheConfig = cacheConfig;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -34,6 +34,7 @@ import com.hazelcast.client.impl.protocol.codec.CacheRemoveAllCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveAllKeysCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveCodec;
 import com.hazelcast.client.impl.protocol.codec.CacheReplaceCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientListenerService;
 import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.EventHandler;
@@ -137,8 +138,8 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
     private final ConcurrentMap<CacheEntryListenerConfiguration, String> syncListenerRegistrations;
     private final ConcurrentMap<Integer, CountDownLatch> syncLocks;
 
-    AbstractClientInternalCacheProxy(CacheConfig<K, V> cacheConfig) {
-        super(cacheConfig);
+    AbstractClientInternalCacheProxy(CacheConfig<K, V> cacheConfig, ClientContext context) {
+        super(cacheConfig, context);
         this.asyncListenerRegistrations = new ConcurrentHashMap<CacheEntryListenerConfiguration, String>();
         this.syncListenerRegistrations = new ConcurrentHashMap<CacheEntryListenerConfiguration, String>();
         this.syncLocks = new ConcurrentHashMap<Integer, CountDownLatch>();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -80,8 +80,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V> {
 
-    ClientCacheProxy(CacheConfig<K, V> cacheConfig) {
-        super(cacheConfig);
+    ClientCacheProxy(CacheConfig<K, V> cacheConfig, ClientContext context) {
+        super(cacheConfig, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -93,8 +93,8 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
     private NearCache<Data, Object> nearCache;
     private String nearCacheMembershipRegistrationId;
 
-    NearCachedClientCacheProxy(CacheConfig<K, V> cacheConfig) {
-        super(cacheConfig);
+    NearCachedClientCacheProxy(CacheConfig<K, V> cacheConfig, ClientContext context) {
+        super(cacheConfig, context);
     }
 
     // for testing only

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/DefaultClientExtension.java
@@ -20,9 +20,11 @@ import com.hazelcast.client.ClientExtension;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.proxy.ClientMapProxy;
 import com.hazelcast.client.proxy.NearCachedClientMapProxy;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.ClientProxyFactory;
 import com.hazelcast.client.spi.impl.ClientExecutionServiceImpl;
+import com.hazelcast.client.spi.impl.ClientProxyFactoryWithContext;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -119,15 +121,15 @@ public class DefaultClientExtension implements ClientExtension {
     }
 
     private ClientProxyFactory createClientMapProxyFactory() {
-        return new ClientProxyFactory() {
+        return new ClientProxyFactoryWithContext() {
             @Override
-            public ClientProxy create(String id) {
+            public ClientProxy create(String id, ClientContext context) {
                 NearCacheConfig nearCacheConfig = client.getClientConfig().getNearCacheConfig(id);
                 if (nearCacheConfig != null) {
                     checkNearCacheConfig(id, nearCacheConfig, true);
-                    return new NearCachedClientMapProxy(MapService.SERVICE_NAME, id);
+                    return new NearCachedClientMapProxy(MapService.SERVICE_NAME, id, context);
                 } else {
-                    return new ClientMapProxy(MapService.SERVICE_NAME, id);
+                    return new ClientMapProxy(MapService.SERVICE_NAME, id, context);
                 }
             }
         };

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicLongProxy.java
@@ -31,6 +31,7 @@ import com.hazelcast.client.impl.protocol.codec.AtomicLongGetAndSetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongGetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongIncrementAndGetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicLongSetCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -134,8 +135,8 @@ public class ClientAtomicLongProxy extends PartitionSpecificClientProxy implemen
         }
     };
 
-    public ClientAtomicLongProxy(String serviceName, String objectId) {
-        super(serviceName, objectId);
+    public ClientAtomicLongProxy(String serviceName, String objectId, ClientContext context) {
+        super(serviceName, objectId, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientAtomicReferenceProxy.java
@@ -30,6 +30,7 @@ import com.hazelcast.client.impl.protocol.codec.AtomicReferenceGetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicReferenceIsNullCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicReferenceSetAndGetCodec;
 import com.hazelcast.client.impl.protocol.codec.AtomicReferenceSetCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -120,8 +121,8 @@ public class ClientAtomicReferenceProxy<E> extends PartitionSpecificClientProxy 
         }
     };
 
-    public ClientAtomicReferenceProxy(String serviceName, String objectId) {
-        super(serviceName, objectId);
+    public ClientAtomicReferenceProxy(String serviceName, String objectId, ClientContext context) {
+        super(serviceName, objectId, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCardinalityEstimatorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCardinalityEstimatorProxy.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CardinalityEstimatorAddCodec;
 import com.hazelcast.client.impl.protocol.codec.CardinalityEstimatorEstimateCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InternalCompletableFuture;
 
@@ -46,8 +47,8 @@ public class ClientCardinalityEstimatorProxy
         }
     };
 
-    public ClientCardinalityEstimatorProxy(String serviceName, String objectId) {
-        super(serviceName, objectId);
+    public ClientCardinalityEstimatorProxy(String serviceName, String objectId, ClientContext context) {
+        super(serviceName, objectId, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
@@ -40,11 +40,9 @@ public class ClientConditionProxy extends PartitionSpecificClientProxy implement
     private final String conditionId;
     private ClientLockReferenceIdGenerator referenceIdGenerator;
 
-    public ClientConditionProxy(ClientLockProxy clientLockProxy, String name, ClientContext ctx) {
-        super(LockService.SERVICE_NAME, clientLockProxy.getName());
+    public ClientConditionProxy(ClientLockProxy clientLockProxy, String name, ClientContext context) {
+        super(LockService.SERVICE_NAME, clientLockProxy.getName(), context);
         this.conditionId = name;
-
-        setContext(ctx);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCountDownLatchProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCountDownLatchProxy.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.CountDownLatchAwaitCodec;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchCountDownCodec;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchGetCountCodec;
 import com.hazelcast.client.impl.protocol.codec.CountDownLatchTrySetCountCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.core.ICountDownLatch;
 
 import java.util.concurrent.TimeUnit;
@@ -30,8 +31,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class ClientCountDownLatchProxy extends PartitionSpecificClientProxy implements ICountDownLatch {
 
-    public ClientCountDownLatchProxy(String serviceName, String objectId) {
-        super(serviceName, objectId);
+    public ClientCountDownLatchProxy(String serviceName, String objectId, ClientContext context) {
+        super(serviceName, objectId, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
@@ -67,14 +67,13 @@ public final class ClientDurableExecutorServiceProxy extends ClientProxy impleme
 
     private int partitionCount;
 
-    public ClientDurableExecutorServiceProxy(String serviceName, String name) {
-        super(serviceName, name);
+    public ClientDurableExecutorServiceProxy(String serviceName, String name, ClientContext context) {
+        super(serviceName, name, context);
     }
 
     @Override
     protected void onInitialize() {
-        ClientContext context = getContext();
-        ClientPartitionService partitionService = context.getPartitionService();
+        ClientPartitionService partitionService = getContext().getPartitionService();
         partitionCount = partitionService.getPartitionCount();
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.protocol.codec.ExecutorServiceIsShutdownCodec;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceShutdownCodec;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceSubmitToAddressCodec;
 import com.hazelcast.client.impl.protocol.codec.ExecutorServiceSubmitToPartitionCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.impl.ClientInvocation;
@@ -89,8 +90,8 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
     private final AtomicInteger consecutiveSubmits = new AtomicInteger();
     private volatile long lastSubmitTime;
 
-    public ClientExecutorServiceProxy(String serviceName, String objectId) {
-        super(serviceName, objectId);
+    public ClientExecutorServiceProxy(String serviceName, String objectId, ClientContext context) {
+        super(serviceName, objectId, context);
     }
 
     // execute on members

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientIdGeneratorProxy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.proxy;
 
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.concurrent.idgen.IdGeneratorImpl;
 import com.hazelcast.core.IAtomicLong;
@@ -28,9 +29,8 @@ public class ClientIdGeneratorProxy extends ClientProxy implements IdGenerator {
 
     private final IdGeneratorImpl idGeneratorImpl;
 
-
-    public ClientIdGeneratorProxy(String serviceName, String objectId, IAtomicLong blockGenerator) {
-        super(serviceName, objectId);
+    public ClientIdGeneratorProxy(String serviceName, String objectId, ClientContext context, IAtomicLong blockGenerator) {
+        super(serviceName, objectId, context);
         this.idGeneratorImpl = new IdGeneratorImpl(blockGenerator);
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -41,6 +41,7 @@ import com.hazelcast.client.impl.protocol.codec.ListSetCodec;
 import com.hazelcast.client.impl.protocol.codec.ListSizeCodec;
 import com.hazelcast.client.impl.protocol.codec.ListSubCodec;
 import com.hazelcast.client.spi.ClientClusterService;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.collection.impl.common.DataAwareItemEvent;
@@ -67,8 +68,8 @@ import java.util.ListIterator;
  */
 public class ClientListProxy<E> extends PartitionSpecificClientProxy implements IList<E> {
 
-    public ClientListProxy(String serviceName, String name) {
-        super(serviceName, name);
+    public ClientListProxy(String serviceName, String name, ClientContext context) {
+        super(serviceName, name, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -26,6 +26,7 @@ import com.hazelcast.client.impl.protocol.codec.LockIsLockedCodec;
 import com.hazelcast.client.impl.protocol.codec.LockLockCodec;
 import com.hazelcast.client.impl.protocol.codec.LockTryLockCodec;
 import com.hazelcast.client.impl.protocol.codec.LockUnlockCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.core.ICondition;
 import com.hazelcast.core.ILock;
 import com.hazelcast.util.ThreadUtil;
@@ -43,8 +44,8 @@ public class ClientLockProxy extends PartitionSpecificClientProxy implements ILo
 
     private ClientLockReferenceIdGenerator referenceIdGenerator;
 
-    public ClientLockProxy(String serviceName, String objectId) {
-        super(serviceName, objectId);
+    public ClientLockProxy(String serviceName, String objectId, ClientContext context) {
+        super(serviceName, objectId, context);
     }
 
     @Deprecated

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -82,6 +82,7 @@ import com.hazelcast.client.impl.protocol.codec.MapValuesWithPredicateCodec;
 import com.hazelcast.client.impl.querycache.ClientQueryCacheContext;
 import com.hazelcast.client.impl.querycache.subscriber.ClientQueryCacheEndToEndConstructor;
 import com.hazelcast.client.map.impl.ClientMapPartitionIterator;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientPartitionService;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.EventHandler;
@@ -224,8 +225,8 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     private ClientLockReferenceIdGenerator lockReferenceIdGenerator;
     private ClientQueryCacheContext queryCacheContext;
 
-    public ClientMapProxy(String serviceName, String name) {
-        super(serviceName, name);
+    public ClientMapProxy(String serviceName, String name, ClientContext context) {
+        super(serviceName, name, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -25,6 +25,7 @@ import com.hazelcast.client.impl.protocol.codec.MapReduceForMapCodec;
 import com.hazelcast.client.impl.protocol.codec.MapReduceForMultiMapCodec;
 import com.hazelcast.client.impl.protocol.codec.MapReduceForSetCodec;
 import com.hazelcast.client.impl.protocol.codec.MapReduceJobProcessInformationCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
@@ -74,8 +75,8 @@ public class ClientMapReduceProxy
 
     private final ConcurrentMap<String, ClientTrackableJob> trackableJobs = new ConcurrentHashMap<String, ClientTrackableJob>();
 
-    public ClientMapReduceProxy(String serviceName, String objectName) {
-        super(serviceName, objectName);
+    public ClientMapReduceProxy(String serviceName, String objectName, ClientContext context) {
+        super(serviceName, objectName, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -39,6 +39,7 @@ import com.hazelcast.client.impl.protocol.codec.MultiMapTryLockCodec;
 import com.hazelcast.client.impl.protocol.codec.MultiMapUnlockCodec;
 import com.hazelcast.client.impl.protocol.codec.MultiMapValueCountCodec;
 import com.hazelcast.client.impl.protocol.codec.MultiMapValuesCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
@@ -97,8 +98,8 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
     private ClientLockReferenceIdGenerator lockReferenceIdGenerator;
 
-    public ClientMultiMapProxy(String serviceName, String name) {
-        super(serviceName, name);
+    public ClientMultiMapProxy(String serviceName, String name, ClientContext context) {
+        super(serviceName, name, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
@@ -39,6 +39,7 @@ import com.hazelcast.client.impl.protocol.codec.QueueRemoveListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.QueueSizeCodec;
 import com.hazelcast.client.impl.protocol.codec.QueueTakeCodec;
 import com.hazelcast.client.spi.ClientClusterService;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.collection.impl.common.DataAwareItemEvent;
@@ -69,8 +70,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy implements IQueue<E> {
 
-    public ClientQueueProxy(String serviceName, String name) {
-        super(serviceName, name);
+    public ClientQueueProxy(String serviceName, String name, ClientContext context) {
+        super(serviceName, name, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.proxy;
 import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.config.ClientReliableTopicConfig;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
@@ -77,8 +78,8 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
     private final Executor executor;
     private final TopicOverloadPolicy overloadPolicy;
 
-    public ClientReliableTopicProxy(String objectId, HazelcastClientInstanceImpl client) {
-        super(SERVICE_NAME, objectId);
+    public ClientReliableTopicProxy(String objectId, ClientContext context, HazelcastClientInstanceImpl client) {
+        super(SERVICE_NAME, objectId, context);
         this.ringbuffer = client.getRingbuffer(TOPIC_RB_PREFIX + objectId);
         this.serializationService = client.getSerializationService();
         this.config = client.getClientConfig().getReliableTopicConfig(objectId);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -90,8 +90,8 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
     private volatile NearCache<K, V> nearCache;
     private volatile String invalidationListenerId;
 
-    public ClientReplicatedMapProxy(String serviceName, String objectName) {
-        super(serviceName, objectName);
+    public ClientReplicatedMapProxy(String serviceName, String objectName, ClientContext context) {
+        super(serviceName, objectName, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -27,6 +27,7 @@ import com.hazelcast.client.impl.protocol.codec.RingbufferReadOneCodec;
 import com.hazelcast.client.impl.protocol.codec.RingbufferRemainingCapacityCodec;
 import com.hazelcast.client.impl.protocol.codec.RingbufferSizeCodec;
 import com.hazelcast.client.impl.protocol.codec.RingbufferTailSequenceCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
@@ -81,8 +82,8 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
     private int partitionId;
     private volatile long capacity = -1;
 
-    public ClientRingbufferProxy(String serviceName, String objectName) {
-        super(serviceName, objectName);
+    public ClientRingbufferProxy(String serviceName, String objectName, ClientContext context) {
+        super(serviceName, objectName, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.protocol.codec.ScheduledExecutorGetAllScheduled
 import com.hazelcast.client.impl.protocol.codec.ScheduledExecutorShutdownCodec;
 import com.hazelcast.client.impl.protocol.codec.ScheduledExecutorSubmitToAddressCodec;
 import com.hazelcast.client.impl.protocol.codec.ScheduledExecutorSubmitToPartitionCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.util.ClientDelegatingFuture;
@@ -77,8 +78,8 @@ public class ClientScheduledExecutorProxy
         }
     };
 
-    public ClientScheduledExecutorProxy(String serviceName, String objectId) {
-        super(serviceName, objectId);
+    public ClientScheduledExecutorProxy(String serviceName, String objectId, ClientContext context) {
+        super(serviceName, objectId, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
@@ -64,8 +64,7 @@ public class ClientScheduledFutureProxy<V>
     private ScheduledTaskHandler handler;
 
     public ClientScheduledFutureProxy(ScheduledTaskHandler handler, ClientContext context) {
-        super(DistributedScheduledExecutorService.SERVICE_NAME, handler.getSchedulerName());
-        setContext(context);
+        super(DistributedScheduledExecutorService.SERVICE_NAME, handler.getSchedulerName(), context);
         this.handler = handler;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
@@ -24,6 +24,7 @@ import com.hazelcast.client.impl.protocol.codec.SemaphoreInitCodec;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreReducePermitsCodec;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreReleaseCodec;
 import com.hazelcast.client.impl.protocol.codec.SemaphoreTryAcquireCodec;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.core.ISemaphore;
 
 import java.util.concurrent.TimeUnit;
@@ -33,8 +34,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class ClientSemaphoreProxy extends PartitionSpecificClientProxy implements ISemaphore {
 
-    public ClientSemaphoreProxy(String serviceName, String objectId) {
-        super(serviceName, objectId);
+    public ClientSemaphoreProxy(String serviceName, String objectId, ClientContext context) {
+        super(serviceName, objectId, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
@@ -32,6 +32,7 @@ import com.hazelcast.client.impl.protocol.codec.SetRemoveCodec;
 import com.hazelcast.client.impl.protocol.codec.SetRemoveListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.SetSizeCodec;
 import com.hazelcast.client.spi.ClientClusterService;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.collection.impl.common.DataAwareItemEvent;
@@ -57,8 +58,8 @@ import java.util.List;
  */
 public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements ISet<E> {
 
-    public ClientSetProxy(String serviceName, String name) {
-        super(serviceName, name);
+    public ClientSetProxy(String serviceName, String name, ClientContext context) {
+        super(serviceName, name, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientTopicProxy.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.TopicAddMessageListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.TopicPublishCodec;
 import com.hazelcast.client.impl.protocol.codec.TopicRemoveMessageListenerCodec;
 import com.hazelcast.client.spi.ClientClusterService;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.core.ITopic;
@@ -39,8 +40,8 @@ import com.hazelcast.topic.impl.DataAwareMessage;
  */
 public class ClientTopicProxy<E> extends PartitionSpecificClientProxy implements ITopic<E> {
 
-    public ClientTopicProxy(String serviceName, String objectId) {
-        super(serviceName, objectId);
+    public ClientTopicProxy(String serviceName, String objectId, ClientContext context) {
+        super(serviceName, objectId, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -87,8 +87,8 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
 
     private volatile String invalidationListenerId;
 
-    public NearCachedClientMapProxy(String serviceName, String name) {
-        super(serviceName, name);
+    public NearCachedClientMapProxy(String serviceName, String name, ClientContext context) {
+        super(serviceName, name, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.proxy;
 
 import com.hazelcast.client.impl.ClientMessageDecoder;
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
@@ -33,8 +34,8 @@ abstract class PartitionSpecificClientProxy extends ClientProxy {
 
     private int partitionId;
 
-    protected PartitionSpecificClientProxy(String serviceName, String objectName) {
-        super(serviceName, objectName);
+    protected PartitionSpecificClientProxy(String serviceName, String objectName, ClientContext context) {
+        super(serviceName, objectName, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/xa/XAResourceProxy.java
@@ -56,8 +56,8 @@ public class XAResourceProxy extends ClientProxy implements HazelcastXAResource 
             = new ConcurrentHashMap<Xid, List<TransactionContext>>();
     private final AtomicInteger timeoutInSeconds = new AtomicInteger(DEFAULT_TIMEOUT_SECONDS);
 
-    public XAResourceProxy(String serviceName, String objectName) {
-        super(serviceName, objectName);
+    public XAResourceProxy(String serviceName, String objectName, ClientContext context) {
+        super(serviceName, objectName, context);
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientProxyFactoryWithContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientProxyFactoryWithContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.client.spi.ClientContext;
+import com.hazelcast.client.spi.ClientProxy;
+import com.hazelcast.client.spi.ClientProxyFactory;
+
+/**
+ * Factory class for creating client proxies with a {@link ClientContext}.
+ * <p>
+ * This class creates a client proxy and passes a {@link ClientContext} directly to the constructor.
+ */
+public abstract class ClientProxyFactoryWithContext implements ClientProxyFactory {
+
+    @Override
+    public final ClientProxy create(String id) {
+        throw new UnsupportedOperationException("Please use create(String id, ClientContext context) instead!");
+    }
+
+    /**
+     * Creates a new client proxy with the given id.
+     *
+     * @param id      the ID of the client proxy
+     * @param context the {@link ClientContext} of the client proxy
+     * @return the client proxy
+     */
+    public abstract ClientProxy create(String id, ClientContext context);
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyProxyFactory.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyProxyFactory.java
@@ -17,8 +17,9 @@
 package com.hazelcast.spring;
 
 import com.hazelcast.client.spi.ClientProxy;
+import com.hazelcast.client.spi.ClientProxyFactory;
 
-public class DummyProxyFactory implements com.hazelcast.client.spi.ClientProxyFactory {
+public class DummyProxyFactory implements ClientProxyFactory {
 
     @Override
     public ClientProxy create(String id) {


### PR DESCRIPTION
There are several reasons to change this:
* the `volatile` field insinuates that the context is changed (by multiple threads) after the proxy creation, but this is not true (the field is just assigned once)
* we lose code motion optimization opportunities and maybe other JIT optimizations (even if the `volatile` read will not introduce a full load barrier on x86 and SPARC machines), which is visible in flamegraphs as gaps before each `getContext()` call
![volatile-context-master](https://cloud.githubusercontent.com/assets/4196298/25675026/4333f07e-303d-11e7-80a1-9497c3d2ef4b.png)
vs.
![volatile-context-fixed](https://cloud.githubusercontent.com/assets/4196298/25675030/45231144-303d-11e7-82f4-9acaca8dc334.png)
* the `ClientContext` and `SerializationService` fields are duplicated in `AbstractClientCacheProxyBase`, most probably to avoid volatile reads in the cache proxies (this will be cleaned up in a follow-up PR)
![screenshot from 2017-05-03 14-43-23](https://cloud.githubusercontent.com/assets/4196298/25660975/e5c507ee-300e-11e7-98ea-33971aeb48ce.png)

The implementation was a little stunt, since the `ClientProxy` and `ClientProxyFactory` are part of the client SPI. I think I managed to add the new constructor without breaking any existing implementations.