### PR TITLE
The SocketChannelWrapper is created earlier for fail fast.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -56,10 +56,12 @@ public class NodeIOService implements IOService {
 
     private final Node node;
     private final NodeEngineImpl nodeEngine;
+    private final SocketChannelWrapperFactory socketChannelWrapperFactory;
 
     public NodeIOService(Node node, NodeEngineImpl nodeEngine) {
         this.node = node;
         this.nodeEngine = nodeEngine;
+        this.socketChannelWrapperFactory = node.getNodeExtension().getSocketChannelWrapperFactory();
     }
 
     @Override
@@ -327,7 +329,7 @@ public class NodeIOService implements IOService {
 
     @Override
     public SocketChannelWrapperFactory getSocketChannelWrapperFactory() {
-        return node.getNodeExtension().getSocketChannelWrapperFactory();
+        return socketChannelWrapperFactory;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapper.java
@@ -28,6 +28,9 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
 
+/**
+ * A {@link SocketChannelWrapper} that sends data plain (unecrypted) over the wire.
+ */
 public class PlainSocketChannelWrapper implements SocketChannelWrapper {
 
     protected final SocketChannel socketChannel;


### PR DESCRIPTION
Currently the SocketChannelWrapperFactory is retrieved when it is truly needed, e.g when
a tcp connection is accepted. If there is a configuration error in setting up the
SocketChannelWrapperFactory (e.g. some tls configuration errors) , the exception will
be thrown on the Acceptor thread.

This PR changes that by creating the SocketChannelWrapper early; so when the user
starts a HZ instance, the IO service is also started and now also the SocketChannelWrapperFactory
as well