### PR TITLE
Removed IOService.isCient since not used

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -121,8 +121,6 @@ public interface IOService {
 
     void onDisconnect(Address endpoint, Throwable cause);
 
-    boolean isClient();
-
     void executeAsync(Runnable runnable);
 
     EventService getEventService();

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -291,11 +291,6 @@ public class NodeIOService implements IOService {
     }
 
     @Override
-    public boolean isClient() {
-        return false;
-    }
-
-    @Override
     public long getConnectionMonitorInterval() {
         return node.getProperties().getMillis(GroupProperty.CONNECTION_MONITOR_INTERVAL);
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -243,11 +243,6 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public boolean isClient() {
-        return false;
-    }
-
-    @Override
     public void executeAsync(final Runnable runnable) {
         new Thread() {
             public void run() {


### PR DESCRIPTION
Method is never used (also not in enterprise). There is only a serverside IOService.