### PR TITLE
Removed TcpIpConnection socket configure methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketReaderInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketReaderInitializer.java
@@ -106,7 +106,7 @@ public class MemberSocketReaderInitializer implements SocketReaderInitializer<Tc
         reader.initInputBuffer(inputBuffer);
 
         try {
-            connection.setReceiveBufferSize(sizeBytes);
+            connection.getSocketChannel().socket().setReceiveBufferSize(sizeBytes);
         } catch (SocketException e) {
             logger.finest("Failed to adjust TCP receive buffer of " + connection + " to " + sizeBytes + " B.", e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketWriterInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketWriterInitializer.java
@@ -77,7 +77,7 @@ public class MemberSocketWriterInitializer implements SocketWriterInitializer<Tc
         writer.initOutputBuffer(outputBuffer);
 
         try {
-            connection.setSendBufferSize(size);
+            connection.getSocketChannel().socket().setSendBufferSize(size);
         } catch (SocketException e) {
             logger.finest("Failed to adjust TCP send buffer of " + connection + " to " + size + " B.", e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -36,7 +36,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.net.SocketException;
 import java.nio.channels.CancelledKeyException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -187,28 +186,15 @@ public final class TcpIpConnection implements SocketConnection, MetricsProvider,
         this.errorHandler = errorHandler;
     }
 
-    public TcpIpConnectionErrorHandler getErrorHandler() {
-        return errorHandler;
-    }
-
     public int getConnectionId() {
         return connectionId;
-    }
-
-    public void setSendBufferSize(int size) throws SocketException {
-        socketChannel.socket().setSendBufferSize(size);
-    }
-
-    public void setReceiveBufferSize(int size) throws SocketException {
-        socketChannel.socket().setReceiveBufferSize(size);
     }
 
     @Override
     public boolean isClient() {
         ConnectionType t = type;
-        return (t != null) && t != ConnectionType.NONE && t.isClient();
+        return t != null && t != ConnectionType.NONE && t.isClient();
     }
-
 
     /**
      * Starts this connection.


### PR DESCRIPTION
The SocketReader/Writer-Initializer now access the socketchannel directly to configure it.
This way the TcpIpConnection can focus on higher level functions and the localization of the
socket configuration is improved (the socket and bytebuffers are now configured in the SocketReader/Writer-Initializer)

No Enterprise PR needed.