### PR TITLE
SocketReader-WriterInitializerImpl rename

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -23,8 +23,8 @@ import com.hazelcast.internal.networking.spinning.SpinningIOThreadingModel;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.NodeIOService;
-import com.hazelcast.nio.tcp.SocketReaderInitializerImpl;
-import com.hazelcast.nio.tcp.SocketWriterInitializerImpl;
+import com.hazelcast.nio.tcp.MemberSocketReaderInitializer;
+import com.hazelcast.nio.tcp.MemberSocketWriterInitializer;
 import com.hazelcast.nio.tcp.TcpIpConnectionManager;
 import com.hazelcast.spi.annotation.PrivateApi;
 
@@ -65,10 +65,10 @@ public class DefaultNodeContext implements NodeContext {
         boolean spinning = Boolean.getBoolean("hazelcast.io.spinning");
         LoggingServiceImpl loggingService = node.loggingService;
 
-        SocketWriterInitializerImpl socketWriterInitializer
-                = new SocketWriterInitializerImpl(loggingService.getLogger(SocketWriterInitializerImpl.class));
-        SocketReaderInitializerImpl socketReaderInitializer
-                = new SocketReaderInitializerImpl(loggingService.getLogger(SocketReaderInitializerImpl.class));
+        MemberSocketWriterInitializer socketWriterInitializer
+                = new MemberSocketWriterInitializer(loggingService.getLogger(MemberSocketWriterInitializer.class));
+        MemberSocketReaderInitializer socketReaderInitializer
+                = new MemberSocketReaderInitializer(loggingService.getLogger(MemberSocketReaderInitializer.class));
         if (spinning) {
             return new SpinningIOThreadingModel(
                     loggingService,

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketReaderInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketReaderInitializer.java
@@ -39,11 +39,11 @@ import static com.hazelcast.nio.Protocols.CLUSTER;
 import static com.hazelcast.nio.Protocols.TEXT;
 import static com.hazelcast.util.StringUtil.bytesToString;
 
-public class SocketReaderInitializerImpl implements SocketReaderInitializer<TcpIpConnection> {
+public class MemberSocketReaderInitializer implements SocketReaderInitializer<TcpIpConnection> {
 
     private final ILogger logger;
 
-    public SocketReaderInitializerImpl(ILogger logger) {
+    public MemberSocketReaderInitializer(ILogger logger) {
         this.logger = logger;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketWriterInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketWriterInitializer.java
@@ -33,11 +33,11 @@ import static com.hazelcast.nio.Protocols.CLIENT_BINARY_NEW;
 import static com.hazelcast.nio.Protocols.CLUSTER;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
-public class SocketWriterInitializerImpl implements SocketWriterInitializer<TcpIpConnection> {
+public class MemberSocketWriterInitializer implements SocketWriterInitializer<TcpIpConnection> {
 
     private final ILogger logger;
 
-    public SocketWriterInitializerImpl(ILogger logger) {
+    public MemberSocketWriterInitializer(ILogger logger) {
         this.logger = logger;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectNow_NonBlockingIOThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectNow_NonBlockingIOThreadingModelFactory.java
@@ -20,8 +20,8 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.tcp.IOThreadingModelFactory;
 import com.hazelcast.nio.tcp.MockIOService;
-import com.hazelcast.nio.tcp.SocketReaderInitializerImpl;
-import com.hazelcast.nio.tcp.SocketWriterInitializerImpl;
+import com.hazelcast.nio.tcp.MemberSocketReaderInitializer;
+import com.hazelcast.nio.tcp.MemberSocketWriterInitializer;
 
 public class SelectNow_NonBlockingIOThreadingModelFactory implements IOThreadingModelFactory {
 
@@ -36,8 +36,8 @@ public class SelectNow_NonBlockingIOThreadingModelFactory implements IOThreading
                 ioService.getIoOutOfMemoryHandler(), ioService.getInputSelectorThreadCount(),
                 ioService.getOutputSelectorThreadCount(),
                 ioService.getBalancerIntervalSeconds(),
-                new SocketWriterInitializerImpl(loggingService.getLogger(SocketWriterInitializerImpl.class)),
-                new SocketReaderInitializerImpl(loggingService.getLogger(SocketReaderInitializerImpl.class))
+                new MemberSocketWriterInitializer(loggingService.getLogger(MemberSocketWriterInitializer.class)),
+                new MemberSocketReaderInitializer(loggingService.getLogger(MemberSocketReaderInitializer.class))
         );
         threadingModel.setSelectorMode(SelectorMode.SELECT_NOW);
         return threadingModel;

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectWithSelectorFix_NonBlockingIOThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/SelectWithSelectorFix_NonBlockingIOThreadingModelFactory.java
@@ -20,8 +20,8 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.tcp.IOThreadingModelFactory;
 import com.hazelcast.nio.tcp.MockIOService;
-import com.hazelcast.nio.tcp.SocketReaderInitializerImpl;
-import com.hazelcast.nio.tcp.SocketWriterInitializerImpl;
+import com.hazelcast.nio.tcp.MemberSocketReaderInitializer;
+import com.hazelcast.nio.tcp.MemberSocketWriterInitializer;
 
 public class SelectWithSelectorFix_NonBlockingIOThreadingModelFactory
         implements IOThreadingModelFactory {
@@ -37,8 +37,8 @@ public class SelectWithSelectorFix_NonBlockingIOThreadingModelFactory
                 ioService.getIoOutOfMemoryHandler(), ioService.getInputSelectorThreadCount(),
                 ioService.getOutputSelectorThreadCount(),
                 ioService.getBalancerIntervalSeconds(),
-                new SocketWriterInitializerImpl(loggingService.getLogger(SocketWriterInitializerImpl.class)),
-                new SocketReaderInitializerImpl(loggingService.getLogger(SocketReaderInitializerImpl.class))
+                new MemberSocketWriterInitializer(loggingService.getLogger(MemberSocketWriterInitializer.class)),
+                new MemberSocketReaderInitializer(loggingService.getLogger(MemberSocketReaderInitializer.class))
         );
         threadingModel.setSelectorMode(SelectorMode.SELECT_WITH_FIX);
         threadingModel.setSelectorWorkaroundTest(true);

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/Select_NonBlockingIOThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nonblocking/Select_NonBlockingIOThreadingModelFactory.java
@@ -20,8 +20,8 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.IOThreadingModelFactory;
 import com.hazelcast.nio.tcp.MockIOService;
-import com.hazelcast.nio.tcp.SocketReaderInitializerImpl;
-import com.hazelcast.nio.tcp.SocketWriterInitializerImpl;
+import com.hazelcast.nio.tcp.MemberSocketReaderInitializer;
+import com.hazelcast.nio.tcp.MemberSocketWriterInitializer;
 
 public class Select_NonBlockingIOThreadingModelFactory implements IOThreadingModelFactory {
 
@@ -35,8 +35,8 @@ public class Select_NonBlockingIOThreadingModelFactory implements IOThreadingMod
                 ioService.getIoOutOfMemoryHandler(), ioService.getInputSelectorThreadCount(),
                 ioService.getOutputSelectorThreadCount(),
                 ioService.getBalancerIntervalSeconds(),
-                new SocketWriterInitializerImpl(loggingService.getLogger(SocketWriterInitializerImpl.class)),
-                new SocketReaderInitializerImpl(loggingService.getLogger(SocketReaderInitializerImpl.class))
+                new MemberSocketWriterInitializer(loggingService.getLogger(MemberSocketWriterInitializer.class)),
+                new MemberSocketReaderInitializer(loggingService.getLogger(MemberSocketReaderInitializer.class))
         );
         threadingModel.setSelectorMode(SelectorMode.SELECT);
         return threadingModel;

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_IOThreadingModelFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/spinning/Spinning_IOThreadingModelFactory.java
@@ -20,8 +20,8 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.IOThreadingModelFactory;
 import com.hazelcast.nio.tcp.MockIOService;
-import com.hazelcast.nio.tcp.SocketReaderInitializerImpl;
-import com.hazelcast.nio.tcp.SocketWriterInitializerImpl;
+import com.hazelcast.nio.tcp.MemberSocketReaderInitializer;
+import com.hazelcast.nio.tcp.MemberSocketWriterInitializer;
 
 public class Spinning_IOThreadingModelFactory implements IOThreadingModelFactory {
 
@@ -31,8 +31,8 @@ public class Spinning_IOThreadingModelFactory implements IOThreadingModelFactory
         return new SpinningIOThreadingModel(
                 loggingService,
                 ioService.getIoOutOfMemoryHandler(),
-                new SocketWriterInitializerImpl(loggingService.getLogger(SocketWriterInitializerImpl.class)),
-                new SocketReaderInitializerImpl(loggingService.getLogger(SocketReaderInitializerImpl.class))
+                new MemberSocketWriterInitializer(loggingService.getLogger(MemberSocketWriterInitializer.class)),
+                new MemberSocketReaderInitializer(loggingService.getLogger(MemberSocketReaderInitializer.class))
                 , "hz");
     }
 }


### PR DESCRIPTION
Renamed to MemberSocketReaderInitializer and MemberSocketWriterInitializer.

It is the member size initializer and now it is in line with the client side naming
of ClientSocketReaderInitializer etc.