### PR TITLE
Fixed renaming and test issues for Near Cache Preloader under Windows

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -188,6 +188,7 @@ public class NearCachePreloader<K> {
             }
 
             fos.flush();
+            closeResource(fos);
             rename(tmpStoreFile, storeFile);
 
             updatePersistenceStats(startedNanos);
@@ -196,8 +197,8 @@ public class NearCachePreloader<K> {
 
             nearCacheStats.addPersistenceFailure(e);
         } finally {
-            deleteQuietly(tmpStoreFile);
             closeResource(fos);
+            deleteQuietly(tmpStoreFile);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCachePreloaderTest.java
@@ -176,7 +176,8 @@ public abstract class AbstractNearCachePreloaderTest<NK, NV> extends HazelcastTe
                 .setStoreIntervalSeconds(1)
                 .setDirectory(directory);
 
-        expectedException.expectMessage("Cannot create lock file " + directory + getStoreFile().getName());
+        File lockFile = new File(directory, getStoreFile().getName());
+        expectedException.expectMessage("Cannot create lock file " + lockFile.getAbsolutePath());
         expectedException.expect(HazelcastException.class);
 
         createContext(true);


### PR DESCRIPTION
Fixes this exception:
```java
com.hazelcast.core.HazelcastException: Failed to rename
    C:\Users\Donnerbart\IdeaProjects\hazelcast\hazelcast-client\nearCache-795ff4a9-595a-4e06-ac6a-712a457ab14f.store~ to
    C:\Users\Donnerbart\IdeaProjects\hazelcast\hazelcast-client\nearCache-795ff4a9-595a-4e06-ac6a-712a457ab14f.store even though
    C:\Users\Donnerbart\IdeaProjects\hazelcast\hazelcast-client\nearCache-795ff4a9-595a-4e06-ac6a-712a457ab14f.store doesn't exist.
	at com.hazelcast.nio.IOUtil.rename(IOUtil.java:366)
	at com.hazelcast.internal.nearcache.impl.preloader.NearCachePreloader.storeKeys(NearCachePreloader.java:192)
	at com.hazelcast.internal.nearcache.impl.store.BaseHeapNearCacheRecordStore.storeKeys(BaseHeapNearCacheRecordStore.java:133)
	at com.hazelcast.internal.nearcache.impl.DefaultNearCache.storeKeys(DefaultNearCache.java:178)
	at com.hazelcast.internal.nearcache.impl.DefaultNearCacheManager$StorageTask.run(DefaultNearCacheManager.java:196)
```
Also fixes `AbstractNearCachePreloaderTest.testCreateStoreFile_withInvalidDirectory()`:
```java
java.lang.AssertionError: 
Expected: (exception with message a string containing "Cannot create lock file /dev/null/nearCache-c3766cca-7127-4511-ab17-64d357de32e4.store" and an instance of com.hazelcast.core.HazelcastException)
     but: exception with message a string containing "Cannot create lock file /dev/null/nearCache-c3766cca-7127-4511-ab17-64d357de32e4.store" message was "Cannot create lock file C:\dev\null\nearCache-c3766cca-7127-4511-ab17-64d357de32e4.store.lock"
```

A customer reported this with HZ 3.8.1, so a backport should be done.