### PR TITLE
Client directBuffer support.

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/DirectBufferTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/DirectBufferTest.java
@@ -1,0 +1,105 @@
+package com.hazelcast.client.io;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+
+import static com.hazelcast.spi.properties.GroupProperty.SOCKET_BUFFER_DIRECT;
+import static com.hazelcast.spi.properties.GroupProperty.SOCKET_CLIENT_BUFFER_DIRECT;
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * A test that verifies that the Client can deal with various permutations of direct-buffers.
+ */
+@Category(QuickTest.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+public class DirectBufferTest extends HazelcastTestSupport {
+
+    @Parameters()
+    public static Collection<Boolean[]> params() {
+        return Arrays.asList(new Boolean[][]{
+                {false, false},
+                {false, true},
+                {true, false},
+                {true, true},
+        });
+    }
+
+    @Parameter(0)
+    public boolean memberDirectBuffer;
+
+    @Parameter(1)
+    public boolean clientDirectBuffer;
+
+    private HazelcastInstance client;
+    private HazelcastInstance server;
+
+    @After
+    public void after() {
+        if (client != null) {
+            client.shutdown();
+        }
+        if (server != null) {
+            server.shutdown();
+        }
+        Hazelcast.shutdownAll();
+        HazelcastClient.shutdownAll();
+    }
+
+    @Test
+    public void test() {
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
+        config.setProperty(SOCKET_BUFFER_DIRECT.getName(), "" + memberDirectBuffer);
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(SOCKET_CLIENT_BUFFER_DIRECT.getName(), "" + clientDirectBuffer);
+
+        server = Hazelcast.newHazelcastInstance(config);
+        client = HazelcastClient.newHazelcastClient(clientConfig);
+
+        List<byte[]> values = new LinkedList<byte[]>();
+
+        IMap<Integer, byte[]> map = client.getMap("foo");
+        for (int k = 0; k < 24; k++) {
+            byte[] value = randomByteArray((int) Math.pow(2, k));
+            values.add(value);
+            map.put(k, value);
+        }
+
+        for (int k = 0; k < values.size(); k++) {
+            byte[] expected = values.get(k);
+            assertArrayEquals(expected, map.get(k));
+        }
+    }
+
+    private static byte[] randomByteArray(int length) {
+        byte[] bytes = new byte[length];
+        new Random().nextBytes(bytes);
+        return bytes;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -328,7 +328,9 @@ public class ClientMessage
                 // we don't have even the frame length ready
                 return false;
             }
-            frameLength = Bits.readIntL(src.array(), src.position());
+            frameLength = Bits.readIntL(src);
+            // we need to restore the position; as if we didn't read the frame-length
+            src.position(src.position() - Bits.INT_SIZE_IN_BYTES);
             if (frameLength < HEADER_SIZE) {
                 throw new IllegalArgumentException("Client message frame length cannot be smaller than header size.");
             }
@@ -343,12 +345,11 @@ public class ClientMessage
         return isComplete();
     }
 
-    private int accumulate(ByteBuffer byteBuffer, int length) {
-        final int remaining = byteBuffer.remaining();
-        final int readLength = remaining < length ? remaining : length;
+    private int accumulate(ByteBuffer src, int length) {
+        int remaining = src.remaining();
+        int readLength = remaining < length ? remaining : length;
         if (readLength > 0) {
-            buffer.putBytes(index(), byteBuffer.array(), byteBuffer.position(), readLength);
-            byteBuffer.position(byteBuffer.position() + readLength);
+            buffer.putBytes(index(), src, readLength);
             index(index() + readLength);
             return readLength;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientProtocolBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientProtocolBuffer.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.client.impl.protocol.util;
 
+import java.nio.ByteBuffer;
+
 /**
  * Interface for buffer to be used in client protocol.
  * Implemented by {@link SafeBuffer} and {@link UnsafeBuffer}
@@ -151,6 +153,8 @@ public interface ClientProtocolBuffer {
      * @param length The length of the supplied buffer to copy.
      */
     void putBytes(int index, byte[] src, int offset, int length);
+
+    void putBytes(int index, ByteBuffer src, int length);
 
     /**
      * Encode a String as UTF-8 bytes to the buffer with a length prefix.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/SafeBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/SafeBuffer.java
@@ -66,6 +66,21 @@ public class SafeBuffer implements ClientProtocolBuffer {
     }
 
     @Override
+    public void putBytes(int index, ByteBuffer src, int length) {
+        byteBuffer.position(index);
+        if (src.isDirect()) {
+            int oldLimit = src.limit();
+            src.limit(src.position() + length);
+            byteBuffer.put(src);
+            src.limit(oldLimit);
+        } else {
+            // to prevent causing any regressions for heap buffer, we leave the original copy logic in place.
+            byteBuffer.put(src.array(), src.position(), length);
+            src.position(src.position() + length);
+        }
+    }
+
+    @Override
     public int putStringUtf8(int index, String value) {
         return putStringUtf8(index, value, Integer.MAX_VALUE);
     }
@@ -101,7 +116,6 @@ public class SafeBuffer implements ClientProtocolBuffer {
 
     @Override
     public long getLong(int index) {
-
         return byteBuffer.getLong(index);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/UnsafeBuffer.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.util;
 import com.hazelcast.nio.Bits;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import static com.hazelcast.internal.memory.GlobalMemoryAccessorRegistry.MEM;
@@ -183,6 +184,17 @@ public class UnsafeBuffer implements ClientProtocolBuffer {
         boundsCheck(src, offset, length);
 
         MEM.copyMemory(src, ARRAY_BASE_OFFSET + offset, byteArray, addressOffset + index, length);
+    }
+
+    @Override
+    public void putBytes(int index, ByteBuffer src, int length) {
+        if (src.isDirect()) {
+            src.get(byteArray, index, length);
+        } else {
+            // to prevent causing any regressions, in case of a heap buffer, we leave the original copy logic in place.
+            putBytes(index, src.array(), src.position(), length);
+            src.position(src.position() + length);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
@@ -21,6 +21,7 @@ import com.hazelcast.spi.annotation.PrivateApi;
 
 import java.io.DataInput;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 import static com.hazelcast.internal.memory.impl.EndiannessUtil.BYTE_ARRAY_ACCESS;
@@ -143,6 +144,14 @@ public final class Bits {
 
     public static int readIntL(byte[] buffer, int pos) {
         return EndiannessUtil.readIntL(BYTE_ARRAY_ACCESS, buffer, pos);
+    }
+
+    public static int readIntL(ByteBuffer buffer) {
+        int byte3 = buffer.get() & 0xFF;
+        int byte2 = (buffer.get() & 0xFF) << 8;
+        int byte1 = (buffer.get() & 0xFF) << 16;
+        int byte0 = (buffer.get() & 0xFF) << 24;
+        return byte3 | byte2 | byte1 | byte0;
     }
 
     public static void writeInt(byte[] buffer, int pos, int v, boolean useBigEndian) {


### PR DESCRIPTION
For TLS/OpenSSL client needs to support direct buffers.

There are only 2 reliances on the byte-array from the regular heap ByteBuffer.
- determine the size of the frame
- copy the payload from the socket buffer into the ClientMessage payload.

Both these have been addressed as part of this PR.