### PR TITLE
[DONT MERGE] Validate & init max-size when eviction is configured

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -20,6 +20,8 @@ import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.io.File;
 import java.net.URL;
@@ -33,8 +35,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
+import static com.hazelcast.internal.config.ConfigValidator.checkMaxSizeEvictionConfig;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.lang.Integer.parseInt;
 
 /**
  * Contains all the configuration to start a {@link com.hazelcast.core.HazelcastInstance}. A Config
@@ -252,6 +256,8 @@ public class Config {
         MapConfig config = lookupByPattern(mapConfigs, baseName);
         if (config != null) {
             initDefaultMaxSizeForOnHeapMaps(config.getNearCacheConfig());
+            int partitionCount = parseInt(HazelcastProperties.getString(properties, GroupProperty.PARTITION_COUNT));
+            checkMaxSizeEvictionConfig(config, partitionCount);
             return config.getAsReadOnly();
         }
         return getMapConfig("default").getAsReadOnly();

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
@@ -99,39 +99,7 @@ public class HazelcastProperties {
      * @return the value or <tt>null</tt> if nothing has been configured
      */
     public String getString(HazelcastProperty property) {
-        String value = properties.getProperty(property.getName());
-        if (value != null) {
-            return value;
-        }
-
-        value = property.getSystemProperty();
-        if (value != null) {
-            return value;
-        }
-
-        HazelcastProperty parent = property.getParent();
-        if (parent != null) {
-            return getString(parent);
-        }
-
-        String deprecatedName = property.getDeprecatedName();
-        if (deprecatedName != null) {
-            value = get(deprecatedName);
-            if (value == null) {
-                value = System.getProperty(deprecatedName);
-            }
-
-            if (value != null) {
-                // we don't have a logger available, and the Logging service is constructed after the Properties are created.
-                System.err.print("Don't use deprecated '" + deprecatedName + "' "
-                        + "but use '" + property.getName() + "' instead. "
-                        + "The former name will be removed in the next Hazelcast release.");
-
-                return value;
-            }
-        }
-
-        return property.getDefaultValue();
+        return getString(properties, property);
     }
 
     /**
@@ -233,5 +201,50 @@ public class HazelcastProperties {
 
         throw new IllegalArgumentException(format("value '%s' for property '%s' is not a valid %s value",
                 value, property.getName(), enumClazz.getName()));
+    }
+
+    /**
+     * Lookup a {@link HazelcastProperty}'s {@link String} value in the given {@code properties} or in
+     * {@link System#getProperties()}, as specified in this class' javadoc.
+     * @param properties    user-provided {@link Properties}. If {@code null}, a {@link NullPointerException} will
+     *                      be thrown.
+     * @param property      the {@link HazelcastProperty} whose value is looked up
+     * @return              the configured value
+     */
+    public static String getString(Properties properties, HazelcastProperty property) {
+
+        String value = properties.getProperty(property.getName());
+        if (value != null) {
+            return value;
+        }
+
+        value = property.getSystemProperty();
+        if (value != null) {
+            return value;
+        }
+
+        HazelcastProperty parent = property.getParent();
+        if (parent != null) {
+            return getString(properties, parent);
+        }
+
+        String deprecatedName = property.getDeprecatedName();
+        if (deprecatedName != null) {
+            value = (String) properties.get(deprecatedName);
+            if (value == null) {
+                value = System.getProperty(deprecatedName);
+            }
+
+            if (value != null) {
+                // we don't have a logger available, and the Logging service is constructed after the Properties are created.
+                System.err.print("Don't use deprecated '" + deprecatedName + "' "
+                        + "but use '" + property.getName() + "' instead. "
+                        + "The former name will be removed in the next Hazelcast release.");
+
+                return value;
+            }
+        }
+
+        return property.getDefaultValue();
     }
 }


### PR DESCRIPTION
Logs a warning and resets the `maxSize` value to be the `max(userConfiguredMaxSize, partitionCount)` when an `IMap` is configured with an `EvictionPolicy` other than `NONE`.

Fixes #10179 