### PR TITLE
Added directBuffer parameter to SocketChannelWrapperFactory

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -392,8 +392,12 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             socket.setReceiveBufferSize(bufferSize);
             InetSocketAddress inetSocketAddress = address.getInetSocketAddress();
             socketChannel.socket().connect(inetSocketAddress, connectionTimeout);
+
+            HazelcastProperties properties = client.getProperties();
+            boolean directBuffer = properties.getBoolean(SOCKET_CLIENT_BUFFER_DIRECT);
+
             SocketChannelWrapper socketChannelWrapper =
-                    socketChannelWrapperFactory.wrapSocketChannel(socketChannel, true);
+                    socketChannelWrapperFactory.wrapSocketChannel(socketChannel, true, directBuffer);
 
             final ClientConnection clientConnection = new ClientConnection(
                     client, ioThreadingModel, connectionIdGen.incrementAndGet(), socketChannelWrapper);
@@ -415,10 +419,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
     private int getBufferSize() {
         int bufferSize = socketOptions.getBufferSize() * KILO_BYTE;
-        if (bufferSize <= 0) {
-            bufferSize = DEFAULT_BUFFER_SIZE_BYTE;
-        }
-        return bufferSize;
+        return bufferSize <= 0 ? DEFAULT_BUFFER_SIZE_BYTE : bufferSize;
     }
 
     void onClose(Connection connection) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/SocketChannelWrapperFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/SocketChannelWrapperFactory.java
@@ -23,5 +23,5 @@ import java.nio.channels.SocketChannel;
  */
 public interface SocketChannelWrapperFactory {
 
-    SocketChannelWrapper wrapSocketChannel(SocketChannel channel, boolean client) throws Exception;
+    SocketChannelWrapper wrapSocketChannel(SocketChannel channel, boolean client, boolean directBuffer) throws Exception;
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -82,7 +82,7 @@ public interface IOService {
 
     int getSocketSendBufferSize();
 
-    boolean isSocketBufferDirect();
+    boolean useDirectSocketBuffer();
 
     /**
      * Size of receive buffers for connections opened by clients

--- a/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/NodeIOService.java
@@ -212,7 +212,7 @@ public class NodeIOService implements IOService {
     }
 
     @Override
-    public boolean isSocketBufferDirect() {
+    public boolean useDirectSocketBuffer() {
         return node.getProperties().getBoolean(GroupProperty.SOCKET_BUFFER_DIRECT);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketReaderInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketReaderInitializer.java
@@ -99,7 +99,7 @@ public class MemberSocketReaderInitializer implements SocketReaderInitializer<Tc
     }
 
     private ByteBuffer initInputBuffer(TcpIpConnection connection, SocketReader reader, int sizeKb) {
-        boolean directBuffer = connection.getConnectionManager().getIoService().isSocketBufferDirect();
+        boolean directBuffer = connection.getConnectionManager().getIoService().useDirectSocketBuffer();
         int sizeBytes = sizeKb * KILO_BYTE;
 
         ByteBuffer inputBuffer = newByteBuffer(sizeBytes, directBuffer);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketWriterInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberSocketWriterInitializer.java
@@ -69,7 +69,7 @@ public class MemberSocketWriterInitializer implements SocketWriterInitializer<Tc
                 : ioService.getSocketClientSendBufferSize();
         int size = KILO_BYTE * sizeKb;
 
-        ByteBuffer outputBuffer = newByteBuffer(size, ioService.isSocketBufferDirect());
+        ByteBuffer outputBuffer = newByteBuffer(size, ioService.useDirectSocketBuffer());
         if (CLUSTER.equals(protocol)) {
             outputBuffer.put(stringToBytes(CLUSTER));
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapperFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapperFactory.java
@@ -24,7 +24,7 @@ import java.nio.channels.SocketChannel;
 public class PlainSocketChannelWrapperFactory implements SocketChannelWrapperFactory {
 
     @Override
-    public SocketChannelWrapper wrapSocketChannel(SocketChannel channel, boolean client) throws Exception {
+    public SocketChannelWrapper wrapSocketChannel(SocketChannel channel, boolean client, boolean directBuffer) throws Exception {
         return new PlainSocketChannelWrapper(channel);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -288,7 +288,8 @@ public class TcpIpConnectionManager implements ConnectionManager, PacketHandler 
     }
 
     SocketChannelWrapper wrapSocketChannel(SocketChannel socketChannel, boolean client) throws Exception {
-        SocketChannelWrapper wrapper = socketChannelWrapperFactory.wrapSocketChannel(socketChannel, client);
+        SocketChannelWrapper wrapper = socketChannelWrapperFactory.wrapSocketChannel(
+                socketChannel, client, ioService.useDirectSocketBuffer());
         acceptedSockets.add(wrapper);
         return wrapper;
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -191,7 +191,7 @@ public class MockIOService implements IOService {
     }
 
     @Override
-    public boolean isSocketBufferDirect() {
+    public boolean useDirectSocketBuffer() {
         return false;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapperFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PlainSocketChannelWrapperFactoryTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import java.nio.channels.SocketChannel;
 
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.floatThat;
 import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -44,7 +45,7 @@ public class PlainSocketChannelWrapperFactoryTest extends HazelcastTestSupport {
     @Test
     public void wrapSocketChannel() throws Exception {
         SocketChannel socketChannel = mock(SocketChannel.class);
-        SocketChannelWrapper wrapper = factory.wrapSocketChannel(socketChannel, false);
+        SocketChannelWrapper wrapper = factory.wrapSocketChannel(socketChannel, false, false);
 
         assertInstanceOf(PlainSocketChannelWrapper.class, wrapper);
     }


### PR DESCRIPTION
needed for tls so that the SSLSocketChannelWrapper knows when it needs to create
direct or indirect buffers.

For enterprise PR see https://github.com/hazelcast/hazelcast-enterprise/pull/1464