### PR TITLE
Prevent leaking ownership info on new arrived node

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -400,7 +400,6 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PostJoinAwar
         return ownershipMappings.remove(clientUuid, memberUuid);
     }
 
-    //implemented for test purpose
     public String getOwnerUuid(String clientUuid) {
         return ownershipMappings.get(clientUuid);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/operations/PostJoinClientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/operations/PostJoinClientOperation.java
@@ -18,12 +18,15 @@ package com.hazelcast.client.impl.operations;
 
 import com.hazelcast.client.impl.ClientDataSerializerHook;
 import com.hazelcast.client.impl.ClientEngineImpl;
+import com.hazelcast.core.Member;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class PostJoinClientOperation extends AbstractClientOperation {
 
@@ -43,8 +46,17 @@ public class PostJoinClientOperation extends AbstractClientOperation {
         }
 
         ClientEngineImpl engine = getService();
+        Set<Member> members = getNodeEngine().getClusterService().getMembers();
+        HashSet<String> uuids = new HashSet<String>();
+        for (Member member : members) {
+            uuids.add(member.getUuid());
+        }
+
         for (Map.Entry<String, String> entry : mappings.entrySet()) {
-            engine.addOwnershipMapping(entry.getKey(), entry.getValue());
+            String ownerMemberUuid = entry.getValue();
+            if (uuids.contains(ownerMemberUuid)) {
+                engine.addOwnershipMapping(entry.getKey(), ownerMemberUuid);
+            }
         }
     }
 


### PR DESCRIPTION
When a new node arrived it gets ownership info of all clients in
the cluster. It could be the case that a client and its owner member
just left the cluster. In this case, new member gets the ownership info
but it will never be deleted. Because it already missed related events/
operation.

To prevent the leak, owner member is checked against current
memberlist in post join operation. If not in the list, we don't add it
in the first place.