### PR TITLE
Introduce missing permissions configuration

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.8.xsd
@@ -2210,6 +2210,8 @@
                         <xs:element name="scheduled-executor-permission" type="instance-permission" minOccurs="0"
                                     maxOccurs="unbounded"/>
                         <xs:element name="transaction-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="cache-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/security/TestSecureApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/security/TestSecureApplicationContext.java
@@ -37,9 +37,12 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 
 import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -150,6 +153,16 @@ public class TestSecureApplicationContext {
                     assertEquals("dev", permConfig.getPrincipal());
                     assertEquals(1, permConfig.getEndpoints().size());
                     assertEquals("127.0.0.1", permConfig.getEndpoints().iterator().next());
+                    break;
+                case CACHE:
+                    assertEquals("test-cache", permConfig.getName());
+                    assertEquals("dev", permConfig.getPrincipal());
+                    assertEquals(1, permConfig.getEndpoints().size());
+                    assertEquals("127.0.0.1", permConfig.getEndpoints().iterator().next());
+                    assertEquals(4, permConfig.getActions().size());
+                    String[] expectedActions = new String[] {"create", "add", "read", "destroy"};
+                    String[] actualActions = permConfig.getActions().toArray(new String[0]);
+                    assertArrayEquals(expectedActions, actualActions);
                     break;
             }
         }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/security/secure-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/security/secure-applicationContext-hazelcast.xml
@@ -107,6 +107,17 @@
                         <hz:action>poll</hz:action>
                     </hz:actions>
                 </hz:queue-permission>
+                <hz:cache-permission name="test-cache" principal="dev">
+                    <hz:endpoints>
+                        <hz:endpoint>127.0.0.1</hz:endpoint>
+                    </hz:endpoints>
+                    <hz:actions>
+                        <hz:action>create</hz:action>
+                        <hz:action>add</hz:action>
+                        <hz:action>read</hz:action>
+                        <hz:action>destroy</hz:action>
+                    </hz:actions>
+                </hz:cache-permission>
             </hz:client-permissions>
             <hz:security-interceptors>
                 <hz:interceptor class-name="com.hazelcast.spring.security.DummySecurityInterceptor"

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAndReplaceMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetAndReplaceMessageTask.java
@@ -22,12 +22,15 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheGetAndReplaceCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.CachePermission;
 import com.hazelcast.spi.Operation;
 
 import javax.cache.expiry.ExpiryPolicy;
+import java.security.Permission;
 
 /**
- * This client request  specifically calls {@link CacheGetAndReplaceOperation} on the server side.
+ * This client request specifically calls {@link CacheGetAndReplaceOperation} on the server side.
  *
  * @see CacheGetAndReplaceOperation
  */
@@ -54,6 +57,11 @@ public class CacheGetAndReplaceMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return CacheGetAndReplaceCodec.encodeResponse(serializationService.toData(response));
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return new CachePermission(parameters.name, ActionConstants.ACTION_READ, ActionConstants.ACTION_PUT);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateEntriesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheIterateEntriesMessageTask.java
@@ -24,13 +24,16 @@ import com.hazelcast.client.impl.protocol.codec.CacheIterateEntriesCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.CachePermission;
 import com.hazelcast.spi.Operation;
 
+import java.security.Permission;
 import java.util.Collections;
 import java.util.Map;
 
 /**
- * This client request  specifically calls {@link CacheEntryIteratorOperation} on the server side.
+ * This client request specifically calls {@link CacheEntryIteratorOperation} on the server side.
  *
  * @see CacheEntryIteratorOperation
  */
@@ -59,6 +62,11 @@ public class CacheIterateEntriesMessageTask
         }
         CacheEntryIterationResult iteratorResult = (CacheEntryIterationResult) response;
         return CacheIterateEntriesCodec.encodeResponse(iteratorResult.getTableIndex(), iteratorResult.getEntries());
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return new CachePermission(parameters.name, ActionConstants.ACTION_READ);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheReplaceMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheReplaceMessageTask.java
@@ -22,12 +22,15 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheReplaceCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.CachePermission;
 import com.hazelcast.spi.Operation;
 
 import javax.cache.expiry.ExpiryPolicy;
+import java.security.Permission;
 
 /**
- * This client request  specifically calls {@link CachePutOperation} on the server side.
+ * This client request specifically calls {@link CachePutOperation} on the server side.
  *
  * @see CachePutOperation
  */
@@ -55,6 +58,11 @@ public class CacheReplaceMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return CacheReplaceCodec.encodeResponse(serializationService.toData(response));
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return new CachePermission(parameters.name, ActionConstants.ACTION_PUT);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSizeMessageTask.java
@@ -23,12 +23,15 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheSizeCodec;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.CachePermission;
 import com.hazelcast.spi.OperationFactory;
 
+import java.security.Permission;
 import java.util.Map;
 
 /**
- * This client request  specifically calls {@link CacheSizeOperationFactory} on the server side.
+ * This client request specifically calls {@link CacheSizeOperationFactory} on the server side.
  *
  * @see CacheSizeOperationFactory
  */
@@ -64,6 +67,11 @@ public class CacheSizeMessageTask
     @Override
     protected ClientMessage encodeResponse(Object response) {
         return CacheSizeCodec.encodeResponse((Integer) response);
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return new CachePermission(parameters.name, ActionConstants.ACTION_READ);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PermissionConfig.java
@@ -106,7 +106,10 @@ public class PermissionConfig {
          * Scheduled executor service
          */
         SCHEDULED_EXECUTOR("scheduled-executor-permission"),
-
+        /**
+         * JCache/ICache
+         */
+        CACHE("cache-permission"),
         /**
          * All
          */

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -2107,6 +2107,14 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 type = PermissionType.TRANSACTION;
             } else if ("all-permissions".equals(nodeName)) {
                 type = PermissionType.ALL;
+            } else if ("durable-executor-service-permission".equals(nodeName)) {
+                type = PermissionType.DURABLE_EXECUTOR_SERVICE;
+            } else if ("cardinality-estimator-permission".equals(nodeName)) {
+                type = PermissionType.CARDINALITY_ESTIMATOR;
+            } else if ("scheduled-executor-permission".equals(nodeName)) {
+                type = PermissionType.SCHEDULED_EXECUTOR;
+            } else if ("cache-permission".equals(nodeName)) {
+                type = PermissionType.CACHE;
             } else {
                 continue;
             }

--- a/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.8.xsd
@@ -2280,6 +2280,7 @@
             <xs:element name="cardinality-estimator-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="scheduled-executor-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="transaction-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="cache-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
         </xs:choice>
     </xs:complexType>
     <xs:complexType name="base-permission">

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -632,6 +632,17 @@
                 </actions>
             </queue-permission>
             <transaction-permission/>
+            <cache-permission name="/hz/cachemanager1/cache1" principal="dev">
+                <endpoints>
+                    <endpoint>127.0.0.1</endpoint>
+                </endpoints>
+                <actions>
+                    <action>create</action>
+                    <action>destroy</action>
+                    <action>add</action>
+                    <action>remove</action>
+                </actions>
+            </cache-permission>
         </client-permissions>
     </security>
 


### PR DESCRIPTION
Introduces `PermissionType.CACHE` and respective `<cache-permission>` elements in XML & Spring configuration.

Fixes #10503