### PR TITLE
Fix PromoteLiteMemberTest failure

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -55,7 +55,6 @@ import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.PROM
 import static com.hazelcast.internal.cluster.impl.MembershipFailureTest.assertMaster;
 import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.dropOperationsBetween;
 import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.dropOperationsFrom;
-import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.resetPacketFiltersFrom;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -319,7 +318,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
             }
         });
 
-        resetPacketFiltersFrom(hz3);
+        dropOperationsBetween(hz3, hz1, EXPLICIT_SUSPICION);
         try {
             future.get();
             fail("Promotion should fail!");


### PR DESCRIPTION
3rd node should not send explicit suspicion to the original master due to the test logic

Fixes #10413