### PR TITLE
Cleanup of ClientProxy method usage

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -103,22 +103,17 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
     }
 
     @Override
-    public ClientContext getClientContext() {
-        return clientContext;
-    }
-
-    @Override
     protected void onInitialize() {
         super.onInitialize();
 
-        ClientConfig clientConfig = clientContext.getClientConfig();
+        ClientConfig clientConfig = getContext().getClientConfig();
         NearCacheConfig nearCacheConfig = checkNearCacheConfig(clientConfig.getNearCacheConfig(name),
                 clientConfig.getNativeMemoryConfig());
         cacheOnUpdate = isCacheOnUpdate(nearCacheConfig, nameWithPrefix, logger);
         invalidateOnChange = nearCacheConfig.isInvalidateOnChange();
 
         ICacheDataStructureAdapter<K, V> adapter = new ICacheDataStructureAdapter<K, V>(this);
-        nearCacheManager = clientContext.getNearCacheManager();
+        nearCacheManager = getContext().getNearCacheManager();
         nearCache = nearCacheManager.getOrCreateNearCache(nameWithPrefix, nearCacheConfig, adapter);
         CacheStatistics localCacheStatistics = super.getLocalCacheStatistics();
         ((ClientCacheStatisticsImpl) localCacheStatistics).setNearCacheStats(nearCache.getNearCacheStats());
@@ -152,8 +147,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
                                                             ExecutionCallback<V> callback) {
         Object value = getCachedValue(dataKey, false);
         if (value != NOT_CACHED) {
-            return new CompletedFuture<V>(clientContext.getSerializationService(), value,
-                    clientContext.getExecutionService().getUserExecutor());
+            return new CompletedFuture<V>(getSerializationService(), value, getContext().getExecutionService().getUserExecutor());
         }
 
         try {
@@ -466,7 +460,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
         }
 
         ListenerMessageCodec listenerCodec = createInvalidationListenerCodec();
-        ClientListenerService listenerService = clientContext.getListenerService();
+        ClientListenerService listenerService = getContext().getListenerService();
 
         EventHandler eventHandler = createInvalidationEventHandler();
         nearCacheMembershipRegistrationId = listenerService.registerListener(listenerCodec, eventHandler);
@@ -511,7 +505,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
     }
 
     private int getConnectedServerVersion() {
-        ClientClusterService clusterService = clientContext.getClusterService();
+        ClientClusterService clusterService = getContext().getClusterService();
         Address ownerConnectionAddress = clusterService.getOwnerConnectionAddress();
 
         HazelcastClientInstanceImpl client = getClient();
@@ -536,8 +530,8 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
 
         String registrationId = nearCacheMembershipRegistrationId;
         if (registrationId != null) {
-            clientContext.getRepairingTask(SERVICE_NAME).deregisterHandler(name);
-            clientContext.getListenerService().deregisterListener(registrationId);
+            getContext().getRepairingTask(SERVICE_NAME).deregisterHandler(name);
+            getContext().getListenerService().deregisterListener(registrationId);
         }
     }
 
@@ -746,7 +740,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
         }
 
         private RepairingTask getRepairingTask() {
-            return clientContext.getRepairingTask(CacheService.SERVICE_NAME);
+            return getContext().getRepairingTask(CacheService.SERVICE_NAME);
         }
     }
 
@@ -764,7 +758,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
         private String clientUuid;
 
         private Pre38NearCacheEventHandler() {
-            this.clientUuid = clientContext.getClusterService().getLocalClient().getUuid();
+            this.clientUuid = getContext().getClusterService().getLocalClient().getUuid();
         }
 
         @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCardinalityEstimatorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientCardinalityEstimatorProxy.java
@@ -70,7 +70,7 @@ public class ClientCardinalityEstimatorProxy
     public InternalCompletableFuture<Void> addAsync(Object obj) {
         checkNotNull(obj, "Object is null");
 
-        Data data = getSerializationService().toData(obj);
+        Data data = toData(obj);
         ClientMessage request = CardinalityEstimatorAddCodec.encodeRequest(name, data.hash64());
         return invokeOnPartitionAsync(request, ADD_DECODER);
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
@@ -206,8 +206,7 @@ public final class ClientDurableExecutorServiceProxy extends ClientProxy impleme
     private <T> DurableExecutorServiceFuture<T> submitToPartition(Callable<T> task, int partitionId, T result) {
         checkNotNull(task, "task should not be null");
 
-        SerializationService serService = getSerializationService();
-        ClientMessage request = DurableExecutorSubmitToPartitionCodec.encodeRequest(name, serService.toData(task));
+        ClientMessage request = DurableExecutorSubmitToPartitionCodec.encodeRequest(name, toData(task));
         int sequence;
         try {
             ClientMessage response = invokeOnPartition(request, partitionId);
@@ -218,7 +217,8 @@ public final class ClientDurableExecutorServiceProxy extends ClientProxy impleme
         ClientMessage clientMessage = DurableExecutorRetrieveResultCodec.encodeRequest(name, sequence);
         ClientInvocationFuture future = new ClientInvocation(getClient(), clientMessage, partitionId).invoke();
         long taskId = Bits.combineToLong(partitionId, sequence);
-        return new ClientDurableExecutorServiceDelegatingFuture<T>(future, serService, RETRIEVE_RESPONSE_DECODER, result, taskId);
+        return new ClientDurableExecutorServiceDelegatingFuture<T>(future, getSerializationService(), RETRIEVE_RESPONSE_DECODER,
+                result, taskId);
     }
 
     private Executor getUserExecutor() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientExecutorServiceProxy.java
@@ -385,7 +385,7 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         Executor userExecutor = getContext().getExecutionService().getUserExecutor();
         for (Future<T> future : futures) {
             Object value = retrieveResult(future);
-            result.add(new CompletedFuture<T>(getContext().getSerializationService(), value, userExecutor));
+            result.add(new CompletedFuture<T>(getSerializationService(), value, userExecutor));
         }
         return result;
     }
@@ -438,12 +438,10 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
 
         String uuid = getUUID();
         int partitionId = getPartitionId(key);
-        ClientMessage request =
-                ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, toData(task), partitionId);
+        ClientMessage request = ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, toData(task), partitionId);
         ClientInvocationFuture f = invokeOnPartitionOwner(request, partitionId);
-        SerializationService serializationService = getContext().getSerializationService();
 
-        ClientDelegatingFuture<T> delegatingFuture = new ClientDelegatingFuture<T>(f, serializationService,
+        ClientDelegatingFuture<T> delegatingFuture = new ClientDelegatingFuture<T>(f, getSerializationService(),
                 SUBMIT_TO_PARTITION_DECODER);
         delegatingFuture.andThen(callback);
     }
@@ -467,10 +465,8 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         ClientMessage request =
                 ExecutorServiceSubmitToPartitionCodec.encodeRequest(name, uuid, toData(task), partitionId);
         ClientInvocationFuture f = invokeOnPartitionOwner(request, partitionId);
-        SerializationService serializationService = getContext().getSerializationService();
-        ClientDelegatingFuture<T> delegatingFuture =
-                new ClientDelegatingFuture<T>(f, serializationService,
-                        SUBMIT_TO_PARTITION_DECODER);
+        ClientDelegatingFuture<T> delegatingFuture = new ClientDelegatingFuture<T>(f, getSerializationService(),
+                SUBMIT_TO_PARTITION_DECODER);
         delegatingFuture.andThen(callback);
     }
 
@@ -490,9 +486,8 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         String uuid = getUUID();
         ClientMessage request = ExecutorServiceSubmitToAddressCodec.encodeRequest(name, uuid, toData(task), address);
         ClientInvocationFuture f = invokeOnTarget(request, address);
-        SerializationService serializationService = getContext().getSerializationService();
-        ClientDelegatingFuture<T> delegatingFuture =
-                new ClientDelegatingFuture<T>(f, serializationService, SUBMIT_TO_ADDRESS_DECODER);
+        ClientDelegatingFuture<T> delegatingFuture = new ClientDelegatingFuture<T>(f, getSerializationService(),
+                SUBMIT_TO_ADDRESS_DECODER);
         delegatingFuture.andThen(callback);
     }
 
@@ -507,10 +502,10 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         if (sync) {
             Object response = retrieveResultFromMessage(f);
             Executor userExecutor = getContext().getExecutionService().getUserExecutor();
-            return new CompletedFuture<T>(getContext().getSerializationService(), response, userExecutor);
+            return new CompletedFuture<T>(getSerializationService(), response, userExecutor);
         } else {
-            return new ClientAddressCancellableDelegatingFuture<T>(f, getContext(), uuid, address, defaultValue
-                    , SUBMIT_TO_ADDRESS_DECODER);
+            return new ClientAddressCancellableDelegatingFuture<T>(f, getContext(), uuid, address, defaultValue,
+                    SUBMIT_TO_ADDRESS_DECODER);
         }
     }
 
@@ -520,10 +515,10 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         if (sync) {
             Object response = retrieveResultFromMessage(f);
             Executor userExecutor = getContext().getExecutionService().getUserExecutor();
-            return new CompletedFuture<T>(getContext().getSerializationService(), response, userExecutor);
+            return new CompletedFuture<T>(getSerializationService(), response, userExecutor);
         } else {
-            return new ClientPartitionCancellableDelegatingFuture<T>(f, getContext(), uuid, partitionId, defaultValue
-                    , SUBMIT_TO_PARTITION_DECODER);
+            return new ClientPartitionCancellableDelegatingFuture<T>(f, getContext(), uuid, partitionId, defaultValue,
+                    SUBMIT_TO_PARTITION_DECODER);
         }
     }
 
@@ -671,5 +666,4 @@ public class ClientExecutorServiceProxy extends ClientProxy implements IExecutor
         ClientPartitionService partitionService = getContext().getPartitionService();
         return random.nextInt(partitionService.getPartitionCount());
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -40,7 +40,6 @@ import com.hazelcast.client.impl.protocol.codec.ListRemoveWithIndexCodec;
 import com.hazelcast.client.impl.protocol.codec.ListSetCodec;
 import com.hazelcast.client.impl.protocol.codec.ListSizeCodec;
 import com.hazelcast.client.impl.protocol.codec.ListSubCodec;
-import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
@@ -52,7 +51,6 @@ import com.hazelcast.core.ItemListener;
 import com.hazelcast.core.Member;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Preconditions;
 
 import java.util.Collection;
@@ -150,8 +148,7 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
         ClientMessage response = invokeOnPartition(request);
         ListIteratorCodec.ResponseParameters resultParameters = ListIteratorCodec.decodeResponse(response);
         List<Data> resultCollection = resultParameters.response;
-        SerializationService serializationService = getContext().getSerializationService();
-        return new UnmodifiableLazyList<E>(resultCollection, serializationService).iterator();
+        return new UnmodifiableLazyList<E>(resultCollection, getSerializationService()).iterator();
     }
 
     @Override
@@ -305,8 +302,7 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
         ClientMessage response = invokeOnPartition(request);
         ListListIteratorCodec.ResponseParameters resultParameters = ListListIteratorCodec.decodeResponse(response);
         List<Data> resultCollection = resultParameters.response;
-        SerializationService serializationService = getContext().getSerializationService();
-        return new UnmodifiableLazyList<E>(resultCollection, serializationService).listIterator();
+        return new UnmodifiableLazyList<E>(resultCollection, getSerializationService()).listIterator();
     }
 
     @Override
@@ -315,8 +311,7 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
         ClientMessage response = invokeOnPartition(request);
         ListSubCodec.ResponseParameters resultParameters = ListSubCodec.decodeResponse(response);
         List<Data> resultCollection = resultParameters.response;
-        SerializationService serializationService = getContext().getSerializationService();
-        return new UnmodifiableLazyList<E>(resultCollection, serializationService);
+        return new UnmodifiableLazyList<E>(resultCollection, getSerializationService());
     }
 
     @Override
@@ -335,11 +330,9 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
 
         @Override
         public void handle(Data dataItem, String uuid, int eventType) {
-            SerializationService serializationService = getContext().getSerializationService();
-            ClientClusterService clusterService = getContext().getClusterService();
-            Member member = clusterService.getMember(uuid);
+            Member member = getContext().getClusterService().getMember(uuid);
             ItemEvent<E> itemEvent = new DataAwareItemEvent(name, ItemEventType.getByType(eventType),
-                    dataItem, member, serializationService);
+                    dataItem, member, getSerializationService());
             if (eventType == ItemEventType.ADDED.getType()) {
                 listener.itemAdded(itemEvent);
             } else {
@@ -349,12 +342,10 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
 
         @Override
         public void beforeListenerRegister() {
-
         }
 
         @Override
         public void onListenerRegister() {
-
         }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -96,7 +96,6 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.IMapEvent;
@@ -359,7 +358,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         try {
             ClientMessage request = MapGetCodec.encodeRequest(name, keyData, getThreadId());
             ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);
-            return new ClientDelegatingFuture<V>(future, getContext().getSerializationService(), GET_ASYNC_RESPONSE_DECODER);
+            return new ClientDelegatingFuture<V>(future, getSerializationService(), GET_ASYNC_RESPONSE_DECODER);
         } catch (Exception e) {
             throw rethrow(e);
         }
@@ -391,7 +390,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             long ttlMillis = getTimeInMillis(ttl, timeunit);
             ClientMessage request = MapPutCodec.encodeRequest(name, keyData, valueData, getThreadId(), ttlMillis);
             ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);
-            return new ClientDelegatingFuture<V>(future, getContext().getSerializationService(), PUT_ASYNC_RESPONSE_DECODER);
+            return new ClientDelegatingFuture<V>(future, getSerializationService(), PUT_ASYNC_RESPONSE_DECODER);
         } catch (Exception e) {
             throw rethrow(e);
         }
@@ -417,7 +416,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
             long ttlMillis = getTimeInMillis(ttl, timeunit);
             ClientMessage request = MapSetCodec.encodeRequest(name, keyData, valueData, getThreadId(), ttlMillis);
             ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);
-            return new ClientDelegatingFuture<Void>(future, getContext().getSerializationService(), SET_ASYNC_RESPONSE_DECODER);
+            return new ClientDelegatingFuture<Void>(future, getSerializationService(), SET_ASYNC_RESPONSE_DECODER);
         } catch (Exception e) {
             throw rethrow(e);
         }
@@ -434,7 +433,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         try {
             ClientMessage request = MapRemoveCodec.encodeRequest(name, keyData, getThreadId());
             ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);
-            return new ClientDelegatingFuture<V>(future, getContext().getSerializationService(), REMOVE_ASYNC_RESPONSE_DECODER);
+            return new ClientDelegatingFuture<V>(future, getSerializationService(), REMOVE_ASYNC_RESPONSE_DECODER);
         } catch (Exception e) {
             throw rethrow(e);
         }
@@ -1262,7 +1261,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, getThreadId());
         try {
             ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);
-            new ClientDelegatingFuture(future, getContext().getSerializationService(), SUBMIT_TO_KEY_RESPONSE_DECODER)
+            new ClientDelegatingFuture(future, getSerializationService(), SUBMIT_TO_KEY_RESPONSE_DECODER)
                     .andThen(callback);
         } catch (Exception e) {
             throw rethrow(e);
@@ -1280,7 +1279,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         ClientMessage request = MapSubmitToKeyCodec.encodeRequest(name, toData(entryProcessor), keyData, getThreadId());
         try {
             ClientInvocationFuture future = invokeOnKeyOwner(request, keyData);
-            return new ClientDelegatingFuture(future, getContext().getSerializationService(), SUBMIT_TO_KEY_RESPONSE_DECODER);
+            return new ClientDelegatingFuture(future, getSerializationService(), SUBMIT_TO_KEY_RESPONSE_DECODER);
         } catch (Exception e) {
             throw rethrow(e);
         }
@@ -1367,8 +1366,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
     @SuppressWarnings({"deprecation"})
     public <SuppliedValue, Result> Result aggregate(Supplier<K, V, SuppliedValue> supplier,
                                                     Aggregation<K, SuppliedValue, Result> aggregation) {
-        HazelcastInstance hazelcastInstance = getContext().getHazelcastInstance();
-        JobTracker jobTracker = hazelcastInstance.getJobTracker("hz::aggregation-map-" + name);
+        JobTracker jobTracker = getClient().getJobTracker("hz::aggregation-map-" + name);
         return aggregate(supplier, aggregation, jobTracker);
     }
 
@@ -1608,7 +1606,7 @@ public class ClientMapProxy<K, V> extends ClientProxy implements IMap<K, V> {
         private EntryEvent<K, V> createEntryEvent(Data keyData, Data valueData, Data oldValueData, Data mergingValueData,
                                                   int eventType, Member member) {
             return new DataAwareEntryEvent<K, V>(member, eventType, name, keyData, valueData, oldValueData, mergingValueData,
-                    getContext().getSerializationService());
+                    getSerializationService());
         }
 
         @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -53,7 +53,6 @@ import com.hazelcast.mapreduce.impl.task.TransferableJobProcessInformation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.AbstractCompletableFuture;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.UuidUtil;
 
@@ -174,12 +173,11 @@ public class ClientMapReduceProxy
     }
 
     private Map toObjectMap(ClientMessage res) {
-        SerializationService serializationService = getContext().getSerializationService();
         Collection<Map.Entry<Data, Data>> entries = MapReduceForCustomCodec.decodeResponse(res).response;
         HashMap hashMap = new HashMap();
         for (Map.Entry<Data, Data> entry : entries) {
-            Object key = serializationService.toObject(entry.getKey());
-            Object value = serializationService.toObject(entry.getValue());
+            Object key = toObject(entry.getKey());
+            Object value = toObject(entry.getValue());
             hashMap.put(key, value);
         }
         return hashMap;
@@ -227,7 +225,6 @@ public class ClientMapReduceProxy
         return MapReduceForCustomCodec
                 .encodeRequest(name, jobId, predicateData, mapperData, combinerFactoryData, reducerFactoryData,
                         toData(keyValueSource), chunkSize, list, topologyChangedStrategyName);
-
     }
 
     private class ClientCompletableFuture<V>
@@ -264,7 +261,6 @@ public class ClientMapReduceProxy
         protected void setResult(Object result) {
             super.setResult(result);
         }
-
     }
 
     private final class ClientTrackableJob<V>
@@ -315,7 +311,5 @@ public class ClientMapReduceProxy
             }
             return null;
         }
-
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -47,7 +47,6 @@ import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IMapEvent;
 import com.hazelcast.core.MapEvent;
@@ -418,8 +417,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
     public <SuppliedValue, Result> Result aggregate(Supplier<K, V, SuppliedValue> supplier,
                                                     Aggregation<K, SuppliedValue, Result> aggregation) {
 
-        HazelcastInstance hazelcastInstance = getContext().getHazelcastInstance();
-        JobTracker jobTracker = hazelcastInstance.getJobTracker("hz::aggregation-multimap-" + name);
+        JobTracker jobTracker = getClient().getJobTracker("hz::aggregation-multimap-" + name);
         return aggregate(supplier, aggregation, jobTracker);
     }
 
@@ -523,8 +521,8 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
         private EntryEvent<K, V> createEntryEvent(Data keyData, Data valueData, Data oldValueData,
                                                   Data mergingValueData, int eventType, Member member) {
-            return new DataAwareEntryEvent<K, V>(member, eventType, name, keyData, valueData,
-                    oldValueData, mergingValueData, getContext().getSerializationService());
+            return new DataAwareEntryEvent<K, V>(member, eventType, name, keyData, valueData, oldValueData, mergingValueData,
+                    getSerializationService());
         }
 
         @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReplicatedMapProxy.java
@@ -103,10 +103,9 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
     }
 
     private void initNearCache() {
-        ClientContext context = getContext();
-        NearCacheConfig nearCacheConfig = context.getClientConfig().getNearCacheConfig(name);
+        NearCacheConfig nearCacheConfig = getContext().getClientConfig().getNearCacheConfig(name);
         if (nearCacheConfig != null) {
-            nearCache = context.getNearCacheManager().getOrCreateNearCache(name, nearCacheConfig);
+            nearCache = getContext().getNearCacheManager().getOrCreateNearCache(name, nearCacheConfig);
             if (nearCacheConfig.isInvalidateOnChange()) {
                 addNearCacheInvalidateListener();
             }
@@ -541,8 +540,8 @@ public class ClientReplicatedMapProxy<K, V> extends ClientProxy implements Repli
                            int numberOfAffectedEntries) {
             Member member = getContext().getClusterService().getMember(uuid);
             EntryEventType eventType = EntryEventType.getByType(eventTypeId);
-            EntryEvent<K, V> entryEvent = new DataAwareEntryEvent<K, V>(member, eventTypeId, name, keyData,
-                    valueData, oldValueData, null, getContext().getSerializationService());
+            EntryEvent<K, V> entryEvent = new DataAwareEntryEvent<K, V>(member, eventTypeId, name, keyData, valueData,
+                    oldValueData, null, getSerializationService());
             switch (eventType) {
                 case ADDED:
                     listener.entryAdded(entryEvent);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledExecutorProxy.java
@@ -37,7 +37,6 @@ import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.scheduledexecutor.impl.ScheduledRunnableAdapter;
 import com.hazelcast.scheduledexecutor.impl.ScheduledTaskHandlerImpl;
 import com.hazelcast.scheduledexecutor.impl.TaskDefinition;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.FutureUtil;
 import com.hazelcast.util.UuidUtil;
 
@@ -369,18 +368,12 @@ public class ClientScheduledExecutorProxy
     }
 
     private <T> ClientDelegatingFuture<T> doSubmitOnAddress(ClientMessage clientMessage,
-                                                            ClientMessageDecoder clientMessageDecoder,
-                                                            Address address) {
-        SerializationService serializationService = getContext().getSerializationService();
-
+                                                            ClientMessageDecoder clientMessageDecoder, Address address) {
         try {
-            final ClientInvocationFuture future = new ClientInvocation(getClient(), clientMessage,
-                    address).invoke();
-
-            return new ClientDelegatingFuture<T>(future, serializationService, clientMessageDecoder);
+            ClientInvocationFuture future = new ClientInvocation(getClient(), clientMessage, address).invoke();
+            return new ClientDelegatingFuture<T>(future, getSerializationService(), clientMessageDecoder);
         } catch (Exception e) {
             throw rethrow(e);
         }
     }
-
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientScheduledFutureProxy.java
@@ -219,12 +219,12 @@ public class ClientScheduledFutureProxy<V>
             ClientMessage request = ScheduledExecutorGetResultFromAddressCodec.encodeRequest(schedulerName, taskName, address);
             ClientMessage response = new ClientInvocation(getClient(), request, address).invoke().get(timeout, unit);
             Data data = ScheduledExecutorGetResultFromAddressCodec.decodeResponse(response).response;
-            return getSerializationService().toObject(data);
+            return toObject(data);
         } else {
             ClientMessage request = ScheduledExecutorGetResultFromPartitionCodec.encodeRequest(schedulerName, taskName);
             ClientMessage response = new ClientInvocation(getClient(), request, partitionId).invoke().get(timeout, unit);
             Data data = ScheduledExecutorGetResultFromPartitionCodec.decodeResponse(response).response;
-            return getSerializationService().toObject(data);
+            return toObject(data);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -95,10 +95,9 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     protected void onInitialize() {
         super.onInitialize();
 
-        ClientContext context = getContext();
-        logger = context.getLoggingService().getLogger(getClass());
-        NearCacheConfig nearCacheConfig = context.getClientConfig().getNearCacheConfig(name);
-        NearCacheManager nearCacheManager = context.getNearCacheManager();
+        logger = getContext().getLoggingService().getLogger(getClass());
+        NearCacheConfig nearCacheConfig = getContext().getClientConfig().getNearCacheConfig(name);
+        NearCacheManager nearCacheManager = getContext().getNearCacheManager();
         IMapDataStructureAdapter<K, V> adapter = new IMapDataStructureAdapter<K, V>(this);
         nearCache = nearCacheManager.getOrCreateNearCache(name, nearCacheConfig, adapter);
 
@@ -142,7 +141,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         Object value = getCachedValue(key, false);
         if (value != NOT_CACHED) {
             ExecutorService executor = getContext().getExecutionService().getUserExecutor();
-            return new CompletedFuture<V>(getContext().getSerializationService(), value, executor);
+            return new CompletedFuture<V>(getSerializationService(), value, executor);
         }
 
         final long reservationId = nearCache.tryReserveForUpdate(key);
@@ -672,8 +671,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         }
 
         private RepairingTask getRepairingTask() {
-            ClientContext clientContext = getClientContext();
-            return clientContext.getRepairingTask(SERVICE_NAME);
+            return getContext().getRepairingTask(SERVICE_NAME);
         }
     }
 
@@ -718,14 +716,8 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         }
     }
 
-    // used in tests
-    public ClientContext getClientContext() {
-        return getContext();
-    }
-
     private int getConnectedServerVersion() {
-        ClientContext clientContext = getClientContext();
-        ClientClusterService clusterService = clientContext.getClusterService();
+        ClientClusterService clusterService = getContext().getClusterService();
         Address ownerConnectionAddress = clusterService.getOwnerConnectionAddress();
 
         HazelcastClientInstanceImpl client = getClient();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionSpecificClientProxy.java
@@ -24,7 +24,7 @@ import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
-import com.hazelcast.spi.serialization.SerializationService;
+
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
@@ -55,11 +55,9 @@ abstract class PartitionSpecificClientProxy extends ClientProxy {
 
     protected <T> ClientDelegatingFuture<T> invokeOnPartitionAsync(ClientMessage clientMessage,
                                                                    ClientMessageDecoder clientMessageDecoder) {
-        SerializationService serializationService = getContext().getSerializationService();
-
         try {
             final ClientInvocationFuture future = new ClientInvocation(getClient(), clientMessage, partitionId).invoke();
-            return new ClientDelegatingFuture<T>(future, serializationService, clientMessageDecoder);
+            return new ClientDelegatingFuture<T>(future, getSerializationService(), clientMessageDecoder);
         } catch (Exception e) {
             throw rethrow(e);
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcherTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheMetaDataFetcherTest.java
@@ -18,10 +18,10 @@ package com.hazelcast.client.cache.impl.nearcache.invalidation;
 import com.hazelcast.cache.impl.CacheEventHandler;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
-import com.hazelcast.client.cache.impl.NearCachedClientCacheProxy;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.spi.ClientContext;
+import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.NearCacheConfig;
@@ -96,7 +96,7 @@ public class ClientCacheMetaDataFetcherTest extends HazelcastTestSupport {
         CachingProvider clientCachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
         Cache<Integer, Integer> clientCache = clientCachingProvider.getCacheManager().createCache(cacheName, newCacheConfig());
 
-        ClientContext clientContext = ((NearCachedClientCacheProxy<Integer, Integer>) clientCache).getClientContext();
+        ClientContext clientContext = ((ClientProxy) clientCache).getContext();
         return clientContext.getRepairingTask(SERVICE_NAME);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcherTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapMetaDataFetcherTest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.client.map.impl.nearcache.invalidation;
 
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.proxy.NearCachedClientMapProxy;
 import com.hazelcast.client.spi.ClientContext;
+import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -91,7 +91,7 @@ public class ClientMapMetaDataFetcherTest extends HazelcastTestSupport {
         HazelcastInstance client = factory.newHazelcastClient(clientConfig);
         IMap<Integer, Integer> clientMap = client.getMap(mapName);
 
-        ClientContext clientContext = ((NearCachedClientMapProxy) clientMap).getClientContext();
+        ClientContext clientContext = ((ClientProxy) clientMap).getContext();
         return clientContext.getRepairingTask(SERVICE_NAME);
     }
 


### PR DESCRIPTION
* removed duplicated fields and methods
* removed chained method calls which have their own method, e.g.
  `getContext().getSerializationService()` -> `getSerializationService()`
  or `getSerializationService().toData()` -> `toData()`

Follow-up PR of https://github.com/hazelcast/hazelcast/pull/10481