### PR TITLE
Encoder/Decoder renaming

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -45,9 +45,9 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.MemberSocketInterceptor;
-import com.hazelcast.nio.tcp.MemberChannelOutboundHandler;
+import com.hazelcast.nio.tcp.PacketEncoder;
 import com.hazelcast.nio.tcp.PlainChannelFactory;
-import com.hazelcast.nio.tcp.MemberChannelInboundHandler;
+import com.hazelcast.nio.tcp.PacketDecoder;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.partition.strategy.DefaultPartitioningStrategy;
 import com.hazelcast.security.SecurityContext;
@@ -201,12 +201,12 @@ public class DefaultNodeExtension implements NodeExtension {
     @Override
     public ChannelInboundHandler createInboundHandler(TcpIpConnection connection, IOService ioService) {
         NodeEngineImpl nodeEngine = node.nodeEngine;
-        return new MemberChannelInboundHandler(connection, nodeEngine.getPacketDispatcher());
+        return new PacketDecoder(connection, nodeEngine.getPacketDispatcher());
     }
 
     @Override
     public ChannelOutboundHandler createOutboundHandler(TcpIpConnection connection, IOService ioService) {
-        return new MemberChannelOutboundHandler();
+        return new PacketEncoder();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/AbstractTextCommand.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.internal.ascii;
 
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
-import com.hazelcast.nio.ascii.TextChannelOutboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
+import com.hazelcast.nio.ascii.TextCommandEncoder;
 
 public abstract class AbstractTextCommand implements TextCommand {
     protected final TextCommandConstants.TextCommandType type;
-    private TextChannelInboundHandler readHandler;
-    private TextChannelOutboundHandler writeHandler;
+    private TextCommandDecoder readHandler;
+    private TextCommandEncoder writeHandler;
     private long requestId = -1;
 
     protected AbstractTextCommand(TextCommandConstants.TextCommandType type) {
@@ -35,12 +35,12 @@ public abstract class AbstractTextCommand implements TextCommand {
     }
 
     @Override
-    public TextChannelInboundHandler getReadHandler() {
+    public TextCommandDecoder getReadHandler() {
         return readHandler;
     }
 
     @Override
-    public TextChannelOutboundHandler getWriteHandler() {
+    public TextCommandEncoder getWriteHandler() {
         return writeHandler;
     }
 
@@ -50,7 +50,7 @@ public abstract class AbstractTextCommand implements TextCommand {
     }
 
     @Override
-    public void init(TextChannelInboundHandler textReadHandler, long requestId) {
+    public void init(TextCommandDecoder textReadHandler, long requestId) {
         this.readHandler = textReadHandler;
         this.requestId = requestId;
         this.writeHandler = textReadHandler.getTextWriteHandler();

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/CommandParser.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.internal.ascii;
 
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 public interface CommandParser  {
-    TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space);
+    TextCommand parser(TextCommandDecoder readHandler, String cmd, int space);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommand.java
@@ -17,8 +17,8 @@
 package com.hazelcast.internal.ascii;
 
 import com.hazelcast.internal.networking.OutboundFrame;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
-import com.hazelcast.nio.ascii.TextChannelOutboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
+import com.hazelcast.nio.ascii.TextCommandEncoder;
 
 import java.nio.ByteBuffer;
 
@@ -26,11 +26,11 @@ public interface TextCommand extends OutboundFrame {
 
     TextCommandConstants.TextCommandType getType();
 
-    void init(TextChannelInboundHandler textReadHandler, long requestId);
+    void init(TextCommandDecoder textReadHandler, long requestId);
 
-    TextChannelInboundHandler getReadHandler();
+    TextCommandDecoder getReadHandler();
 
-    TextChannelOutboundHandler getWriteHandler();
+    TextCommandEncoder getWriteHandler();
 
     long getRequestId();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -37,7 +37,7 @@ import com.hazelcast.internal.ascii.rest.HttpGetCommandProcessor;
 import com.hazelcast.internal.ascii.rest.HttpPostCommandProcessor;
 import com.hazelcast.internal.ascii.rest.RestValue;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.nio.ascii.TextChannelOutboundHandler;
+import com.hazelcast.nio.ascii.TextCommandEncoder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.EmptyStatement;
@@ -390,7 +390,7 @@ public class TextCommandServiceImpl implements TextCommandService {
                             stopObject.notify();
                         }
                     } else {
-                        TextChannelOutboundHandler textWriteHandler = textCommand.getWriteHandler();
+                        TextCommandEncoder textWriteHandler = textCommand.getWriteHandler();
                         textWriteHandler.enqueue(textCommand);
                     }
                 } catch (InterruptedException e) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/DeleteCommandParser.java
@@ -18,13 +18,13 @@ package com.hazelcast.internal.ascii.memcache;
 
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 import java.util.StringTokenizer;
 
 public class DeleteCommandParser implements CommandParser {
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextCommandDecoder readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key = null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/GetCommandParser.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.ascii.memcache;
 
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.StringTokenizer;
 public class GetCommandParser implements CommandParser {
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextCommandDecoder readHandler, String cmd, int space) {
         String key = cmd.substring(space + 1);
         if (key.indexOf(' ') == -1) {
             GetCommand r = new GetCommand(key);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/IncrementCommandParser.java
@@ -20,7 +20,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 import java.util.StringTokenizer;
 
@@ -33,7 +33,7 @@ public class IncrementCommandParser extends TypeAwareCommandParser {
     }
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextCommandDecoder readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SetCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 import java.util.StringTokenizer;
 
@@ -32,7 +32,7 @@ public class SetCommandParser extends TypeAwareCommandParser {
     }
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextCommandDecoder readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/SimpleCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.QUIT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.STATS;
@@ -33,7 +33,7 @@ public class SimpleCommandParser extends TypeAwareCommandParser {
     }
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextCommandDecoder readHandler, String cmd, int space) {
         if (type == QUIT) {
             return new SimpleCommand(type);
         } else if (type == STATS) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/memcache/TouchCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.memcache;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType;
 import com.hazelcast.internal.ascii.TypeAwareCommandParser;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 import java.util.StringTokenizer;
 
@@ -32,7 +32,7 @@ public class TouchCommandParser extends TypeAwareCommandParser {
     }
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextCommandDecoder readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String key;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 import java.util.StringTokenizer;
 
@@ -28,7 +28,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 public class HttpDeleteCommandParser implements CommandParser {
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextCommandDecoder readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 import java.util.StringTokenizer;
 
@@ -28,7 +28,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 public class HttpGetCommandParser implements CommandParser {
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextCommandDecoder readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri;

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommand.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.ascii.rest;
 
 import com.hazelcast.internal.ascii.NoOpCommand;
 import com.hazelcast.nio.IOUtil;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 import com.hazelcast.util.StringUtil;
 
 import java.nio.ByteBuffer;
@@ -36,10 +36,10 @@ public class HttpPostCommand extends HttpCommand {
     private ByteBuffer data;
     private ByteBuffer line = ByteBuffer.allocate(CAPACITY);
     private String contentType;
-    private final TextChannelInboundHandler readHandler;
+    private final TextCommandDecoder readHandler;
     private boolean chunked;
 
-    public HttpPostCommand(TextChannelInboundHandler readHandler, String uri) {
+    public HttpPostCommand(TextCommandDecoder readHandler, String uri) {
         super(HTTP_POST, uri);
         this.readHandler = readHandler;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandParser.java
@@ -19,7 +19,7 @@ package com.hazelcast.internal.ascii.rest;
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 
 import java.util.StringTokenizer;
 
@@ -28,7 +28,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 public class HttpPostCommandParser implements CommandParser {
 
     @Override
-    public TextCommand parser(TextChannelInboundHandler readHandler, String cmd, int space) {
+    public TextCommand parser(TextCommandDecoder readHandler, String cmd, int space) {
         StringTokenizer st = new StringTokenizer(cmd);
         st.nextToken();
         String uri;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelInboundHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelInboundHandler.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.networking;
 
-import com.hazelcast.nio.tcp.MemberChannelInboundHandler;
+import com.hazelcast.nio.tcp.PacketDecoder;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 
 import java.nio.ByteBuffer;
@@ -26,7 +26,7 @@ import java.nio.ByteBuffer;
  * after it has read data from the socket.
  *
  * A typical example is that Packet instances are created from the buffered data and handing them over the the
- * {@link com.hazelcast.spi.impl.packetdispatcher.PacketDispatcher}. See {@link MemberChannelInboundHandler} for more information.
+ * {@link com.hazelcast.spi.impl.packetdispatcher.PacketDispatcher}. See {@link PacketDecoder} for more information.
  *
  * Each {@link ChannelReader} will have its own {@link ChannelInboundHandler} instance. Therefor it doesn't need to be
  * thread-safe.
@@ -34,7 +34,7 @@ import java.nio.ByteBuffer;
  * <h1>Pipelining & Encryption</h1>
  * The ChannelInboundHandler/ChannelOutboundHandler can also form a pipeline. For example for SSL there could be a initial
  * ChannelInboundHandler that decryption the ByteBuffer and passes the decrypted ByteBuffer to the next ChannelInboundHandler;
- * which could be a {@link MemberChannelInboundHandler} that reads out any Packet from the decrypted ByteBuffer. Using this
+ * which could be a {@link PacketDecoder} that reads out any Packet from the decrypted ByteBuffer. Using this
  * approach encryption can easily be added to any type of communication, not only member 2 member communication.
  *
  * Currently security is added by using a {@link Channel}, but this is not needed if the handlers form a pipeline.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelWriter.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.networking;
 
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 
 /**
@@ -62,7 +62,7 @@ public interface ChannelWriter {
     /**
      * Gets the {@link ChannelOutboundHandler} that belongs to this ChannelWriter.
      *
-     * This method exists for the {@link TextChannelInboundHandler}, but probably should be deleted.
+     * This method exists for the {@link TextCommandDecoder}, but probably should be deleted.
      *
      * @return the ChannelOutboundHandler
      */

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextCommandDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextCommandDecoder.java
@@ -59,7 +59,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.VERSION;
 
 @PrivateApi
-public class TextChannelInboundHandler implements ChannelInboundHandler {
+public class TextCommandDecoder implements ChannelInboundHandler {
 
     private static final Map<String, CommandParser> MAP_COMMAND_PARSERS = new HashMap<String, CommandParser>();
 
@@ -94,7 +94,7 @@ public class TextChannelInboundHandler implements ChannelInboundHandler {
     private boolean commandLineRead;
     private TextCommand command;
     private final TextCommandService textCommandService;
-    private final TextChannelOutboundHandler textWriteHandler;
+    private final TextCommandEncoder textWriteHandler;
     private final TcpIpConnection connection;
     private final boolean restEnabled;
     private final boolean memcacheEnabled;
@@ -103,10 +103,10 @@ public class TextChannelInboundHandler implements ChannelInboundHandler {
     private long requestIdGen;
     private final ILogger logger;
 
-    public TextChannelInboundHandler(TcpIpConnection connection) {
+    public TextCommandDecoder(TcpIpConnection connection) {
         IOService ioService = connection.getConnectionManager().getIoService();
         this.textCommandService = ioService.getTextCommandService();
-        this.textWriteHandler = (TextChannelOutboundHandler) connection.getChannelWriter().getOutboundHandler();
+        this.textWriteHandler = (TextCommandEncoder) connection.getChannelWriter().getOutboundHandler();
         this.connection = connection;
         this.memcacheEnabled = ioService.isMemcacheEnabled();
         this.restEnabled = ioService.isRestEnabled();
@@ -244,7 +244,7 @@ public class TextChannelInboundHandler implements ChannelInboundHandler {
         }
     }
 
-    public TextChannelOutboundHandler getTextWriteHandler() {
+    public TextCommandEncoder getTextWriteHandler() {
         return textWriteHandler;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextCommandEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextCommandEncoder.java
@@ -26,12 +26,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @PrivateApi
-public class TextChannelOutboundHandler implements ChannelOutboundHandler<TextCommand> {
+public class TextCommandEncoder implements ChannelOutboundHandler<TextCommand> {
     private final TcpIpConnection connection;
     private final Map<Long, TextCommand> responses = new ConcurrentHashMap<Long, TextCommand>(100);
     private long currentRequestId;
 
-    public TextChannelOutboundHandler(TcpIpConnection connection) {
+    public TextCommandEncoder(TcpIpConnection connection) {
         this.connection = connection;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageDecoder.java
@@ -32,18 +32,18 @@ import java.nio.ByteBuffer;
  * to the {@link IOService#handleClientMessage(ClientMessage, Connection)}.
  *
  * Probably the design can be simplified if the IOService would expose a method getMessageHandler; so we
- * don't need to let the ClientChannelInboundHandler act like the MessageHandler, but directly send to the right
+ * don't need to let the ClientMessageDecoder act like the MessageHandler, but directly send to the right
  * data-structure.
  *
- * @see ClientChannelOutboundHandler
+ * @see ClientMessageEncoder
  */
-public class ClientChannelInboundHandler implements ChannelInboundHandler, ClientMessageChannelInboundHandler.MessageHandler {
+public class ClientMessageDecoder implements ChannelInboundHandler, ClientMessageChannelInboundHandler.MessageHandler {
 
     private final ClientMessageChannelInboundHandler readHandler;
     private final Connection connection;
     private final IOService ioService;
 
-    public ClientChannelInboundHandler(SwCounter messageCounter, Connection connection, IOService ioService) throws IOException {
+    public ClientMessageDecoder(SwCounter messageCounter, Connection connection, IOService ioService) throws IOException {
         this.connection = connection;
         this.ioService = ioService;
         this.readHandler = new ClientMessageChannelInboundHandler(messageCounter, this);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientMessageEncoder.java
@@ -24,9 +24,9 @@ import java.nio.ByteBuffer;
 /**
  * A {@link ChannelOutboundHandler} for the new-client. It writes ClientMessages to the ByteBuffer.
  *
- * @see ClientChannelInboundHandler
+ * @see ClientMessageDecoder
  */
-public class ClientChannelOutboundHandler implements ChannelOutboundHandler<ClientMessage> {
+public class ClientMessageEncoder implements ChannelOutboundHandler<ClientMessage> {
 
     @Override
     public boolean onWrite(ClientMessage message, ByteBuffer dst) throws Exception {

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
@@ -27,8 +27,8 @@ import com.hazelcast.internal.networking.InitResult;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.Protocols;
-import com.hazelcast.nio.ascii.TextChannelInboundHandler;
-import com.hazelcast.nio.ascii.TextChannelOutboundHandler;
+import com.hazelcast.nio.ascii.TextCommandDecoder;
+import com.hazelcast.nio.ascii.TextCommandEncoder;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -94,12 +94,12 @@ public class MemberChannelInitializer implements ChannelInitializer<TcpIpConnect
         } else if (CLIENT_BINARY_NEW.equals(protocol)) {
             inputBuffer = initInputBuffer(connection, ioService.getSocketClientReceiveBufferSize());
             channelWriter.setProtocol(CLIENT_BINARY_NEW);
-            inboundHandler = new ClientChannelInboundHandler(reader.getNormalFramesReadCounter(), connection, ioService);
+            inboundHandler = new ClientMessageDecoder(reader.getNormalFramesReadCounter(), connection, ioService);
         } else {
             inputBuffer = initInputBuffer(connection, ioService.getSocketReceiveBufferSize());
             channelWriter.setProtocol(TEXT);
             inputBuffer.put(protocolBuffer.array());
-            inboundHandler = new TextChannelInboundHandler(connection);
+            inboundHandler = new TextCommandDecoder(connection);
             connectionManager.incrementTextConnections();
         }
 
@@ -154,9 +154,9 @@ public class MemberChannelInitializer implements ChannelInitializer<TcpIpConnect
             IOService ioService = connection.getConnectionManager().getIoService();
             return ioService.createWriteHandler(connection);
         } else if (CLIENT_BINARY_NEW.equals(protocol)) {
-            return new ClientChannelOutboundHandler();
+            return new ClientMessageEncoder();
         } else {
-            return new TextChannelOutboundHandler(connection);
+            return new TextCommandEncoder(connection);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/PacketDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/PacketDecoder.java
@@ -25,14 +25,14 @@ import com.hazelcast.spi.impl.packetdispatcher.PacketDispatcher;
 import java.nio.ByteBuffer;
 
 /**
- * The {@link ChannelInboundHandler} for member to member communication.
+ * The {@link ChannelInboundHandler} that decodes packet; for member to member communication.
  *
  * It reads as many packets from the src ByteBuffer as possible, and each of the Packets is send to the {@link PacketDispatcher}.
  *
  * @see PacketDispatcher
- * @see MemberChannelOutboundHandler
+ * @see PacketEncoder
  */
-public class MemberChannelInboundHandler implements ChannelInboundHandler {
+public class PacketDecoder implements ChannelInboundHandler {
 
     protected final TcpIpConnection connection;
     protected Packet packet;
@@ -41,7 +41,7 @@ public class MemberChannelInboundHandler implements ChannelInboundHandler {
     private final Counter normalPacketsRead;
     private final Counter priorityPacketsRead;
 
-    public MemberChannelInboundHandler(TcpIpConnection connection, PacketDispatcher packetDispatcher) {
+    public PacketDecoder(TcpIpConnection connection, PacketDispatcher packetDispatcher) {
         this.connection = connection;
         this.packetDispatcher = packetDispatcher;
         ChannelReader channelReader = connection.getChannelReader();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/PacketEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/PacketEncoder.java
@@ -22,13 +22,13 @@ import com.hazelcast.nio.Packet;
 import java.nio.ByteBuffer;
 
 /**
- * A {@link ChannelOutboundHandler} that for member to member communication.
+ * A {@link ChannelOutboundHandler} that decodes packets, for member to member communication.
  *
  * It writes {@link Packet} instances to the {@link ByteBuffer}.
  *
- * @see MemberChannelInboundHandler
+ * @see PacketDecoder
  */
-public class MemberChannelOutboundHandler implements ChannelOutboundHandler<Packet> {
+public class PacketEncoder implements ChannelOutboundHandler<Packet> {
 
     @Override
     public boolean onWrite(Packet packet, ByteBuffer dst) {

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/ClientMessageDecoderTest.java
@@ -38,9 +38,9 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientChannelInboundHandlerTest {
+public class ClientMessageDecoderTest {
 
-    private ClientChannelInboundHandler readHandler;
+    private ClientMessageDecoder readHandler;
     private IOService ioService;
     private Connection connection;
     private SwCounter counter;
@@ -50,7 +50,7 @@ public class ClientChannelInboundHandlerTest {
         ioService = mock(IOService.class);
         connection = mock(Connection.class);
         counter = SwCounter.newSwCounter();
-        readHandler = new ClientChannelInboundHandler(counter, connection, ioService);
+        readHandler = new ClientMessageDecoder(counter, connection, ioService);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -361,7 +361,7 @@ public class MockIOService implements IOService {
 
     @Override
     public ChannelInboundHandler createReadHandler(final TcpIpConnection connection) {
-        return new MemberChannelInboundHandler(connection, new PacketDispatcher() {
+        return new PacketDecoder(connection, new PacketDispatcher() {
             private ILogger logger = loggingService.getLogger("MockIOService");
 
             @Override
@@ -384,7 +384,7 @@ public class MockIOService implements IOService {
 
     @Override
     public ChannelOutboundHandler createWriteHandler(TcpIpConnection connection) {
-        return new MemberChannelOutboundHandler();
+        return new PacketEncoder();
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketDecoderTest.java
@@ -35,10 +35,10 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class MemberChannelInboundHandlerTest extends TcpIpConnection_AbstractTest {
+public class PacketDecoderTest extends TcpIpConnection_AbstractTest {
 
     private MockPacketDispatcher dispatcher;
-    private MemberChannelInboundHandler readHandler;
+    private PacketDecoder readHandler;
     private long oldPriorityPacketsRead;
     private long oldNormalPacketsRead;
     private ChannelReader channelReader;
@@ -55,7 +55,7 @@ public class MemberChannelInboundHandlerTest extends TcpIpConnection_AbstractTes
         TcpIpConnection connection = connect(connManagerA, addressB);
 
         dispatcher = new MockPacketDispatcher();
-        readHandler = new MemberChannelInboundHandler(connection, dispatcher);
+        readHandler = new PacketDecoder(connection, dispatcher);
 
         channelReader = connection.getChannelReader();
         oldNormalPacketsRead = channelReader.getNormalFramesReadCounter().get();

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketEncoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketEncoderTest.java
@@ -16,8 +16,9 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.util.SafeBuffer;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.Packet;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -34,29 +35,29 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientChannelOutboundHandlerTest extends HazelcastTestSupport {
+public class PacketEncoderTest extends HazelcastTestSupport {
 
-    private ClientChannelOutboundHandler writeHandler;
+    private InternalSerializationService serializationService;
+    private PacketEncoder writeHandler;
 
     @Before
     public void setup() {
-        writeHandler = new ClientChannelOutboundHandler();
+        serializationService = new DefaultSerializationServiceBuilder().build();
+        writeHandler = new PacketEncoder();
     }
 
     @Test
     public void test() throws Exception {
-        ClientMessage message = ClientMessage.createForEncode(1000)
-                .setPartitionId(10)
-                .setMessageType(1);
-
+        Packet packet = new Packet(serializationService.toBytes("foobar"));
         ByteBuffer bb = ByteBuffer.allocate(1000);
-        boolean result = writeHandler.onWrite(message, bb);
+        boolean result = writeHandler.onWrite(packet, bb);
 
         assertTrue(result);
-        bb.flip();
-        ClientMessage clone = ClientMessage.createForDecode(new SafeBuffer(bb.array()), 0);
 
-        assertEquals(message.getPartitionId(), clone.getPartitionId());
-        assertEquals(message.getMessageType(), clone.getMessageType());
+        // now we read out the bb and check if we can find the written packet.
+        bb.flip();
+        Packet resultPacket = new Packet();
+        resultPacket.readFrom(bb);
+        assertEquals(packet, resultPacket);
     }
 }


### PR DESCRIPTION
The Packet/ClientMessage/TextCommand channel handlers are renamed to
Encoder/Decoder. This is also in line with Netty naming. It also makes
the classes a bit easier to read since the name is not that long.