### PR TITLE
Configurable event sync timeout

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -117,6 +117,17 @@ public final class GroupProperty {
     public static final HazelcastProperty EVENT_QUEUE_TIMEOUT_MILLIS
             = new HazelcastProperty("hazelcast.event.queue.timeout.millis", 250, MILLISECONDS);
 
+    /**
+     * To prevent overload on the outbound connections, once and a while an event is made synchronous by wrapping it in a
+     * fake operation and waiting for a fake response. This causes the outbound write queue of the connection to get drained.
+     *
+     * This timeout configures the maximum amount of waiting time for this fake response. Setting it to a too low value
+     * can lead to an uncontrolled growth of the outbound write queue of the connection.
+     */
+    public static final HazelcastProperty EVENT_SYNC_TIMEOUT_MILLIS
+            = new HazelcastProperty("hazelcast.event.sync.timeout.millis", 5000, MILLISECONDS);
+
+
     public static final HazelcastProperty HEALTH_MONITORING_LEVEL
             = new HazelcastProperty("hazelcast.health.monitoring.level", HealthMonitorLevel.SILENT.toString());
     public static final HazelcastProperty HEALTH_MONITORING_DELAY_SECONDS


### PR DESCRIPTION
It was hardcoded at 5 seconds, but now it is made configurable. This property is needed
to configure the max waiting time for a 'fake synchronous event' to get the outbound
queue of a connection drained. But if the wait is short; the mechanism doesn't provide
sufficient back pressure and you still end up with an overloaded connection.

Backport of https://github.com/hazelcast/hazelcast/pull/10520