### PR TITLE
Fixed testNearCacheMemoryCostCalculation_withConcurrentCacheMisses

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -955,7 +955,6 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
     }
 
     private void testNearCacheMemoryCostCalculation(int threadCount) {
-        nearCacheConfig.setInvalidateOnChange(true);
         final NearCacheTestContext<Integer, String, NK, NV> context = createContext();
 
         populateDataAdapter(context);


### PR DESCRIPTION
removed unneeded `setInvalidateOnChange`, it complicates goal of the test.