### PR TITLE
Refactor cluster service related tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
@@ -92,7 +92,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         Member m2 = h2.getCluster().getLocalMember();
         assertEquals(123, (int) m2.getIntAttribute("Test"));
 
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
@@ -127,7 +127,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         m1.setIntAttribute("Test", 123);
 
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(c);
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
@@ -168,7 +168,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         m1.setIntAttribute("Test", 123);
 
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(c);
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
@@ -223,7 +223,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         m1.setIntAttribute("Test", 123);
 
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(c);
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
@@ -278,7 +278,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         m1.setIntAttribute("Test", 123);
 
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(c);
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientOwnershipTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientOwnershipTest.java
@@ -174,8 +174,8 @@ public class ClientOwnershipTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(1, client.getCluster().getMembers().size());
-                assertEquals(1, instance2.getCluster().getMembers().size());
+                assertClusterSize(1, client);
+                assertClusterSize(1, instance2);
             }
         });
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -99,7 +99,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(1, client.getCluster().getMembers().size());
+                assertClusterSize(1, client);
                 Iterator<Member> iterator = client.getCluster().getMembers().iterator();
                 Member member = iterator.next();
                 assertEquals(instance2.getCluster().getLocalMember(), member);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -39,7 +39,6 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -90,8 +89,8 @@ public class ClientSplitBrainTest extends HazelcastTestSupport {
         closeConnectionBetween(h2, h1);
 
         assertOpenEventually(mergedLatch);
-        assertEquals(2, h1.getCluster().getMembers().size());
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h1);
+        assertClusterSize(2, h2);
 
         AtomicBoolean testFinished = new AtomicBoolean(false);
         final Thread clientThread = startClientPutThread(mapClient, testFinished);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -174,11 +174,10 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
                 @Override
                 public void run()
                         throws Exception {
-
-                    assertEquals(3, hazelcastInstance1.getCluster().getMembers().size());
-                    assertEquals(3, hazelcastInstance2.getCluster().getMembers().size());
-                    assertEquals(3, hazelcastInstance3.getCluster().getMembers().size());
-                    assertEquals(3, client.getCluster().getMembers().size());
+                    assertClusterSize(3, hazelcastInstance1);
+                    assertClusterSize(3, hazelcastInstance2);
+                    assertClusterSize(3, hazelcastInstance3);
+                    assertClusterSize(3, client);
                 }
             });
         } finally {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientToMemberDiscoveryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientToMemberDiscoveryTest.java
@@ -22,9 +22,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.Member;
 import com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -34,9 +32,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.InputStream;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -65,15 +60,8 @@ public class ClientToMemberDiscoveryTest extends HazelcastTestSupport {
         instance1 = factory.newHazelcastInstance(serverConfig);
         instance2 = factory.newHazelcastInstance(serverConfig);
 
-        final HazelcastInstance client = factory.newHazelcastClient(clientConfig);
-
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                Set<Member> members = client.getCluster().getMembers();
-                assertEquals(2, members.size());
-            }
-        });
+        HazelcastInstance client = factory.newHazelcastClient(clientConfig);
+        assertClusterSizeEventually(2, client);
         factory.shutdownAll();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/HazelcastFactoryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/HazelcastFactoryTest.java
@@ -62,9 +62,9 @@ public class HazelcastFactoryTest extends HazelcastTestSupport {
                 touchRandomNode(client1);
                 touchRandomNode(client2);
 
-                assertEquals(3, instance1.getCluster().getMembers().size());
-                assertEquals(3, instance2.getCluster().getMembers().size());
-                assertEquals(3, instance3.getCluster().getMembers().size());
+                assertClusterSize(3, instance1);
+                assertClusterSize(3, instance2);
+                assertClusterSize(3, instance3);
 
                 assertEquals(2, instance1.getClientService().getConnectedClients().size());
                 assertEquals(2, instance2.getClientService().getConnectedClients().size());
@@ -87,9 +87,9 @@ public class HazelcastFactoryTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(3, instance1.getCluster().getMembers().size());
-                assertEquals(3, instance2.getCluster().getMembers().size());
-                assertEquals(3, instance3.getCluster().getMembers().size());
+                assertClusterSize(3, instance1);
+                assertClusterSize(3, instance2);
+                assertClusterSize(3, instance3);
             }
         });
 
@@ -109,8 +109,8 @@ public class HazelcastFactoryTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(3, client1.getCluster().getMembers().size());
-                assertEquals(3, client1.getCluster().getMembers().size());
+                assertClusterSize(3, client1);
+                assertClusterSize(3, client1);
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -33,11 +32,11 @@ public class AbstractJoinTest extends HazelcastTestSupport {
         config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
 
         HazelcastInstance h1 = Hazelcast.newHazelcastInstance(config);
-        assertEquals(1, h1.getCluster().getMembers().size());
+        assertClusterSize(1, h1);
 
         HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
-        assertEquals(2, h1.getCluster().getMembers().size());
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h1);
+        assertClusterSize(2, h2);
 
         h1.shutdown();
         h1 = Hazelcast.newHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterJoinConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterJoinConfigCheckTest.java
@@ -30,7 +30,7 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -99,10 +99,10 @@ public class ClusterJoinConfigCheckTest {
         HazelcastInstance hz2 = Hazelcast.newHazelcastInstance(config2);
 
         assertTrue(hz1.getLifecycleService().isRunning());
-        assertEquals(1, hz1.getCluster().getMembers().size());
+        assertClusterSize(1, hz1);
 
         assertTrue(hz2.getLifecycleService().isRunning());
-        assertEquals(1, hz2.getCluster().getMembers().size());
+        assertClusterSize(1, hz2);
     }
 
     private void assertIncompatible(Config config1, Config config2, boolean tcp) {
@@ -121,7 +121,7 @@ public class ClusterJoinConfigCheckTest {
         }
 
         assertTrue(hz1.getLifecycleService().isRunning());
-        assertEquals(1, hz1.getCluster().getMembers().size());
+        assertClusterSize(1, hz1);
     }
 
     private void enableTcp(Config config) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
@@ -132,7 +132,7 @@ public class JoinStressTest extends HazelcastTestSupport {
         for (int i = 0; i < nodeCount; i++) {
             HazelcastInstance hz = instances.get(i);
             assertNotNull(hz);
-            assertEquals(nodeCount, hz.getCluster().getMembers().size());
+            assertClusterSize(nodeCount, hz);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
@@ -58,8 +58,8 @@ public class MemberAttributeTest extends HazelcastTestSupport {
         Member m2 = h2.getCluster().getLocalMember();
         assertEquals(123, (int) m2.getIntAttribute("Test"));
 
-        assertEquals(2, h1.getCluster().getMembers().size());
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h1);
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
@@ -99,7 +99,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
         m1.setIntAttribute("Test", 123);
 
         HazelcastInstance h2 = factory.newHazelcastInstance();
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
@@ -127,7 +127,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
         m1.setIntAttribute("Test", 123);
 
         HazelcastInstance h2 = factory.newHazelcastInstance();
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
@@ -168,7 +168,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
         m1.setIntAttribute("Test", 123);
 
         HazelcastInstance h2 = factory.newHazelcastInstance();
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {
@@ -209,7 +209,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
         m1.setIntAttribute("Test", 123);
 
         HazelcastInstance h2 = factory.newHazelcastInstance();
-        assertEquals(2, h2.getCluster().getMembers().size());
+        assertClusterSize(2, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastJoinTest.java
@@ -185,8 +185,8 @@ public class MulticastJoinTest extends AbstractJoinTest {
         HazelcastInstance h2 = Hazelcast.newHazelcastInstance(c2);
 
         // First two nodes are up. All should be in separate clusters.
-        assertEquals(1, h1.getCluster().getMembers().size());
-        assertEquals(1, h2.getCluster().getMembers().size());
+        assertClusterSize(1, h1);
+        assertClusterSize(1, h2);
 
         HazelcastInstance h3 = Hazelcast.newHazelcastInstance(c3);
 

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SlowMulticastJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SlowMulticastJoinTest.java
@@ -84,7 +84,7 @@ public class SlowMulticastJoinTest extends AbstractJoinTest {
             joiners[i] = (MulticastJoiner) getNode(instances[i]).getJoiner();
         }
 
-        assertEquals(clusterSize, instances[0].getCluster().getMembers().size());
+        assertClusterSize(clusterSize, instances[0]);
 
         // we will split the cluster to subclusters (0, 1), (2)
         final CountDownLatch splitLatch = new CountDownLatch(2);
@@ -122,7 +122,7 @@ public class SlowMulticastJoinTest extends AbstractJoinTest {
                 new MulticastJoiner[] {joiners[1]});
 
         assertTrue(mergeLatch.await(30, TimeUnit.SECONDS));
-        assertEquals(clusterSize, instances[0].getCluster().getMembers().size());
+        assertClusterSize(clusterSize, instances[0]);
 
         // cluster is merged & stable again, split brain join messages should not be accumulated.
         assertSplitBrainMessagesCount(clusterSize, instances, joiners);

--- a/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryTest.java
@@ -34,7 +34,6 @@ import org.mockito.stubbing.Answer;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 
@@ -72,9 +71,9 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    assertEquals(3, instance1.getCluster().getMembers().size());
-                    assertEquals(3, instance2.getCluster().getMembers().size());
-                    assertEquals(3, instance3.getCluster().getMembers().size());
+                    assertClusterSize(3, instance1);
+                    assertClusterSize(3, instance2);
+                    assertClusterSize(3, instance3);
                 }
             });
         } finally {
@@ -97,16 +96,16 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    assertEquals(2, instance21.getCluster().getMembers().size());
-                    assertEquals(2, instance22.getCluster().getMembers().size());
+                    assertClusterSize(2, instance21);
+                    assertClusterSize(2, instance22);
                 }
             });
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
-                    assertEquals(3, instance11.getCluster().getMembers().size());
-                    assertEquals(3, instance12.getCluster().getMembers().size());
-                    assertEquals(3, instance13.getCluster().getMembers().size());
+                    assertClusterSize(3, instance11);
+                    assertClusterSize(3, instance12);
+                    assertClusterSize(3, instance13);
                 }
             });
         } finally {

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -125,14 +125,9 @@ public class RestClusterTest extends HazelcastTestSupport {
 
         assertEquals(STATUS_FORBIDDEN, communicator.changeClusterState("dev1", "dev-pass", "frozen").response);
         assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterState("dev", "dev-pass", "frozen").responseCode);
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertEquals(ClusterState.FROZEN, instance1.getCluster().getClusterState());
-                assertEquals(ClusterState.FROZEN, instance2.getCluster().getClusterState());
-            }
-        });
+
+        assertClusterStateEventually(ClusterState.FROZEN, instance1);
+        assertClusterStateEventually(ClusterState.FROZEN, instance2);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -197,12 +197,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         } catch (HazelcastInstanceNotActiveException ignored) {
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertClusterState(ClusterState.ACTIVE, instances[0], instances[1]);
-            }
-        });
+        assertClusterStateEventually(ClusterState.ACTIVE, instances[0], instances[1]);
     }
 
     @Test
@@ -227,13 +222,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         } catch (HazelcastInstanceNotActiveException ignored) {
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertClusterState(ClusterState.FROZEN, instances[0], instances[1]);
-            }
-        });
+        assertClusterStateEventually(ClusterState.FROZEN, instances[0], instances[1]);
     }
 
     @Test
@@ -258,12 +247,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         } catch (HazelcastInstanceNotActiveException ignored) {
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertClusterState(ClusterState.ACTIVE, instances[0], instances[1]);
-            }
-        });
+        assertClusterStateEventually(ClusterState.ACTIVE, instances[0], instances[1]);
     }
 
     @Test
@@ -288,12 +272,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         } catch (HazelcastInstanceNotActiveException ignored) {
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertClusterState(ClusterState.ACTIVE, instances[0], instances[1]);
-            }
-        });
+        assertClusterStateEventually(ClusterState.ACTIVE, instances[0], instances[1]);
     }
 
     @Test
@@ -316,13 +295,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
         hz.getCluster().changeClusterState(ClusterState.FROZEN, options);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertClusterState(ClusterState.FROZEN, instances[2], instances[1]);
-            }
-        });
+        assertClusterStateEventually(ClusterState.FROZEN, instances[2], instances[1]);
 
         instances[0] = factory.newHazelcastInstance(address);
 
@@ -356,12 +329,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         } catch (TargetNotMemberException ignored) {
         }
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertClusterState(ClusterState.ACTIVE, instances[2], instances[1]);
-            }
-        });
+        assertClusterStateEventually(ClusterState.ACTIVE, instances[2], instances[1]);
 
         instances[0] = factory.newHazelcastInstance(address);
 
@@ -675,13 +643,6 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         transactionManagerServiceField.setAccessible(true);
         transactionManagerServiceField.set(nodeEngine, spiedTransactionManagerService);
         return spiedTransactionManagerService;
-    }
-
-    private static void assertClusterState(ClusterState expectedState, HazelcastInstance... instances) {
-        for (HazelcastInstance instance : instances) {
-            assertEquals("Instance " + instance.getCluster().getLocalMember(),
-                    expectedState, instance.getCluster().getClusterState());
-        }
     }
 
     private static abstract class TransactionAnswer implements Answer<Transaction> {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
@@ -394,12 +394,6 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
         });
     }
 
-    static void assertClusterState(ClusterState expectedState, HazelcastInstance... instances) {
-        for (HazelcastInstance instance : instances) {
-            assertEquals(expectedState, instance.getCluster().getClusterState());
-        }
-    }
-
     private static void assertNodeState(HazelcastInstance[] instances, NodeState expectedState) {
         for (HazelcastInstance instance : instances) {
             Node node = getNode(instance);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterRollingRestartTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterRollingRestartTest.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
@@ -85,7 +84,7 @@ public class ClusterRollingRestartTest extends HazelcastTestSupport {
 
         for (HazelcastInstance instance : instances) {
             assertClusterSizeEventually(nodeCount, instance);
-            assertEquals(clusterState, instance.getCluster().getClusterState());
+            assertClusterState(clusterState, instance);
         }
 
         changeClusterStateEventually(instances[0], ClusterState.ACTIVE);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -107,8 +107,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, master);
         assertClusterSizeEventually(2, slave2);
 
-        assertMaster(getAddress(master), master);
-        assertMaster(getAddress(master), slave2);
+        assertMasterAddress(getAddress(master), master);
+        assertMasterAddress(getAddress(master), slave2);
         assertMemberViewsAreSame(getMemberMap(master), getMemberMap(slave2));
     }
 
@@ -140,8 +140,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, slave1);
         assertClusterSizeEventually(2, slave2);
 
-        assertMaster(getAddress(slave1), slave1);
-        assertMaster(getAddress(slave1), slave2);
+        assertMasterAddress(getAddress(slave1), slave1);
+        assertMasterAddress(getAddress(slave1), slave2);
         assertMemberViewsAreSame(getMemberMap(slave1), getMemberMap(slave2));
     }
 
@@ -176,8 +176,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, slave1);
         assertClusterSizeEventually(2, slave2);
 
-        assertMaster(getAddress(slave1), slave1);
-        assertMaster(getAddress(slave1), slave2);
+        assertMasterAddress(getAddress(slave1), slave1);
+        assertMasterAddress(getAddress(slave1), slave2);
         assertMemberViewsAreSame(getMemberMap(slave1), getMemberMap(slave2));
     }
 
@@ -221,8 +221,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, masterCandidate);
         assertClusterSizeEventually(2, slave2);
 
-        assertMaster(getAddress(masterCandidate), masterCandidate);
-        assertMaster(getAddress(masterCandidate), slave2);
+        assertMasterAddress(getAddress(masterCandidate), masterCandidate);
+        assertMasterAddress(getAddress(masterCandidate), slave2);
         assertMemberViewsAreSame(getMemberMap(masterCandidate), getMemberMap(slave2));
     }
 
@@ -257,8 +257,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, slave1);
         assertClusterSizeEventually(2, slave2);
 
-        assertMaster(getAddress(slave1), slave1);
-        assertMaster(getAddress(slave1), slave2);
+        assertMasterAddress(getAddress(slave1), slave1);
+        assertMasterAddress(getAddress(slave1), slave2);
         assertMemberViewsAreSame(getMemberMap(slave1), getMemberMap(slave2));
     }
 
@@ -500,9 +500,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(3, slave3);
 
         Address newMasterAddress = getAddress(slave1);
-        assertEquals(newMasterAddress, getNode(slave1).getMasterAddress());
-        assertEquals(newMasterAddress, getNode(slave2).getMasterAddress());
-        assertEquals(newMasterAddress, getNode(slave3).getMasterAddress());
+        assertMasterAddress(newMasterAddress, slave1);
+        assertMasterAddress(newMasterAddress, slave2);
+        assertMasterAddress(newMasterAddress, slave3);
     }
 
     @Test
@@ -557,10 +557,10 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(5, slave3);
 
         Address newMasterAddress = getAddress(slave1);
-        assertEquals(newMasterAddress, getNode(slave2).getMasterAddress());
-        assertEquals(newMasterAddress, getNode(slave3).getMasterAddress());
-        assertEquals(newMasterAddress, getNode(slave4).getMasterAddress());
-        assertEquals(newMasterAddress, getNode(slave5).getMasterAddress());
+        assertMasterAddress(newMasterAddress, slave2);
+        assertMasterAddress(newMasterAddress, slave3);
+        assertMasterAddress(newMasterAddress, slave4);
+        assertMasterAddress(newMasterAddress, slave5);
     }
 
     @Test
@@ -586,8 +586,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(1, slave1);
         assertClusterSizeEventually(1, slave2);
 
-        assertEquals(getAddress(slave1), getNode(slave1).getMasterAddress());
-        assertEquals(getAddress(slave2), getNode(slave2).getMasterAddress());
+        assertMasterAddress(getAddress(slave1), slave1);
+        assertMasterAddress(getAddress(slave2), slave2);
     }
 
     @Test
@@ -693,12 +693,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         // member2 will complete mastership claim, but member4 won't learn new member list
         dropOperationsFrom(member2, MEMBER_INFO_UPDATE);
         // member4 should accept member2 as master during mastership claim
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertMaster(getAddress(member2), member4);
-            }
-        });
+        assertMasterAddressEventually(getAddress(member2), member4);
         resetPacketFiltersFrom(member3);
         // member3 will be split when master claim timeouts
         assertClusterSizeEventually(1, member3);
@@ -743,12 +738,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         // member3 will complete mastership claim, but member4 won't learn new member list
         dropOperationsFrom(member3, MEMBER_INFO_UPDATE);
         // member4 should accept member3 as master during mastership claim
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertMaster(getAddress(member3), member4);
-            }
-        });
+        assertMasterAddressEventually(getAddress(member3), member4);
         resetPacketFiltersFrom(member2);
         // member2 will be split when master claim timeouts
         assertClusterSizeEventually(1, member2);
@@ -825,10 +815,6 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
     Collection<HazelcastInstance> getAllHazelcastInstances() {
         return factory.getAllHazelcastInstances();
-    }
-
-    static void assertMaster(Address masterAddress, HazelcastInstance instance) {
-        assertEquals(masterAddress, getNode(instance).getMasterAddress());
     }
 
     static void suspectMember(HazelcastInstance suspectingInstance, HazelcastInstance suspectedInstance) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -52,7 +52,6 @@ import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.EXPL
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.HEARTBEAT;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMBER_INFO_UPDATE;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.PROMOTE_LITE_MEMBER;
-import static com.hazelcast.internal.cluster.impl.MembershipFailureTest.assertMaster;
 import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.dropOperationsBetween;
 import static com.hazelcast.internal.cluster.impl.PacketFiltersUtil.dropOperationsFrom;
 import static org.hamcrest.Matchers.greaterThan;
@@ -311,12 +310,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         suspectMember(getNode(hz3), getNode(hz1));
         suspectMember(getNode(hz2), getNode(hz1));
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertMaster(getAddress(hz2), hz3);
-            }
-        });
+        assertMasterAddressEventually(getAddress(hz2), hz3);
 
         dropOperationsBetween(hz3, hz1, EXPLICIT_SUSPICION);
         try {

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -605,9 +605,9 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(cfg);
         HazelcastInstance instance3 = nodeFactory.newHazelcastInstance(cfg);
 
-        assertTrue(instance1.getCluster().getMembers().size() == 3);
-        assertTrue(instance2.getCluster().getMembers().size() == 3);
-        assertTrue(instance3.getCluster().getMembers().size() == 3);
+        assertClusterSize(3, instance1);
+        assertClusterSize(3, instance2);
+        assertClusterSize(3, instance3);
 
         IMap<Integer, Integer> map = instance1.getMap(MAP_NAME);
         int size = 100;
@@ -622,8 +622,8 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         instance1.shutdown();
         sleepSeconds(1);
 
-        assertTrue(instance2.getCluster().getMembers().size() == 2);
-        assertTrue(instance3.getCluster().getMembers().size() == 2);
+        assertClusterSize(2, instance2);
+        assertClusterSize(2, instance3);
 
         IMap<Integer, Integer> map2 = instance2.getMap(MAP_NAME);
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
@@ -165,8 +165,8 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
             Employee employee = new Employee(i, "name" + i % 100, "city" + (i % 100), i % 60, ((i & 1) == 1), (double) i);
             map.put(String.valueOf(i), employee);
         }
-        assertEquals(2, instance1.getCluster().getMembers().size());
-        assertEquals(2, instance2.getCluster().getMembers().size());
+        assertClusterSize(2, instance1);
+        assertClusterSize(2, instance2);
 
         map = instance2.getMap("employees");
         map.addIndex("name", false);
@@ -213,8 +213,8 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
             Employee employee = new Employee(i, "name" + i % 100, "city" + (i % 100), i % 60, ((i & 1) == 1), (double) i);
             map.put(String.valueOf(i), employee);
         }
-        assertEquals(2, instance1.getCluster().getMembers().size());
-        assertEquals(2, instance2.getCluster().getMembers().size());
+        assertClusterSize(2, instance1);
+        assertClusterSize(2, instance2);
 
         map = instance2.getMap("employees");
         map.addIndex("name", false);

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -186,10 +186,9 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
                 @Override
                 public void run()
                         throws Exception {
-
-                    assertEquals(3, hazelcastInstance1.getCluster().getMembers().size());
-                    assertEquals(3, hazelcastInstance2.getCluster().getMembers().size());
-                    assertEquals(3, hazelcastInstance3.getCluster().getMembers().size());
+                    assertClusterSize(3, hazelcastInstance1);
+                    assertClusterSize(3, hazelcastInstance2);
+                    assertClusterSize(3, hazelcastInstance3);
                 }
             });
         } finally {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -891,6 +891,51 @@ public abstract class HazelcastTestSupport {
         }, timeoutSeconds);
     }
 
+    public static void assertMasterAddress(HazelcastInstance master, HazelcastInstance instance) {
+        assertEquals(getAddress(master), getNode(instance).getMasterAddress());
+    }
+
+    public static void assertMasterAddressEventually(final HazelcastInstance master, final HazelcastInstance instance) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertMasterAddress(master, instance);
+            }
+        });
+    }
+
+    public static void assertMasterAddress(Address masterAddress, HazelcastInstance instance) {
+        assertEquals(masterAddress, getNode(instance).getMasterAddress());
+    }
+
+    public static void assertMasterAddressEventually(final Address masterAddress, final HazelcastInstance instance) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertMasterAddress(masterAddress, instance);
+            }
+        });
+    }
+
+    public static void assertClusterState(ClusterState expectedState, HazelcastInstance... instances) {
+        for (HazelcastInstance instance : instances) {
+            assertEquals("Instance " + instance.getCluster().getLocalMember(),
+                    expectedState, instance.getCluster().getClusterState());
+        }
+    }
+
+    public static void assertClusterStateEventually(final ClusterState expectedState, final HazelcastInstance... instances) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run()
+                    throws Exception {
+                assertClusterState(expectedState, instances);
+            }
+        });
+    }
+
     public static void assertOpenEventually(CountDownLatch latch) {
         assertOpenEventually(latch, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }


### PR DESCRIPTION
* Move cluster state / member list / master address assertions to HazelcastTestSupport
* Use new assertions provided in HazelcastTestSupport
* Add cluster size assertions in a few places in split brain test