### PR TITLE
Added NearCacheTestContextBuilder to ease NearCacheTestContext usage

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
@@ -35,6 +35,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -118,19 +119,16 @@ public class ClientCacheNearCacheBasicTest extends AbstractNearCacheBasicTest<Da
 
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(cacheNameWithPrefix);
 
-        return new NearCacheTestContext<K, V, Data, String>(
-                client.getSerializationService(),
-                client,
-                member,
-                new ICacheDataStructureAdapter<K, V>(clientCache),
-                new ICacheDataStructureAdapter<K, V>(memberCache),
-                nearCacheConfig,
-                false,
-                nearCache,
-                nearCacheManager,
-                cacheManager,
-                memberCacheManager
-        );
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
+                .setNearCacheInstance(client)
+                .setDataInstance(member)
+                .setNearCacheAdapter(new ICacheDataStructureAdapter<K, V>(clientCache))
+                .setDataAdapter(new ICacheDataStructureAdapter<K, V>(memberCache))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setCacheManager(cacheManager)
+                .setMemberCacheManager(memberCacheManager)
+                .build();
     }
 
     protected ClientConfig getClientConfig() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
@@ -34,6 +34,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -152,19 +153,16 @@ public class ClientCacheNearCacheSerializationCountTest extends AbstractNearCach
 
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(cacheNameWithPrefix);
 
-        return new NearCacheTestContext<K, V, Data, String>(
-                client.getSerializationService(),
-                client,
-                member,
-                new ICacheDataStructureAdapter<K, V>(clientCache),
-                new ICacheDataStructureAdapter<K, V>(memberCache),
-                nearCacheConfig,
-                false,
-                nearCache,
-                nearCacheManager,
-                cacheManager,
-                memberCacheManager
-        );
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
+                .setNearCacheInstance(client)
+                .setDataInstance(member)
+                .setNearCacheAdapter(new ICacheDataStructureAdapter<K, V>(clientCache))
+                .setDataAdapter(new ICacheDataStructureAdapter<K, V>(memberCache))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setCacheManager(cacheManager)
+                .setMemberCacheManager(memberCacheManager)
+                .build();
     }
 
     protected ClientConfig getClientConfig() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -99,17 +100,15 @@ public class ClientMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data
         NearCacheManager nearCacheManager = client.client.getNearCacheManager();
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
 
-        return new NearCacheTestContext<K, V, Data, String>(
-                client.getSerializationService(),
-                client,
-                member,
-                new IMapDataStructureAdapter<K, V>(clientMap),
-                new IMapDataStructureAdapter<K, V>(memberMap),
-                nearCacheConfig,
-                false,
-                nearCache,
-                nearCacheManager,
-                mapStore);
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
+                .setNearCacheInstance(client)
+                .setDataInstance(member)
+                .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(clientMap))
+                .setDataAdapter(new IMapDataStructureAdapter<K, V>(memberMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setLoader(mapStore)
+                .build();
     }
 
     protected ClientConfig getClientConfig() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -129,16 +130,14 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
         NearCacheManager nearCacheManager = client.client.getNearCacheManager();
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
 
-        return new NearCacheTestContext<K, V, Data, String>(
-                client.getSerializationService(),
-                client,
-                member,
-                new IMapDataStructureAdapter<K, V>(clientMap),
-                new IMapDataStructureAdapter<K, V>(memberMap),
-                nearCacheConfig,
-                false,
-                nearCache,
-                nearCacheManager);
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
+                .setNearCacheInstance(client)
+                .setDataInstance(member)
+                .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(clientMap))
+                .setDataAdapter(new IMapDataStructureAdapter<K, V>(memberMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .build();
     }
 
     protected ClientConfig getClientConfig() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheBasicTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
@@ -92,16 +93,14 @@ public class ClientReplicatedMapNearCacheBasicTest extends AbstractNearCacheBasi
 
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
 
-        return new NearCacheTestContext<K, V, Data, String>(
-                client.getSerializationService(),
-                client,
-                member,
-                new ReplicatedMapDataStructureAdapter<K, V>(clientMap),
-                new ReplicatedMapDataStructureAdapter<K, V>(memberMap),
-                nearCacheConfig,
-                false,
-                nearCache,
-                nearCacheManager);
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
+                .setNearCacheInstance(client)
+                .setDataInstance(member)
+                .setNearCacheAdapter(new ReplicatedMapDataStructureAdapter<K, V>(clientMap))
+                .setDataAdapter(new ReplicatedMapDataStructureAdapter<K, V>(memberMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .build();
     }
 
     protected ClientConfig getClientConfig() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
@@ -127,16 +128,14 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
 
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
 
-        return new NearCacheTestContext<K, V, Data, String>(
-                client.getSerializationService(),
-                client,
-                member,
-                new ReplicatedMapDataStructureAdapter<K, V>(clientMap),
-                new ReplicatedMapDataStructureAdapter<K, V>(memberMap),
-                nearCacheConfig,
-                false,
-                nearCache,
-                nearCacheManager);
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, client.getSerializationService())
+                .setNearCacheInstance(client)
+                .setDataInstance(member)
+                .setNearCacheAdapter(new ReplicatedMapDataStructureAdapter<K, V>(clientMap))
+                .setDataAdapter(new ReplicatedMapDataStructureAdapter<K, V>(memberMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .build();
     }
 
     protected ClientConfig getClientConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.hazelcast.internal.nearcache;
 
 import com.hazelcast.cache.impl.HazelcastServerCacheManager;
@@ -31,9 +32,14 @@ import javax.cache.CacheManager;
 public class NearCacheTestContext<K, V, NK, NV> {
 
     /**
+     * The {@link NearCacheConfig} of the configured Near Cache.
+     */
+    public final NearCacheConfig nearCacheConfig;
+    /**
      * The {@link SerializationService} used by the configured Near Cache.
      */
     public final SerializationService serializationService;
+
     /**
      * The {@link HazelcastInstance} which has the configured Near Cache.
      *
@@ -58,14 +64,6 @@ public class NearCacheTestContext<K, V, NK, NV> {
      * In a scenario with Hazelcast client and member, this will be the original data structure on the member.
      */
     public final DataStructureAdapter<K, V> dataAdapter;
-    /**
-     * The {@link NearCacheConfig} of the configured Near Cache.
-     */
-    public final NearCacheConfig nearCacheConfig;
-    /**
-     * Specifies if the we are able to retrieve {@link DataStructureAdapter#getLocalMapStats()}.
-     */
-    public final boolean hasLocalData;
 
     /**
      * The configured {@link NearCache}.
@@ -87,83 +85,35 @@ public class NearCacheTestContext<K, V, NK, NV> {
      * The {@link HazelcastServerCacheManager} if the configured {@link DataStructureAdapter} is a JCache implementation.
      */
     public final HazelcastServerCacheManager memberCacheManager;
+
+    /**
+     * Specifies if the we are able to retrieve {@link DataStructureAdapter#getLocalMapStats()}.
+     */
+    public final boolean hasLocalData;
     /**
      * The {@link DataStructureLoader} which manages
      */
     public final DataStructureLoader loader;
 
-    public NearCacheTestContext(SerializationService serializationService,
-                                HazelcastInstance nearCacheInstance,
-                                DataStructureAdapter<K, V> nearCacheAdapter,
-                                NearCacheConfig nearCacheConfig,
-                                boolean hasLocalData,
-                                NearCache<NK, NV> nearCache,
-                                NearCacheManager nearCacheManager) {
-        this(serializationService, nearCacheInstance, nearCacheInstance, nearCacheAdapter, nearCacheAdapter, nearCacheConfig,
-                hasLocalData, nearCache, nearCacheManager, null, null, null);
-    }
-
-    public NearCacheTestContext(SerializationService serializationService,
-                                HazelcastInstance nearCacheInstance,
-                                HazelcastInstance dataInstance,
-                                DataStructureAdapter<K, V> nearCacheAdapter,
-                                DataStructureAdapter<K, V> dataAdapter,
-                                NearCacheConfig nearCacheConfig,
-                                boolean hasLocalData,
-                                NearCache<NK, NV> nearCache,
-                                NearCacheManager nearCacheManager) {
-        this(serializationService, nearCacheInstance, dataInstance, nearCacheAdapter, dataAdapter, nearCacheConfig, hasLocalData,
-                nearCache, nearCacheManager, null, null, null);
-    }
-
-    public NearCacheTestContext(SerializationService serializationService,
-                                HazelcastInstance nearCacheInstance,
-                                HazelcastInstance dataInstance,
-                                DataStructureAdapter<K, V> nearCacheAdapter,
-                                DataStructureAdapter<K, V> dataAdapter,
-                                NearCacheConfig nearCacheConfig,
-                                boolean hasLocalData,
-                                NearCache<NK, NV> nearCache,
-                                NearCacheManager nearCacheManager,
-                                DataStructureLoader loader) {
-        this(serializationService, nearCacheInstance, dataInstance, nearCacheAdapter, dataAdapter, nearCacheConfig, hasLocalData,
-                nearCache, nearCacheManager, null, null, loader);
-    }
-
-    public NearCacheTestContext(SerializationService serializationService,
-                                HazelcastInstance nearCacheInstance,
-                                HazelcastInstance dataInstance,
-                                DataStructureAdapter<K, V> nearCacheAdapter,
-                                DataStructureAdapter<K, V> dataAdapter,
-                                NearCacheConfig nearCacheConfig,
-                                boolean hasLocalData,
-                                NearCache<NK, NV> nearCache,
-                                NearCacheManager nearCacheManager,
-                                CacheManager cacheManager,
-                                HazelcastServerCacheManager memberCacheManager) {
-        this(serializationService, nearCacheInstance, dataInstance, nearCacheAdapter, dataAdapter, nearCacheConfig, hasLocalData,
-                nearCache, nearCacheManager, cacheManager, memberCacheManager, null);
-    }
-
-    public NearCacheTestContext(SerializationService serializationService,
-                                HazelcastInstance nearCacheInstance,
-                                HazelcastInstance dataInstance,
-                                DataStructureAdapter<K, V> nearCacheAdapter,
-                                DataStructureAdapter<K, V> dataAdapter,
-                                NearCacheConfig nearCacheConfig,
-                                boolean hasLocalData,
-                                NearCache<NK, NV> nearCache,
-                                NearCacheManager nearCacheManager,
-                                CacheManager cacheManager,
-                                HazelcastServerCacheManager memberCacheManager,
-                                DataStructureLoader loader) {
+    NearCacheTestContext(NearCacheConfig nearCacheConfig,
+                         SerializationService serializationService,
+                         HazelcastInstance nearCacheInstance,
+                         HazelcastInstance dataInstance,
+                         DataStructureAdapter<K, V> nearCacheAdapter,
+                         DataStructureAdapter<K, V> dataAdapter,
+                         NearCache<NK, NV> nearCache,
+                         NearCacheManager nearCacheManager,
+                         CacheManager cacheManager,
+                         HazelcastServerCacheManager memberCacheManager,
+                         boolean hasLocalData,
+                         DataStructureLoader loader) {
+        this.nearCacheConfig = nearCacheConfig;
         this.serializationService = serializationService;
+
         this.nearCacheInstance = nearCacheInstance;
         this.dataInstance = dataInstance;
         this.nearCacheAdapter = nearCacheAdapter;
         this.dataAdapter = dataAdapter;
-        this.nearCacheConfig = nearCacheConfig;
-        this.hasLocalData = hasLocalData;
 
         this.nearCache = nearCache;
         this.stats = (nearCache == null) ? null : nearCache.getNearCacheStats();
@@ -171,6 +121,7 @@ public class NearCacheTestContext<K, V, NK, NV> {
         this.cacheManager = cacheManager;
         this.memberCacheManager = memberCacheManager;
 
+        this.hasLocalData = hasLocalData;
         this.loader = loader;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.nearcache;
+
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.adapter.DataStructureAdapter;
+import com.hazelcast.internal.adapter.DataStructureLoader;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import javax.cache.CacheManager;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Builder for {@link NearCacheTestContext}.
+ */
+public class NearCacheTestContextBuilder<K, V, NK, NV> {
+
+    private NearCacheConfig nearCacheConfig;
+    private SerializationService serializationService;
+
+    private HazelcastInstance nearCacheInstance;
+    private HazelcastInstance dataInstance;
+    private DataStructureAdapter<K, V> nearCacheAdapter;
+    private DataStructureAdapter<K, V> dataAdapter;
+
+    private NearCache<NK, NV> nearCache;
+    private NearCacheManager nearCacheManager;
+    private CacheManager cacheManager;
+    private HazelcastServerCacheManager memberCacheManager;
+
+    private boolean hasLocalData;
+    private DataStructureLoader loader;
+
+    public NearCacheTestContextBuilder(NearCacheConfig nearCacheConfig, SerializationService serializationService) {
+        this.nearCacheConfig = nearCacheConfig;
+        this.serializationService = serializationService;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setNearCacheInstance(HazelcastInstance nearCacheInstance) {
+        this.nearCacheInstance = nearCacheInstance;
+        return this;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setDataInstance(HazelcastInstance dataInstance) {
+        this.dataInstance = dataInstance;
+        return this;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setNearCacheAdapter(DataStructureAdapter<K, V> nearCacheAdapter) {
+        this.nearCacheAdapter = nearCacheAdapter;
+        return this;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setDataAdapter(DataStructureAdapter<K, V> dataAdapter) {
+        this.dataAdapter = dataAdapter;
+        return this;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setNearCache(NearCache<NK, NV> nearCache) {
+        this.nearCache = nearCache;
+        return this;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setNearCacheManager(NearCacheManager nearCacheManager) {
+        this.nearCacheManager = nearCacheManager;
+        return this;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setCacheManager(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+        return this;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setMemberCacheManager(HazelcastServerCacheManager memberCacheManager) {
+        this.memberCacheManager = memberCacheManager;
+        return this;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setHasLocalData(boolean hasLocalData) {
+        this.hasLocalData = hasLocalData;
+        return this;
+    }
+
+    public NearCacheTestContextBuilder<K, V, NK, NV> setLoader(DataStructureLoader loader) {
+        this.loader = loader;
+        return this;
+    }
+
+    public NearCacheTestContext<K, V, NK, NV> build() {
+        checkNotNull(serializationService, "serializationService cannot be null!");
+
+        assertNotEquals("nearCacheInstance and dataInstance have to be different instances", nearCacheInstance, dataInstance);
+        assertNotEquals("nearCacheAdapter and dataAdapter have to be different instances", nearCacheAdapter, dataAdapter);
+
+        return new NearCacheTestContext<K, V, NK, NV>(
+                nearCacheConfig,
+                serializationService,
+                nearCacheInstance,
+                dataInstance,
+                nearCacheAdapter,
+                dataAdapter,
+                nearCache,
+                nearCacheManager,
+                cacheManager,
+                memberCacheManager,
+                hasLocalData,
+                loader);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheBasicTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -92,17 +93,15 @@ public class LiteMemberMapNearCacheBasicTest extends AbstractNearCacheBasicTest<
         NearCacheManager nearCacheManager = getMapNearCacheManager(liteMember);
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
 
-        return new NearCacheTestContext<K, V, Data, String>(
-                getSerializationService(member),
-                liteMember,
-                member,
-                new IMapDataStructureAdapter<K, V>(liteMemberMap),
-                new IMapDataStructureAdapter<K, V>(memberMap),
-                nearCacheConfig,
-                true,
-                nearCache,
-                nearCacheManager,
-                mapStore);
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(member))
+                .setNearCacheInstance(liteMember)
+                .setDataInstance(member)
+                .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(liteMemberMap))
+                .setDataAdapter(new IMapDataStructureAdapter<K, V>(memberMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setLoader(mapStore)
+                .build();
     }
 
     protected Config createConfig(NearCacheConfig nearCacheConfig, IMapMapStore mapStore, boolean liteMember) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheBasicTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -107,17 +108,16 @@ public class MapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, Stri
         NearCacheManager nearCacheManager = getMapNearCacheManager(nearCacheInstance);
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
 
-        return new NearCacheTestContext<K, V, Data, String>(
-                getSerializationService(nearCacheInstance),
-                nearCacheInstance,
-                dataInstance,
-                new IMapDataStructureAdapter<K, V>(nearCacheMap),
-                new IMapDataStructureAdapter<K, V>(dataMap),
-                nearCacheConfig,
-                true,
-                nearCache,
-                nearCacheManager,
-                mapStore);
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(nearCacheInstance))
+                .setNearCacheInstance(nearCacheInstance)
+                .setDataInstance(dataInstance)
+                .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(nearCacheMap))
+                .setDataAdapter(new IMapDataStructureAdapter<K, V>(dataMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setLoader(mapStore)
+                .setHasLocalData(true)
+                .build();
     }
 
     public static void addMapStoreConfig(IMapMapStore mapStore, MapConfig mapConfig) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheSerializationCountTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -68,7 +69,7 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
     @Parameter(value = 3)
     public InMemoryFormat nearCacheInMemoryFormat;
 
-    private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory(2);
+    private final TestHazelcastInstanceFactory hazelcastFactory = createHazelcastInstanceFactory();
 
     @Parameters(name = "mapFormat:{2} nearCacheFormat:{3}")
     public static Collection<Object[]> parameters() {
@@ -108,30 +109,39 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
 
     @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
+        Config configWithNearCache = getConfig(true);
+        Config config = getConfig(false);
+
+        HazelcastInstance nearCacheMember = hazelcastFactory.newHazelcastInstance(configWithNearCache);
+        HazelcastInstance dataMember = hazelcastFactory.newHazelcastInstance(config);
+
+        IMap<K, V> nearCacheMap = nearCacheMember.getMap(DEFAULT_NEAR_CACHE_NAME);
+        IMap<K, V> dataMap = dataMember.getMap(DEFAULT_NEAR_CACHE_NAME);
+
+        NearCacheManager nearCacheManager = getMapNearCacheManager(dataMember);
+        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
+
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(dataMember))
+                .setNearCacheInstance(nearCacheMember)
+                .setDataInstance(dataMember)
+                .setNearCacheAdapter(new IMapDataStructureAdapter<K, V>(nearCacheMap))
+                .setDataAdapter(new IMapDataStructureAdapter<K, V>(dataMap))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .setHasLocalData(true)
+                .build();
+    }
+
+    private Config getConfig(boolean withNearCache) {
         Config config = getConfig();
         MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
                 .setInMemoryFormat(mapInMemoryFormat)
                 .setBackupCount(0)
                 .setAsyncBackupCount(0);
-        if (nearCacheConfig != null) {
+        if (withNearCache && nearCacheConfig != null) {
             mapConfig.setNearCacheConfig(nearCacheConfig);
         }
         prepareSerializationConfig(config.getSerializationConfig());
-
-        HazelcastInstance[] instances = hazelcastFactory.newInstances(config);
-        HazelcastInstance member = instances[0];
-        IMap<K, V> map = member.getMap(DEFAULT_NEAR_CACHE_NAME);
-
-        NearCacheManager nearCacheManager = getMapNearCacheManager(member);
-        NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
-
-        return new NearCacheTestContext<K, V, Data, String>(
-                getSerializationService(member),
-                member,
-                new IMapDataStructureAdapter<K, V>(map),
-                nearCacheConfig,
-                true,
-                nearCache,
-                nearCacheManager);
+        return config;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheBasicTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.nearcache.AbstractNearCacheBasicTest;
 import com.hazelcast.internal.nearcache.NearCache;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
+import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -102,17 +103,14 @@ public class TxnMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, S
         NearCacheManager nearCacheManager = getMapNearCacheManager(nearCacheInstance);
         NearCache<Data, String> nearCache = nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME);
 
-        return new NearCacheTestContext<K, V, Data, String>(
-                getSerializationService(nearCacheInstance),
-                nearCacheInstance,
-                dataInstance,
-                new TransactionalMapDataStructureAdapter<K, V>(nearCacheInstance, DEFAULT_NEAR_CACHE_NAME),
-                new TransactionalMapDataStructureAdapter<K, V>(dataInstance, DEFAULT_NEAR_CACHE_NAME),
-                nearCacheConfig,
-                false,
-                nearCache,
-                nearCacheManager,
-                null);
+        return new NearCacheTestContextBuilder<K, V, Data, String>(nearCacheConfig, getSerializationService(nearCacheInstance))
+                .setNearCacheInstance(nearCacheInstance)
+                .setDataInstance(dataInstance)
+                .setNearCacheAdapter(new TransactionalMapDataStructureAdapter<K, V>(nearCacheInstance, DEFAULT_NEAR_CACHE_NAME))
+                .setDataAdapter(new TransactionalMapDataStructureAdapter<K, V>(dataInstance, DEFAULT_NEAR_CACHE_NAME))
+                .setNearCache(nearCache)
+                .setNearCacheManager(nearCacheManager)
+                .build();
     }
 
     /**


### PR DESCRIPTION
* added builder for `NearCacheTestContext` and changed all tests to use it
* created distinct configurations with and without Near Cache for the
  remaining serialization count tests

The `NearCacheTestContext` gets more and more fields which are not set in all tested scenarios. So we are getting more and more specialized constructors or `null` fields. This PR cleans this up by using the builder pattern.

I also created distinct configurations for the last tests which used the same config (or even same instance) for the `NearCacheTestContext` creation.