### PR TITLE
Added Near Cache invalidation listeners for unified test

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -29,7 +29,6 @@ import com.hazelcast.client.impl.protocol.codec.CacheAddNearCacheInvalidationLis
 import com.hazelcast.client.impl.protocol.codec.CacheRemoveEntryListenerCodec;
 import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientContext;
-import com.hazelcast.client.spi.ClientListenerService;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
@@ -454,16 +453,17 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
         }
     }
 
+    public String addNearCacheInvalidationListener(EventHandler eventHandler) {
+        return registerListener(createInvalidationListenerCodec(), eventHandler);
+    }
+
     private void registerInvalidationListener() {
         if (!invalidateOnChange) {
             return;
         }
 
-        ListenerMessageCodec listenerCodec = createInvalidationListenerCodec();
-        ClientListenerService listenerService = getContext().getListenerService();
-
         EventHandler eventHandler = createInvalidationEventHandler();
-        nearCacheMembershipRegistrationId = listenerService.registerListener(listenerCodec, eventHandler);
+        nearCacheMembershipRegistrationId = addNearCacheInvalidationListener(eventHandler);
     }
 
     private EventHandler createInvalidationEventHandler() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -102,7 +102,7 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         nearCache = nearCacheManager.getOrCreateNearCache(name, nearCacheConfig, adapter);
 
         if (nearCacheConfig.isInvalidateOnChange()) {
-            addNearCacheInvalidationListener(new ConnectedServerVersionAwareNearCacheEventHandler());
+            registerInvalidationListener();
         }
     }
 
@@ -541,9 +541,13 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
         }
     }
 
-    public void addNearCacheInvalidationListener(EventHandler handler) {
+    public String addNearCacheInvalidationListener(EventHandler handler) {
+        return registerListener(createNearCacheEntryListenerCodec(), handler);
+    }
+
+    private void registerInvalidationListener() {
         try {
-            invalidationListenerId = registerListener(createNearCacheEntryListenerCodec(), handler);
+            invalidationListenerId = addNearCacheInvalidationListener(new ConnectedServerVersionAwareNearCacheEventHandler());
         } catch (Exception e) {
             ILogger logger = getContext().getLoggingService().getLogger(getClass());
             logger.severe("-----------------\nNear Cache is not initialized!\n-----------------", e);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.cache.impl.NearCachedClientCacheProxy;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.CacheAddNearCacheInvalidationListenerCodec;
+import com.hazelcast.client.spi.EventHandler;
+import com.hazelcast.internal.nearcache.InvalidationListener;
+import com.hazelcast.nio.serialization.Data;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+class ClientCacheInvalidationListener
+        extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler
+        implements InvalidationListener, EventHandler<ClientMessage> {
+
+    private final AtomicLong invalidationCount = new AtomicLong();
+
+    @Override
+    public long getInvalidationCount() {
+        return invalidationCount.get();
+    }
+
+    @Override
+    public void resetInvalidationCount() {
+        invalidationCount.set(0);
+    }
+
+    @Override
+    public void handle(String name, Data key, String sourceUuid, UUID partitionUuid, long sequence) {
+        invalidationCount.addAndGet(1);
+    }
+
+    @Override
+    public void handle(String name, Collection<Data> keys, Collection<String> sourceUuids,
+                       Collection<UUID> partitionUuids, Collection<Long> sequences) {
+        invalidationCount.addAndGet(keys.size());
+    }
+
+    @Override
+    public void beforeListenerRegister() {
+    }
+
+    @Override
+    public void onListenerRegister() {
+    }
+
+    static InvalidationListener createInvalidationEventHandler(ICache clientCache) {
+        EventHandler invalidationListener = new ClientCacheInvalidationListener();
+        ((NearCachedClientCacheProxy) clientCache).addNearCacheInvalidationListener(invalidationListener);
+
+        return (InvalidationListener) invalidationListener;
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
@@ -128,6 +128,9 @@ public class ClientCacheNearCacheBasicTest extends AbstractNearCacheBasicTest<Da
                 .setNearCacheManager(nearCacheManager)
                 .setCacheManager(cacheManager)
                 .setMemberCacheManager(memberCacheManager)
+                // FIXME: the JCache doesn't send invalidation on CREATED entries, so this will crash some tests
+                // see AbstractCacheRecordStore.doPutRecord()
+                //.setInvalidationListener(createInvalidationEventHandler(clientCache))
                 .build();
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapInvalidationListener.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.MapAddNearCacheInvalidationListenerCodec;
+import com.hazelcast.client.proxy.NearCachedClientMapProxy;
+import com.hazelcast.client.spi.EventHandler;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.nearcache.InvalidationListener;
+import com.hazelcast.nio.serialization.Data;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+class ClientMapInvalidationListener
+        extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler
+        implements InvalidationListener, EventHandler<ClientMessage> {
+
+    private final AtomicLong invalidationCount = new AtomicLong();
+
+    @Override
+    public long getInvalidationCount() {
+        return invalidationCount.get();
+    }
+
+    @Override
+    public void resetInvalidationCount() {
+        invalidationCount.set(0);
+    }
+
+    @Override
+    public void handle(Data key, String sourceUuid, UUID partitionUuid, long sequence) {
+        invalidationCount.addAndGet(1);
+    }
+
+    @Override
+    public void handle(Collection<Data> keys, Collection<String> sourceUuids,
+                       Collection<UUID> partitionUuids, Collection<Long> sequences) {
+        invalidationCount.addAndGet(keys.size());
+    }
+
+    @Override
+    public void beforeListenerRegister() {
+    }
+
+    @Override
+    public void onListenerRegister() {
+    }
+
+    static InvalidationListener createInvalidationEventHandler(IMap clientMap) {
+        InvalidationListener invalidationListener = new ClientMapInvalidationListener();
+        ((NearCachedClientMapProxy) clientMap).addNearCacheInvalidationListener((EventHandler) invalidationListener);
+
+        return invalidationListener;
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
@@ -45,6 +45,7 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
+import static com.hazelcast.client.map.impl.nearcache.ClientMapInvalidationListener.createInvalidationEventHandler;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.map.impl.nearcache.MapNearCacheBasicTest.addMapStoreConfig;
 import static java.util.Arrays.asList;
@@ -108,6 +109,7 @@ public class ClientMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data
                 .setNearCache(nearCache)
                 .setNearCacheManager(nearCacheManager)
                 .setLoader(mapStore)
+                .setInvalidationListener(createInvalidationEventHandler(clientMap))
                 .build();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -55,6 +55,7 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getFromNearCac
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getFuture;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.isCacheOnUpdate;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.setEvictionConfig;
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.assertNearCacheInvalidations;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.waitUntilLoaded;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.warmupPartitionsAndWaitForAllSafeState;
 import static java.lang.String.format;
@@ -116,8 +117,8 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
      * Creates the {@link NearCacheTestContext} used by the Near Cache tests.
      *
      * @param loaderEnabled determines if a loader should be configured
-     * @param <K>        key type of the created {@link DataStructureAdapter}
-     * @param <V>        value type of the created {@link DataStructureAdapter}
+     * @param <K>           key type of the created {@link DataStructureAdapter}
+     * @param <V>           value type of the created {@link DataStructureAdapter}
      * @return a {@link NearCacheTestContext} used by the Near Cache tests
      */
     protected abstract <K, V> NearCacheTestContext<K, V, NK, NV> createContext(boolean loaderEnabled);
@@ -126,6 +127,7 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             context.dataAdapter.put(i, "value-" + i);
         }
+        assertNearCacheInvalidations(context, DEFAULT_RECORD_COUNT, nearCacheConfig);
     }
 
     protected final void populateNearCache(NearCacheTestContext<Integer, String, NK, NV> context) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/InvalidationListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/InvalidationListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.nearcache;
+
+/**
+ * Listener for Near Cache invalidations.
+ */
+public interface InvalidationListener {
+
+    long getInvalidationCount();
+
+    void resetInvalidationCount();
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContext.java
@@ -91,9 +91,13 @@ public class NearCacheTestContext<K, V, NK, NV> {
      */
     public final boolean hasLocalData;
     /**
-     * The {@link DataStructureLoader} which manages
+     * The {@link DataStructureLoader} which loads entries into the data structure.
      */
     public final DataStructureLoader loader;
+    /**
+     * The {@link InvalidationListener} which monitors invalidation events.
+     */
+    public final InvalidationListener invalidationListener;
 
     NearCacheTestContext(NearCacheConfig nearCacheConfig,
                          SerializationService serializationService,
@@ -106,7 +110,8 @@ public class NearCacheTestContext<K, V, NK, NV> {
                          CacheManager cacheManager,
                          HazelcastServerCacheManager memberCacheManager,
                          boolean hasLocalData,
-                         DataStructureLoader loader) {
+                         DataStructureLoader loader,
+                         InvalidationListener invalidationListener) {
         this.nearCacheConfig = nearCacheConfig;
         this.serializationService = serializationService;
 
@@ -123,5 +128,6 @@ public class NearCacheTestContext<K, V, NK, NV> {
 
         this.hasLocalData = hasLocalData;
         this.loader = loader;
+        this.invalidationListener = invalidationListener;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestContextBuilder.java
@@ -48,6 +48,7 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> {
 
     private boolean hasLocalData;
     private DataStructureLoader loader;
+    private InvalidationListener invalidationListener;
 
     public NearCacheTestContextBuilder(NearCacheConfig nearCacheConfig, SerializationService serializationService) {
         this.nearCacheConfig = nearCacheConfig;
@@ -104,6 +105,11 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> {
         return this;
     }
 
+    public NearCacheTestContextBuilder<K, V, NK, NV> setInvalidationListener(InvalidationListener invalidationListener) {
+        this.invalidationListener = invalidationListener;
+        return this;
+    }
+
     public NearCacheTestContext<K, V, NK, NV> build() {
         checkNotNull(serializationService, "serializationService cannot be null!");
 
@@ -122,6 +128,7 @@ public class NearCacheTestContextBuilder<K, V, NK, NV> {
                 cacheManager,
                 memberCacheManager,
                 hasLocalData,
-                loader);
+                loader,
+                invalidationListener);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -230,6 +230,27 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
     }
 
     /**
+     * Asserts the number of Near Cache invalidations.
+     *
+     * @param context         the given {@link NearCacheTestContext} to retrieve the {@link InvalidationListener} from
+     * @param invalidations   the given number of Near Cache invalidations to wait for
+     * @param nearCacheConfig the {@link NearCacheConfig} to check if invalidations are enabled
+     */
+    public static void assertNearCacheInvalidations(final NearCacheTestContext<?, ?, ?, ?> context, final int invalidations,
+                                                    NearCacheConfig nearCacheConfig) {
+        if (context.invalidationListener != null && invalidations > 0 && nearCacheConfig.isInvalidateOnChange()) {
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run() throws Exception {
+                    assertEqualsFormat("Expected %d Near Cache invalidations, but found %d (%s)",
+                            invalidations, context.invalidationListener.getInvalidationCount(), context.stats);
+                }
+            });
+            context.invalidationListener.resetInvalidationCount();
+        }
+    }
+
+    /**
      * Asserts the number of evicted entries of a {@link NearCache}.
      *
      * @param context       the {@link NearCacheTestContext} to retrieve the eviction count from


### PR DESCRIPTION
There was a race between the data structure population, which can create
invalidation events and the Near Cache population. If the Near Cache is
populated faster than the invalidations batches are sent or processed,
the Near Cache entries are invalidated and the `assertNearCacheSize()`
check fails.

Depends on https://github.com/hazelcast/hazelcast/pull/10524
Fixes https://github.com/hazelcast/hazelcast/issues/10389