### PR TITLE
Fixed missing Near Cache invalidations on ICache.put() for new entries

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/ClientNearCacheInvalidationTest.java
@@ -35,6 +35,7 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheInvalidationListener;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.AssertTask;
@@ -56,6 +57,7 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.client.cache.nearcache.ClientCacheInvalidationListener.createInvalidationEventHandler;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -136,9 +138,10 @@ public class ClientNearCacheInvalidationTest extends HazelcastTestSupport {
 
         NearCache<Object, String> nearCache = nearCacheManager.getNearCache(
                 cacheManager.getCacheNameWithPrefix(DEFAULT_CACHE_NAME));
+        NearCacheInvalidationListener invalidationListener = createInvalidationEventHandler(cache);
 
         testContext = new NearCacheTestContext(client, member, cacheManager, memberCacheManager, nearCacheManager, cache,
-                memberCache, nearCache);
+                memberCache, nearCache, invalidationListener);
 
         // make sure several partitions are populated with data
         for (int i = 0; i < 1000; i++) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/NearCacheTestContext.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/nearcache/NearCacheTestContext.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.cache.impl.HazelcastClientCacheManager;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nearcache.NearCache;
+import com.hazelcast.internal.nearcache.NearCacheInvalidationListener;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.spi.serialization.SerializationService;
 
@@ -38,10 +39,11 @@ public class NearCacheTestContext {
     protected final ICache<Object, String> cache;
     protected final ICache<Object, String> memberCache;
     protected final NearCache<Object, String> nearCache;
+    protected final NearCacheInvalidationListener invalidationListener;
 
     NearCacheTestContext(HazelcastClientProxy client, HazelcastClientCacheManager cacheManager,
                          NearCacheManager nearCacheManager, ICache<Object, String> cache,
-                         NearCache<Object, String> nearCache) {
+                         NearCache<Object, String> nearCache, NearCacheInvalidationListener invalidationListener) {
         this.client = client;
         this.member = null;
         this.serializationService = client.getSerializationService();
@@ -51,13 +53,14 @@ public class NearCacheTestContext {
         this.cache = cache;
         this.memberCache = null;
         this.nearCache = nearCache;
+        this.invalidationListener = invalidationListener;
     }
 
     NearCacheTestContext(HazelcastClientProxy client, HazelcastInstance member,
                          HazelcastClientCacheManager cacheManager, HazelcastServerCacheManager memberCacheManager,
                          NearCacheManager nearCacheManager,
                          ICache<Object, String> cache, ICache<Object, String> memberCache,
-                         NearCache<Object, String> nearCache) {
+                         NearCache<Object, String> nearCache, NearCacheInvalidationListener invalidationListener) {
         this.client = client;
         this.member = member;
         this.serializationService = client.getSerializationService();
@@ -67,5 +70,6 @@ public class NearCacheTestContext {
         this.cache = cache;
         this.memberCache = memberCache;
         this.nearCache = nearCache;
+        this.invalidationListener = invalidationListener;
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheInvalidationListener.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
-class ClientCacheInvalidationListener
+public class ClientCacheInvalidationListener
         extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler
         implements NearCacheInvalidationListener, EventHandler<ClientMessage> {
 
@@ -63,7 +63,7 @@ class ClientCacheInvalidationListener
     public void onListenerRegister() {
     }
 
-    static NearCacheInvalidationListener createInvalidationEventHandler(ICache clientCache) {
+    public static NearCacheInvalidationListener createInvalidationEventHandler(ICache clientCache) {
         EventHandler invalidationListener = new ClientCacheInvalidationListener();
         ((NearCachedClientCacheProxy) clientCache).addNearCacheInvalidationListener(invalidationListener);
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
@@ -57,6 +57,7 @@ import javax.cache.configuration.FactoryBuilder;
 import javax.cache.spi.CachingProvider;
 import java.util.Collection;
 
+import static com.hazelcast.client.cache.nearcache.ClientCacheInvalidationListener.createInvalidationEventHandler;
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
@@ -143,9 +144,7 @@ public class ClientCacheNearCacheBasicTest extends AbstractNearCacheBasicTest<Da
                 .setNearCacheManager(nearCacheManager)
                 .setCacheManager(cacheManager)
                 .setMemberCacheManager(memberCacheManager)
-                // FIXME: the JCache doesn't send invalidation on CREATED entries, so this will crash some tests
-                // see AbstractCacheRecordStore.doPutRecord()
-                //.setInvalidationListener(createInvalidationEventHandler(clientCache))
+                .setInvalidationListener(createInvalidationEventHandler(clientCache))
                 .build();
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
@@ -54,6 +54,7 @@ import java.io.File;
 import java.util.Collection;
 
 import static com.hazelcast.cache.CacheUtil.getDistributedObjectName;
+import static com.hazelcast.client.cache.nearcache.ClientCacheInvalidationListener.createInvalidationEventHandler;
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
@@ -193,9 +194,6 @@ public class ClientCacheNearCachePreloaderTest extends AbstractNearCachePreloade
                 .setNearCache(nearCache)
                 .setNearCacheManager(nearCacheManager)
                 .setCacheManager(cacheManager)
-                // FIXME: the JCache doesn't send invalidation on CREATED entries, so this will crash some tests
-                // see AbstractCacheRecordStore.doPutRecord()
-                //.setInvalidationListener(createInvalidationEventHandler(clientCache))
-                ;
+                .setInvalidationListener(createInvalidationEventHandler(clientCache));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -541,7 +541,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                              boolean disableWriteThrough, int completionId, String origin) {
         R record = createRecord(value, now, expiryTime);
         try {
-            doPutRecord(key, record);
+            doPutRecord(key, record, origin);
         } catch (Throwable error) {
             onCreateRecordError(key, value, expiryTime, now, disableWriteThrough,
                     completionId, origin, record, error);
@@ -913,10 +913,10 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         if (oldRecord != null) {
             cacheService.eventJournal.writeUpdateEvent(
                     objectNamespace, partitionId, key, oldRecord.getValue(), record.getValue());
-            invalidateEntry(key, source);
         } else {
             cacheService.eventJournal.writeCreatedEvent(objectNamespace, partitionId, key, record.getValue());
         }
+        invalidateEntry(key, source);
         return oldRecord;
     }
 
@@ -1018,7 +1018,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
             // not be added to the cache or listeners called or writers called.
             if (record == null || isExpired) {
                 isOnNewPut = true;
-                record = createRecordWithExpiry(key, value, expiryPolicy, now, disableWriteThrough, completionId);
+                record = createRecordWithExpiry(key, value, expiryPolicy, now, disableWriteThrough, completionId, source);
                 isSaveSucceed = record != null;
             } else {
                 if (getValue) {
@@ -1076,7 +1076,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         try {
             if (record == null || isExpired) {
                 saved = createRecordWithExpiry(key, value, expiryPolicy, now,
-                        disableWriteThrough, completionId) != null;
+                        disableWriteThrough, completionId, source) != null;
             } else {
                 if (isEventsEnabled()) {
                     publishEvent(createCacheCompleteEvent(toEventData(key), completionId));

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestUtils.java
@@ -308,16 +308,30 @@ public final class NearCacheTestUtils extends HazelcastTestSupport {
      * @param context       the given {@link NearCacheTestContext} to retrieve the {@link NearCacheInvalidationListener} from
      * @param invalidations the given number of Near Cache invalidations to wait for
      */
-    public static void assertNearCacheInvalidations(final NearCacheTestContext<?, ?, ?, ?> context, final int invalidations) {
+    public static void assertNearCacheInvalidations(NearCacheTestContext<?, ?, ?, ?> context, int invalidations) {
         if (context.nearCacheConfig.isInvalidateOnChange() && context.invalidationListener != null && invalidations > 0) {
+            assertNearCacheInvalidations(context.invalidationListener, invalidations, context.stats);
+        }
+    }
+
+    /**
+     * Asserts the number of Near Cache invalidations.
+     *
+     * @param listener      the given {@link NearCacheInvalidationListener}
+     * @param invalidations the given number of Near Cache invalidations to wait for
+     * @param stats         the given {@link NearCacheStats} for the assert message
+     */
+    public static void assertNearCacheInvalidations(final NearCacheInvalidationListener listener, final int invalidations,
+                                                    final NearCacheStats stats) {
+        if (listener != null && invalidations > 0) {
             assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     assertEqualsFormat("Expected %d Near Cache invalidations, but found %d (%s)",
-                            invalidations, context.invalidationListener.getInvalidationCount(), context.stats);
+                            invalidations, listener.getInvalidationCount(), stats);
                 }
             });
-            context.invalidationListener.resetInvalidationCount();
+            listener.resetInvalidationCount();
         }
     }
 


### PR DESCRIPTION
While fixing the race between Near Cache invalidations and Near Cache population I found out, that `JCache` doesn't send invalidation events on created entries (which `IMap` and `ReplicatedMap` do). This PR adds the missing invalidations to `JCache` and activates the assertion for the invalidations (via an invalidation listener).

It also adds the `NearCacheInvalidationListener` to the `NearCacheTestContext` and tests, so there are no race conditions in the JCache Near Cache tests.