### PR TITLE
Clean up cluster-related assertions in tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -89,8 +89,7 @@ public class ClientSplitBrainTest extends HazelcastTestSupport {
         closeConnectionBetween(h2, h1);
 
         assertOpenEventually(mergedLatch);
-        assertClusterSize(2, h1);
-        assertClusterSize(2, h2);
+        assertClusterSize(2, h1, h2);
 
         AtomicBoolean testFinished = new AtomicBoolean(false);
         final Thread clientThread = startClientPutThread(mapClient, testFinished);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ConnectedClientOperationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ConnectedClientOperationTest.java
@@ -54,8 +54,7 @@ public class ConnectedClientOperationTest extends HazelcastTestSupport {
     public void testNumberOfConnectedClients() throws Exception {
         HazelcastInstance h1 = factory.newHazelcastInstance();
         HazelcastInstance h2 = factory.newHazelcastInstance();
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSize(2, h1, h2);
 
         int numberOfClients = 6;
         for (int i = 0; i < numberOfClients; i++) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientListSetMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientListSetMapReduceTest.java
@@ -60,9 +60,8 @@ public class ClientListSetMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
@@ -98,9 +97,8 @@ public class ClientListSetMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMapReduceTest.java
@@ -85,9 +85,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -118,9 +117,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -152,9 +150,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -182,9 +179,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -219,9 +215,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -250,9 +245,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -277,9 +271,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -305,9 +298,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -341,9 +333,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -388,9 +379,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -435,9 +425,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -489,9 +478,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -542,9 +530,8 @@ public class ClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         IMap<Integer, Integer> m1 = client.getMap(randomString());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMultiMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ClientMultiMapReduceTest.java
@@ -85,9 +85,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -118,9 +117,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -152,9 +150,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -182,9 +179,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -219,9 +215,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -250,9 +245,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -277,9 +271,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -305,9 +298,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -341,9 +333,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -388,9 +379,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -435,9 +425,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -489,9 +478,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -542,9 +530,8 @@ public class ClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMapReduceTest.java
@@ -82,9 +82,8 @@ public class DistributedMapperClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -119,9 +118,8 @@ public class DistributedMapperClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -155,9 +153,8 @@ public class DistributedMapperClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
         IMap<Integer, Integer> m1 = client.getMap(randomString());
@@ -212,9 +209,8 @@ public class DistributedMapperClientMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
         IMap<Integer, Integer> m1 = client.getMap(randomString());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMultiMapReduceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/DistributedMapperClientMultiMapReduceTest.java
@@ -82,9 +82,8 @@ public class DistributedMapperClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -119,9 +118,8 @@ public class DistributedMapperClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -155,9 +153,8 @@ public class DistributedMapperClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());
@@ -212,9 +209,8 @@ public class DistributedMapperClientMultiMapReduceTest
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(config);
         HazelcastInstance h3 = hazelcastFactory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(null);
         MultiMap<Integer, Integer> m1 = client.getMultiMap(randomString());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ListSetMapReduceLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/ListSetMapReduceLiteMemberTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -48,10 +49,8 @@ public class ListSetMapReduceLiteMemberTest {
         final HazelcastInstance instance1 = factory.newHazelcastInstance();
         final HazelcastInstance instance2 = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(4, lite);
-        assertClusterSizeEventually(4, lite2);
-        assertClusterSizeEventually(4, instance1);
-        assertClusterSizeEventually(4, instance2);
+        assertClusterSize(4, lite, instance2);
+        assertClusterSizeEventually(4, lite2, instance1);
 
         client = factory.newHazelcastClient();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/MapReduceLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/MapReduceLiteMemberTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -64,10 +65,8 @@ public class MapReduceLiteMemberTest {
         instance = factory.newHazelcastInstance();
         instance2 = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(4, lite);
-        assertClusterSizeEventually(4, lite2);
-        assertClusterSizeEventually(4, instance);
-        assertClusterSizeEventually(4, instance2);
+        assertClusterSize(4, lite, instance2);
+        assertClusterSizeEventually(4, lite2, instance);
 
         client = factory.newHazelcastClient();
     }
@@ -111,8 +110,7 @@ public class MapReduceLiteMemberTest {
     public void testMapReduceJobSubmissionWithNoDataNode() throws Exception {
         instance.getLifecycleService().terminate();
         instance2.getLifecycleService().terminate();
-        assertClusterSizeEventually(2, lite);
-        assertClusterSizeEventually(2, lite2);
+        assertClusterSizeEventually(2, lite, lite2);
 
         ICompletableFuture<Map<String, List<Integer>>> future = com.hazelcast.mapreduce.MapReduceLiteMemberTest
                 .testMapReduceJobSubmissionWithNoDataNode(client);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AbstractAggregationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/AbstractAggregationTest.java
@@ -41,8 +41,7 @@ public class AbstractAggregationTest
         HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance();
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSize(2, h1, h2);
 
         client = hazelcastFactory.newHazelcastClient();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MapAggregationLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MapAggregationLiteMemberTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -46,9 +47,8 @@ public class MapAggregationLiteMemberTest {
         final HazelcastInstance instance1 = factory.newHazelcastInstance();
         final HazelcastInstance instance2 = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, lite);
+        assertClusterSize(3, lite, instance2);
         assertClusterSizeEventually(3, instance1);
-        assertClusterSizeEventually(3, instance2);
 
         client = factory.newHazelcastClient();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MultiMapAggregationLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/mapreduce/aggregation/MultiMapAggregationLiteMemberTest.java
@@ -58,9 +58,8 @@ public class MultiMapAggregationLiteMemberTest extends HazelcastTestSupport {
         final HazelcastInstance instance1 = factory.newHazelcastInstance();
         final HazelcastInstance instance2 = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, lite);
+        assertClusterSize(3, lite, instance2);
         assertClusterSizeEventually(3, instance1);
-        assertClusterSizeEventually(3, instance2);
 
         client = factory.newHazelcastClient();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadQuorumTest.java
@@ -87,11 +87,8 @@ public class ClientMapReadQuorumTest extends HazelcastTestSupport {
     }
 
     private static void verifyClients() {
-        assertClusterSizeEventually(3, c1);
-        assertClusterSizeEventually(3, c2);
-        assertClusterSizeEventually(3, c3);
-        assertClusterSizeEventually(2, c4);
-        assertClusterSizeEventually(2, c5);
+        assertClusterSizeEventually(3, c1, c2, c3);
+        assertClusterSizeEventually(2, c4, c5);
     }
 
     @Before

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapReadWriteQuorumTest.java
@@ -91,11 +91,8 @@ public class ClientMapReadWriteQuorumTest extends HazelcastTestSupport {
     }
 
     private static void verifyClients() {
-        assertClusterSizeEventually(3, c1);
-        assertClusterSizeEventually(3, c2);
-        assertClusterSizeEventually(3, c3);
-        assertClusterSizeEventually(2, c4);
-        assertClusterSizeEventually(2, c5);
+        assertClusterSizeEventually(3, c1, c2, c3);
+        assertClusterSizeEventually(2, c4, c5);
     }
 
     @Before

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientMapWriteQuorumTest.java
@@ -91,11 +91,8 @@ public class ClientMapWriteQuorumTest extends HazelcastTestSupport {
     }
 
     private static void verifyClients() {
-        assertClusterSizeEventually(3, c1);
-        assertClusterSizeEventually(3, c2);
-        assertClusterSizeEventually(3, c3);
-        assertClusterSizeEventually(2, c4);
-        assertClusterSizeEventually(2, c5);
+        assertClusterSizeEventually(3, c1, c2, c3);
+        assertClusterSizeEventually(2, c4, c5);
     }
 
     @Before

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ClientTransactionalMapQuorumTest.java
@@ -109,11 +109,8 @@ public class ClientTransactionalMapQuorumTest extends HazelcastTestSupport {
     }
 
     private static void verifyClients() {
-        assertClusterSizeEventually(3, c1);
-        assertClusterSizeEventually(3, c2);
-        assertClusterSizeEventually(3, c3);
-        assertClusterSizeEventually(2, c4);
-        assertClusterSizeEventually(2, c5);
+        assertClusterSizeEventually(3, c1, c2, c3);
+        assertClusterSizeEventually(2, c4, c5);
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadQuorumTest.java
@@ -111,11 +111,8 @@ public class ClientCacheReadQuorumTest extends HazelcastTestSupport {
     }
 
     private static void verifyClients() {
-        assertClusterSizeEventually(3, c1);
-        assertClusterSizeEventually(3, c2);
-        assertClusterSizeEventually(3, c3);
-        assertClusterSizeEventually(2, c4);
-        assertClusterSizeEventually(2, c5);
+        assertClusterSizeEventually(3, c1, c2, c3);
+        assertClusterSizeEventually(2, c4, c5);
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheReadWriteQuorumTest.java
@@ -118,11 +118,8 @@ public class ClientCacheReadWriteQuorumTest extends HazelcastTestSupport {
     }
 
     private static void verifyClients() {
-        assertClusterSizeEventually(3, c1);
-        assertClusterSizeEventually(3, c2);
-        assertClusterSizeEventually(3, c3);
-        assertClusterSizeEventually(2, c4);
-        assertClusterSizeEventually(2, c5);
+        assertClusterSizeEventually(3, c1, c2, c3);
+        assertClusterSizeEventually(2, c4, c5);
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheWriteQuorumTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheWriteQuorumTest.java
@@ -118,11 +118,8 @@ public class ClientCacheWriteQuorumTest extends HazelcastTestSupport {
     }
 
     private static void verifyClients() {
-        assertClusterSizeEventually(3, c1);
-        assertClusterSizeEventually(3, c2);
-        assertClusterSizeEventually(3, c3);
-        assertClusterSizeEventually(2, c4);
-        assertClusterSizeEventually(2, c5);
+        assertClusterSizeEventually(3, c1, c2, c3);
+        assertClusterSizeEventually(2, c4, c5);
     }
 
     @AfterClass

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -49,7 +49,6 @@ import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -170,16 +169,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
             assertNotNull(hazelcastInstance3);
             assertNotNull(client);
 
-            assertTrueEventually(new AssertTask() {
-                @Override
-                public void run()
-                        throws Exception {
-                    assertClusterSize(3, hazelcastInstance1);
-                    assertClusterSize(3, hazelcastInstance2);
-                    assertClusterSize(3, hazelcastInstance3);
-                    assertClusterSize(3, client);
-                }
-            });
+            assertClusterSizeEventually(3, hazelcastInstance1, hazelcastInstance2, hazelcastInstance3, client);
         } finally {
             HazelcastClient.shutdownAll();
             Hazelcast.shutdownAll();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/HazelcastFactoryTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/HazelcastFactoryTest.java
@@ -62,9 +62,7 @@ public class HazelcastFactoryTest extends HazelcastTestSupport {
                 touchRandomNode(client1);
                 touchRandomNode(client2);
 
-                assertClusterSize(3, instance1);
-                assertClusterSize(3, instance2);
-                assertClusterSize(3, instance3);
+                assertClusterSize(3, instance1, instance2, instance3);
 
                 assertEquals(2, instance1.getClientService().getConnectedClients().size());
                 assertEquals(2, instance2.getClientService().getConnectedClients().size());
@@ -84,14 +82,7 @@ public class HazelcastFactoryTest extends HazelcastTestSupport {
         final HazelcastInstance client1 = instanceFactory.newHazelcastClient(clientConfig);
         final HazelcastInstance client2 = instanceFactory.newHazelcastClient(clientConfig);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertClusterSize(3, instance1);
-                assertClusterSize(3, instance2);
-                assertClusterSize(3, instance3);
-            }
-        });
+        assertClusterSizeEventually(3, instance1, instance2, instance3);
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -106,13 +97,7 @@ public class HazelcastFactoryTest extends HazelcastTestSupport {
             }
         });
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertClusterSize(3, client1);
-                assertClusterSize(3, client1);
-            }
-        });
+        assertClusterSizeEventually(3, client1, client2);
     }
 
     private static void touchRandomNode(HazelcastInstance hazelcastInstance) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/AbstractJoinTest.java
@@ -35,15 +35,14 @@ public class AbstractJoinTest extends HazelcastTestSupport {
         assertClusterSize(1, h1);
 
         HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
-        assertClusterSize(2, h1);
-        assertClusterSize(2, h2);
+        assertClusterSize(2, h1, h2);
 
         h1.shutdown();
         h1 = Hazelcast.newHazelcastInstance(config);
         // when h1 is returned, it's guaranteed that it should see 2 members
         assertClusterSize(2, h1);
-        // but h2 will report newly joining member eventually
-        assertClusterSizeEventually(2, h2);
+
+        assertClusterSize(2, h2);
     }
 
     protected void testJoin_With_DifferentBuildNumber(Config config) {
@@ -57,8 +56,7 @@ public class AbstractJoinTest extends HazelcastTestSupport {
             System.setProperty(buildNumberProp, "2");
             HazelcastInstance h2 = Hazelcast.newHazelcastInstance(config);
 
-            assertClusterSize(2, h1);
-            assertClusterSize(2, h2);
+            assertClusterSize(2, h1, h2);
         } finally {
             System.clearProperty(buildNumberProp);
         }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
@@ -63,14 +63,12 @@ public class ClusterInfoTest extends HazelcastTestSupport {
 
     @Test
     public void all_nodes_should_have_the_same_cluster_start_time_and_cluster_id() throws Exception {
-
         HazelcastInstance h1 = factory.newHazelcastInstance();
         HazelcastInstance h2 = factory.newHazelcastInstance();
         HazelcastInstance h3 = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         Node node1 = TestUtil.getNode(h1);
         Node node2 = TestUtil.getNode(h2);
@@ -91,20 +89,16 @@ public class ClusterInfoTest extends HazelcastTestSupport {
         assertNotNull(node1ClusterId);
         assertEquals(node1ClusterId, node2.getClusterService().getClusterId());
         assertEquals(node1ClusterId, node3.getClusterService().getClusterId());
-
-
     }
 
     @Test
     public void all_nodes_should_have_the_same_cluster_start_time_and_id_after_master_shutdown_and_new_node_join() {
-
         HazelcastInstance h1 = factory.newHazelcastInstance();
         HazelcastInstance h2 = factory.newHazelcastInstance();
         HazelcastInstance h3 = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         Node node1 = TestUtil.getNode(h1);
         final ClusterServiceImpl clusterService = node1.getClusterService();
@@ -133,6 +127,5 @@ public class ClusterInfoTest extends HazelcastTestSupport {
         assertEquals(node1ClusterId, node2.getClusterService().getClusterId());
         assertEquals(node1ClusterId, node3.getClusterService().getClusterId());
         assertEquals(node1ClusterId, node4.getClusterService().getClusterId());
-
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
@@ -37,6 +37,7 @@ import org.junit.runner.RunWith;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.closeConnectionBetween;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
@@ -82,8 +83,8 @@ public class LiteMemberJoinTest {
         final HazelcastInstance other = Hazelcast.newHazelcastInstance(configCreator.create(name, pw, false));
 
         assertTrue(getNode(liteMaster).isMaster());
-        assertClusterSizeEventually(2, liteMaster);
-        assertClusterSizeEventually(2, other);
+        assertClusterSize(2, liteMaster);
+        assertClusterSize(2, other);
 
         final Set<Member> members = other.getCluster().getMembers();
         assertLiteMemberExcluding(members, other);
@@ -120,8 +121,9 @@ public class LiteMemberJoinTest {
     private void test_liteMemberBecomesVisibleTo2ndNode(final ConfigCreator configCreator) {
         final HazelcastInstance master = Hazelcast.newHazelcastInstance(configCreator.create(name, pw, false));
         final HazelcastInstance other = Hazelcast.newHazelcastInstance(configCreator.create(name, pw, false));
-        Hazelcast.newHazelcastInstance(configCreator.create(name, pw, true));
+        final HazelcastInstance other2 = Hazelcast.newHazelcastInstance(configCreator.create(name, pw, true));
 
+        assertClusterSize(3, master, other2);
         assertClusterSizeEventually(3, other);
 
         final Set<Member> members = other.getCluster().getMembers();
@@ -168,8 +170,7 @@ public class LiteMemberJoinTest {
 
         reconnect(master, liteInstance);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, liteInstance);
+        assertClusterSizeEventually(2, master, liteInstance);
 
         final Set<Member> members = master.getCluster().getMembers();
         assertLiteMemberExcluding(members, master);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
@@ -58,8 +58,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
         Member m2 = h2.getCluster().getLocalMember();
         assertEquals(123, (int) m2.getIntAttribute("Test"));
 
-        assertClusterSize(2, h1);
-        assertClusterSize(2, h2);
+        assertClusterSize(2, h1, h2);
 
         Member member = null;
         for (Member m : h2.getCluster().getMembers()) {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitMergeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitMergeTest.java
@@ -62,8 +62,7 @@ public class SplitMergeTest extends HazelcastTestSupport {
 
         // merge back
         mergeBack(h2, getAddress(h1));
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSizeEventually(2, h1, h2);
 
         String currentUuid_H1 = getNode(h1).getThisUuid();
         String currentUuid_H2 = getNode(h2).getThisUuid();
@@ -91,15 +90,12 @@ public class SplitMergeTest extends HazelcastTestSupport {
         // create split
         closeConnectionBetween(h1, h3);
         closeConnectionBetween(h2, h3);
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSizeEventually(2, h1, h2);
         assertClusterSizeEventually(1, h3);
 
         // merge back
         mergeBack(h3, getAddress(h1));
-        assertClusterSizeEventually(3, h1);
-        assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
+        assertClusterSizeEventually(3, h1, h2, h3);
 
         // all partitions are assigned and all migrations & promotions are completed
         waitAllForSafeState(h1, h2, h3);
@@ -120,8 +116,7 @@ public class SplitMergeTest extends HazelcastTestSupport {
 
         // merge back
         mergeBack(h2, getAddress(h1));
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSizeEventually(2, h1, h2);
 
         lifecycleListener.assertStates(LifecycleState.MERGING, LifecycleState.MERGED);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SystemClockChangeTest.java
@@ -87,13 +87,11 @@ public class SystemClockChangeTest extends AbstractClockTest {
         HazelcastInstance hz1 = startNode();
         HazelcastInstance hz2 = startNode();
 
-        assertClusterSizeEventually(3, hz1);
-        assertClusterSizeEventually(3, hz2);
+        assertClusterSizeEventually(3, hz1, hz2);
 
         shutdownIsolatedNode();
 
-        assertClusterSizeEventually(2, hz1);
-        assertClusterSizeEventually(2, hz2);
+        assertClusterSizeEventually(2, hz1, hz2);
 
         assertClusterTime(hz1, hz2);
     }

--- a/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.instance;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -68,14 +67,7 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
             final HazelcastInstance instance2 = instanceFactory.newHazelcastInstance();
             final HazelcastInstance instance3 = instanceFactory.newHazelcastInstance();
 
-            assertTrueEventually(new AssertTask() {
-                @Override
-                public void run() throws Exception {
-                    assertClusterSize(3, instance1);
-                    assertClusterSize(3, instance2);
-                    assertClusterSize(3, instance3);
-                }
-            });
+            assertClusterSizeEventually(3, instance1, instance2, instance3);
         } finally {
             instanceFactory.terminateAll();
         }
@@ -93,21 +85,8 @@ public class HazelcastInstanceFactoryTest extends HazelcastTestSupport {
             final HazelcastInstance instance21 = instanceFactory2.newHazelcastInstance();
             final HazelcastInstance instance22 = instanceFactory2.newHazelcastInstance();
 
-            assertTrueEventually(new AssertTask() {
-                @Override
-                public void run() throws Exception {
-                    assertClusterSize(2, instance21);
-                    assertClusterSize(2, instance22);
-                }
-            });
-            assertTrueEventually(new AssertTask() {
-                @Override
-                public void run() throws Exception {
-                    assertClusterSize(3, instance11);
-                    assertClusterSize(3, instance12);
-                    assertClusterSize(3, instance13);
-                }
-            });
+            assertClusterSizeEventually(2, instance21, instance22);
+            assertClusterSizeEventually(3, instance11, instance12, instance13);
         } finally {
             instanceFactory1.terminateAll();
             instanceFactory2.terminateAll();

--- a/hazelcast/src/test/java/com/hazelcast/instance/MulticastLoopbackModeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MulticastLoopbackModeTest.java
@@ -113,8 +113,7 @@ public class MulticastLoopbackModeTest extends HazelcastTestSupport {
     public void testEnabledMode() throws Exception {
         createTestEnvironment(true);
 
-        assertClusterSize(2, hz1);
-        assertClusterSize(2, hz2);
+        assertClusterSize(2, hz1, hz2);
 
         Cluster cluster1 = hz1.getCluster();
         Cluster cluster2 = hz2.getCluster();

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -299,9 +299,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
         instances[0] = factory.newHazelcastInstance(address);
 
-        assertClusterSizeEventually(3, instances[0]);
-        assertClusterSizeEventually(3, instances[1]);
-        assertClusterSizeEventually(3, instances[2]);
+        assertClusterSizeEventually(3, instances);
         assertClusterState(ClusterState.FROZEN, instances);
     }
 
@@ -333,9 +331,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
         instances[0] = factory.newHazelcastInstance(address);
 
-        assertClusterSizeEventually(3, instances[0]);
-        assertClusterSizeEventually(3, instances[1]);
-        assertClusterSizeEventually(3, instances[2]);
+        assertClusterSizeEventually(3, instances);
         assertClusterState(ClusterState.ACTIVE, instances);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
@@ -130,8 +130,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
         hz2 = factory.newHazelcastInstance(address);
 
-        assertClusterSizeEventually(3, hz1);
-        assertClusterSizeEventually(3, hz2);
+        assertClusterSizeEventually(3, hz1, hz2);
         assertEquals(NodeState.ACTIVE, getNode(hz2).getState());
     }
 
@@ -152,8 +151,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
         hz2 = factory.newHazelcastInstance(address);
 
-        assertClusterSizeEventually(3, hz1);
-        assertClusterSizeEventually(3, hz2);
+        assertClusterSizeEventually(3, hz1, hz2);
         assertEquals(NodeState.PASSIVE, getNode(hz2).getState());
     }
 
@@ -215,8 +213,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
         changeClusterStateEventually(hz2, ClusterState.FROZEN);
         terminateInstance(hz1);
-        assertClusterSizeEventually(2, hz2);
-        assertClusterSizeEventually(2, hz3);
+        assertClusterSizeEventually(2, hz2, hz3);
 
         // try until member is removed and partition-service takes care of removal
         changeClusterStateEventually(hz3, ClusterState.ACTIVE);
@@ -239,8 +236,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
         changeClusterStateEventually(hz2, ClusterState.FROZEN);
         terminateInstance(hz1);
-        assertClusterSizeEventually(2, hz2);
-        assertClusterSizeEventually(2, hz3);
+        assertClusterSizeEventually(2, hz2, hz3);
 
         // try until member is removed and partition-service takes care of removal
         changeClusterStateEventually(hz3, ClusterState.PASSIVE);
@@ -340,8 +336,7 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
         other = factory.newHazelcastInstance(otherAddress);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, other);
+        assertClusterSizeEventually(2, master, other);
 
         other.shutdown();
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -94,9 +94,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance();
         HazelcastInstance slave2 = newHazelcastInstance();
 
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
 
         if (terminate) {
             terminateInstance(slave1);
@@ -104,11 +103,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
             slave1.shutdown();
         }
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave2);
+        assertClusterSizeEventually(2, master, slave2);
 
-        assertMasterAddress(getAddress(master), master);
-        assertMasterAddress(getAddress(master), slave2);
+        assertMasterAddress(getAddress(master), master, slave2);
         assertMemberViewsAreSame(getMemberMap(master), getMemberMap(slave2));
     }
 
@@ -127,9 +124,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance();
         HazelcastInstance slave2 = newHazelcastInstance();
 
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
 
         if (terminate) {
             terminateInstance(master);
@@ -137,11 +133,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
             master.shutdown();
         }
 
-        assertClusterSizeEventually(2, slave1);
-        assertClusterSizeEventually(2, slave2);
+        assertClusterSizeEventually(2, slave1, slave2);
 
-        assertMasterAddress(getAddress(slave1), slave1);
-        assertMasterAddress(getAddress(slave1), slave2);
+        assertMasterAddress(getAddress(slave1), slave1, slave2);
         assertMemberViewsAreSame(getMemberMap(slave1), getMemberMap(slave2));
     }
 
@@ -161,9 +155,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance();
         HazelcastInstance slave2 = newHazelcastInstance();
 
-        assertClusterSizeEventually(4, master);
-        assertClusterSizeEventually(4, masterCandidate);
-        assertClusterSizeEventually(4, slave1);
+        assertClusterSize(4, master, slave2);
+        assertClusterSizeEventually(4, masterCandidate, slave1);
 
         if (simultaneousCrash) {
             terminateInstanceAsync(master);
@@ -173,11 +166,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
             terminateInstance(masterCandidate);
         }
 
-        assertClusterSizeEventually(2, slave1);
-        assertClusterSizeEventually(2, slave2);
+        assertClusterSizeEventually(2, slave1, slave2);
 
-        assertMasterAddress(getAddress(slave1), slave1);
-        assertMasterAddress(getAddress(slave1), slave2);
+        assertMasterAddress(getAddress(slave1), slave1, slave2);
         assertMemberViewsAreSame(getMemberMap(slave1), getMemberMap(slave2));
     }
 
@@ -197,10 +188,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance();
         HazelcastInstance slave2 = newHazelcastInstance();
 
-        assertClusterSizeEventually(4, master);
-        assertClusterSizeEventually(4, masterCandidate);
-        assertClusterSizeEventually(4, slave1);
-        assertClusterSizeEventually(4, slave2);
+        assertClusterSize(4, master, slave2);
+        assertClusterSizeEventually(4, masterCandidate, slave1);
 
         // drop FETCH_MEMBER_LIST_STATE packets to block mastership claim process
         dropOperationsBetween(masterCandidate, slave1, FETCH_MEMBER_LIST_STATE);
@@ -221,8 +210,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(2, masterCandidate);
         assertClusterSizeEventually(2, slave2);
 
-        assertMasterAddress(getAddress(masterCandidate), masterCandidate);
-        assertMasterAddress(getAddress(masterCandidate), slave2);
+        assertMasterAddress(getAddress(masterCandidate), masterCandidate, slave2);
         assertMemberViewsAreSame(getMemberMap(masterCandidate), getMemberMap(slave2));
     }
 
@@ -233,10 +221,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance();
         HazelcastInstance slave2 = newHazelcastInstance();
 
-        assertClusterSizeEventually(4, master);
-        assertClusterSizeEventually(4, masterCandidate);
-        assertClusterSizeEventually(4, slave1);
-        assertClusterSizeEventually(4, slave2);
+        assertClusterSize(4, master, slave2);
+        assertClusterSizeEventually(4, masterCandidate, slave1);
 
         // drop FETCH_MEMBER_LIST_STATE packets to block mastership claim process
         dropOperationsBetween(masterCandidate, slave1, FETCH_MEMBER_LIST_STATE);
@@ -254,11 +240,9 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         sleepSeconds(3);
         terminateInstance(masterCandidate);
 
-        assertClusterSizeEventually(2, slave1);
-        assertClusterSizeEventually(2, slave2);
+        assertClusterSizeEventually(2, slave1, slave2);
 
-        assertMasterAddress(getAddress(slave1), slave1);
-        assertMasterAddress(getAddress(slave1), slave2);
+        assertMasterAddress(getAddress(slave1), slave1, slave2);
         assertMemberViewsAreSame(getMemberMap(slave1), getMemberMap(slave2));
     }
 
@@ -270,14 +254,12 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance(config);
         HazelcastInstance slave2 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
 
         dropOperationsFrom(slave2, HEARTBEAT);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave1);
+        assertClusterSizeEventually(2, master, slave1);
         assertClusterSizeEventually(1, slave2);
     }
 
@@ -290,20 +272,15 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance(config);
         HazelcastInstance slave2 = newHazelcastInstance(config);
 
-
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
-
-        dropOperationsFrom(master, HEARTBEAT);
 
         dropOperationsFrom(master, HEARTBEAT);
         dropOperationsFrom(slave1, HEARTBEAT_COMPLAINT);
         dropOperationsFrom(slave2, HEARTBEAT_COMPLAINT);
 
         assertClusterSizeEventually(1, master);
-        assertClusterSizeEventually(2, slave1);
-        assertClusterSizeEventually(2, slave2);
+        assertClusterSizeEventually(2, slave1, slave2);
     }
 
     @Test
@@ -314,16 +291,14 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance(config);
         final HazelcastInstance slave2 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
 
         // prevent heartbeat from master to slave to prevent suspect to be removed
         dropOperationsBetween(master, slave1, HEARTBEAT);
         suspectMember(slave1, master);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave2);
+        assertClusterSizeEventually(2, master, slave2);
         assertClusterSizeEventually(1, slave1);
     }
 
@@ -335,16 +310,14 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance(config);
         final HazelcastInstance slave2 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
 
         // prevent heartbeat from master to slave to prevent suspect to be removed
         dropOperationsBetween(master, slave1, HEARTBEAT);
         suspectMember(slave1, master);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave2);
+        assertClusterSizeEventually(2, master, slave2);
         assertClusterSizeEventually(1, slave1);
     }
 
@@ -356,9 +329,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance(config);
         final HazelcastInstance slave2 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
 
         dropOperationsBetween(slave2, slave1, HEARTBEAT);
 
@@ -390,14 +362,12 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance(config);
         HazelcastInstance slave2 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
 
         dropOperationsFrom(slave2, MASTER_CONFIRM);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave1);
+        assertClusterSizeEventually(2, master, slave1);
         assertClusterSizeEventually(1, slave2);
     }
 
@@ -416,15 +386,13 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave1 = newHazelcastInstance(config1);
         HazelcastInstance slave2 = newHazelcastInstance(config2);
 
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
 
         dropOperationsBetween(master, slave2, MEMBER_INFO_UPDATE);
         dropOperationsFrom(slave2, MASTER_CONFIRM, HEARTBEAT);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave1);
+        assertClusterSizeEventually(2, master, slave1);
 
         dropOperationsFrom(slave2, HEARTBEAT);
         ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(slave2);
@@ -445,10 +413,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave2 = newHazelcastInstance(config);
         HazelcastInstance slave3 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(4, master);
-        assertClusterSizeEventually(4, slave1);
-        assertClusterSizeEventually(4, slave2);
-        assertClusterSizeEventually(4, slave3);
+        assertClusterSize(4, master, slave3);
+        assertClusterSizeEventually(4, slave1, slave2);
 
         dropOperationsFrom(master, HEARTBEAT, MASTER_CONFIRM);
         dropOperationsFrom(slave1, HEARTBEAT, MASTER_CONFIRM);
@@ -460,13 +426,11 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         suspectMember(slave3, master);
         suspectMember(slave3, slave1);
 
-        assertClusterSizeEventually(2, slave2);
-        assertClusterSizeEventually(2, slave3);
+        assertClusterSizeEventually(2, slave2, slave3);
 
         assertMemberViewsAreSame(getMemberMap(slave2), getMemberMap(slave3));
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave1);
+        assertClusterSizeEventually(2, master, slave1);
 
         assertMemberViewsAreSame(getMemberMap(master), getMemberMap(slave1));
     }
@@ -477,32 +441,28 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance master = newHazelcastInstance(config);
         HazelcastInstance slave1 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave1);
+        assertClusterSize(2, master);
+        assertClusterSize(2, slave1);
 
         HazelcastInstance slave2 = newHazelcastInstance(config);
-        assertClusterSizeEventually(3, master);
+        assertClusterSize(3, master);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
+        assertClusterSize(3, slave2);
 
         dropOperationsBetween(master, slave1, MEMBER_INFO_UPDATE);
 
         HazelcastInstance slave3 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(4, slave3);
+        assertClusterSize(4, slave3);
         assertClusterSizeEventually(4, slave2);
         assertClusterSize(3, slave1);
 
         master.getLifecycleService().terminate();
 
-        assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
-        assertClusterSizeEventually(3, slave3);
+        assertClusterSizeEventually(3, slave1, slave2, slave3);
 
         Address newMasterAddress = getAddress(slave1);
-        assertMasterAddress(newMasterAddress, slave1);
-        assertMasterAddress(newMasterAddress, slave2);
-        assertMasterAddress(newMasterAddress, slave3);
+        assertMasterAddress(newMasterAddress, slave1, slave2, slave3);
     }
 
     @Test
@@ -510,14 +470,10 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         Config config = new Config().setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
         HazelcastInstance master = newHazelcastInstance(config);
         HazelcastInstance slave1 = newHazelcastInstance(config);
-
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave1);
-
         HazelcastInstance slave2 = newHazelcastInstance(config);
-        assertClusterSizeEventually(3, master);
+
+        assertClusterSize(3, master, slave2);
         assertClusterSizeEventually(3, slave1);
-        assertClusterSizeEventually(3, slave2);
         // master, slave1, slave2
 
         dropOperationsBetween(master, slave1, MEMBER_INFO_UPDATE);
@@ -525,8 +481,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave3 = newHazelcastInstance(config);
         // master, slave1, slave2, slave3
 
-        assertClusterSizeEventually(4, slave3);
-        assertClusterSizeEventually(4, slave2);
+        assertClusterSizeEventually(4, slave3, slave2);
         assertClusterSize(3, slave1);
 
         dropOperationsBetween(master, asList(slave1, slave2), MEMBER_INFO_UPDATE);
@@ -534,8 +489,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave4 = newHazelcastInstance(config);
         // master, slave1, slave2, slave3, slave4
 
-        assertClusterSizeEventually(5, slave4);
-        assertClusterSizeEventually(5, slave3);
+        assertClusterSizeEventually(5, slave4, slave3);
         assertClusterSizeEventually(4, slave2);
         assertClusterSize(3, slave1);
 
@@ -544,7 +498,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance slave5 = newHazelcastInstance(config);
         // master, slave1, slave2, slave3, slave4, slave5
 
-        assertClusterSizeEventually(6, slave5);
+        assertClusterSize(6, slave5);
         assertClusterSizeEventually(6, slave4);
         assertClusterSizeEventually(5, slave3);
         assertClusterSizeEventually(4, slave2);
@@ -552,15 +506,10 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
         master.getLifecycleService().terminate();
 
-        assertClusterSizeEventually(5, slave1);
-        assertClusterSizeEventually(5, slave2);
-        assertClusterSizeEventually(5, slave3);
+        assertClusterSizeEventually(5, slave1, slave2, slave3);
 
         Address newMasterAddress = getAddress(slave1);
-        assertMasterAddress(newMasterAddress, slave2);
-        assertMasterAddress(newMasterAddress, slave3);
-        assertMasterAddress(newMasterAddress, slave4);
-        assertMasterAddress(newMasterAddress, slave5);
+        assertMasterAddress(newMasterAddress, slave2, slave3, slave4, slave5);
     }
 
     @Test
@@ -571,14 +520,13 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         HazelcastInstance master = newHazelcastInstance(config);
         HazelcastInstance slave1 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, slave1);
+        assertClusterSize(2, master, slave1);
 
         dropOperationsBetween(master, slave1, MEMBER_INFO_UPDATE);
 
         HazelcastInstance slave2 = newHazelcastInstance(config);
-        assertClusterSizeEventually(3, master);
-        assertClusterSizeEventually(3, slave2);
+        assertClusterSize(3, master);
+        assertClusterSize(3, slave2);
         assertClusterSize(2, slave1);
 
         master.getLifecycleService().terminate();
@@ -599,9 +547,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         final HazelcastInstance member2 = newHazelcastInstance(config);
         final HazelcastInstance member3 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, member1);
+        assertClusterSize(3, member1, member3);
         assertClusterSizeEventually(3, member2);
-        assertClusterSizeEventually(3, member3);
 
         final CountDownLatch mergeLatch = new CountDownLatch(1);
         member3.getLifecycleService().addLifecycleListener(new LifecycleListener() {
@@ -673,10 +620,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
                 .setProperty(GroupProperty.MASTERSHIP_CLAIM_TIMEOUT_SECONDS.getName(), "10"));
         final HazelcastInstance member4 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(4, member1);
-        assertClusterSizeEventually(4, member2);
-        assertClusterSizeEventually(4, member3);
-        assertClusterSizeEventually(4, member4);
+        assertClusterSize(4, member1, member4);
+        assertClusterSizeEventually(4, member2, member3);
 
         dropOperationsFrom(member1, MEMBER_INFO_UPDATE, HEARTBEAT);
         dropOperationsFrom(member2, FETCH_MEMBER_LIST_STATE);
@@ -700,8 +645,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
         // member4 will learn member list
         resetPacketFiltersFrom(member2);
-        assertClusterSizeEventually(2, member2);
-        assertClusterSizeEventually(2, member4);
+        assertClusterSizeEventually(2, member2, member4);
         assertMemberViewsAreSame(getMemberMap(member2), getMemberMap(member4));
 
         resetPacketFiltersFrom(member1);
@@ -718,10 +662,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         final HazelcastInstance member3 = newHazelcastInstance(config);
         final HazelcastInstance member4 = newHazelcastInstance(config);
 
-        assertClusterSizeEventually(4, member1);
-        assertClusterSizeEventually(4, member2);
-        assertClusterSizeEventually(4, member3);
-        assertClusterSizeEventually(4, member4);
+        assertClusterSize(4, member1, member4);
+        assertClusterSizeEventually(4, member2, member3);
 
         dropOperationsFrom(member1, MEMBER_INFO_UPDATE, HEARTBEAT);
         dropOperationsFrom(member2, FETCH_MEMBER_LIST_STATE, HEARTBEAT);
@@ -745,8 +687,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
         // member4 will learn member list
         resetPacketFiltersFrom(member3);
-        assertClusterSizeEventually(2, member3);
-        assertClusterSizeEventually(2, member4);
+        assertClusterSizeEventually(2, member3, member4);
         assertMemberViewsAreSame(getMemberMap(member3), getMemberMap(member4));
 
         resetPacketFiltersFrom(member1);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -319,14 +319,13 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(2, hz1);
+        assertClusterSize(2, hz1, hz2);
 
         dropOperationsFrom(hz1, MEMBER_INFO_UPDATE);
 
         HazelcastInstance hz3 = factory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, hz1);
-        assertClusterSizeEventually(3, hz3);
+        assertClusterSize(3, hz1, hz3);
         assertClusterSize(2, hz2);
 
         resetPacketFiltersFrom(hz1);
@@ -348,14 +347,13 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(2, hz1);
+        assertClusterSize(2, hz1, hz2);
 
         dropOperationsFrom(hz1, MEMBER_INFO_UPDATE);
 
         HazelcastInstance hz3 = factory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(3, hz1);
-        assertClusterSizeEventually(3, hz3);
+        assertClusterSize(3, hz1, hz3);
         assertClusterSize(2, hz2);
 
         resetPacketFiltersFrom(hz1);
@@ -425,6 +423,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
         HazelcastInstance hz3 = factory.newHazelcastInstance(config);
 
+        assertClusterSize(3, hz1, hz3);
         assertClusterSizeEventually(3, hz2);
 
         dropOperationsBetween(hz1, hz3, MEMBER_INFO_UPDATE);
@@ -448,6 +447,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
         HazelcastInstance hz3 = factory.newHazelcastInstance(config);
 
+        assertClusterSize(3, hz1, hz3);
         assertClusterSizeEventually(3, hz2);
 
         dropOperationsBetween(hz1, hz3, MEMBER_INFO_UPDATE);
@@ -525,9 +525,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         future.get();
 
         // member update should not be applied
-        assertClusterSize(3, hz1);
-        assertClusterSize(3, hz2);
-        assertClusterSize(3, hz3);
+        assertClusterSize(3, hz1, hz2, hz3);
 
         assertMemberViewsAreSame(getMemberMap(hz1), getMemberMap(hz2));
         assertMemberViewsAreSame(getMemberMap(hz1), getMemberMap(hz3));
@@ -544,22 +542,19 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         HazelcastInstance hz3 = factory.newHazelcastInstance(config);
         HazelcastInstance hz4 = factory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(4, hz2);
-        assertClusterSizeEventually(4, hz3);
+        assertClusterSize(4, hz2, hz3);
 
         dropOperationsBetween(hz1, hz2, MEMBER_INFO_UPDATE);
 
         final MemberImpl member3 = getNode(hz3).getLocalMember();
         hz3.getLifecycleService().terminate();
 
-        assertClusterSizeEventually(3, hz1);
-        assertClusterSizeEventually(3, hz4);
+        assertClusterSizeEventually(3, hz1, hz4);
         assertClusterSize(4, hz2);
 
         hz3 = newHazelcastInstance(config, "test-instance", new StaticMemberNodeContext(member3));
 
-        assertClusterSizeEventually(4, hz1);
-        assertClusterSizeEventually(4, hz4);
+        assertClusterSizeEventually(4, hz1, hz4);
 
         resetPacketFiltersFrom(hz1);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/NoMigrationClusterStateTest.java
@@ -126,8 +126,7 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
         changeClusterStateEventually(instances[1], ClusterState.NO_MIGRATION);
         terminateInstance(instances[0]);
 
-        assertClusterSizeEventually(2, instances[1]);
-        assertClusterSizeEventually(2, instances[2]);
+        assertClusterSizeEventually(2, instances[1], instances[2]);
 
         assertTrueAllTheTime(new AssertTask() {
             @Override
@@ -147,8 +146,7 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
         changeClusterStateEventually(instances[1], ClusterState.NO_MIGRATION);
         terminateInstance(instances[0]);
 
-        assertClusterSizeEventually(2, instances[1]);
-        assertClusterSizeEventually(2, instances[2]);
+        assertClusterSizeEventually(2, instances[1], instances[2]);
 
         changeClusterStateEventually(instances[1], ClusterState.ACTIVE);
         assertAllPartitionsAreAssigned(instances[1], 2);
@@ -165,8 +163,7 @@ public class NoMigrationClusterStateTest extends HazelcastTestSupport {
         changeClusterStateEventually(instances[1], ClusterState.NO_MIGRATION);
         terminateInstance(instances[0]);
 
-        assertClusterSizeEventually(2, instances[1]);
-        assertClusterSizeEventually(2, instances[2]);
+        assertClusterSizeEventually(2, instances[1], instances[2]);
 
         changeClusterStateEventually(instances[1], ClusterState.FROZEN);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -275,8 +275,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
         assertPromotionInvocationStarted(hz3);
 
         hz1.getLifecycleService().terminate();
-        assertClusterSizeEventually(2, hz2);
-        assertClusterSizeEventually(2, hz3);
+        assertClusterSizeEventually(2, hz2, hz3);
 
         Exception exception = future.get();
         // MemberLeftException is wrapped by HazelcastException

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionServiceSafetyCheckTest.java
@@ -189,8 +189,7 @@ public class PartitionServiceSafetyCheckTest extends PartitionCorrectnessTestSup
         waitAllForSafeState(hz1, hz2, hz3);
 
         hz2.getLifecycleService().terminate();
-        assertClusterSizeEventually(2, hz1);
-        assertClusterSizeEventually(2, hz3);
+        assertClusterSizeEventually(2, hz1, hz3);
         waitAllForSafeState(hz1, hz3);
         assertPartitionAssignments(factory);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
@@ -75,9 +75,7 @@ public class FrozenPartitionTableTest extends HazelcastTestSupport {
         terminateInstance(hz3);
         hz3 = factory.newHazelcastInstance(hz3Address);
 
-        assertClusterSizeEventually(3, hz1);
-        assertClusterSizeEventually(3, hz2);
-        assertClusterSizeEventually(3, hz3);
+        assertClusterSizeEventually(3, hz1, hz2, hz3);
 
         for (HazelcastInstance instance : Arrays.asList(hz1, hz2, hz3)) {
             final HazelcastInstance hz = instance;

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceLiteMemberTest.java
@@ -98,8 +98,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance master = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance other = factory.newHazelcastInstance(liteMemberConfig);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, other);
+        assertClusterSize(2, master, other);
 
         for (HazelcastInstance instance : asList(master, other)) {
             final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
@@ -173,8 +172,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance master = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance other = factory.newHazelcastInstance(liteMemberConfig);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, other);
+        assertClusterSize(2, master, other);
 
         for (HazelcastInstance instance : asList(master, other)) {
             final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(instance);
@@ -197,8 +195,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance master = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance other = factory.newHazelcastInstance(liteMemberConfig);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, other);
+        assertClusterSize(2, master, other);
 
         final InternalPartitionServiceImpl partitionService = getInternalPartitionServiceImpl(other);
         partitionService.getPartitionOwnerOrWait(0);
@@ -234,8 +231,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance master = factory.newHazelcastInstance();
         final HazelcastInstance lite = factory.newHazelcastInstance(liteMemberConfig);
 
-        assertClusterSizeEventually(2, master);
-        assertClusterSizeEventually(2, lite);
+        assertClusterSize(2, master, lite);
         warmUpPartitions(master, lite);
 
         master.getLifecycleService().shutdown();
@@ -320,8 +316,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance lite1 = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteMemberConfig);
 
-        assertClusterSizeEventually(2, lite1);
-        assertClusterSizeEventually(2, lite2);
+        assertClusterSize(2, lite1, lite2);
 
         lite1.getLifecycleService().terminate();
     }
@@ -404,8 +399,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance lite = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteMemberConfig);
 
-        assertClusterSizeEventually(2, lite);
-        assertClusterSizeEventually(2, lite2);
+        assertClusterSize(2, lite, lite2);
 
         for (HazelcastInstance instance : asList(lite, lite2)) {
             assertMemberGroupsSizeEventually(instance, 0);
@@ -418,8 +412,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance lite = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance other = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(2, lite);
-        assertClusterSizeEventually(2, other);
+        assertClusterSize(2, lite, other);
 
         for (HazelcastInstance instance : asList(lite, other)) {
             assertMemberGroupsSizeEventually(instance, 1);
@@ -432,8 +425,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance lite = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance other = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(2, lite);
-        assertClusterSizeEventually(2, other);
+        assertClusterSize(2, lite, other);
 
         for (HazelcastInstance instance : asList(lite, other)) {
             assertMemberGroupsSizeEventually(instance, 1);
@@ -450,8 +442,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance lite = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance other = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(2, lite);
-        assertClusterSizeEventually(2, other);
+        assertClusterSize(2, lite, other);
 
         for (HazelcastInstance instance : asList(lite, other)) {
             assertMemberGroupsSizeEventually(instance, 1);
@@ -490,8 +481,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance lite = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteMemberConfig);
 
-        assertClusterSizeEventually(2, lite);
-        assertClusterSizeEventually(2, lite2);
+        assertClusterSize(2, lite, lite2);
 
         for (HazelcastInstance instance : asList(lite, lite2)) {
             assertMaxBackupCountEventually(instance, 0);
@@ -504,8 +494,7 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance lite = factory.newHazelcastInstance(liteMemberConfig);
         final HazelcastInstance other = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(2, lite);
-        assertClusterSizeEventually(2, other);
+        assertClusterSize(2, lite, other);
 
         for (HazelcastInstance instance : asList(lite, other)) {
             assertMaxBackupCountEventually(instance, 0);
@@ -519,9 +508,8 @@ public class InternalPartitionServiceLiteMemberTest extends HazelcastTestSupport
         final HazelcastInstance other = factory.newHazelcastInstance();
         final HazelcastInstance other2 = factory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, lite);
+        assertClusterSize(3, lite, other2);
         assertClusterSizeEventually(3, other);
-        assertClusterSizeEventually(3, other2);
 
         for (HazelcastInstance instance : asList(lite, other, other2)) {
             assertMaxBackupCountEventually(instance, 1);

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
@@ -148,10 +148,8 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         config1.setLiteMember(true);
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config1);
-        assertNodeStartedEventually(hz1);
 
         HazelcastInstance hz2 = factory.newHazelcastInstance(createConfig());
-        assertNodeStartedEventually(hz2);
 
         warmUpPartitions(hz1, hz2);
         waitAllForSafeState(hz1, hz2);
@@ -166,7 +164,7 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         HazelcastInstance hz3 = factory.newHazelcastInstance(config3);
 
         assertClusterSizeEventually(2, hz2);
-        assertClusterSizeEventually(2, hz3);
+        assertClusterSize(2, hz3);
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -191,20 +189,16 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         config1.addListenerConfig(new ListenerConfig(masterListener));
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config1);
-        assertNodeStartedEventually(hz1);
 
         HazelcastInstance hz2 = factory.newHazelcastInstance(createConfig());
-        assertNodeStartedEventually(hz2);
 
         warmUpPartitions(hz1, hz2);
         waitAllForSafeState(hz1, hz2);
 
         HazelcastInstance hz3 = factory.newHazelcastInstance(createConfig());
-        assertNodeStartedEventually(hz3);
 
-        assertClusterSizeEventually(3, hz1);
+        assertClusterSize(3, hz1, hz3);
         assertClusterSizeEventually(3, hz2);
-        assertClusterSizeEventually(3, hz3);
 
         masterListener.other = hz3;
         migrationStartLatch.countDown();
@@ -230,13 +224,11 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         config1.setLiteMember(true);
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config1);
-        assertNodeStartedEventually(hz1);
 
         Config config2 = createConfig();
         final CollectMigrationTaskOnCommit sourceListener = new CollectMigrationTaskOnCommit();
         config2.addListenerConfig(new ListenerConfig(sourceListener));
         HazelcastInstance hz2 = factory.newHazelcastInstance(config2);
-        assertNodeStartedEventually(hz2);
 
         warmUpPartitions(hz1, hz2);
         waitAllForSafeState(hz1, hz2);
@@ -247,11 +239,9 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         destinationListener.other = hz1;
         config3.addListenerConfig(new ListenerConfig(destinationListener));
         HazelcastInstance hz3 = factory.newHazelcastInstance(config3);
-        assertNodeStartedEventually(hz3);
 
-        assertClusterSizeEventually(3, hz1);
+        assertClusterSize(3, hz1, hz3);
         assertClusterSizeEventually(3, hz2);
-        assertClusterSizeEventually(3, hz3);
 
         migrationStartLatch.countDown();
 
@@ -283,10 +273,8 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         config1.addListenerConfig(new ListenerConfig(masterListener));
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config1);
-        assertNodeStartedEventually(hz1);
 
         HazelcastInstance hz2 = factory.newHazelcastInstance(createConfig());
-        assertNodeStartedEventually(hz2);
 
         warmUpPartitions(hz1, hz2);
         waitAllForSafeState(hz1, hz2);
@@ -295,13 +283,11 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         InternalMigrationListenerImpl targetListener = new InternalMigrationListenerImpl();
         config3.addListenerConfig(new ListenerConfig(targetListener));
         HazelcastInstance hz3 = factory.newHazelcastInstance(config3);
-        assertNodeStartedEventually(hz3);
 
         masterListener.other = hz2;
 
-        assertClusterSizeEventually(3, hz1);
+        assertClusterSize(3, hz1, hz3);
         assertClusterSizeEventually(3, hz2);
-        assertClusterSizeEventually(3, hz3);
 
         migrationStartLatch.countDown();
 
@@ -329,10 +315,8 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         config1.addListenerConfig(new ListenerConfig(masterListener));
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config1);
-        assertNodeStartedEventually(hz1);
 
         HazelcastInstance hz2 = factory.newHazelcastInstance(createConfig());
-        assertNodeStartedEventually(hz2);
 
         warmUpPartitions(hz1, hz2);
         waitAllForSafeState(hz1, hz2);
@@ -342,13 +326,11 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         Config config3 = createConfig();
         config3.addListenerConfig(new ListenerConfig(memberListener));
         HazelcastInstance hz3 = factory.newHazelcastInstance(config3);
-        assertNodeStartedEventually(hz3);
 
         warmUpPartitions(hz1, hz2, hz3);
 
-        assertClusterSizeEventually(3, hz1);
+        assertClusterSize(3, hz1, hz3);
         assertClusterSizeEventually(3, hz2);
-        assertClusterSizeEventually(3, hz3);
 
         migrationStartLatch.countDown();
 
@@ -376,10 +358,8 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         config1.addListenerConfig(new ListenerConfig(masterListener));
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config1);
-        assertNodeStartedEventually(hz1);
 
         HazelcastInstance hz2 = factory.newHazelcastInstance(createConfig());
-        assertNodeStartedEventually(hz2);
 
         warmUpPartitions(hz1, hz2);
         waitAllForSafeState(hz1, hz2);
@@ -388,11 +368,9 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         InternalMigrationListenerImpl targetListener = new InternalMigrationListenerImpl();
         config3.addListenerConfig(new ListenerConfig(targetListener));
         HazelcastInstance hz3 = factory.newHazelcastInstance(config3);
-        assertNodeStartedEventually(hz3);
 
-        assertClusterSizeEventually(3, hz1);
+        assertClusterSize(3, hz1, hz3);
         assertClusterSizeEventually(3, hz2);
-        assertClusterSizeEventually(3, hz3);
 
         migrationStartLatch.countDown();
 
@@ -416,13 +394,11 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         config1.addListenerConfig(new ListenerConfig(masterListener));
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config1);
-        assertNodeStartedEventually(hz1);
 
         InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) getPartitionService(hz1);
         final MigrationManager migrationManager = partitionService.getMigrationManager();
 
         HazelcastInstance hz2 = factory.newHazelcastInstance(createConfig());
-        assertNodeStartedEventually(hz2);
 
         warmUpPartitions(hz1, hz2);
         waitAllForSafeState(hz1, hz2);
@@ -432,11 +408,9 @@ public class MigrationCommitTest extends HazelcastTestSupport {
 
         config3.addListenerConfig(new ListenerConfig(destinationListener));
         HazelcastInstance hz3 = factory.newHazelcastInstance(config3);
-        assertNodeStartedEventually(hz3);
 
-        assertClusterSizeEventually(3, hz1);
+        assertClusterSize(3, hz1, hz3);
         assertClusterSizeEventually(3, hz2);
-        assertClusterSizeEventually(3, hz3);
 
         migrationStartLatch.countDown();
 
@@ -460,22 +434,18 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         config1.addListenerConfig(new ListenerConfig(new DelayMigrationStart(migrationStartLatch)));
 
         final HazelcastInstance hz1 = factory.newHazelcastInstance(config1);
-        assertNodeStartedEventually(hz1);
 
         Config config2 = createConfig();
         config2.addListenerConfig(new ListenerConfig(new DelayMigrationCommit(migrationCommitLatch)));
         HazelcastInstance hz2 = factory.newHazelcastInstance(config2);
-        assertNodeStartedEventually(hz2);
 
         warmUpPartitions(hz1, hz2);
         waitAllForSafeState(hz1, hz2);
 
         final HazelcastInstance hz3 = factory.newHazelcastInstance(createConfig());
-        assertNodeStartedEventually(hz3);
 
-        assertClusterSizeEventually(3, hz1);
+        assertClusterSize(3, hz1, hz3);
         assertClusterSizeEventually(3, hz2);
-        assertClusterSizeEventually(3, hz3);
 
         migrationStartLatch.countDown();
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
@@ -104,7 +104,9 @@ public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
         HazelcastInstance instance = newInstance(withIndex);
         HazelcastInstance instance2 = newInstance(withIndex);
         HazelcastInstance instance3 = newInstance(withIndex);
-        assertClusterSizeEventually(3, instance);
+
+        assertClusterSize(3, instance, instance3);
+        assertClusterSizeEventually(3, instance2);
 
         final IMap<Integer, ListHolder> map = instance.getMap(MAP_NAME);
         final ListHolder expected = new ListHolder();

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -605,9 +605,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(cfg);
         HazelcastInstance instance3 = nodeFactory.newHazelcastInstance(cfg);
 
-        assertClusterSize(3, instance1);
-        assertClusterSize(3, instance2);
-        assertClusterSize(3, instance3);
+        assertClusterSize(3, instance1, instance2, instance3);
 
         IMap<Integer, Integer> map = instance1.getMap(MAP_NAME);
         int size = 100;
@@ -622,8 +620,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         instance1.shutdown();
         sleepSeconds(1);
 
-        assertClusterSize(2, instance2);
-        assertClusterSize(2, instance3);
+        assertClusterSize(2, instance2, instance3);
 
         IMap<Integer, Integer> map2 = instance2.getMap(MAP_NAME);
         for (int i = 0; i < size; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapUnboundedReturnValuesTestSupport.java
@@ -169,8 +169,8 @@ abstract class MapUnboundedReturnValuesTestSupport extends HazelcastTestSupport 
         instance = instances[0];
         logger = instance.getLoggingService().getLogger(getClass());
 
-        HazelcastTestSupport.assertClusterSizeEventually(factory.getCount(), instance);
-        HazelcastTestSupport.assertAllInSafeState(asList(instances));
+        assertClusterSizeEventually(factory.getCount(), instance);
+        assertAllInSafeState(asList(instances));
 
         return instance.getMap(name);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
@@ -95,8 +95,7 @@ public class MergePolicyTest extends HazelcastTestSupport {
         mergeBlockingLatch.countDown();
 
         assertOpenEventually(lifeCycleListener.mergeFinishedLatch);
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSizeEventually(2, h1, h2);
 
         IMap<Object, Object> mapTest = h1.getMap(mapName);
         assertEquals("LatestUpdatedValue", mapTest.get("key1"));
@@ -143,8 +142,7 @@ public class MergePolicyTest extends HazelcastTestSupport {
         mergeBlockingLatch.countDown();
 
         assertOpenEventually(lifeCycleListener.mergeFinishedLatch);
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSizeEventually(2, h1, h2);
 
         IMap<Object, Object> mapTest = h2.getMap(mapName);
         assertEquals("higherHitsValue", mapTest.get("key1"));
@@ -184,8 +182,7 @@ public class MergePolicyTest extends HazelcastTestSupport {
         mergeBlockingLatch.countDown();
 
         assertOpenEventually(lifeCycleListener.mergeFinishedLatch);
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSizeEventually(2, h1, h2);
 
         IMap<Object, Object> mapTest = h2.getMap(mapName);
         assertEquals("PutIfAbsentValue1", mapTest.get("key1"));
@@ -225,8 +222,7 @@ public class MergePolicyTest extends HazelcastTestSupport {
         mergeBlockingLatch.countDown();
 
         assertOpenEventually(lifeCycleListener.mergeFinishedLatch);
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSizeEventually(2, h1, h2);
 
         IMap<Object, Object> mapTest = h2.getMap(mapName);
         assertEquals("passThroughValue", mapTest.get(key));
@@ -265,8 +261,7 @@ public class MergePolicyTest extends HazelcastTestSupport {
         mergeBlockingLatch.countDown();
 
         assertOpenEventually(lifeCycleListener.mergeFinishedLatch);
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSizeEventually(2, h1, h2);
 
         IMap<Object, Object> mapTest = h2.getMap(mapName);
         assertNotNull(mapTest.get(key));

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
@@ -65,6 +65,7 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
         HazelcastInstance fullMember = nodeFactory.newHazelcastInstance();
         HazelcastInstance liteMember = nodeFactory.newHazelcastInstance(new Config().setLiteMember(true));
+
         assertClusterSizeEventually(2, fullMember);
 
         IMap<Integer, Integer> map = fullMember.getMap(randomMapName());
@@ -165,8 +166,7 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
             Employee employee = new Employee(i, "name" + i % 100, "city" + (i % 100), i % 60, ((i & 1) == 1), (double) i);
             map.put(String.valueOf(i), employee);
         }
-        assertClusterSize(2, instance1);
-        assertClusterSize(2, instance2);
+        assertClusterSize(2, instance1, instance2);
 
         map = instance2.getMap("employees");
         map.addIndex("name", false);
@@ -213,8 +213,7 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
             Employee employee = new Employee(i, "name" + i % 100, "city" + (i % 100), i % 60, ((i & 1) == 1), (double) i);
             map.put(String.valueOf(i), employee);
         }
-        assertClusterSize(2, instance1);
-        assertClusterSize(2, instance2);
+        assertClusterSize(2, instance1, instance2);
 
         map = instance2.getMap("employees");
         map.addIndex("name", false);

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/CustomDataSourceMapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/CustomDataSourceMapReduceTest.java
@@ -67,9 +67,8 @@ public class CustomDataSourceMapReduceTest
         final HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         final HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         JobTracker jobTracker = h1.getJobTracker("default");
         Job<String, Integer> job = jobTracker.newJob(new CustomKeyValueSource());

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/DistributedMapperMapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/DistributedMapperMapReduceTest.java
@@ -67,9 +67,8 @@ public class DistributedMapperMapReduceTest
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
         for (int i = 0; i < 100; i++) {
@@ -102,9 +101,8 @@ public class DistributedMapperMapReduceTest
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
         for (int i = 0; i < 100; i++) {
@@ -138,9 +136,8 @@ public class DistributedMapperMapReduceTest
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
         for (int i = 0; i < 100; i++) {
@@ -172,9 +169,8 @@ public class DistributedMapperMapReduceTest
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
         for (int i = 0; i < 100; i++) {
@@ -224,9 +220,8 @@ public class DistributedMapperMapReduceTest
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
         for (int i = 0; i < 100; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/ListSetMapReduceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/ListSetMapReduceLiteMemberTest.java
@@ -61,10 +61,8 @@ public class ListSetMapReduceLiteMemberTest
         lite = factory.newHazelcastInstance(liteConfig);
         final HazelcastInstance lite2 = factory.newHazelcastInstance(liteConfig);
 
-        assertClusterSizeEventually(4, instance);
-        assertClusterSizeEventually(4, instance2);
-        assertClusterSizeEventually(4, lite);
-        assertClusterSizeEventually(4, lite2);
+        assertClusterSize(4, instance, lite2);
+        assertClusterSizeEventually(4, instance2, lite);
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/ListSetMapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/ListSetMapReduceTest.java
@@ -49,9 +49,8 @@ public class ListSetMapReduceTest
         final HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         final HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         int expectedResult = 0;
         IList<Integer> list = h1.getList("default");
@@ -85,9 +84,8 @@ public class ListSetMapReduceTest
         final HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         final HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         int expectedResult = 0;
         ISet<Integer> set = h1.getSet("default");

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceLiteMemberTest.java
@@ -63,10 +63,8 @@ public class MapReduceLiteMemberTest
         lite = factory.newHazelcastInstance(new Config().setLiteMember(true));
         lite2 = factory.newHazelcastInstance(new Config().setLiteMember(true));
 
-        assertClusterSizeEventually(4, instance);
-        assertClusterSizeEventually(4, instance2);
-        assertClusterSizeEventually(4, lite);
-        assertClusterSizeEventually(4, lite2);
+        assertClusterSize(4, instance, lite2);
+        assertClusterSizeEventually(4, instance2, lite);
     }
 
     @After
@@ -150,8 +148,7 @@ public class MapReduceLiteMemberTest
     public void testMapReduceJobSubmissionWithNoDataNode() {
         instance.shutdown();
         instance2.shutdown();
-        assertClusterSizeEventually(2, lite);
-        assertClusterSizeEventually(2, lite2);
+        assertClusterSizeEventually(2, lite, lite2);
 
         testMapReduceJobSubmissionWithNoDataNode(lite);
     }

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceManagedContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceManagedContextTest.java
@@ -56,9 +56,8 @@ public class MapReduceManagedContextTest
         final HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         final HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         IMap<String, Integer> m1 = h1.getMap(MAP_NAME);
         for (int i = 0; i < 100; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MapReduceTest.java
@@ -98,9 +98,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -138,9 +137,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -173,9 +171,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -212,9 +209,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -255,9 +251,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -290,9 +285,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -326,9 +320,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -360,9 +353,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -391,9 +383,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -424,9 +415,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -455,9 +445,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -497,9 +486,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -552,9 +540,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -590,9 +577,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -629,9 +615,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -682,9 +667,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -735,9 +719,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
 
@@ -796,9 +779,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -854,9 +836,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -913,9 +894,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         try {
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
@@ -953,9 +933,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
         try {
-            assertClusterSizeEventually(3, h1);
+            assertClusterSize(3, h1, h3);
             assertClusterSizeEventually(3, h2);
-            assertClusterSizeEventually(3, h3);
 
             IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
             for (int i = 0; i < 100; i++) {
@@ -983,9 +962,8 @@ public class MapReduceTest extends HazelcastTestSupport {
         HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         IMap<Integer, Integer> m1 = h1.getMap(MAP_NAME);
         for (int i = 0; i < 100; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/MultiMapMapReduceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/MultiMapMapReduceTest.java
@@ -63,9 +63,8 @@ public class MultiMapMapReduceTest
         final HazelcastInstance h2 = nodeFactory.newHazelcastInstance();
         final HazelcastInstance h3 = nodeFactory.newHazelcastInstance();
 
-        assertClusterSizeEventually(3, h1);
+        assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
 
         MultiMap<Integer, Integer> multiMap = h1.getMultiMap("default");
         for (int i = 0; i < keyCount; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/AbstractAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/AbstractAggregationTest.java
@@ -44,8 +44,7 @@ public class AbstractAggregationTest
         HAZELCAST_INSTANCE = INSTANCE_FACTORY.newHazelcastInstance();
         HazelcastInstance hazelcastInstance = INSTANCE_FACTORY.newHazelcastInstance();
 
-        assertClusterSizeEventually(2, HAZELCAST_INSTANCE);
-        assertClusterSizeEventually(2, hazelcastInstance);
+        assertClusterSize(2, HAZELCAST_INSTANCE, hazelcastInstance);
     }
 
     @AfterClass

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapAggregationLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/aggregation/MapAggregationLiteMemberTest.java
@@ -59,10 +59,8 @@ public class MapAggregationLiteMemberTest
         lite = factory.newHazelcastInstance(new Config().setLiteMember(true));
         final HazelcastInstance lite2 = factory.newHazelcastInstance(new Config().setLiteMember(true));
 
-        assertClusterSizeEventually(4, instance);
-        assertClusterSizeEventually(4, instance2);
-        assertClusterSizeEventually(4, lite);
-        assertClusterSizeEventually(4, lite2);
+        assertClusterSize(4, instance, lite2);
+        assertClusterSizeEventually(4, instance2, lite);
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -34,6 +34,7 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static com.hazelcast.test.HazelcastTestSupport.generateRandomString;
@@ -134,11 +135,8 @@ public class PartitionedCluster {
         splitCluster();
 
         assertTrue(splitLatch.await(30, TimeUnit.SECONDS));
-        assertClusterSizeEventually(3, h1);
-        assertClusterSizeEventually(3, h2);
-        assertClusterSizeEventually(3, h3);
-        assertClusterSizeEventually(2, h4);
-        assertClusterSizeEventually(2, h5);
+        assertClusterSizeEventually(3, h1, h2, h3);
+        assertClusterSizeEventually(2, h4, h5);
         assertTrueEventually(new AssertTask() {
             @Override
             public void run()
@@ -157,11 +155,8 @@ public class PartitionedCluster {
         h4 = factory.newHazelcastInstance(config);
         h5 = factory.newHazelcastInstance(config);
 
-        assertClusterSizeEventually(5, h1);
-        assertClusterSizeEventually(5, h2);
-        assertClusterSizeEventually(5, h3);
-        assertClusterSizeEventually(5, h4);
-        assertClusterSizeEventually(5, h5);
+        assertClusterSize(5, h1, h4);
+        assertClusterSizeEventually(5, h2, h3, h4);
     }
 
     private QuorumConfig createSuccessfulSplitTestQuorum() {

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapMergePolicyTest.java
@@ -102,8 +102,7 @@ public class ReplicatedMapMergePolicyTest extends HazelcastTestSupport {
         final Map<Object, Object> expectedValues = testCase.populateMaps(map1, map2, h1);
 
         assertOpenEventually(lifeCycleListener.latch);
-        assertClusterSizeEventually(2, h1);
-        assertClusterSizeEventually(2, h2);
+        assertClusterSizeEventually(2, h1, h2);
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -50,7 +50,6 @@ import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.partitiongroup.PartitionGroupStrategy;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -182,15 +181,7 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
             assertNotNull(hazelcastInstance2);
             assertNotNull(hazelcastInstance3);
 
-            assertTrueEventually(new AssertTask() {
-                @Override
-                public void run()
-                        throws Exception {
-                    assertClusterSize(3, hazelcastInstance1);
-                    assertClusterSize(3, hazelcastInstance2);
-                    assertClusterSize(3, hazelcastInstance3);
-                }
-            });
+            assertClusterSizeEventually(3, hazelcastInstance1, hazelcastInstance2, hazelcastInstance3);
         } finally {
             Hazelcast.shutdownAll();
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -97,9 +97,7 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
         ClusterServiceImpl clusterService3 = node3.getClusterService();
         clusterService3.merge(node1.address);
 
-        assertClusterSizeEventually(3, hz1);
-        assertClusterSizeEventually(3, hz2);
-        assertClusterSizeEventually(3, hz3);
+        assertClusterSizeEventually(3, hz1, hz2, hz3);
 
         try {
             future.get(1, TimeUnit.MINUTES);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -864,10 +864,12 @@ public abstract class HazelcastTestSupport {
         });
     }
 
-    public static void assertClusterSize(int expectedSize, HazelcastInstance instance) {
-        int clusterSize = getClusterSize(instance);
-        if (expectedSize != clusterSize) {
-            fail(format("Cluster size is not correct. Expected: %d Actual: %d", expectedSize, clusterSize));
+    public static void assertClusterSize(int expectedSize, HazelcastInstance... instances) {
+        for (HazelcastInstance instance : instances) {
+            int clusterSize = getClusterSize(instance);
+            if (expectedSize != clusterSize) {
+                fail(format("Cluster size is not correct. Expected: %d Actual: %d", expectedSize, clusterSize));
+            }
         }
     }
 
@@ -876,8 +878,10 @@ public abstract class HazelcastTestSupport {
         return members == null ? 0 : members.size();
     }
 
-    public static void assertClusterSizeEventually(int expectedSize, HazelcastInstance instance) {
-        assertClusterSizeEventually(expectedSize, instance, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+    public static void assertClusterSizeEventually(int expectedSize, HazelcastInstance... instances) {
+        for (HazelcastInstance instance : instances) {
+            assertClusterSizeEventually(expectedSize, instance, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+        }
     }
 
     public static void assertClusterSizeEventually(final int expectedSize, final HazelcastInstance instance,
@@ -891,30 +895,20 @@ public abstract class HazelcastTestSupport {
         }, timeoutSeconds);
     }
 
-    public static void assertMasterAddress(HazelcastInstance master, HazelcastInstance instance) {
-        assertEquals(getAddress(master), getNode(instance).getMasterAddress());
+    public static void assertMasterAddress(Address masterAddress, HazelcastInstance... instances) {
+        for (HazelcastInstance instance : instances) {
+            assertEquals(masterAddress, getNode(instance).getMasterAddress());
+        }
     }
 
-    public static void assertMasterAddressEventually(final HazelcastInstance master, final HazelcastInstance instance) {
+    public static void assertMasterAddressEventually(final Address masterAddress, final HazelcastInstance... instances) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run()
                     throws Exception {
-                assertMasterAddress(master, instance);
-            }
-        });
-    }
-
-    public static void assertMasterAddress(Address masterAddress, HazelcastInstance instance) {
-        assertEquals(masterAddress, getNode(instance).getMasterAddress());
-    }
-
-    public static void assertMasterAddressEventually(final Address masterAddress, final HazelcastInstance instance) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run()
-                    throws Exception {
-                assertMasterAddress(masterAddress, instance);
+                for (HazelcastInstance instance : instances) {
+                    assertMasterAddress(masterAddress, instance);
+                }
             }
         });
     }


### PR DESCRIPTION
* Fix some usages of assertClusterSize() and assertClusterSizeEventually()
* Use var-args based cluster size assertions to reduce duplicate code

This pr does not make any change related to test logic.