### PR TITLE
Fixes for reading/writing ObjectNamespace compatibly

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ObjectNamespaceSerializationHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ObjectNamespaceSerializationHelper.java
@@ -57,7 +57,6 @@ public final class ObjectNamespaceSerializationHelper {
     }
 
     public static ObjectNamespace readNamespaceCompatibly(ObjectDataInput in) throws IOException {
-        assert !in.getVersion().isUnknown();
         ObjectNamespace namespace = in.readObject();
         if (namespace.getClass() == DefaultObjectNamespace.class) {
             namespace = new DistributedObjectNamespace(namespace);

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 public class LockReplicationOperation extends Operation
-        implements IdentifiedDataSerializable {
+        implements IdentifiedDataSerializable, Versioned {
 
     private final Collection<LockStoreImpl> locks = new LinkedList<LockStoreImpl>();
 


### PR DESCRIPTION
* An `ObjectDataInput` from a 3.8 member will not have the versioned flag set (`AbstractLockOperation` was not `Versioned` in 3.8) so it is valid for `readNamespaceCompatibly` to read from an `ObjectDataInput` that has `Version.UNKNOWN`
* `LockReplicationOperation` should become `Versioned` so all objects serialized on its `ObjectDataOutput` observe a proper `Version` set.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1470 & https://github.com/hazelcast/hazelcast-enterprise/issues/1471