### PR TITLE
Make lock replication operation implement Versioned

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LockReplicationOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.concurrent.lock.LockStoreImpl;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 public class LockReplicationOperation extends Operation
-        implements IdentifiedDataSerializable {
+        implements IdentifiedDataSerializable, Versioned {
 
     private final Collection<LockStoreImpl> locks = new LinkedList<LockStoreImpl>();
 


### PR DESCRIPTION
This will set the cluster version on the output and input stream.
The cluster version is needed when serializing and deserializing
the replication operation.

Fixes test failures in EE : 
https://hazelcast-l337.ci.cloudbees.com/job/new-lab-fast-EE-pr/2155/#showFailuresLink