### PR TITLE
Adds Channel attribute map

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
@@ -23,6 +23,7 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SocketChannel;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Wraps a {@link java.nio.channels.SocketChannel}.
@@ -37,6 +38,16 @@ import java.nio.channels.SocketChannel;
  * chaining to add encryption. This will remove more artifacts from the architecture that can't carry their weight.
  */
 public interface Channel extends Closeable {
+
+    /**
+     * Returns the attribute map.
+     *
+     * Attribute map can be used to store data into a socket. For example to find the Connection for a Channel, one can
+     * store the Connection in this channel using some well known key.
+     *
+     * @return the attribute map.
+     */
+    ConcurrentMap attributeMap();
 
     /**
      * @see java.nio.channels.SocketChannel#socket()

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelReader.java
@@ -85,6 +85,4 @@ public interface ChannelReader {
     void setInboundHandler(ChannelInboundHandler inboundHandler);
 
     Channel getChannel();
-
-    ByteBuffer getProtocolBuffer();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelReader.java
@@ -53,7 +53,6 @@ public final class NioChannelReader
     @Probe(name = "priorityFramesRead")
     private final SwCounter priorityFramesRead = newSwCounter();
     private final ChannelReaderInitializer initializer;
-    private final ByteBuffer protocolBuffer = ByteBuffer.allocate(3);
     private ChannelInboundHandler inboundHandler;
     private volatile long lastReadTime;
 
@@ -84,11 +83,6 @@ public final class NioChannelReader
             default:
                 throw new RuntimeException();
         }
-    }
-
-    @Override
-    public ByteBuffer getProtocolBuffer() {
-        return protocolBuffer;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/spinning/SpinningChannelReader.java
@@ -17,11 +17,11 @@
 package com.hazelcast.internal.networking.spinning;
 
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.networking.ChannelConnection;
 import com.hazelcast.internal.networking.ChannelInboundHandler;
 import com.hazelcast.internal.networking.ChannelReader;
-import com.hazelcast.internal.networking.IOOutOfMemoryHandler;
-import com.hazelcast.internal.networking.ChannelConnection;
 import com.hazelcast.internal.networking.ChannelReaderInitializer;
+import com.hazelcast.internal.networking.IOOutOfMemoryHandler;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 
@@ -44,7 +44,6 @@ public class SpinningChannelReader extends AbstractHandler implements ChannelRea
     private volatile long lastReadTime;
     private ChannelInboundHandler inboundHandler;
     private ByteBuffer inputBuffer;
-    private final ByteBuffer protocolBuffer = ByteBuffer.allocate(3);
 
     public SpinningChannelReader(ChannelConnection connection,
                                  ILogger logger,
@@ -52,11 +51,6 @@ public class SpinningChannelReader extends AbstractHandler implements ChannelRea
                                  ChannelReaderInitializer initializer) {
         super(connection, logger, oomeHandler);
         this.initializer = initializer;
-    }
-
-    @Override
-    public ByteBuffer getProtocolBuffer() {
-        return protocolBuffer;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/PlainChannel.java
@@ -24,13 +24,20 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SocketChannel;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class PlainChannel implements Channel {
 
     protected final SocketChannel socketChannel;
+    private final ConcurrentMap<?, ?> attributeMap = new ConcurrentHashMap<Object, Object>();
 
     public PlainChannel(SocketChannel socketChannel) {
         this.socketChannel = socketChannel;
+    }
+
+    public ConcurrentMap attributeMap() {
+        return attributeMap;
     }
 
     @Override


### PR DESCRIPTION
Using the attribute map one can add data to a channel without needing to add fields to that channel.

The protocol-buffer has been removed as explicit field on the channelreaders; and is now stored
as attachment on the channel. The protocol is server-side specific; client doesn't care for
protocol-buffer; so it should not be part of the shared infrastructure.