### PR TITLE
Channel InitResult

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelReader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelReader.java
@@ -18,8 +18,6 @@ package com.hazelcast.internal.networking;
 
 import com.hazelcast.internal.util.counters.SwCounter;
 
-import java.nio.ByteBuffer;
-
 /**
  * The ChannelReader is responsible for reading data from the socket, on behalf of a connection, into a
  * {@link java.nio.ByteBuffer}. Once the data is read into the ByteBuffer, this ByteBuffer is passed to the
@@ -79,10 +77,6 @@ public interface ChannelReader {
      * through the {@link com.hazelcast.nio.Connection#close(String, Throwable)} method.
      */
     void close();
-
-    void initInputBuffer(ByteBuffer inputBuffer);
-
-    void setInboundHandler(ChannelInboundHandler inboundHandler);
 
     Channel getChannel();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelWriter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelWriter.java
@@ -20,8 +20,6 @@ import com.hazelcast.nio.OutboundFrame;
 import com.hazelcast.nio.ascii.TextChannelInboundHandler;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 
-import java.nio.ByteBuffer;
-
 /**
  * Each {@link TcpIpConnection} has a {@link ChannelWriter} and it writes {@link OutboundFrame} instances to the socket. Copying
  * the Frame instances to the byte-buffer is done using the {@link ChannelOutboundHandler}.
@@ -89,8 +87,4 @@ public interface ChannelWriter {
      * through the {@link TcpIpConnection#close(String, Throwable)} method.
      */
     void close();
-
-    void initOutputBuffer(ByteBuffer outputBuffer);
-
-    void setOutboundHandler(ChannelOutboundHandler outboundHandler);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelWriterInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelWriterInitializer.java
@@ -20,5 +20,5 @@ import com.hazelcast.nio.Connection;
 
 public interface ChannelWriterInitializer<C extends Connection> {
 
-    void init(C connection, ChannelWriter writer, String protocol);
+    InitResult<ChannelOutboundHandler> init(C connection, ChannelWriter writer, String protocol);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/InitResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/InitResult.java
@@ -16,13 +16,22 @@
 
 package com.hazelcast.internal.networking;
 
-import com.hazelcast.nio.Connection;
+import java.nio.ByteBuffer;
 
-import java.io.IOException;
+public class InitResult<H> {
+    private final ByteBuffer byteBuffer;
+    private final H handler;
 
-public interface ChannelReaderInitializer<C extends Connection> {
-    /**
-     * Returned value could be null if not enough data is available to determine how to init (e.g. protocol info locking)
-     */
-    InitResult<ChannelInboundHandler> init(C connection, ChannelReader reader) throws IOException;
+    public InitResult(ByteBuffer byteBuffer, H handler) {
+        this.byteBuffer = byteBuffer;
+        this.handler = handler;
+    }
+
+    public ByteBuffer getByteBuffer() {
+        return byteBuffer;
+    }
+
+    public H getHandler() {
+        return handler;
+    }
 }


### PR DESCRIPTION
Instead of doing calling back on the ChannelReader/Writer the initializer returns the bb/handler that need to be used in the form of an InitResult

This reduces the dependence on the ChannelReader/ChannelWriter interfaces and make the
flow also a easier to understand since you don't get a callback into the reader/writer but just return what needs to be set.

In one of my follow up PR's the ChannelReader/ChannelWriter are completely removed from
the API, so callbacks are not desirable. 