### PR TITLE
getConnection method is removed from ClientInvocationService

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
@@ -47,6 +47,4 @@ public interface ClientInvocationService {
     void shutdown();
 
     void handleClientMessage(ClientMessage message, Connection connection);
-
-    ClientConnection getConnection(int partitionId) throws IOException;
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientNonSmartInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientNonSmartInvocationServiceImpl.java
@@ -54,17 +54,6 @@ public class ClientNonSmartInvocationServiceImpl extends ClientInvocationService
         sendToOwner(invocation);
     }
 
-    @Override
-    public ClientConnection getConnection(int partitionId)
-            throws IOException {
-        ClientClusterService clusterService = client.getClientClusterService();
-        Address ownerConnectionAddress = clusterService.getOwnerConnectionAddress();
-        if (ownerConnectionAddress == null) {
-            throw new IOException("ClientNonSmartInvocationServiceImpl: Owner connection is not available.");
-        }
-        return (ClientConnection) connectionManager.getConnection(ownerConnectionAddress);
-    }
-
     private void sendToOwner(ClientInvocation invocation) throws IOException {
         ClientClusterService clusterService = client.getClientClusterService();
         Address ownerConnectionAddress = clusterService.getOwnerConnectionAddress();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientSmartInvocationServiceImpl.java
@@ -52,43 +52,22 @@ public final class ClientSmartInvocationServiceImpl extends ClientInvocationServ
         if (randomAddress == null) {
             throw new IOException("No address found to invoke");
         }
-        final Connection connection = getOrTriggerConnect(randomAddress);
+        Connection connection = getOrTriggerConnect(randomAddress);
         send(invocation, (ClientConnection) connection);
     }
 
     @Override
-    public ClientConnection getConnection(int partitionId)
-            throws IOException {
-        final Address owner = partitionService.getPartitionOwner(partitionId);
-        if (owner == null) {
-            throw new IOException("Partition does not have an owner. partitionId: " + partitionId);
-        }
-        return (ClientConnection) getOrConnect(owner);
-    }
-
-    @Override
-    public void invokeOnTarget(ClientInvocation invocation, Address target)
-            throws IOException {
-        if (target == null) {
-            throw new NullPointerException("Target can not be null");
-        }
+    public void invokeOnTarget(ClientInvocation invocation, Address target) throws IOException {
+        assert (target != null);
         if (!isMember(target)) {
             throw new TargetNotMemberException("Target '" + target + "' is not a member.");
         }
-        final Connection connection = getOrTriggerConnect(target);
+        Connection connection = getOrTriggerConnect(target);
         invokeOnConnection(invocation, (ClientConnection) connection);
     }
 
     private Connection getOrTriggerConnect(Address target) throws IOException {
         Connection connection = connectionManager.getOrTriggerConnect(target, false);
-        if (connection == null) {
-            throw new IOException("No available connection to address " + target);
-        }
-        return connection;
-    }
-
-    private Connection getOrConnect(Address target) throws IOException {
-        Connection connection = connectionManager.getOrConnect(target, false);
         if (connection == null) {
             throw new IOException("No available connection to address " + target);
         }


### PR DESCRIPTION
This method is introduced when implementing a warkaround for
CacheCreateConfig compatibility issue.
Since getConnection method is specific to one workaround,
it is removed from the ClientInvocationService interface.

Pull request aims to not to change bahaviour.